### PR TITLE
Reliable Browse reads under load: surface fetch timeouts, stop per-assist SSE reconnect churn

### DIFF
--- a/docs/protocol/CHANNELS.md
+++ b/docs/protocol/CHANNELS.md
@@ -51,7 +51,9 @@ Channels every viewer of a specific resource wants to see, regardless of who tri
 
 The authoritative list is `RESOURCE_BROADCAST_TYPES` in [`packages/core/src/bus-protocol.ts`](../../packages/core/src/bus-protocol.ts):
 
-- `yield:progress`, `yield:finished`, `yield:failed`
+- `job:complete`, `job:fail`
+
+**Dual-emit.** These two are emitted by the worker **both** resource-scoped (for viewers, above) **and** globally (so the caller that dispatched the job receives them on the always-on global bridge, keyed by `jobId`, without holding a resource-scoped subscription — see `emitEvent` in [`packages/jobs/src/worker-process.ts`](../../packages/jobs/src/worker-process.ts)). A client subscribed to both delivery paths sees each event **twice**; raw `job.complete$`/`job.fail$` consumers must key on `jobId` and stay idempotent. The reason for the global path: a resource-scoped subscription mutates the SSE channel set, which forces a reconnect that drops in-flight correlation results — the Link 1 root cause in [`.plans/SEMIONT-BUG-browse-annotations.md`](../../.plans/SEMIONT-BUG-browse-annotations.md).
 
 ## Bridged channels (HTTP transport fan-in)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1606,6 +1606,13 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@colordx/core": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
+      "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -2479,6 +2486,39 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@headlessui/react": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
@@ -2792,6 +2832,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@jsdevtools/ono": {
@@ -3699,6 +3750,15 @@
         "pako": "^1.0.10"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3709,6 +3769,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@prisma/adapter-pg": {
       "version": "7.8.0",
@@ -6879,6 +6946,18 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -6902,6 +6981,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -7177,6 +7263,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caniuse-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001797",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
@@ -7310,6 +7409,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/classnames": {
       "version": "2.5.1",
@@ -7851,6 +7957,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -7877,6 +8000,19 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -7895,6 +8031,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/csstype": {
@@ -8045,12 +8195,72 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
     },
     "node_modules/dompurify": {
       "version": "3.4.8",
@@ -8060,6 +8270,21 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -8966,6 +9191,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -10769,6 +11001,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -10805,6 +11044,13 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10822,6 +11068,13 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12017,6 +12270,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -12110,6 +12370,16 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -12397,6 +12667,15 @@
       "integrity": "sha512-5I2KxICAvcHxnWdJyDqwu8PBAQvWVTlQH2ve3VQmtVdJScPqWhpXN1PiX5IIl+cRF3pFpz9GQF53B5n6s0QQUQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -12456,6 +12735,17 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
@@ -12484,6 +12774,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oas-kit-common": {
@@ -13266,6 +13569,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-calc": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12 || ^20.9 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/postcss-import": {
@@ -14693,6 +15013,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -15008,6 +15338,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -15184,6 +15529,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -15829,6 +16181,32 @@
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
+    "node_modules/svgo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
     "node_modules/swagger2openapi": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
@@ -16156,6 +16534,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -18979,394 +19367,6 @@
       },
       "engines": {
         "node": ">=24.0.0"
-      }
-    },
-    "node_modules/sirv": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
-      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@phc/format": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
-      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.8.0",
-        "@js-sdsl/ordered-map": "^4.4.2"
-      },
-      "engines": {
-        "node": ">=12.10.0"
-      }
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/docker-modem": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
-      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "readable-stream": "^3.5.0",
-        "split-ca": "^1.0.1",
-        "ssh2": "^1.15.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-calc": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
-      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12 || ^20.9 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.38"
-      }
-    },
-    "node_modules/@colordx/core": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
-      "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
-      }
-    },
-    "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^11.1.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.29",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mrmime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@js-sdsl/ordered-map": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
-      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
-      }
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/split-ca": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     }
   }

--- a/packages/api-client/src/transport/__tests__/actor-state-unit.test.ts
+++ b/packages/api-client/src/transport/__tests__/actor-state-unit.test.ts
@@ -449,6 +449,59 @@ describe('createActorStateUnit', () => {
     stateUnit.dispose();
   });
 
+  it('recovers (does not crash) when a channel-set change fires while degraded (#844)', { timeout: 12_000 }, async () => {
+    // Regression for #844: a channel-set change while `degraded` scheduled a
+    // reconnect whose `degraded → reconnecting` transition the state machine
+    // rejected — `transition()` threw from inside the reconnect timer, an
+    // uncaught exception that killed the host process. The connection must
+    // instead treat it as a legitimate recovery edge and head back to `open`.
+    const sse1 = mockSSEResponse();
+    mockSSEResponse(); // for the recovery reconnect
+
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['test:event'],
+      // Long, so the retry timer doesn't fire during the wait — we want to
+      // sit in `reconnecting` long enough to cross the degraded threshold.
+      reconnectMs: 10_000,
+    });
+
+    const states: string[] = [];
+    stateUnit.state$.subscribe((s) => states.push(s));
+
+    // A listener keeps an uncaught throw from the buggy reconnect timer from
+    // tearing down the test worker, and lets us assert it didn't happen.
+    const uncaught: Error[] = [];
+    const onUncaught = (e: Error) => uncaught.push(e);
+    process.on('uncaughtException', onUncaught);
+
+    try {
+      stateUnit.start();
+      await vi.waitFor(() => expect(states).toContain('open'));
+
+      // Drop the stream → reconnecting, then wait past the degraded threshold.
+      sse1.close();
+      await vi.waitFor(() => expect(states).toContain('reconnecting'));
+      await new Promise((r) => setTimeout(r, 3_100));
+      expect(states).toContain('degraded');
+
+      const fetchesBefore = mockFetch.mock.calls.length;
+
+      // Channel-set change while degraded → schedules a reconnect.
+      stateUnit.addChannels(['mark:added'], 'res-1');
+
+      // Must attempt a reconnect (new fetch) and head back to `open` —
+      // not throw a fatal `degraded → reconnecting`.
+      await vi.waitFor(() => expect(states[states.length - 1]).toBe('open'), { timeout: 3_000 });
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(fetchesBefore);
+      expect(uncaught.map((e) => e.message)).toEqual([]);
+    } finally {
+      process.off('uncaughtException', onUncaught);
+      stateUnit.dispose();
+    }
+  });
+
   it('invalid transition throws (e.g. stop() after stop() is a no-op, not a throw)', async () => {
     // The state machine is internal; the public API is stop()/dispose().
     // Assert that idempotent usage doesn't throw.

--- a/packages/api-client/src/transport/actor-state-unit.ts
+++ b/packages/api-client/src/transport/actor-state-unit.ts
@@ -49,7 +49,11 @@ const ALLOWED_TRANSITIONS: Record<ConnectionState, ReadonlyArray<ConnectionState
   connecting:   ['open', 'reconnecting', 'closed'],
   open:         ['reconnecting', 'closed'],
   reconnecting: ['connecting', 'degraded', 'closed'],
-  degraded:     ['connecting', 'closed'],
+  // `degraded → reconnecting` is a legitimate recovery edge: a channel-set
+  // change (`addChannels`/`removeChannels`) schedules a reconnect that can
+  // fire while the connection is degraded. Omitting it made `reconnect()`
+  // throw a fatal, uncaught exception from the reconnect timer (#844).
+  degraded:     ['connecting', 'reconnecting', 'closed'],
   closed:       [],
 };
 
@@ -67,11 +71,14 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
   let degradedTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
-   * Move the state machine to `next`. Throws on invalid transitions.
-   * The throw is deliberate — a bad transition means a bug in the
-   * reconnect loop; silent correction would hide it. The reconnect
-   * timer logic is responsible for ensuring we only transition
-   * between valid states.
+   * Move the state machine to `next`. An unexpected edge is logged and
+   * ignored — NOT thrown. `transition()` runs inside timer callbacks (the
+   * reconnect and degraded timers), so a throw here is an uncaught exception
+   * that takes down the host process (#844). A bad edge means a bug in the
+   * reconnect loop, but degrading gracefully (keep the current state, warn)
+   * is strictly better than killing a long-running job. The permitted edges
+   * — including the `degraded → reconnecting` recovery edge — are in
+   * `ALLOWED_TRANSITIONS`.
    *
    * Side effect: manages the `degraded` timer. Enters on
    * `reconnecting`, cleared on exit.
@@ -80,7 +87,8 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
     if (currentState === next) return;
     const allowed = ALLOWED_TRANSITIONS[currentState];
     if (!allowed.includes(next)) {
-      throw new Error(`Invalid connection state transition: ${currentState} → ${next}`);
+      console.warn(`[actor] ignoring invalid connection state transition: ${currentState} → ${next}`);
+      return;
     }
     const prev = currentState;
     currentState = next;

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -12,6 +12,13 @@
  *                                                 (generation only; creates the resource)
  *     → job:complete                            (at success exit)
  *
+ * `job:complete` and `job:fail` are resource broadcasts: `emitEvent` emits each
+ * BOTH globally (so the dispatching caller receives it on the always-on bridge)
+ * and resource-scoped (so viewers of the resource get the broadcast) — see #843
+ * / RESOURCE_BROADCAST_TYPES. Sequence assertions below filter on
+ * `scope === undefined` for the caller's lifecycle stream; the scoped copy is
+ * asserted separately under 'resource-broadcast scope routing'.
+ *
  * Post-WORKER-SESSIONS refactor, the worker runs on top of a
  * `SemiontSession`. Tests use a fake session whose `client.actor.emit`
  * captures bus emits, `client.browse.resourceContent` returns test
@@ -147,8 +154,13 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
 
-      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'mark:create', 'job:complete']);
-      expect(h.busEmits[3]!.payload).toMatchObject({ jobType: 'highlight-annotation', result: { highlightsFound: 2 } });
+      // Global stream = the dispatching caller's lifecycle view. job:complete
+      // is dual-emitted (global + resource-scoped, #843); the scoped copy is
+      // asserted under 'resource-broadcast scope routing'.
+      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+        .toEqual(['job:start', 'mark:create', 'mark:create', 'job:complete']);
+      expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload)
+        .toMatchObject({ jobType: 'highlight-annotation', result: { highlightsFound: 2 } });
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
   });
@@ -163,7 +175,8 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('comment-annotation'));
 
-      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'job:complete']);
+      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+        .toEqual(['job:start', 'mark:create', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
   });
@@ -178,7 +191,8 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('assessment-annotation'));
 
-      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'job:complete']);
+      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+        .toEqual(['job:start', 'mark:create', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
   });
@@ -193,7 +207,8 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation'));
 
-      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'mark:create', 'mark:create', 'job:complete']);
+      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+        .toEqual(['job:start', 'mark:create', 'mark:create', 'mark:create', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
   });
@@ -208,8 +223,9 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('tag-annotation'));
 
-      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'job:complete']);
-      expect(h.busEmits[2]!.payload).toMatchObject({
+      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+        .toEqual(['job:start', 'mark:create', 'job:complete']);
+      expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload).toMatchObject({
         jobType: 'tag-annotation',
         result: { tagsFound: 1, tagsCreated: 1 },
       });
@@ -242,8 +258,9 @@ describe('handleJob orchestration', () => {
       expect(uploaded.generator).toBeTruthy();
 
       // Bus emits: job:start then job:complete (no yield:create, no mark:create).
-      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'job:complete']);
-      expect(h.busEmits[1]!.payload).toMatchObject({
+      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+        .toEqual(['job:start', 'job:complete']);
+      expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload).toMatchObject({
         jobType: 'generation',
         result: { resourceId: 'new-res-42', resourceName: 'New Resource' },
       });
@@ -357,7 +374,7 @@ describe('handleJob orchestration', () => {
 // ──────────────────────────────────────────────────────────────────────
 
 describe('handleJob — resource-broadcast scope routing', () => {
-  it('emits job:complete with scope=resourceId (resource broadcast)', async () => {
+  it('emits job:complete both globally and resource-scoped (dual-emit, #843)', async () => {
     vi.mocked(processHighlightJob).mockResolvedValue({
       annotations: [] as never,
       result: {} as never,
@@ -366,9 +383,11 @@ describe('handleJob — resource-broadcast scope routing', () => {
 
     await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
 
-    const completeEmit = h.busEmits.find(e => e.channel === 'job:complete');
-    expect(completeEmit).toBeDefined();
-    expect(completeEmit!.scope).toBe(RID);
+    const completes = h.busEmits.filter(e => e.channel === 'job:complete');
+    // Global copy: the dispatching caller receives it on the always-on bridge.
+    expect(completes.some(e => e.scope === undefined)).toBe(true);
+    // Scoped copy: every viewer of the resource receives the broadcast.
+    expect(completes.some(e => e.scope === RID)).toBe(true);
   });
 
   it('emits job:start globally (no scope — not a resource broadcast)', async () => {
@@ -504,7 +523,9 @@ describe('startWorkerProcess', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     // Outer handler emits job:fail on the bus and calls adapter.failJob.
-    const failEmit = h.busEmits.find((e) => e.channel === 'job:fail');
+    // job:fail is dual-emitted (global + resource-scoped, #843); assert the
+    // resource-scoped broadcast carries scope=resourceId.
+    const failEmit = h.busEmits.find((e) => e.channel === 'job:fail' && e.scope === RID);
     expect(failEmit).toBeDefined();
     expect(failEmit!.payload).toMatchObject({
       jobId: JID,

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -70,7 +70,24 @@ async function emitEvent<K extends keyof EventMap>(
   const isBroadcast = (RESOURCE_BROADCAST_TYPES as readonly string[]).includes(channel as string);
   const rawScope = isBroadcast ? ((payload as { resourceId?: string }).resourceId) : undefined;
   const resourceScope = rawScope ? makeResourceId(rawScope) : undefined;
-  await session.client.transport.emit(channel, payload as EventMap[K], resourceScope);
+
+  if (resourceScope) {
+    // Dual-emit a resource-broadcast event:
+    //  - globally, so the dispatching caller (`mark.assist` /
+    //    `yield.fromAnnotation`) receives it on the always-on global bridge
+    //    and filters by `jobId` — no resource-scoped subscription, hence no
+    //    SSE channel-set churn (the Link 1 root cause in
+    //    .plans/SEMIONT-BUG-browse-annotations.md);
+    //  - resource-scoped, so every viewer of the resource still gets the
+    //    broadcast without a global fan-out widening their interest set.
+    // A client subscribed to both sees it twice; SDK consumers key on
+    // `jobId`/`resourceId` and treat completion as terminal, so the doubled
+    // delivery collapses to a single observed completion.
+    await session.client.transport.emit(channel, payload as EventMap[K]);
+    await session.client.transport.emit(channel, payload as EventMap[K], resourceScope);
+  } else {
+    await session.client.transport.emit(channel, payload as EventMap[K]);
+  }
 }
 
 export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter {

--- a/packages/sdk/docs/Usage.md
+++ b/packages/sdk/docs/Usage.md
@@ -449,6 +449,51 @@ const final = await semiont.job.pollUntilComplete(jobId, {
 });
 ```
 
+### `job:complete` / `job:fail` are dual-delivered — keep raw-stream consumers idempotent
+
+The worker emits `job:complete` and `job:fail` **twice**: once globally (so the
+caller that dispatched the job receives it on the always-on global bridge,
+filtered by `jobId`) and once resource-scoped (so viewers of the resource react
+too). A client subscribed to *both* a resource scope and the global bus — e.g. a
+frontend with that resource's tab open — therefore sees each event twice.
+
+The single-job consumers absorb this for you and emit **one** completion:
+
+```typescript
+// Terminal by design — one `complete`, no matter how many job:complete hit the bus.
+const result = await semiont.mark.assist(rId, 'linking', { entityTypes });
+await semiont.yield.fromAnnotation(rId, aId, { /* ... */ });
+await semiont.job.pollUntilComplete(jobId);
+```
+
+If you subscribe to the **raw** `job.complete$` / `job.fail$` streams, key on
+`jobId` and keep the reaction idempotent:
+
+```typescript
+import { filter, take } from 'rxjs/operators';
+import { firstValueFrom } from '@semiont/sdk';
+
+// One job: make it terminal.
+const done = await firstValueFrom(
+  semiont.job.complete$.pipe(filter((e) => e.jobId === jobId), take(1)),
+);
+
+// Many jobs over time: prefer an idempotent side effect…
+semiont.job.complete$.subscribe((e) => refetchResourceView(e.resourceId)); // refetch is idempotent
+
+// …or guard a non-idempotent reaction by jobId.
+const handled = new Set<string>();
+semiont.job.complete$.subscribe((e) => {
+  if (handled.has(e.jobId)) return;
+  handled.add(e.jobId);
+  toast(`Job ${e.jobId} finished`);
+});
+```
+
+A headless caller that never subscribes to a resource scope (the common SDK-script
+case) receives each event exactly once, so this only matters for clients that hold
+both subscriptions.
+
 ## Bus Connection
 
 For HTTP transports, the client lazily opens a single SSE connection to `/bus/subscribe`. Result channels, global domain events, and resource-scoped fan-out all flow through it. For in-process transports, the bus is the in-memory `EventBus` from `@semiont/core`. Either way, the namespace methods hide the wire.

--- a/packages/sdk/src/__tests__/browse-fetch-failure.test.ts
+++ b/packages/sdk/src/__tests__/browse-fetch-failure.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression: a one-shot `await` of a Browse live-query must REJECT when the
+ * underlying bus request fails — it must not hang forever.
+ *
+ * Root cause (see .plans/SEMIONT-BUG-browse-annotations.md, "Link 3"): the
+ * cache primitive's `doFetch` swallows fetch failures (CACHE-SEMANTICS B6 —
+ * "fetch failure leaves the previous state intact") so that live-query
+ * *subscribers* keep their stale value / stay in the loading state. That is
+ * correct for the subscribe path. But the *await* path
+ * (`CacheObservable.then` = first-non-undefined emission) then never sees a
+ * value and never rejects — so `await client.browse.annotations(rId)` hangs
+ * indefinitely when the result is lost on the wire, instead of surfacing the
+ * `bus.timeout` / `bus.rejected` the busRequest already produced.
+ *
+ * The contract this pins:
+ *   1. `await` of a Browse read REJECTS when the underlying fetch fails.
+ *   2. `.subscribe(...)` of the same read PRESERVES B6 — it sees `undefined`
+ *      (loading) and is NOT errored. The fix must surface the failure to the
+ *      awaiter WITHOUT erroring live-query subscribers.
+ *
+ * No backend: a fake transport drives `busRequest` to a deterministic
+ * failure-channel rejection.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Observable, Subject } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { IContentTransport, ITransport, ResourceId } from '@semiont/core';
+import { BrowseNamespace } from '../namespaces/browse';
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Minimal `ITransport` stand-in exercising only what `busRequest` touches:
+ * `emit(channel, payload)` and `stream(channel)`. `onEmit` lets a test react
+ * to an outbound request; `push` injects a response onto the SAME subject the
+ * transport's `stream(...)` hands back, so busRequest's subscriber receives it.
+ */
+function makeFakeTransport() {
+  const subjects = new Map<string, Subject<Record<string, unknown>>>();
+  const subjectFor = (channel: string) => {
+    let s = subjects.get(channel);
+    if (!s) {
+      s = new Subject<Record<string, unknown>>();
+      subjects.set(channel, s);
+    }
+    return s;
+  };
+
+  let onEmit: ((channel: string, payload: Record<string, unknown>) => void) | undefined;
+
+  const transport = {
+    baseUrl: 'http://test',
+    emit: async (channel: string, payload: Record<string, unknown>) => {
+      onEmit?.(channel, payload);
+    },
+    stream: (channel: string): Observable<Record<string, unknown>> =>
+      subjectFor(channel).asObservable(),
+    subscribeToResource: () => () => {},
+    bridgeInto: () => {},
+    state$: new Subject(),
+    errors$: new Subject(),
+    dispose: () => {},
+  };
+
+  return {
+    transport: transport as unknown as ITransport,
+    setOnEmit: (f: (channel: string, payload: Record<string, unknown>) => void) => {
+      onEmit = f;
+    },
+    push: (channel: string, payload: Record<string, unknown>) => subjectFor(channel).next(payload),
+  };
+}
+
+const noopContent = {
+  getBinary: async () => ({ data: new ArrayBuffer(0), contentType: 'text/plain' }),
+  getBinaryStream: async () => ({ stream: new ReadableStream(), contentType: 'text/plain' }),
+  dispose: () => {},
+} as unknown as IContentTransport;
+
+describe('browse read — await semantics on fetch failure (Link 3)', () => {
+  let bus: EventBus;
+  let browse: BrowseNamespace;
+  let setOnEmit: ReturnType<typeof makeFakeTransport>['setOnEmit'];
+  let push: ReturnType<typeof makeFakeTransport>['push'];
+  const rId: ResourceId = makeResourceId('res-1');
+
+  beforeEach(() => {
+    bus = new EventBus();
+    const fake = makeFakeTransport();
+    setOnEmit = fake.setOnEmit;
+    push = fake.push;
+    browse = new BrowseNamespace(fake.transport, bus, noopContent);
+
+    // Every annotations request gets an immediate failure response on the
+    // matching correlationId. busRequest subscribes to the failure stream
+    // before emitting, so a synchronous push during emit is delivered.
+    setOnEmit((channel, payload) => {
+      if (channel === 'browse:annotations-requested') {
+        push('browse:annotations-failed', {
+          correlationId: payload.correlationId as string,
+          message: 'boom',
+        });
+      }
+    });
+  });
+
+  afterEach(() => {
+    bus.destroy();
+  });
+
+  it('await rejects when the bus request fails (does not hang)', async () => {
+    // Today the cache swallows the rejection → the await hangs → 'hung' (RED).
+    // After the fix the await rejects → 'rejected' (GREEN).
+    const outcome = await Promise.race([
+      browse.annotations(rId).then(() => 'resolved', () => 'rejected'),
+      delay(250).then(() => 'hung'),
+    ]);
+
+    expect(outcome).toBe('rejected');
+  });
+
+  it('subscribe preserves SWR on fetch failure — stays undefined, not errored (B6)', async () => {
+    const seen: Array<unknown> = [];
+    let errored = false;
+    const sub = browse.annotations(rId).subscribe({
+      next: (v) => seen.push(v),
+      error: () => {
+        errored = true;
+      },
+    });
+
+    await delay(50);
+    sub.unsubscribe();
+
+    expect(seen).toEqual([undefined]);
+    expect(errored).toBe(false);
+  });
+});

--- a/packages/sdk/src/awaitable.ts
+++ b/packages/sdk/src/awaitable.ts
@@ -18,8 +18,8 @@
  * RxJS land; `lastValueFrom` from `rxjs` is the right bridge there.
  */
 
-import { Observable, firstValueFrom, lastValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { Observable, firstValueFrom, lastValueFrom, merge } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 import type { ResourceId } from '@semiont/core';
 
 /**
@@ -61,16 +61,43 @@ export class StreamObservable<T> extends Observable<T> implements PromiseLike<T>
  * `.pipe` in the natural way.
  */
 export class CacheObservable<T> extends Observable<T | undefined> implements PromiseLike<T> {
+  /**
+   * Optional per-key fetch-failure stream. Consulted only by `then()` (the
+   * await path). `.subscribe(...)` never touches it — live-query subscribers
+   * keep the stale-while-revalidate contract (a failed fetch leaves them at
+   * their last value / loading state, never errored). See cache.ts B6.
+   */
+  private errors$?: Observable<unknown>;
+
   then<R1 = T, R2 = never>(
     onfulfilled?: ((v: T) => R1 | PromiseLike<R1>) | null,
     onrejected?: ((e: unknown) => R2 | PromiseLike<R2>) | null,
   ): PromiseLike<R1 | R2> {
-    return firstValueFrom(this.pipe(filter((v): v is T => v !== undefined)))
+    const value$ = this.pipe(
+      filter((v): v is T => v !== undefined),
+      map((value): { ok: true; value: T } => ({ ok: true, value })),
+    );
+    // Race first-defined-value against first-fetch-error. firstValueFrom
+    // takes the first emission and unsubscribes from both, so a later
+    // error (e.g. a subsequent failed refetch) can't produce a dangling
+    // rejection after the value already won.
+    const settled$ = this.errors$
+      ? merge(value$, this.errors$.pipe(map((error): { ok: false; error: unknown } => ({ ok: false, error }))))
+      : value$;
+    return firstValueFrom(settled$)
+      .then((r) => {
+        if (r.ok) return r.value;
+        throw r.error;
+      })
       .then(onfulfilled, onrejected);
   }
 
   /**
    * Wrap an existing Observable's subscribe behavior in a `CacheObservable`.
+   *
+   * `errors$`, when supplied, is the cache's per-key fetch-failure stream:
+   * it lets `await` reject on a lost/failed fetch instead of hanging
+   * forever, without erroring `.subscribe(...)` consumers (B6).
    *
    * Memoizes on source identity: passing the same `source` returns the same
    * wrapper instance. The Browse cache primitive already returns a stable
@@ -81,10 +108,11 @@ export class CacheObservable<T> extends Observable<T | undefined> implements Pro
    *
    * Backed by a `WeakMap`, so wrappers are GC'd when their source is.
    */
-  static from<T>(source: Observable<T | undefined>): CacheObservable<T> {
+  static from<T>(source: Observable<T | undefined>, errors$?: Observable<unknown>): CacheObservable<T> {
     let wrapper = wrapperCache.get(source) as CacheObservable<T> | undefined;
     if (!wrapper) {
       wrapper = new CacheObservable<T>((subscriber) => source.subscribe(subscriber));
+      wrapper.errors$ = errors$;
       wrapperCache.set(source, wrapper);
     }
     return wrapper;

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -32,11 +32,20 @@
  *     (B6); the caller drives retry via invalidate.
  */
 
-import { BehaviorSubject, Observable, distinctUntilChanged, map } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, distinctUntilChanged, filter, map } from 'rxjs';
 
 export interface Cache<K, V> {
   /** Observable stream of the value at `key`. Triggers a fetch if not cached. */
   observe(key: K): Observable<V | undefined>;
+
+  /**
+   * Per-key stream of fetch failures. Emits each time a fetch for `key`
+   * rejects. This is the await-path counterpart to B6: live-query
+   * *subscribers* of `observe(key)` never see these (they keep their
+   * stale value / loading state), but a one-shot awaiter can consume
+   * this to reject instead of hanging forever on a lost result.
+   */
+  errors(key: K): Observable<unknown>;
 
   /** Synchronous snapshot of the current value, without triggering a fetch. */
   get(key: K): V | undefined;
@@ -67,6 +76,9 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
   const store$ = new BehaviorSubject<Map<K, V>>(new Map());
   const inflight = new Set<K>();
   const obsCache = new Map<K, Observable<V | undefined>>();
+  const errCache = new Map<K, Observable<unknown>>();
+  /** Per-key fetch-failure channel. See `Cache.errors`. */
+  const fetchErrors$ = new Subject<{ key: K; error: unknown }>();
 
   const doFetch = async (key: K): Promise<void> => {
     // In-flight guard: concurrent first-observations deduplicate (B3).
@@ -81,10 +93,17 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
       const next = new Map(store$.value);
       next.set(key, value);
       store$.next(next);
-    } catch {
-      // B6: fetch failure leaves the previous state intact. Observer
-      // that was seeing `undefined` stays at `undefined`; observer
-      // that was seeing a stale value keeps the stale value.
+    } catch (error) {
+      // B6: fetch failure leaves the previous state intact for
+      // *subscribers* — an observer seeing `undefined` stays at
+      // `undefined`; one seeing a stale value keeps it. We do NOT error
+      // the store Subject (that would break every observer of every key).
+      //
+      // But surface the failure on the per-key error channel so a
+      // one-shot *awaiter* (CacheObservable.then) can reject instead of
+      // hanging forever on a lost result. Live-query subscribers never
+      // touch this stream.
+      fetchErrors$.next({ key, error });
     } finally {
       inflight.delete(key);
     }
@@ -103,6 +122,19 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
           distinctUntilChanged(),
         );
         obsCache.set(key, obs);
+      }
+      return obs;
+    },
+
+    errors(key: K): Observable<unknown> {
+      // Stable per-key error observable (mirrors B4 for the value path).
+      let obs = errCache.get(key);
+      if (!obs) {
+        obs = fetchErrors$.pipe(
+          filter((e) => e.key === key),
+          map((e) => e.error),
+        );
+        errCache.set(key, obs);
       }
       return obs;
     },
@@ -149,7 +181,9 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
 
     dispose(): void {
       store$.complete();
+      fetchErrors$.complete();
       obsCache.clear();
+      errCache.clear();
       inflight.clear();
     },
   };

--- a/packages/sdk/src/namespaces/__tests__/mark-assist-churn.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/mark-assist-churn.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression: `mark.assist` must not churn the SSE connection.
+ *
+ * Root cause (see .plans/SEMIONT-BUG-browse-annotations.md, "Link 1"): a
+ * headless `mark.assist` called `transport.subscribeToResource(rId)` to
+ * receive the resource-scoped `job:complete`/`job:fail`. That mutates the
+ * SSE channel set, which can only be changed by tearing down and re-opening
+ * the connection — so every assist forced (two) SSE reconnects, and a
+ * `browse.*` result emitted during the reconnect gap was dropped.
+ *
+ * The fix makes the worker also emit `job:complete`/`job:fail` globally
+ * (dual-emit), so the dispatching caller receives them via the always-on
+ * global bridge — no scoped subscription, no channel-set mutation, no
+ * reconnect. `mark.assist` therefore must NOT call `subscribeToResource`,
+ * and must still complete on a globally-delivered `job:complete`.
+ *
+ * No backend: a fake transport stands in for the bus.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Observable, Subject } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { ITransport, ResourceId } from '@semiont/core';
+import { MarkNamespace } from '../mark';
+import { JobNamespace } from '../job';
+import type { MarkAssistEvent } from '../types';
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+function makeFakeTransport() {
+  const subjects = new Map<string, Subject<Record<string, unknown>>>();
+  const subjectFor = (channel: string) => {
+    let s = subjects.get(channel);
+    if (!s) {
+      s = new Subject<Record<string, unknown>>();
+      subjects.set(channel, s);
+    }
+    return s;
+  };
+  const subscribeToResource = vi.fn((_rId: ResourceId) => () => {});
+
+  const transport = {
+    baseUrl: 'http://test',
+    subscribeToResource,
+    emit: async (channel: string, payload: Record<string, unknown>) => {
+      // Resolve the job:create round-trip so dispatchAssist gets a jobId.
+      if (channel === 'job:create') {
+        subjectFor('job:created').next({
+          correlationId: payload.correlationId,
+          response: { jobId: 'job-1' },
+        });
+      }
+    },
+    stream: (channel: string): Observable<Record<string, unknown>> => subjectFor(channel).asObservable(),
+    bridgeInto: () => {},
+    state$: new Subject(),
+    errors$: new Subject(),
+    dispose: () => {},
+  };
+
+  return { transport: transport as unknown as ITransport, subscribeToResource };
+}
+
+describe('mark.assist — no SSE churn (Link 1)', () => {
+  let bus: EventBus;
+  const rId = makeResourceId('res-1');
+
+  beforeEach(() => {
+    bus = new EventBus();
+  });
+
+  afterEach(() => {
+    bus.destroy();
+  });
+
+  it('does not subscribe to the resource scope (which would churn the SSE)', () => {
+    const { transport, subscribeToResource } = makeFakeTransport();
+    const mark = new MarkNamespace(transport, bus);
+
+    const sub = mark
+      .assist(rId, 'linking', { entityTypes: ['Person'] })
+      .subscribe({ next: () => {}, error: () => {} });
+
+    expect(subscribeToResource).not.toHaveBeenCalled();
+    sub.unsubscribe();
+  });
+
+  it('completes on a globally-delivered job:complete (no scoped subscription needed)', async () => {
+    const { transport } = makeFakeTransport();
+    const mark = new MarkNamespace(transport, bus);
+
+    const events: MarkAssistEvent[] = [];
+    let completed = false;
+    mark.assist(rId, 'linking', { entityTypes: ['Person'] }).subscribe({
+      next: (e) => events.push(e),
+      complete: () => {
+        completed = true;
+      },
+      error: () => {},
+    });
+
+    // Let dispatchAssist resolve (job:create → job:created) and set activeJobId.
+    await flush();
+
+    // Completion arrives on the global bus (as it would via the global bridge).
+    bus.get('job:complete').next({ resourceId: rId, jobId: 'job-1', jobType: 'reference-annotation' });
+
+    expect(events.some((e) => e.kind === 'complete')).toBe(true);
+    expect(completed).toBe(true);
+  });
+});
+
+describe('job:complete dual-delivery contract (Link 1 / approach A)', () => {
+  let bus: EventBus;
+  const rId = makeResourceId('res-1');
+  const completePayload = { resourceId: rId, jobId: 'job-1', jobType: 'reference-annotation' as const };
+
+  beforeEach(() => {
+    bus = new EventBus();
+  });
+
+  afterEach(() => {
+    bus.destroy();
+  });
+
+  it('mark.assist collapses a doubled job:complete into a single completion', async () => {
+    const { transport } = makeFakeTransport();
+    const mark = new MarkNamespace(transport, bus);
+
+    const completes: MarkAssistEvent[] = [];
+    let completeCount = 0;
+    mark.assist(rId, 'linking', { entityTypes: ['Person'] }).subscribe({
+      next: (e) => {
+        if (e.kind === 'complete') completes.push(e);
+      },
+      complete: () => {
+        completeCount++;
+      },
+      error: () => {},
+    });
+    await flush();
+
+    // Worker dual-emit: the same completion arrives globally AND scoped, so a
+    // client subscribed to both sees two bus deliveries.
+    bus.get('job:complete').next(completePayload);
+    bus.get('job:complete').next(completePayload);
+
+    expect(completes).toHaveLength(1);
+    expect(completeCount).toBe(1);
+  });
+
+  it('job.complete$ is a raw passthrough — each delivery is observed (consumers must key on jobId)', () => {
+    const { transport } = makeFakeTransport();
+    const job = new JobNamespace(transport, bus);
+
+    const seen: string[] = [];
+    job.complete$.subscribe((e) => seen.push(e.jobId));
+
+    bus.get('job:complete').next(completePayload);
+    bus.get('job:complete').next(completePayload);
+
+    // Documents the contract: the SDK does NOT dedupe the raw stream.
+    expect(seen).toEqual(['job-1', 'job-1']);
+  });
+});

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -195,7 +195,7 @@ export class BrowseNamespace implements IBrowseNamespace {
   // first non-undefined value.
 
   resource(resourceId: ResourceId): CacheObservable<ResourceDescriptor> {
-    return CacheObservable.from(this.resourceCache.observe(resourceId));
+    return CacheObservable.from(this.resourceCache.observe(resourceId), this.resourceCache.errors(resourceId));
   }
 
   resources(filters?: ResourceListFilters): CacheObservable<ResourceDescriptor[]> {
@@ -203,7 +203,7 @@ export class BrowseNamespace implements IBrowseNamespace {
     // Remember the filter blob so `invalidateResourceLists` can drive
     // per-key SWR refetches without the caller re-passing filters.
     this.resourceListFilters.set(key, filters ?? {});
-    return CacheObservable.from(this.resourceListCache.observe(key));
+    return CacheObservable.from(this.resourceListCache.observe(key), this.resourceListCache.errors(key));
   }
 
   annotations(resourceId: ResourceId): CacheObservable<Annotation[]> {
@@ -212,7 +212,7 @@ export class BrowseNamespace implements IBrowseNamespace {
       obs = this.annotationListCache.observe(resourceId).pipe(map((r) => r?.annotations as Annotation[] | undefined));
       this.annotationListObs.set(resourceId, obs);
     }
-    return CacheObservable.from(obs);
+    return CacheObservable.from(obs, this.annotationListCache.errors(resourceId));
   }
 
   annotation(resourceId: ResourceId, annotationId: AnnotationId): CacheObservable<Annotation> {
@@ -220,23 +220,23 @@ export class BrowseNamespace implements IBrowseNamespace {
     // the cache key, `annotationId`) can look up the resourceId it
     // needs for the bus request.
     this.annotationResources.set(annotationId, resourceId);
-    return CacheObservable.from(this.annotationDetailCache.observe(annotationId));
+    return CacheObservable.from(this.annotationDetailCache.observe(annotationId), this.annotationDetailCache.errors(annotationId));
   }
 
   entityTypes(): CacheObservable<string[]> {
-    return CacheObservable.from(this.entityTypesCache.observe(ENTITY_TYPES_KEY));
+    return CacheObservable.from(this.entityTypesCache.observe(ENTITY_TYPES_KEY), this.entityTypesCache.errors(ENTITY_TYPES_KEY));
   }
 
   tagSchemas(): CacheObservable<TagSchema[]> {
-    return CacheObservable.from(this.tagSchemasCache.observe(TAG_SCHEMAS_KEY));
+    return CacheObservable.from(this.tagSchemasCache.observe(TAG_SCHEMAS_KEY), this.tagSchemasCache.errors(TAG_SCHEMAS_KEY));
   }
 
   referencedBy(resourceId: ResourceId): CacheObservable<ReferencedByEntry[]> {
-    return CacheObservable.from(this.referencedByCache.observe(resourceId));
+    return CacheObservable.from(this.referencedByCache.observe(resourceId), this.referencedByCache.errors(resourceId));
   }
 
   events(resourceId: ResourceId): CacheObservable<StoredEventResponse[]> {
-    return CacheObservable.from(this.resourceEventsCache.observe(resourceId));
+    return CacheObservable.from(this.resourceEventsCache.observe(resourceId), this.resourceEventsCache.errors(resourceId));
   }
 
   // ── One-shot reads ──────────────────────────────────────────────────────

--- a/packages/sdk/src/namespaces/job.ts
+++ b/packages/sdk/src/namespaces/job.ts
@@ -26,12 +26,32 @@ export class JobNamespace implements IJobNamespace {
     return this.bus.get('job:report-progress');
   }
 
-  /** Live stream of `job:complete` events. */
+  /**
+   * Live stream of `job:complete` events.
+   *
+   * **Dual-delivery — consumers must be idempotent.** The worker emits
+   * `job:complete` both globally (so a dispatching caller receives it on the
+   * always-on global bridge, keyed by `jobId`) and resource-scoped (so
+   * viewers of the resource react too). A client subscribed to *both* a
+   * resource scope and the global bus therefore sees each completion
+   * **twice**. This stream is a raw passthrough and does NOT dedupe.
+   *
+   * Key on `jobId` and keep the reaction idempotent — prefer naturally
+   * idempotent side effects; for a single job use
+   * `complete$.pipe(filter(e => e.jobId === id), take(1))`. The single-job
+   * consumers (`mark.assist`, `yield.fromAnnotation`, `pollUntilComplete`)
+   * already collapse the doubled delivery to one observed completion.
+   */
   get complete$(): Observable<EventMap['job:complete']> {
     return this.bus.get('job:complete');
   }
 
-  /** Live stream of `job:fail` events. */
+  /**
+   * Live stream of `job:fail` events.
+   *
+   * Dual-delivered like {@link complete$} — see its note. Raw passthrough,
+   * not deduped; key on `jobId` and keep the reaction idempotent.
+   */
   get fail$(): Observable<EventMap['job:fail']> {
     return this.bus.get('job:fail');
   }

--- a/packages/sdk/src/namespaces/mark.ts
+++ b/packages/sdk/src/namespaces/mark.ts
@@ -60,20 +60,21 @@ export class MarkNamespace implements IMarkNamespace {
       let pollTimer: ReturnType<typeof setTimeout> | null = null;
       let pollInterval: ReturnType<typeof setInterval> | null = null;
 
-      // `job:complete` and `job:report-progress` are resource-scoped on
-      // the SSE wire — subscribe for the lifetime of the Observable so
-      // headless callers (a parallel SDK client, a worker harness, an
-      // e2e spec) receive them without having to remember to call
-      // `subscribeToResource` first. UI code is unaffected: the page's
-      // resource-tab subscriptions already cover this, so the extra
-      // subscribe is a no-op for the common path.
-      let unsubscribeResource: (() => void) | null = this.transport.subscribeToResource(resourceId);
+      // `job:report-progress`, `job:complete`, and `job:fail` all reach us
+      // on the always-on global bridge — the worker dual-emits the
+      // resource-broadcast ones (`job:complete`/`job:fail`) globally as well
+      // as scoped, so the dispatching caller gets them without a scoped
+      // subscription. We deliberately do NOT call
+      // `transport.subscribeToResource(resourceId)` here: that mutates the
+      // SSE channel set, which can only change by tearing down and
+      // re-opening the connection, so it forced a reconnect on every assist
+      // and dropped in-flight `browse.*` results in the reconnect gap. See
+      // Link 1 in .plans/SEMIONT-BUG-browse-annotations.md.
 
       const cleanup = () => {
         done = true;
         if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
         if (pollInterval) { clearInterval(pollInterval); pollInterval = null; }
-        if (unsubscribeResource) { unsubscribeResource(); unsubscribeResource = null; }
       };
 
       const resetPollTimer = (jobId: string) => {

--- a/packages/sdk/src/namespaces/yield.ts
+++ b/packages/sdk/src/namespaces/yield.ts
@@ -103,19 +103,18 @@ export class YieldNamespace implements IYieldNamespace {
       let pollTimer: ReturnType<typeof setTimeout> | null = null;
       let pollInterval: ReturnType<typeof setInterval> | null = null;
 
-      // `job:complete` and `job:report-progress` are resource-scoped on
-      // the SSE wire — subscribe for the lifetime of the Observable so
-      // headless callers receive them without first calling
-      // `subscribeToResource`. UI code is unaffected: the page's
-      // resource-tab subscriptions already cover this. Symmetric with
-      // `mark.assist` — both StreamObservable callers need the scope.
-      let unsubscribeResource: (() => void) | null = this.transport.subscribeToResource(resourceId);
+      // `job:report-progress`, `job:complete`, and `job:fail` reach us on the
+      // always-on global bridge — the worker dual-emits the resource-broadcast
+      // ones globally as well as scoped. We deliberately do NOT call
+      // `transport.subscribeToResource(resourceId)`: mutating the SSE channel
+      // set forces a reconnect on every generation, which dropped in-flight
+      // `browse.*` results in the reconnect gap. Symmetric with `mark.assist`.
+      // See Link 1 in .plans/SEMIONT-BUG-browse-annotations.md.
 
       const cleanup = () => {
         done = true;
         if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
         if (pollInterval) { clearInterval(pollInterval); pollInterval = null; }
-        if (unsubscribeResource) { unsubscribeResource(); unsubscribeResource = null; }
       };
 
       const resetPollTimer = (jid: string) => {


### PR DESCRIPTION
## Summary

Three reliability bugs surfaced by long-running, unattended SDK jobs (a corpus loader driving `mark.assist` + `browse.annotations` over thousands of resources). All changes sit behind the SDK surface — namespace contracts are unchanged.

The headline symptom — `browse.annotations` hanging forever — was the product of #843 and #842 compounding; #844 is an independent transport crash the same workload exposed.

## #842 — `browse.*` reads hang forever instead of timing out

Browse reads are backed by a stale-while-revalidate cache that intentionally swallows fetch failures so live-query **subscribers** keep their last value. The one-shot `await` path resolved on "first non-undefined value," which never arrives on failure — so it hung, and the underlying 30s `busRequest` timeout was dropped.

- `packages/sdk/src/cache.ts` — per-key `errors(key)` fetch-failure stream; failures surfaced there (subscribers still keep SWR).
- `packages/sdk/src/awaitable.ts` — `CacheObservable.then` races first-value vs. first-error and **rejects** on failure; `.subscribe(...)` stays values-only.
- `packages/sdk/src/namespaces/browse.ts` — all eight live-query methods wire the error stream through.

## #843 — `mark.assist` / `yield.fromAnnotation` force an SSE reconnect every call

`job:complete` / `job:fail` were emitted resource-scoped only, so a headless caller had to `subscribeToResource` to receive them — which mutates the SSE channel set, and the only way to change that set is to reconnect (channels live in the `/bus/subscribe` query string). Result: two reconnects per assist, dropping concurrent reads in the reconnect gap (correlation results are ephemeral, not replayed).

- `packages/jobs/src/worker-process.ts` — dual-emit `job:complete` / `job:fail` **globally** (keyed by `jobId`, for the dispatching caller) **and** resource-scoped (for viewers).
- `packages/sdk/src/namespaces/mark.ts`, `yield.ts` — drop `subscribeToResource`; completion arrives on the always-on global bridge, so no channel-set mutation and no reconnect per assist.
- `packages/sdk/src/namespaces/job.ts`, `packages/sdk/docs/Usage.md`, `docs/protocol/CHANNELS.md` — document the dual-delivery contract.

### Behavioral note (dual-delivery)

`job:complete` / `job:fail` are now delivered both globally and resource-scoped. A client subscribed to both (e.g. a frontend with the resource's tab open) sees each event twice. The single-job consumers — `mark.assist`, `yield.fromAnnotation`, `job.pollUntilComplete` — collapse this to one observed completion. Consumers of the **raw** `job.complete$` / `job.fail$` streams must key on `jobId` and stay idempotent (documented in the JSDoc + Usage.md + CHANNELS.md).

## #844 — transient transport timeout crashes the process via illegal `degraded → reconnecting`

A recoverable transport timeout became an uncaught throw inside the reconnect timer (outside any caller `try/catch`), killing the process: the reconnect path attempted `degraded → reconnecting`, which the connection state machine's allowed-transitions table forbade, so `transition()` threw.

- `packages/api-client/src/transport/actor-state-unit.ts` — allow `degraded → reconnecting` (a legitimate recovery edge), and make `transition()` non-fatal on an unexpected edge (log + no-op instead of throwing into the event loop, since it runs inside timer callbacks).

## Testing

- `browse-fetch-failure.test.ts` — `await` rejects on a failed fetch; `.subscribe` keeps SWR.
- `mark-assist-churn.test.ts` — `mark.assist` no longer calls `subscribeToResource`; completes on a globally-delivered `job:complete`; a doubled `job:complete` collapses to one completion.
- `actor-state-unit.test.ts` — a channel-set change while `degraded` recovers instead of crashing.
- `worker-process.test.ts` — updated to the dual-emit contract.
- Full suites green: `@semiont/sdk` (334), `@semiont/api-client` (92), `@semiont/jobs` (240); typechecks clean.
- #842 / #843 verified end-to-end on a live KB: 0 SSE reconnects across 12 `mark.assist` calls; every `browse.annotations` resolved (no hang).

Closes #842
Closes #843
Closes #844
