### PR TITLE
Emit job:complete/job:fail globally, not dual-emit (#847 phase 1)

### DIFF
--- a/docs/protocol/CHANNELS.md
+++ b/docs/protocol/CHANNELS.md
@@ -48,7 +48,7 @@ Non-persisted results matched back to the originating request by `correlationId`
 
 ## Resource-bound broadcasts
 
-Channels every viewer of a specific resource wants to see, regardless of who triggered them. Published on `eventBus.scope(resourceId)`; received via `scope=rId&scoped=X` SSE subscription wired up by `client.subscribeToResource()`.
+Channels every viewer of a specific resource wants to see, regardless of who triggered them. Published on `eventBus.scope(resourceId)`; received via a `scope=rId&scoped=X` SSE subscription the SDK wires up automatically when a consumer subscribes to that resource's `browse.*` live queries (freshness follows observation; #847).
 
 The authoritative list is `RESOURCE_BROADCAST_TYPES` in [`packages/core/src/bus-protocol.ts`](../../packages/core/src/bus-protocol.ts) — **currently empty.** `job:complete` / `job:fail` used to live here but were moved to global, `jobId`-keyed delivery (see *Correlation-ID responses* above, and #847): the dispatcher filters by `jobId`, viewers filter the global stream by `resourceId`, so a client that is both no longer receives them twice. The set remains as the extension point for genuine multi-viewer resource broadcasts (e.g. generation progress).
 

--- a/docs/protocol/CHANNELS.md
+++ b/docs/protocol/CHANNELS.md
@@ -42,6 +42,7 @@ Non-persisted results matched back to the originating request by `correlationId`
 - `gather:summary-result` / `gather:summary-failed`
 - `mark:progress` / `mark:assist-finished` / `mark:assist-failed`
 - `job:created` / `job:create-failed` / `job:claimed` / `job:claim-failed`
+- `job:complete` / `job:fail` — global job-lifecycle signals; the dispatching caller filters by `jobId`, resource viewers filter the same global stream by `resourceId` (keyed by id, not `correlationId`)
 - `yield:clone-token-generated` / `yield:clone-token-failed`
 - `yield:clone-resource-result` / `yield:clone-resource-failed`
 
@@ -49,11 +50,7 @@ Non-persisted results matched back to the originating request by `correlationId`
 
 Channels every viewer of a specific resource wants to see, regardless of who triggered them. Published on `eventBus.scope(resourceId)`; received via `scope=rId&scoped=X` SSE subscription wired up by `client.subscribeToResource()`.
 
-The authoritative list is `RESOURCE_BROADCAST_TYPES` in [`packages/core/src/bus-protocol.ts`](../../packages/core/src/bus-protocol.ts):
-
-- `job:complete`, `job:fail`
-
-**Dual-emit.** These two are emitted by the worker **both** resource-scoped (for viewers, above) **and** globally (so the caller that dispatched the job receives them on the always-on global bridge, keyed by `jobId`, without holding a resource-scoped subscription — see `emitEvent` in [`packages/jobs/src/worker-process.ts`](../../packages/jobs/src/worker-process.ts)). A client subscribed to both delivery paths sees each event **twice**; raw `job.complete$`/`job.fail$` consumers must key on `jobId` and stay idempotent. The reason for the global path: a resource-scoped subscription mutates the SSE channel set, which forces a reconnect that drops in-flight correlation results — the Link 1 root cause in [`.plans/SEMIONT-BUG-browse-annotations.md`](../../.plans/SEMIONT-BUG-browse-annotations.md).
+The authoritative list is `RESOURCE_BROADCAST_TYPES` in [`packages/core/src/bus-protocol.ts`](../../packages/core/src/bus-protocol.ts) — **currently empty.** `job:complete` / `job:fail` used to live here but were moved to global, `jobId`-keyed delivery (see *Correlation-ID responses* above, and #847): the dispatcher filters by `jobId`, viewers filter the global stream by `resourceId`, so a client that is both no longer receives them twice. The set remains as the extension point for genuine multi-viewer resource broadcasts (e.g. generation progress).
 
 ## Bridged channels (HTTP transport fan-in)
 

--- a/docs/protocol/EVENT-BUS.md
+++ b/docs/protocol/EVENT-BUS.md
@@ -150,7 +150,7 @@ export const RESOURCE_BROADCAST_TYPES = [
 ] as const;
 ```
 
-Publishers emit these on a scoped bus (`eventBus.scope(resourceId)`); the HTTP transport carries the scope through SSE via a `scope=<resourceId>&scoped=<channel>` URL parameter. On the client, `client.subscribeToResource(resourceId)` attaches a ref-counted scope that auto-detaches when the last subscriber unsubscribes.
+Publishers emit these on a scoped bus (`eventBus.scope(resourceId)`); the HTTP transport carries the scope through SSE via a `scope=<resourceId>&scoped=<channel>` URL parameter. On the client, subscribing to a resource's `browse.*` live queries attaches a ref-counted scope (the SDK drives the transport's internal `subscribeToResource` on observation) that auto-detaches when the last subscriber unsubscribes (#847).
 
 Per-caller progress (AI-assist progress, search results) is *not* scoped — it's a correlation-ID-shaped response that publishes globally and the caller filters by `correlationId`. Resource scoping is for genuine multi-participant fan-out: events that *every* viewer of a resource should see.
 

--- a/docs/protocol/TRANSPORT-CONTRACT.md
+++ b/docs/protocol/TRANSPORT-CONTRACT.md
@@ -88,7 +88,11 @@ streaming concerns away from the typed-channel surface.
   fires.
 - **One distinct scope at a time.** Calling with a different
   resourceId while a subscription is live throws. Widening is deferred
-  until a product requirement forces it.
+  until a product requirement forces it (`.plans/MULTI-RESOURCE-SCOPE.md`).
+- **SDK-internal, not consumer-facing.** Application code does not call
+  this — the SDK's resource-scoped `browse.*` live queries drive it:
+  subscribing acquires the scope, the last unsubscribe releases it
+  (freshness follows observation; #847).
 
 ### `bridgeInto(bus)`
 

--- a/docs/protocol/TRANSPORT-HTTP.md
+++ b/docs/protocol/TRANSPORT-HTTP.md
@@ -139,17 +139,23 @@ if no header were sent.
 
 Clients that never send `Last-Event-ID` get live-only behavior.
 
-### HTTP-specific quirk: response-lost during reconnect
+### HTTP-specific quirk: response-lost during a genuine disconnect
 
 The shared contract defines `busRequest` as at-most-once with a 30s
-timeout. Over HTTP, **if the SSE connection was torn down and replaced
-during the request window, the response was published to a dead
-subscriber and is lost.** The client sees only the 30s timeout. There
-is no retry.
+timeout. Over HTTP, if the SSE connection is lost during the request
+window, the response is published to a dead subscriber and lost — the
+client sees only the 30s timeout, and there is no retry.
 
-This is the load-bearing HTTP quirk. Consumers that must eventually
-complete must either (a) accept the timeout and retry, or (b) layer a
-cache that refetches on reconnect (`BrowseNamespace` does the latter).
+A **channel-set change no longer causes this** (#847): those reconnects
+are make-before-break (see "Reconnect discipline" below), so the old
+connection stays live to deliver the in-flight result while the new one
+takes over. The loss now applies only to a genuine **server/network
+disconnect**, where the old connection is already dead.
+
+This is the load-bearing HTTP quirk. Consumers that must survive a real
+disconnect either (a) accept the timeout and retry, or (b) layer a cache
+that refetches (`BrowseNamespace` does the latter; its one-shot `await`
+path also refetches fresh — #847).
 
 `LocalTransport` doesn't have this failure mode — in-process
 subscribers never disconnect during a call.
@@ -169,9 +175,11 @@ from construction. The HTTP state machine:
 | `degraded` | Has been in `reconnecting` for longer than `DEGRADED_THRESHOLD_MS` (3 s). UI banner threshold — distinguishes brief churn from real disconnection. |
 | `closed` | `stop()` or `dispose()` was called. Terminal. |
 
-Transitions are enforced by an internal helper that throws on invalid
-moves, so a buggy reconnect path surfaces in tests rather than
-stranding the observable at a lying value.
+Transitions are enforced by an internal helper. An invalid move is
+logged and ignored — never thrown: `transition()` runs inside timer
+callbacks (the reconnect and degraded timers), where a throw would be an
+uncaught exception that kills a long-running host process (#844). A bad
+edge is a bug, but degrading gracefully beats crashing a job.
 
 Allowed transitions:
 
@@ -180,9 +188,12 @@ initial      → connecting | closed
 connecting   → open | reconnecting | closed
 open         → reconnecting | closed
 reconnecting → connecting | degraded | closed
-degraded     → connecting | closed
+degraded     → connecting | reconnecting | closed
 closed       → (terminal)
 ```
+
+`degraded → reconnecting` is the #844 recovery edge: a channel-set
+change can schedule a reconnect while the connection is degraded.
 
 Gap detection is handled by the resumption protocol (see "Event id and
 resumption"), not by consumers interpreting state edges.
@@ -195,12 +206,15 @@ The client-side `ActorStateUnit` handles three reconnect triggers:
    transitions to `reconnecting`; `connect()` is retried after
    `reconnectMs` (default 5 s). If the retry takes longer than
    `DEGRADED_THRESHOLD_MS`, state enters `degraded`.
-2. **Channel-set change** (`addChannels` / `removeChannels`). The
-   current SSE is aborted and a new one is opened with the updated
-   query string. Reconnects are **debounced 100 ms** so React Strict
-   Mode's mount → cleanup → mount sequence collapses into one
-   reconnect. State cycles `open → reconnecting → connecting → open`
-   without reaching `degraded` (the round-trip is sub-second).
+2. **Channel-set change** (`addChannels` / `removeChannels`). A new SSE
+   is opened with the updated query string and, **only once it is
+   `open`, the old one is aborted** — make-before-break (#847), so an
+   ephemeral result in flight during the swap is delivered on the still-
+   live old connection instead of dropped in a gap. Reconnects are
+   **debounced 100 ms** so React Strict Mode's mount → cleanup → mount
+   sequence collapses into one reconnect. State cycles `open →
+   reconnecting → connecting → open` without reaching `degraded` (the
+   round-trip is sub-second).
 3. **Explicit `stop()` / `dispose()`.** State transitions to `closed`;
    the observable completes. No retry.
 
@@ -211,10 +225,21 @@ Consumers should NOT revalidate caches on the `reconnecting → open`
 transition — that work is driven by `bus:resume-gap`, which the server
 emits only when it genuinely can't cover the gap.
 
-**All in-flight fetches are aborted when a new connect starts.** The
-client tracks SSE fetch controllers as a set; every previous one is
-aborted before the new one begins. Prevents orphaned streams from
-accumulating when rapid channel-set changes race each other.
+**Connection handoff (make-before-break).** On a channel-set change the
+client keeps the previous connection(s) live and aborts them only after
+the new fetch resolves (#847) — closing the reconnect gap. A genuine
+disconnect or the initial connect has nothing live to preserve, so it
+aborts up front. Either way the client tracks SSE fetch controllers as a
+set and converges to a single live stream: when the newest connection
+opens it aborts every prior controller, so rapid channel-set changes
+racing each other can't accumulate orphaned streams.
+
+During the brief handoff overlap the same live event can arrive on both
+connections. Persisted ids (`p-<scope>-<seq>`) are stable across
+connections, so the client dedups them to a single emission; ephemeral
+ids (`e-<connectionId>-<counter>`) are per-connection and not deduped —
+their consumers tolerate a rare double (`busRequest` takes the first;
+cache invalidations and job-completion are idempotent/terminal).
 
 ## Wire framing and client parser obligations
 

--- a/docs/protocol/TRANSPORT-HTTP.md
+++ b/docs/protocol/TRANSPORT-HTTP.md
@@ -356,14 +356,15 @@ Genuine limitation for any multi-tenant deployment.
 ### Effects that subscribe MUST be idempotent across cleanup cycles
 
 React Strict Mode double-invokes effects (mount → cleanup → mount) to
-shake out cleanup bugs. Any code that interacts with the bus — calling
-`subscribeToResource`, registering an event handler, wiring a StateUnit
-— must survive this. Concretely:
+shake out cleanup bugs. Any code that interacts with the bus —
+subscribing to a resource's `browse.*` live queries, registering an
+event handler, wiring a StateUnit — must survive this. Concretely:
 
-- `subscribeToResource(X)` called twice in a row with the same `X` must
-  be a no-op on the second call (ref-counted today; first call adds,
-  second increments a count, both unsubscribes required before the
-  scope is actually removed).
+- Subscribing to `browse.*(X)` twice for the same resource `X` must
+  ref-count the scope: the SDK calls the transport's internal
+  `subscribeToResource(X)` per subscription; the first acquires the SSE
+  scope, the rest increment a count, and the scope is removed only after
+  every subscription is torn down (freshness follows observation; #847).
 - A StateUnit whose factory captures props must be keyed on those
   props (`<Inner key={rId} />`) so the factory reruns when they change.
   `useStateUnit`'s factory does NOT re-run across renders by design —

--- a/packages/api-client/src/transport/__tests__/actor-state-unit.test.ts
+++ b/packages/api-client/src/transport/__tests__/actor-state-unit.test.ts
@@ -9,6 +9,10 @@ function sseChunk(event: string, data: string): string {
   return `event: ${event}\ndata: ${data}\n\n`;
 }
 
+function sseChunkId(event: string, data: string, id: string): string {
+  return `event: ${event}\nid: ${id}\ndata: ${data}\n\n`;
+}
+
 function createSSEStream() {
   let controller!: ReadableStreamDefaultController<Uint8Array>;
   const encoder = new TextEncoder();
@@ -17,8 +21,12 @@ function createSSEStream() {
   });
   return {
     stream,
-    push: (text: string) => controller.enqueue(encoder.encode(text)),
-    close: () => controller.close(),
+    // Swallow enqueue/close after the stream has errored or closed. Aborting a
+    // connection errors its stream; a test may still try to push to the now-
+    // retired connection, and that should be a no-op rather than a throw.
+    push: (text: string) => { try { controller.enqueue(encoder.encode(text)); } catch { /* errored/closed */ } },
+    close: () => { try { controller.close(); } catch { /* already errored/closed */ } },
+    error: (e: unknown) => { try { controller.error(e); } catch { /* already errored/closed */ } },
   };
 }
 
@@ -31,6 +39,38 @@ function mockSSEResponse() {
   };
   mockFetch.mockResolvedValueOnce(response);
   return sse;
+}
+
+/**
+ * A signal-honoring, optionally-deferred SSE connection mock. Unlike
+ * `mockSSEResponse` (which ignores the abort signal), this errors its stream
+ * when the connection's `AbortController` fires — faithfully reproducing how a
+ * real `fetch(url, { signal })` cancels the response body. `defer: true` holds
+ * the fetch promise unresolved until `open()` is called, so a test can observe
+ * the window where a new connection is connecting-but-not-yet-open (the
+ * make-before-break handoff). `aborted` reflects the captured signal.
+ */
+function mockConn({ defer = false }: { defer?: boolean } = {}) {
+  const sse = createSSEStream();
+  let capturedSignal: AbortSignal | undefined;
+  let resolveFetch!: (r: unknown) => void;
+  const fetchPromise = new Promise((res) => { resolveFetch = res; });
+  const response = { ok: true, status: 200, body: sse.stream };
+  mockFetch.mockImplementationOnce((_url: string, opts: { signal?: AbortSignal }) => {
+    capturedSignal = opts.signal;
+    if (capturedSignal) {
+      capturedSignal.addEventListener('abort', () =>
+        sse.error(new DOMException('Aborted', 'AbortError')),
+      );
+    }
+    if (!defer) resolveFetch(response);
+    return fetchPromise;
+  });
+  return {
+    sse,
+    open: () => resolveFetch(response),
+    get aborted() { return capturedSignal?.aborted ?? false; },
+  };
 }
 
 describe('createActorStateUnit', () => {
@@ -572,40 +612,110 @@ describe('createActorStateUnit', () => {
     stateUnit.dispose();
   });
 
-  it('aborts previous in-flight fetch when a reconnect starts (orphan-stream fix)', async () => {
-    // Regression: prior versions kept a single `abortController` slot,
-    // so a rapid sequence of connect() calls could orphan earlier
-    // fetches — their signals were replaced before they could be
-    // aborted. Post-fix, every previous controller is aborted before a
-    // new connect starts. Diagnosed from the suite-flake investigation
-    // which captured 3 concurrent SSE subscribes in a single 8ms window.
-    mockSSEResponse();
+  // ── #847 Phase 3: make-before-break reconnect ─────────────────────────
 
+  it('retires the old connection only after the new one opens (make-before-break)', async () => {
+    // Pre-#847 a scope-change reconnect aborted the live connection up front
+    // (break-before-make), opening a gap in which an in-flight ephemeral
+    // result was dropped. Now the old connection stays live until the new
+    // fetch resolves, then is retired — and rapid connects still converge to
+    // a single live stream (the orphan-stream guarantee).
+    const c1 = mockConn();
     const stateUnit = createActorStateUnit({
       baseUrl: 'http://localhost:4000',
       token: 'tok',
       channels: ['test:event'],
     });
-
     stateUnit.start();
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
 
-    const firstSignal = (mockFetch.mock.calls[0][1] as { signal: AbortSignal }).signal;
-    expect(firstSignal.aborted).toBe(false);
-
-    mockSSEResponse();
-    stateUnit.addChannels(['other:one']);
-    await new Promise((r) => setTimeout(r, 150));
+    // Scope change → reconnect. The new connection is deferred: connecting,
+    // not yet open.
+    const c2 = mockConn({ defer: true });
+    stateUnit.addChannels(['mark:added'], 'res-1');
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
 
-    // First fetch's signal must now be aborted — the connect() that
-    // produced the second fetch is responsible for aborting all prior
-    // in-flight controllers.
-    expect(firstSignal.aborted).toBe(true);
+    // Make-before-break: while the new connection is still connecting, the
+    // old one MUST remain live.
+    expect(c1.aborted).toBe(false);
 
-    // And the second fetch's signal is still live.
-    const secondSignal = (mockFetch.mock.calls[1][1] as { signal: AbortSignal }).signal;
-    expect(secondSignal.aborted).toBe(false);
+    // Once the new connection opens, the old is retired.
+    c2.open();
+    await vi.waitFor(() => expect(c1.aborted).toBe(true));
+
+    stateUnit.dispose();
+  });
+
+  it('delivers an event arriving on the old connection during a scope change', async () => {
+    // The gap that hung browse.* (#842/#843): a result emitted while the
+    // connection was being swapped for a scope change was lost. With make-
+    // before-break the old connection is still live and delivers it.
+    const c1 = mockConn();
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['browse:annotations-result'],
+    });
+    const received: unknown[] = [];
+    stateUnit.on$('browse:annotations-result').subscribe((p) => received.push(p));
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    const c2 = mockConn({ defer: true });
+    stateUnit.addChannels(['mark:added'], 'res-1');
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+
+    // New connection still connecting; the result arrives on the live old one.
+    c1.sse.push(sseChunk('bus-event', JSON.stringify({
+      channel: 'browse:annotations-result',
+      payload: { correlationId: 'x', annotations: [] },
+    })));
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    expect(received[0]).toEqual({ correlationId: 'x', annotations: [] });
+
+    // Let the handoff complete (old retired, new open) before teardown.
+    c2.open();
+    await vi.waitFor(() => expect(c1.aborted).toBe(true));
+    stateUnit.dispose();
+  });
+
+  it('dedupes a persisted event delivered by both connections during the overlap', async () => {
+    // During the handoff the same live persisted event can arrive on both
+    // connections — its `p-*` id is stable across connections — so it must be
+    // emitted to consumers exactly once.
+    const c1 = mockConn();
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['mark:added'],
+    });
+    const received: unknown[] = [];
+    stateUnit.on$('mark:added').subscribe((p) => received.push(p));
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    const c2 = mockConn({ defer: true });
+    stateUnit.addChannels(['other:channel']);
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+
+    const frame = sseChunkId(
+      'bus-event',
+      JSON.stringify({ channel: 'mark:added', payload: { seq: 1 } }),
+      'p-res-1-1',
+    );
+    // Old connection delivers it.
+    c1.sse.push(frame);
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    // New connection opens (old retired); it re-delivers the same id.
+    c2.open();
+    await vi.waitFor(() => expect(c1.aborted).toBe(true));
+    c2.sse.push(frame);
+
+    // Give the parser time to process the second frame; it must be deduped.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(received).toHaveLength(1);
 
     stateUnit.dispose();
   });

--- a/packages/api-client/src/transport/actor-state-unit.ts
+++ b/packages/api-client/src/transport/actor-state-unit.ts
@@ -136,6 +136,27 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
    */
   let lastEventId: string | null = null;
 
+  /**
+   * Recently-delivered event ids, to dedup the make-before-break overlap: the
+   * brief window where the old and new connection both deliver the same live
+   * event during a scope-change handoff. Persisted ids (`p-<scope>-<seq>`) are
+   * stable across connections, so this collapses such an overlap to a single
+   * emission. Ephemeral ids (`e-<connectionId>-<counter>`) are per-connection,
+   * so a cross-connection ephemeral duplicate is NOT caught here — its
+   * consumers tolerate the rare double (a correlation reply is taken with
+   * `take(1)`; cache invalidations and job-completion are idempotent/terminal).
+   * Bounded FIFO (insertion-ordered Set) to cap memory.
+   */
+  const seenEventIds = new Set<string>();
+  const SEEN_EVENT_IDS_MAX = 512;
+  const rememberEventId = (id: string): void => {
+    seenEventIds.add(id);
+    if (seenEventIds.size > SEEN_EVENT_IDS_MAX) {
+      const oldest = seenEventIds.values().next().value;
+      if (oldest !== undefined) seenEventIds.delete(oldest);
+    }
+  };
+
   const shared$ = events$.pipe(share());
 
   const disconnect = () => {
@@ -146,17 +167,27 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
     if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
   };
 
-  const connect = async () => {
+  const connect = async (keepPrevious = false) => {
     // Transition to `connecting` from whichever reconnect-ish state
     // we're currently in (`initial`, `reconnecting`, `degraded`).
     transition('connecting');
 
-    // Abort every previous in-flight fetch before starting a new one.
-    // This closes the orphan-stream leak described above.
-    for (const c of inflightControllers) {
-      try { c.abort(); } catch { /* noop */ }
+    // Snapshot the connections this connect() supersedes.
+    //   - keepPrevious=false (initial connect / drop-recovery): there is no
+    //     live connection worth preserving, so abort up front — this closes
+    //     the orphan-stream leak described above.
+    //   - keepPrevious=true (scope-change reconnect): MAKE-BEFORE-BREAK. Keep
+    //     the previous connection(s) ALIVE until the new one is `open`, then
+    //     abort them (below, after the fetch resolves), so an in-flight
+    //     ephemeral result isn't dropped in a reconnect gap (#847). The brief
+    //     window where old and new both deliver is deduped by event id.
+    const previous = [...inflightControllers];
+    if (!keepPrevious) {
+      for (const c of previous) {
+        try { c.abort(); } catch { /* noop */ }
+      }
+      inflightControllers.clear();
     }
-    inflightControllers.clear();
 
     const params = new URLSearchParams();
     for (const ch of globalChannels) {
@@ -180,6 +211,26 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
 
       if (!response.ok || !response.body) {
         throw new Error(`SSE connect failed: ${response.status}`);
+      }
+
+      // Stopped/disposed while the fetch was in flight — don't proceed to open
+      // (and retire the old connection on) a stream we've been told to tear
+      // down. `stop()`/`dispose()` already aborted this controller.
+      if (!running) return;
+
+      // Make-before-break handoff: the new connection is established (the
+      // backend has subscribed it and any `Last-Event-ID` replay is flowing),
+      // so NOW retire the previous connection(s). Aborting only after the new
+      // fetch resolves is what closes the reconnect gap — an event in flight
+      // on the old connection during a scope change is delivered, not dropped
+      // (#847). A live event delivered by both during the overlap is deduped
+      // by id in the read loop below. Had the fetch failed, we'd have thrown
+      // above and never reached here, leaving the old connection live (no gap).
+      if (keepPrevious) {
+        for (const c of previous) {
+          try { c.abort(); } catch { /* noop */ }
+          inflightControllers.delete(c);
+        }
       }
 
       transition('open');
@@ -215,8 +266,16 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
           } else if (line.startsWith('id: ')) {
             currentId = line.slice(4);
           } else if (line === '') {
-            if (currentEvent === 'bus-event' && currentData) {
-              if (currentId !== undefined) lastEventId = currentId;
+            // Skip an overlap duplicate — the same stable-id event delivered
+            // by both the old and new connection during a make-before-break
+            // handoff (#847). Ephemeral ids are unique per connection, so this
+            // never spuriously drops a distinct event.
+            const isDuplicate = currentId !== undefined && seenEventIds.has(currentId);
+            if (currentEvent === 'bus-event' && currentData && !isDuplicate) {
+              if (currentId !== undefined) {
+                lastEventId = currentId;
+                rememberEventId(currentId);
+              }
               const parsed = JSON.parse(currentData) as BusEvent;
               busLog('RECV', parsed.channel, parsed.payload, parsed.scope);
               // Tier 2: lift trace context off the SSE payload (the
@@ -276,8 +335,11 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
     if (currentState === 'open' || currentState === 'connecting' || currentState === 'degraded') {
       transition('reconnecting');
     }
-    disconnect();
-    connect();
+    // Make-before-break: do NOT abort the live connection here. Cancel only a
+    // pending drop-recovery retry, then connect — `connect(keepPrevious=true)`
+    // retires the old connection after the new one is open (no gap).
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    connect(true);
   };
 
   // Debounce channel-set-change reconnects. React StrictMode in dev

--- a/packages/api-client/src/transport/actor-state-unit.ts
+++ b/packages/api-client/src/transport/actor-state-unit.ts
@@ -146,6 +146,16 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
    * consumers tolerate the rare double (a correlation reply is taken with
    * `take(1)`; cache invalidations and job-completion are idempotent/terminal).
    * Bounded FIFO (insertion-ordered Set) to cap memory.
+   *
+   * Cost note: this is *always-on* — every delivered event does a has/add here
+   * — yet a duplicate is only possible during a handoff overlap; in steady
+   * state there's a single connection and nothing can collide. So every
+   * consumer of this transport carries a small standing structure for a path
+   * that fires only on (now-rare) scope changes. It's left unconditional
+   * because the per-event cost is negligible next to the JSON.parse + trace
+   * span already on this path. If that ever stops being true, scope it to the
+   * overlap (build on handoff start, drop once the old read loop exits) or
+   * track a high-water `Map<scope, maxSeq>` instead of every id.
    */
   const seenEventIds = new Set<string>();
   const SEEN_EVENT_IDS_MAX = 512;

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -360,10 +360,11 @@ export type EventName = keyof EventMap;
  * for one caller) does NOT belong here. Those are per-caller correlation-ID
  * responses and publish globally — the caller filters by `correlationId`.
  *
- * The frontend's `subscribeToResource(id)` wires these channels via
- * `scope=id&scoped=<channel>` so the SSE route delivers them to that
- * participant. WorkerStateUnit uses this list to decide which emitted events to
- * scope to their resource.
+ * The SDK's resource-scoped `browse.*` live queries wire these channels —
+ * subscribing acquires the scope via the transport's `subscribeToResource`
+ * (`scope=id&scoped=<channel>`) so the SSE route delivers them to that
+ * participant (freshness follows observation; #847). WorkerStateUnit uses this
+ * list to decide which emitted events to scope to their resource.
  */
 export const RESOURCE_BROADCAST_TYPES = [
   // Currently empty. `job:complete` / `job:fail` were moved to GLOBAL,

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -365,24 +365,15 @@ export type EventName = keyof EventMap;
  * participant. WorkerStateUnit uses this list to decide which emitted events to
  * scope to their resource.
  */
-/**
- * Audit note (SIMPLE-BUS Phase 3 close): `yield:progress` was
- * considered for inclusion but has only one consumer — the
- * yield-initiator's Observable in `packages/api-client/src/namespaces/yield.ts`.
- * No viewer of the resource other than the initiator subscribes to
- * progress. Scoping therefore serves no fan-out-narrowing purpose for
- * that channel, so it stays global (as a correlation-ID-shaped
- * response, filtered by `referenceId`). Only `yield:finished` and
- * `yield:failed` have a genuine multi-participant consumer (the
- * ResourceViewerPage toast on the source resource).
- */
 export const RESOURCE_BROADCAST_TYPES = [
-  // Post-unification: job:complete / job:fail carry the "job ended on
-  // this resource" signal that yield:finished / yield:failed used to.
-  // Scope them by resource so every viewer of the affected resource
-  // — not just the initiator — can react (toast, refresh, etc.).
-  'job:complete',
-  'job:fail',
+  // Currently empty. `job:complete` / `job:fail` were moved to GLOBAL,
+  // `jobId`-keyed correlation delivery (#847): the dispatching caller
+  // filters by `jobId`, and resource viewers filter the same global stream
+  // by `resourceId` — no resource-scoped copy, so a client that is both
+  // dispatcher and viewer no longer receives it twice. This set remains as
+  // the extension point for *genuine* resource-bound broadcasts — events
+  // every viewer of a resource should see and no single caller owns (e.g.
+  // resource-generation progress for multiple viewers).
 ] as const satisfies readonly EventName[];
 
 export type ResourceBroadcastType = typeof RESOURCE_BROADCAST_TYPES[number];

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -147,6 +147,12 @@ export interface ITransport {
    *
    * Returns a disposer that detaches the scope when the last subscriber
    * unsubscribes (ref-counted).
+   *
+   * SDK-internal: this is the scope primitive the SDK's resource-scoped
+   * `browse.*` live queries drive on subscribe/teardown (freshness follows
+   * observation; #847) — it is not part of the application-facing surface.
+   * Single-scope at a time; multi-scope is deferred
+   * (`.plans/MULTI-RESOURCE-SCOPE.md`).
    */
   subscribeToResource(resourceId: ResourceId): () => void;
 

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -12,12 +12,9 @@
  *                                                 (generation only; creates the resource)
  *     → job:complete                            (at success exit)
  *
- * `job:complete` and `job:fail` are resource broadcasts: `emitEvent` emits each
- * BOTH globally (so the dispatching caller receives it on the always-on bridge)
- * and resource-scoped (so viewers of the resource get the broadcast) — see #843
- * / RESOURCE_BROADCAST_TYPES. Sequence assertions below filter on
- * `scope === undefined` for the caller's lifecycle stream; the scoped copy is
- * asserted separately under 'resource-broadcast scope routing'.
+ * `job:complete` / `job:fail` are global, `jobId`-keyed signals (#847) — emitted
+ * once, with no resource scope. The dispatching caller filters by `jobId`;
+ * resource viewers filter the same global stream by `resourceId`.
  *
  * Post-WORKER-SESSIONS refactor, the worker runs on top of a
  * `SemiontSession`. Tests use a fake session whose `client.actor.emit`
@@ -154,10 +151,7 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
 
-      // Global stream = the dispatching caller's lifecycle view. job:complete
-      // is dual-emitted (global + resource-scoped, #843); the scoped copy is
-      // asserted under 'resource-broadcast scope routing'.
-      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+      expect(h.busEmits.map(e => e.channel))
         .toEqual(['job:start', 'mark:create', 'mark:create', 'job:complete']);
       expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload)
         .toMatchObject({ jobType: 'highlight-annotation', result: { highlightsFound: 2 } });
@@ -175,7 +169,7 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('comment-annotation'));
 
-      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+      expect(h.busEmits.map(e => e.channel))
         .toEqual(['job:start', 'mark:create', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
@@ -191,7 +185,7 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('assessment-annotation'));
 
-      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+      expect(h.busEmits.map(e => e.channel))
         .toEqual(['job:start', 'mark:create', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
@@ -207,7 +201,7 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation'));
 
-      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+      expect(h.busEmits.map(e => e.channel))
         .toEqual(['job:start', 'mark:create', 'mark:create', 'mark:create', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
@@ -223,7 +217,7 @@ describe('handleJob orchestration', () => {
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('tag-annotation'));
 
-      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+      expect(h.busEmits.map(e => e.channel))
         .toEqual(['job:start', 'mark:create', 'job:complete']);
       expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload).toMatchObject({
         jobType: 'tag-annotation',
@@ -258,7 +252,7 @@ describe('handleJob orchestration', () => {
       expect(uploaded.generator).toBeTruthy();
 
       // Bus emits: job:start then job:complete (no yield:create, no mark:create).
-      expect(h.busEmits.filter(e => e.scope === undefined).map(e => e.channel))
+      expect(h.busEmits.map(e => e.channel))
         .toEqual(['job:start', 'job:complete']);
       expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload).toMatchObject({
         jobType: 'generation',
@@ -364,17 +358,17 @@ describe('handleJob orchestration', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────
-// Helper: emitEvent's resource-broadcast routing.
+// emitEvent routing.
 //
-// RESOURCE_BROADCAST_TYPES lists channels whose payloads carry a
-// resource-scoped broadcast semantic — `job:complete` and `job:fail`.
-// handleJob's emitEvent helper must route those with `scope: resourceId`
-// so per-resource subscribers (not just the initiator) receive them.
-// All other channels emit globally with no scope.
+// `job:complete` / `job:fail` are GLOBAL, `jobId`-keyed correlation signals
+// (uniform with every other result in the system). The dispatching caller
+// filters by `jobId`; resource viewers filter the same global stream by
+// `resourceId`. There is no resource-scoped copy — `RESOURCE_BROADCAST_TYPES`
+// is empty. All channels emit globally with no scope.
 // ──────────────────────────────────────────────────────────────────────
 
-describe('handleJob — resource-broadcast scope routing', () => {
-  it('emits job:complete both globally and resource-scoped (dual-emit, #843)', async () => {
+describe('handleJob — global job-completion', () => {
+  it('emits job:complete exactly once, globally (no scope)', async () => {
     vi.mocked(processHighlightJob).mockResolvedValue({
       annotations: [] as never,
       result: {} as never,
@@ -384,10 +378,8 @@ describe('handleJob — resource-broadcast scope routing', () => {
     await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
 
     const completes = h.busEmits.filter(e => e.channel === 'job:complete');
-    // Global copy: the dispatching caller receives it on the always-on bridge.
-    expect(completes.some(e => e.scope === undefined)).toBe(true);
-    // Scoped copy: every viewer of the resource receives the broadcast.
-    expect(completes.some(e => e.scope === RID)).toBe(true);
+    expect(completes).toHaveLength(1);
+    expect(completes[0]!.scope).toBeUndefined();
   });
 
   it('emits job:start globally (no scope — not a resource broadcast)', async () => {
@@ -523,17 +515,17 @@ describe('startWorkerProcess', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     // Outer handler emits job:fail on the bus and calls adapter.failJob.
-    // job:fail is dual-emitted (global + resource-scoped, #843); assert the
-    // resource-scoped broadcast carries scope=resourceId.
-    const failEmit = h.busEmits.find((e) => e.channel === 'job:fail' && e.scope === RID);
-    expect(failEmit).toBeDefined();
-    expect(failEmit!.payload).toMatchObject({
+    // job:fail is a global, jobId-keyed signal — emitted once, no resource scope.
+    const failEmits = h.busEmits.filter((e) => e.channel === 'job:fail');
+    expect(failEmits).toHaveLength(1);
+    const failEmit = failEmits[0]!;
+    expect(failEmit.scope).toBeUndefined();
+    expect(failEmit.payload).toMatchObject({
       jobId: JID,
       jobType: 'reference-annotation',
       annotationId: 'ann-1',
       error: 'inference blew up',
     });
-    expect(failEmit!.scope).toBe(RID);
     expect(failJob).toHaveBeenCalledWith(JID, 'inference blew up');
 
     vi.doUnmock('../job-claim-adapter');

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -18,7 +18,7 @@
 import { createJobClaimAdapter, type JobClaimAdapter, type ActiveJob } from './job-claim-adapter';
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/api-client';
-import { RESOURCE_BROADCAST_TYPES, resourceId as makeResourceId, type EventMap } from '@semiont/core';
+import { type EventMap } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 import type { Logger, components } from '@semiont/core';
 import { deriveStorageUri } from '@semiont/content';
@@ -67,27 +67,11 @@ async function emitEvent<K extends keyof EventMap>(
   channel: K,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const isBroadcast = (RESOURCE_BROADCAST_TYPES as readonly string[]).includes(channel as string);
-  const rawScope = isBroadcast ? ((payload as { resourceId?: string }).resourceId) : undefined;
-  const resourceScope = rawScope ? makeResourceId(rawScope) : undefined;
-
-  if (resourceScope) {
-    // Dual-emit a resource-broadcast event:
-    //  - globally, so the dispatching caller (`mark.assist` /
-    //    `yield.fromAnnotation`) receives it on the always-on global bridge
-    //    and filters by `jobId` — no resource-scoped subscription, hence no
-    //    SSE channel-set churn (the Link 1 root cause in
-    //    .plans/SEMIONT-BUG-browse-annotations.md);
-    //  - resource-scoped, so every viewer of the resource still gets the
-    //    broadcast without a global fan-out widening their interest set.
-    // A client subscribed to both sees it twice; SDK consumers key on
-    // `jobId`/`resourceId` and treat completion as terminal, so the doubled
-    // delivery collapses to a single observed completion.
-    await session.client.transport.emit(channel, payload as EventMap[K]);
-    await session.client.transport.emit(channel, payload as EventMap[K], resourceScope);
-  } else {
-    await session.client.transport.emit(channel, payload as EventMap[K]);
-  }
+  // All worker-emitted bus events are global. `job:complete` / `job:fail`
+  // are global, `jobId`-keyed correlation signals (#847): the dispatching
+  // caller filters by `jobId`, and resource viewers filter the same global
+  // stream by `resourceId`. No resource-scoped copy (see RESOURCE_BROADCAST_TYPES).
+  await session.client.transport.emit(channel, payload as EventMap[K]);
 }
 
 export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter {

--- a/packages/react-ui/docs/SERVICE-HOOK-COMPONENT.md
+++ b/packages/react-ui/docs/SERVICE-HOOK-COMPONENT.md
@@ -28,26 +28,33 @@ This architecture leverages RxJS EventBus for event routing, eliminates callback
 - ❌ NO JSX rendering
 - ❌ NO manual event forwarding (the ActorStateUnit bridge is EventBus-native)
 
-**Implementation**: `SemiontApiClient.subscribeToResource(resourceId)`
+**Implementation**: subscribe to the resource's `browse.*(resourceId)` live queries.
 
-Called from the page state unit (`resource-viewer-page-state-unit`), not from
-a React hook. Returns a cleanup function that the state unit's disposer runs
-on unmount.
+The page state unit (`resource-viewer-page-state-unit`) builds its
+`annotations$`, `events$`, and `referencedBy$` observables from
+`client.browse.*(resourceId)`. **Freshness follows observation** (#847):
+subscribing to any of them acquires the resource's SSE scope (ref-counted
+across all of them), and the last unsubscribe releases it. There is no
+explicit `subscribeToResource` call.
 
 ```typescript
-// packages/api-client/src/state/pages/resource-viewer-page-state-unit.ts
-const unsubscribeResource = client.subscribeToResource(resourceId);
-disposer.add(unsubscribeResource);
+// packages/react-ui/src/features/resource-viewer/state/resource-viewer-page-state-unit.ts
+const annotations$ = client.browse.annotations(resourceId).pipe(map((a) => a ?? []));
+const events$ = client.browse.events(resourceId).pipe(map((e) => e ?? []));
+const referencedBy$ = client.browse.referencedBy(resourceId).pipe(map((r) => r ?? []));
+// Subscribing to any of these (from Layer 2 / Layer 3) keeps the resource
+// scope live; dropping the last subscriber releases it on teardown.
 ```
 
-Under the hood: `subscribeToResource` calls
-`actor.addChannels([...DOMAIN_CHANNELS], resourceId)` and sets up a
-bridge that forwards each bus event onto the same channel in the local
-EventBus.
+Under the hood: a `browse.*(resourceId)` subscription drives the transport's
+internal, SDK-only `subscribeToResource(rId)` — it adds the resource-scoped
+bus channels to the ActorStateUnit and bridges each event onto the same
+channel in the local EventBus. Application code never calls
+`subscribeToResource` itself; it just observes the live queries.
 
 **Key Architecture Points**:
 - One ActorStateUnit per client — one SSE connection to `/bus/subscribe`
-- Resource-scoped channels added/removed as pages mount/unmount
+- Resource-scoped channels added/removed automatically as the resource's `browse.*` live queries gain/lose subscribers
 - Events auto-bridge to the local EventBus for layer 2 consumption
 - No callbacks; pure pub/sub
 
@@ -149,8 +156,8 @@ export function ResourceViewerPage({ rId, resource, ... }: ResourceViewerPagePro
   const { detectingMotivation, detectionProgress } = useDetectionFlow(rId);
   const { activePanel, scrollToAnnotationId } = usePanelNavigation();
 
-  // Layer 1: bus subscription happens inside the page state unit
-  // (client.subscribeToResource(rId)) — no per-component hook needed
+  // Layer 1: the page state unit's browse.*(rId) live queries acquire the
+  // resource scope when observed — no explicit subscribe call, no per-component hook
 
   // Event emission (user interaction)
   const eventBus = useEventBus();
@@ -216,11 +223,11 @@ export function ResourceViewerPage({ rId, resource, ... }: ResourceViewerPagePro
                    │ auto-emits from SSE streams
                    ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ Layer 1: Service (client.subscribeToResource)               │
+│ Layer 1: Service (browse.*(rId) live queries)               │
 │                                                              │
-│  - Adds scoped bus channels to the ActorStateUnit                  │
-│  - Passes eventBus to stream                                │
-│  - Stream auto-emits to EventBus                            │
+│  - Subscribing to browse.*(rId) acquires scope              │
+│  - SDK drives transport-internal subscribeToResource        │
+│  - Scoped bus events auto-bridge to the EventBus            │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -233,8 +240,8 @@ export function ResourceViewerPage({ rId, resource, ... }: ResourceViewerPagePro
 ```typescript
 // In ResourceViewerPage.tsx
 export function ResourceViewerPage({ rId, ... }: ResourceViewerPageProps) {
-  // Layer 1: the page state unit calls client.subscribeToResource(rId)
-  // internally — no per-component hook needed.
+  // Layer 1: the page state unit's browse.*(rId) live queries acquire the
+  // resource scope when observed — no explicit subscribe call, no per-component hook.
 
   // ... rest of component
 }
@@ -348,8 +355,8 @@ function ResourceViewerPage({ rId, resource, ... }: ResourceViewerPageProps) {
   const { activePanel, scrollToAnnotationId } = usePanelNavigation();
   const { generationModalOpen } = useGenerationFlow(locale, rId, ...);
 
-  // Layer 1: bus subscription happens inside the page state unit
-  // (client.subscribeToResource(rId)) — no per-component hook needed
+  // Layer 1: the page state unit's browse.*(rId) live queries acquire the
+  // resource scope when observed — no explicit subscribe call, no per-component hook
 
   // Layer 3: Render UI directly
   return (
@@ -475,7 +482,7 @@ These violations will cause the compliance audit to fail:
    - Detection: AST analysis finds `eventBus.off()` calls in component files
 
 3. **Components creating `new EventSource()`**
-   - Should use: `client.subscribeToResource(id)` via the page state unit
+   - Should use: the SDK's managed bus connection — resource freshness comes from subscribing to `client.browse.*(resourceId)` live queries
    - Detection: AST analysis finds `new EventSource()` in component files
 
 4. **Hooks returning JSX**
@@ -660,7 +667,7 @@ The layer separation principles remain the same. See [RXJS-SERVICE-HOOK-COMPONEN
 
 - **Components**: Call hooks, emit events, render JSX
 - **Hooks**: Use `useEventSubscriptions`, manage state with `useState`, return data objects
-- **Service**: Bus connection managed by `SemiontApiClient` (one ActorStateUnit per client; resource-scoped channels added via `client.subscribeToResource(id)`)
+- **Service**: Bus connection managed by `SemiontApiClient` (one ActorStateUnit per client; resource-scoped channels acquired by subscribing to `client.browse.*(resourceId)` live queries — freshness follows observation)
 
 ### ❌ DON'T
 
@@ -672,7 +679,7 @@ The layer separation principles remain the same. See [RXJS-SERVICE-HOOK-COMPONEN
 
 - `useEventBus()` - Access event bus (for emitting events)
 - `useEventSubscriptions()` - Subscribe to events (for receiving events)
-- `client.subscribeToResource(id)` - Adds resource-scoped bus channels (called by page state unit)
+- `client.browse.*(resourceId)` - Resource-scoped live queries; subscribing acquires the resource's bus scope (freshness follows observation), the last unsubscribe releases it
 - `useDetectionFlow()` - Detection state management (bus events, progress, annotation operations)
 - `useResolutionFlow()` - Annotation body update and reference linking
 - `useGenerationFlow()` - Generation state management (SSE, modal, progress)

--- a/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
+++ b/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
@@ -265,8 +265,9 @@ export function ResourceViewerPage({
 
   // Domain events flow through the bus gateway (ActorStateUnit → local EventBus).
   // BrowseNamespace cache invalidation handles annotation/resource updates.
-  // The resource-viewer-page-state-unit calls client.subscribeToResource(resourceId)
-  // which bridges scoped domain events into the local EventBus.
+  // Resource-scoped freshness follows observation (#847): subscribing to the
+  // resource's `browse.*` live queries acquires its scope (which bridges scoped
+  // domain events into the local EventBus) and releases it on teardown.
 
   const handleResourceArchive = useCallback(async () => {
     if (!semiont) return;

--- a/packages/react-ui/src/features/resource-viewer/state/__tests__/resource-viewer-page-state-unit.test.ts
+++ b/packages/react-ui/src/features/resource-viewer/state/__tests__/resource-viewer-page-state-unit.test.ts
@@ -56,7 +56,6 @@ function clientWithNamespaces(overrides: {
     match: { search: vi.fn(() => new Observable(() => {})) },
     yield: { fromAnnotation: vi.fn(() => new Observable(() => {})) },
     bind: { body: vi.fn().mockResolvedValue(undefined) },
-    subscribeToResource: vi.fn().mockReturnValue(() => {}),
   });
 }
 

--- a/packages/react-ui/src/features/resource-viewer/state/resource-viewer-page-state-unit.ts
+++ b/packages/react-ui/src/features/resource-viewer/state/resource-viewer-page-state-unit.ts
@@ -133,8 +133,11 @@ export function createResourceViewerPageStateUnit(
 
   const wizard$ = new BehaviorSubject<WizardState>(WIZARD_CLOSED);
 
-  const unsubscribeResource = client.subscribeToResource(resourceId);
-  disposer.add(unsubscribeResource);
+  // Resource-scoped freshness follows observation (#847): subscribing to the
+  // `browse.*(resourceId)` live queries exposed by this state unit
+  // (annotations$, events$, referencedBy$) acquires the resource scope for as
+  // long as they're observed and releases it on teardown — so no manual
+  // `subscribeToResource` call is needed.
 
   const bindInitiateSub = client.bus.get('bind:initiate').subscribe((event) => {
     wizard$.next({

--- a/packages/sdk/docs/CACHE-SEMANTICS.md
+++ b/packages/sdk/docs/CACHE-SEMANTICS.md
@@ -82,9 +82,24 @@ Consequences:
 3. **Empty is terminal only until an observer or invalidate acts.**
    A permanent fetch failure does not auto-retry.
 
+## Two consumption paths
+
+The cache has two read paths with different freshness semantics, and B1–B13
+below describe the **`observe` / subscribe** path (the stale-while-revalidate
+live view). The second path:
+
+- **`fetch(key)` — one-shot, always fresh.** Forces a fetch (bypassing the
+  memo), updates the store so subscribers see it too, and resolves with the
+  value — *rejecting* on failure. Concurrent calls for the same key dedup-join
+  one in-flight fetch. This backs the awaitable's `then` (`await browse.X(id)`),
+  so a `read → write → read` in one process reflects the write rather than
+  serving the memo (#847). A failed `fetch` still leaves the store untouched
+  for subscribers (B6); only the `fetch` caller sees the rejection.
+
 ## Core behaviors
 
-Each behavior is numbered for cross-reference from tests and code.
+Each behavior is numbered for cross-reference from tests and code. They govern
+the `observe` / subscribe path.
 
 ### B1 — First observation triggers a fetch
 

--- a/packages/sdk/docs/REACTIVE-MODEL.md
+++ b/packages/sdk/docs/REACTIVE-MODEL.md
@@ -41,8 +41,8 @@ export class StreamObservable<T> extends Observable<T> implements PromiseLike<T>
 
 export class CacheObservable<T> extends Observable<T | undefined> implements PromiseLike<T> {
   then(onfulfilled, onrejected) {
-    return firstValueFrom(this.pipe(filter((v): v is T => v !== undefined)))
-      .then(onfulfilled, onrejected);
+    // Cache-backed: fetch fresh (a re-read reflects writes), reject on failure.
+    return this.fetchFresh!().then(onfulfilled, onrejected);
   }
 }
 ```
@@ -50,7 +50,7 @@ export class CacheObservable<T> extends Observable<T | undefined> implements Pro
 The asymmetric `then()` semantics are deliberate:
 
 - **`StreamObservable.then`** resolves to the **last** value on completion. Bounded progress streams have a final answer — the search result, the generated resource, the assembled context.
-- **`CacheObservable.then`** resolves to the **first non-undefined** value. Cache reads start in a "loading" state (`undefined`) and transition to the loaded value; `await` skips the loading state.
+- **`CacheObservable.then`** **fetches a fresh value** (and rejects on failure), so a one-shot `await` — e.g. a script's `read → write → read` — reflects the write rather than serving a stale memo (#847). `.subscribe(...)`, by contrast, is the stale-while-revalidate live view: it emits the cached value (after an initial `undefined`) and re-emits on invalidation. The split is the point — **`await` = "the value now"; `subscribe` = "the value, kept live."** (A `CacheObservable` with no fetch action — a non-cache wrapper — falls back to resolving on the first non-undefined emission.)
 
 The subclass name documents which semantics apply. `.subscribe(...)` works on both — yields the full sequence including loading states or progress events. `.pipe(...)` returns a plain `Observable<T>` and loses the thenable; once you compose with operators you've explicitly opted into RxJS, and `lastValueFrom` from `rxjs` is the right bridge.
 
@@ -128,7 +128,7 @@ Four idiomatic shapes, all on the same return value. The script-author who's nev
 
 - `yield.resource`
 
-**`CacheObservable<T>`** (multicast cache; `then` resolves on first non-undefined emission):
+**`CacheObservable<T>`** (multicast SWR cache for `.subscribe`; `await` fetches fresh and rejects on failure — #847):
 
 - `browse.resource`
 - `browse.resources`

--- a/packages/sdk/docs/Usage.md
+++ b/packages/sdk/docs/Usage.md
@@ -453,18 +453,26 @@ const final = await semiont.job.pollUntilComplete(jobId, {
 
 For HTTP transports, the client lazily opens a single SSE connection to `/bus/subscribe`. Result channels, global domain events, and resource-scoped fan-out all flow through it. For in-process transports, the bus is the in-memory `EventBus` from `@semiont/core`. Either way, the namespace methods hide the wire.
 
-To receive live updates for a specific resource:
+To receive live updates for a specific resource, subscribe to its
+`browse.*` live queries — **freshness follows observation** (#847).
+Subscribing acquires the resource's scope (resource-scoped events like
+`mark:added` flow in and invalidate the cache, so the Observable
+re-emits); the last unsubscribe releases it. There's no separate call to make.
 
 ```typescript
-// Adds resource-scoped channels to the transport's subscription set and
-// bridges them into the client's local EventBus so `semiont.browse.*`
-// Observables update in real-time. Call on mount; call the returned
-// cleanup function on unmount. Ref-counted across overlapping calls.
-const cleanup = semiont.subscribeToResource(resourceId);
+// Subscribing keeps the view live. The SDK acquires `resourceId`'s scope
+// for as long as it's observed (ref-counted across all
+// `browse.*(resourceId)` subscriptions) and releases it on teardown.
+const sub = semiont.browse.annotations(resourceId).subscribe((annotations) => {
+  render(annotations);
+});
 
-// ... later
-cleanup();
+// ... later, on unmount
+sub.unsubscribe();
 ```
+
+A one-shot read needs no subscription and acquires no scope —
+`await semiont.browse.annotations(resourceId)` fetches a fresh value and returns.
 
 For HTTP, the underlying connection auto-reconnects with exponential backoff. On reconnect, `BrowseNamespace` invalidates active caches and refetches — no `Last-Event-ID` replay needed.
 

--- a/packages/sdk/docs/Usage.md
+++ b/packages/sdk/docs/Usage.md
@@ -449,51 +449,6 @@ const final = await semiont.job.pollUntilComplete(jobId, {
 });
 ```
 
-### `job:complete` / `job:fail` are dual-delivered — keep raw-stream consumers idempotent
-
-The worker emits `job:complete` and `job:fail` **twice**: once globally (so the
-caller that dispatched the job receives it on the always-on global bridge,
-filtered by `jobId`) and once resource-scoped (so viewers of the resource react
-too). A client subscribed to *both* a resource scope and the global bus — e.g. a
-frontend with that resource's tab open — therefore sees each event twice.
-
-The single-job consumers absorb this for you and emit **one** completion:
-
-```typescript
-// Terminal by design — one `complete`, no matter how many job:complete hit the bus.
-const result = await semiont.mark.assist(rId, 'linking', { entityTypes });
-await semiont.yield.fromAnnotation(rId, aId, { /* ... */ });
-await semiont.job.pollUntilComplete(jobId);
-```
-
-If you subscribe to the **raw** `job.complete$` / `job.fail$` streams, key on
-`jobId` and keep the reaction idempotent:
-
-```typescript
-import { filter, take } from 'rxjs/operators';
-import { firstValueFrom } from '@semiont/sdk';
-
-// One job: make it terminal.
-const done = await firstValueFrom(
-  semiont.job.complete$.pipe(filter((e) => e.jobId === jobId), take(1)),
-);
-
-// Many jobs over time: prefer an idempotent side effect…
-semiont.job.complete$.subscribe((e) => refetchResourceView(e.resourceId)); // refetch is idempotent
-
-// …or guard a non-idempotent reaction by jobId.
-const handled = new Set<string>();
-semiont.job.complete$.subscribe((e) => {
-  if (handled.has(e.jobId)) return;
-  handled.add(e.jobId);
-  toast(`Job ${e.jobId} finished`);
-});
-```
-
-A headless caller that never subscribes to a resource scope (the common SDK-script
-case) receives each event exactly once, so this only matters for clients that hold
-both subscriptions.
-
 ## Bus Connection
 
 For HTTP transports, the client lazily opens a single SSE connection to `/bus/subscribe`. Result channels, global domain events, and resource-scoped fan-out all flow through it. For in-process transports, the bus is the in-memory `EventBus` from `@semiont/core`. Either way, the namespace methods hide the wire.

--- a/packages/sdk/src/__tests__/browse-await-fresh.test.ts
+++ b/packages/sdk/src/__tests__/browse-await-fresh.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #847 Phase 2 — a one-shot `await` of a Browse live-query returns a FRESH
+ * value, not the stale memoized one, on re-read.
+ *
+ * A headless consumer (e.g. a loader's resume-guard) does `read → write →
+ * read` in the same process. The first read populates the cache; without a
+ * scoped subscription, no `mark:added` invalidation arrives, so the second
+ * `await` previously returned the stale memo. The fix: the await path fetches
+ * fresh (`cache.fetch`) rather than serving the memo. `.subscribe(...)` keeps
+ * the stale-while-revalidate cached view.
+ *
+ * No backend: a fake transport returns an incrementing `browse:annotations-result`
+ * so a fresh fetch is observably different from the memo.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Observable, Subject } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { IContentTransport, ITransport, ResourceId } from '@semiont/core';
+import { BrowseNamespace } from '../namespaces/browse';
+
+function makeFakeTransport() {
+  const subjects = new Map<string, Subject<Record<string, unknown>>>();
+  const subjectFor = (channel: string) => {
+    let s = subjects.get(channel);
+    if (!s) {
+      s = new Subject<Record<string, unknown>>();
+      subjects.set(channel, s);
+    }
+    return s;
+  };
+
+  // Each annotations request returns a distinct result so a fresh fetch is
+  // observably different from a cached one.
+  let n = 0;
+  const transport = {
+    baseUrl: 'http://test',
+    emit: async (channel: string, payload: Record<string, unknown>) => {
+      if (channel === 'browse:annotations-requested') {
+        n += 1;
+        subjectFor('browse:annotations-result').next({
+          correlationId: payload.correlationId as string,
+          response: { annotations: [{ id: `a${n}` }], total: 1 },
+        });
+      }
+    },
+    stream: (channel: string): Observable<Record<string, unknown>> => subjectFor(channel).asObservable(),
+    subscribeToResource: () => () => {},
+    bridgeInto: () => {},
+    state$: new Subject(),
+    errors$: new Subject(),
+    dispose: () => {},
+  };
+
+  return { transport: transport as unknown as ITransport };
+}
+
+const noopContent = {
+  getBinary: async () => ({ data: new ArrayBuffer(0), contentType: 'text/plain' }),
+  getBinaryStream: async () => ({ stream: new ReadableStream(), contentType: 'text/plain' }),
+  dispose: () => {},
+} as unknown as IContentTransport;
+
+describe('browse read — one-shot await is fresh (#847 Phase 2)', () => {
+  let bus: EventBus;
+  let browse: BrowseNamespace;
+  const rId: ResourceId = makeResourceId('res-1');
+
+  beforeEach(() => {
+    bus = new EventBus();
+    browse = new BrowseNamespace(makeFakeTransport().transport, bus, noopContent);
+  });
+
+  afterEach(() => {
+    bus.destroy();
+  });
+
+  it('a re-read reflects the latest backend value (not the stale memo)', async () => {
+    const first = await browse.annotations(rId);
+    expect(first[0]!.id).toBe('a1');
+
+    // Simulates read → write → read: the backend now returns a newer value.
+    const second = await browse.annotations(rId);
+    expect(second[0]!.id).toBe('a2'); // fresh, not the cached 'a1'
+  });
+
+  it('still resolves the first read', async () => {
+    const v = await browse.annotations(rId);
+    expect(v).toHaveLength(1);
+  });
+});

--- a/packages/sdk/src/__tests__/browse-scope-by-observation.test.ts
+++ b/packages/sdk/src/__tests__/browse-scope-by-observation.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #847 Phase 4 — live-query freshness follows observation.
+ *
+ * Subscribing to a resource-scoped `browse.*(rId)` live query acquires that
+ * resource's scope (via the transport's ref-counted `subscribeToResource`);
+ * the last unsubscribe releases it. No consumer needs to call
+ * `subscribeToResource` manually — freshness comes from observation.
+ *
+ * The one-shot `await` path (Phase 2) acquires NO scope: it fetches fresh and
+ * returns. Global queries (`entityTypes`, `tagSchemas`, `resources`) acquire
+ * no scope either — they aren't resource-bound.
+ *
+ * Single-scope model is unchanged (multi-scope stays deferred): the SDK calls
+ * `subscribeToResource(rId)` once per resource-scoped subscription and the
+ * transport ref-counts them onto one SSE scope.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Observable, Subject } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { IContentTransport, ITransport, ResourceId } from '@semiont/core';
+import { BrowseNamespace } from '../namespaces/browse';
+
+function makeFakeTransport() {
+  const subjects = new Map<string, Subject<Record<string, unknown>>>();
+  const subjectFor = (channel: string) => {
+    let s = subjects.get(channel);
+    if (!s) {
+      s = new Subject<Record<string, unknown>>();
+      subjects.set(channel, s);
+    }
+    return s;
+  };
+
+  const releases: Array<ReturnType<typeof vi.fn>> = [];
+  const subscribeToResource = vi.fn((_rId: ResourceId) => {
+    const release = vi.fn();
+    releases.push(release);
+    return release;
+  });
+
+  const respond = (channel: string, resultChannel: string, payload: Record<string, unknown>, response: unknown) => {
+    if (channel === resultChannel) {
+      subjectFor(channel.replace('-requested', '-result')).next({
+        correlationId: payload.correlationId as string,
+        response,
+      });
+    }
+  };
+
+  const transport = {
+    baseUrl: 'http://test',
+    emit: async (channel: string, payload: Record<string, unknown>) => {
+      respond(channel, 'browse:annotations-requested', payload, { annotations: [{ id: 'a1' }], total: 1 });
+      respond(channel, 'browse:resource-requested', payload, { resource: { id: 'res-1' } });
+      respond(channel, 'browse:events-requested', payload, { events: [] });
+      respond(channel, 'browse:referenced-by-requested', payload, { referencedBy: [] });
+      respond(channel, 'browse:entity-types-requested', payload, { entityTypes: [] });
+    },
+    stream: (channel: string): Observable<Record<string, unknown>> => subjectFor(channel).asObservable(),
+    subscribeToResource,
+    bridgeInto: () => {},
+    state$: new Subject(),
+    errors$: new Subject(),
+    dispose: () => {},
+  };
+
+  return { transport: transport as unknown as ITransport, subscribeToResource, releases };
+}
+
+const noopContent = {
+  getBinary: async () => ({ data: new ArrayBuffer(0), contentType: 'text/plain' }),
+  getBinaryStream: async () => ({ stream: new ReadableStream(), contentType: 'text/plain' }),
+  dispose: () => {},
+} as unknown as IContentTransport;
+
+describe('browse live-query subscription acquires the resource scope (#847 Phase 4)', () => {
+  let bus: EventBus;
+  let browse: BrowseNamespace;
+  let subscribeToResource: ReturnType<typeof makeFakeTransport>['subscribeToResource'];
+  let releases: ReturnType<typeof makeFakeTransport>['releases'];
+  const rId: ResourceId = makeResourceId('res-1');
+
+  beforeEach(() => {
+    bus = new EventBus();
+    const fake = makeFakeTransport();
+    subscribeToResource = fake.subscribeToResource;
+    releases = fake.releases;
+    browse = new BrowseNamespace(fake.transport, bus, noopContent);
+  });
+
+  afterEach(() => {
+    bus.destroy();
+  });
+
+  it('subscribing to browse.annotations(rId) acquires the scope; unsubscribe releases', () => {
+    expect(subscribeToResource).not.toHaveBeenCalled();
+
+    const sub = browse.annotations(rId).subscribe(() => {});
+    expect(subscribeToResource).toHaveBeenCalledTimes(1);
+    expect(subscribeToResource).toHaveBeenCalledWith(rId);
+    expect(releases[0]).not.toHaveBeenCalled();
+
+    sub.unsubscribe();
+    expect(releases[0]).toHaveBeenCalledTimes(1);
+  });
+
+  it('a one-shot await acquires no scope', async () => {
+    await browse.annotations(rId);
+    expect(subscribeToResource).not.toHaveBeenCalled();
+  });
+
+  it('each resource-scoped live query acquires (the transport ref-counts them to one scope)', () => {
+    const s1 = browse.resource(rId).subscribe(() => {});
+    const s2 = browse.annotations(rId).subscribe(() => {});
+    const s3 = browse.events(rId).subscribe(() => {});
+    expect(subscribeToResource).toHaveBeenCalledTimes(3);
+    expect(subscribeToResource).toHaveBeenCalledWith(rId);
+
+    s1.unsubscribe();
+    s2.unsubscribe();
+    s3.unsubscribe();
+    expect(releases.filter((r) => r.mock.calls.length > 0)).toHaveLength(3);
+  });
+
+  it('global queries acquire no scope', () => {
+    const sub = browse.entityTypes().subscribe(() => {});
+    expect(subscribeToResource).not.toHaveBeenCalled();
+    sub.unsubscribe();
+  });
+});

--- a/packages/sdk/src/__tests__/cache.test.ts
+++ b/packages/sdk/src/__tests__/cache.test.ts
@@ -284,6 +284,41 @@ describe('Cache<K, V>', () => {
     });
   });
 
+  describe('fetch — one-shot fresh (#847)', () => {
+    it('always re-fetches (returns the fresh value, not the memo)', async () => {
+      let n = 0;
+      const fetchFn = vi.fn().mockImplementation(() => Promise.resolve(`v${++n}`));
+      const cache = createCache<string, string>(fetchFn);
+      expect(await cache.fetch('k')).toBe('v1');
+      expect(await cache.fetch('k')).toBe('v2'); // fresh, not memoized 'v1'
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('dedups concurrent fetches for the same key', async () => {
+      let resolveFetch!: (v: string) => void;
+      const fetchFn = vi.fn().mockImplementation(() => new Promise<string>((r) => { resolveFetch = r; }));
+      const cache = createCache<string, string>(fetchFn);
+      const a = cache.fetch('k');
+      const b = cache.fetch('k');
+      resolveFetch('v1');
+      expect(await a).toBe('v1');
+      expect(await b).toBe('v1');
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects on failure and leaves subscribers untouched (B6)', async () => {
+      const fetchFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce('v1');
+      const cache = createCache<string, string>(fetchFn);
+      const seen: Array<string | undefined> = [];
+      cache.observe('k').subscribe((v) => seen.push(v));
+      await expect(cache.fetch('k')).rejects.toThrow('boom');
+      expect(seen).toEqual([undefined]); // subscriber stays at loading state
+    });
+  });
+
   describe('dispose()', () => {
     it('completes the store and observers receive no further values', async () => {
       const cache = createCache<string, string>(vi.fn().mockResolvedValue('v'));

--- a/packages/sdk/src/__tests__/client-passthroughs.test.ts
+++ b/packages/sdk/src/__tests__/client-passthroughs.test.ts
@@ -2,7 +2,7 @@
  * SemiontClient lifecycle + namespace-routing tests.
  *
  * Covers the wiring on `client.ts` itself: bus bridge construction,
- * `state$` / `subscribeToResource` / `dispose` plumbing, and the few
+ * `state$` / `dispose` plumbing, and the few
  * namespace flows that resolve via the bridged `client.bus` rather than
  * `transport.stream` directly (match.search, gather.annotation).
  *
@@ -103,15 +103,6 @@ describe('SemiontClient lifecycle + namespace routing', () => {
       (transport.state$ as BehaviorSubject<ConnectionState>).next('reconnecting');
       sub2.unsubscribe();
       expect(observed).toEqual(['open', 'reconnecting']);
-    });
-
-    test('subscribeToResource forwards the resource id', () => {
-      const id = resourceId('res-x');
-      const disposer = client.subscribeToResource(id);
-      expect(transport.subscribeToResource).toHaveBeenCalledWith(id);
-      // Returned disposer should not throw when called.
-      expect(disposer).toBeInstanceOf(Function);
-      disposer();
     });
 
     test('dispose disposes both transport and content', () => {

--- a/packages/sdk/src/awaitable.ts
+++ b/packages/sdk/src/awaitable.ts
@@ -18,8 +18,8 @@
  * RxJS land; `lastValueFrom` from `rxjs` is the right bridge there.
  */
 
-import { Observable, firstValueFrom, lastValueFrom, merge } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { Observable, firstValueFrom, lastValueFrom } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import type { ResourceId } from '@semiont/core';
 
 /**
@@ -50,9 +50,12 @@ export class StreamObservable<T> extends Observable<T> implements PromiseLike<T>
  * cache entry. Used by Browse live-query methods (`browse.resource`,
  * `browse.annotations`, etc.).
  *
- * Awaiting resolves to the **first non-undefined** value (waits past the
- * loading state). Subscribing yields the full sequence including the
- * initial `undefined`, so reactive consumers can render a loading state.
+ * Awaiting (the one-shot path) fetches a **fresh** value via the optional
+ * `fetchFresh` action and rejects on failure — a re-read reflects writes
+ * (#847). Subscribing yields the SWR sequence: the initial `undefined`, the
+ * loaded value, and re-emits on invalidation. (Without a `fetchFresh` action
+ * — e.g. a non-cache wrapper — the await falls back to the first
+ * non-undefined emission.)
  *
  * The class is parameterized as `CacheObservable<T>` even though the
  * stream's element type is `T | undefined` — `T` is what the consumer
@@ -62,42 +65,33 @@ export class StreamObservable<T> extends Observable<T> implements PromiseLike<T>
  */
 export class CacheObservable<T> extends Observable<T | undefined> implements PromiseLike<T> {
   /**
-   * Optional per-key fetch-failure stream. Consulted only by `then()` (the
-   * await path). `.subscribe(...)` never touches it — live-query subscribers
-   * keep the stale-while-revalidate contract (a failed fetch leaves them at
-   * their last value / loading state, never errored). See cache.ts B6.
+   * Optional one-shot fresh-fetch action. When present, `then()` (the await
+   * path) resolves to a freshly fetched value and rejects on fetch failure —
+   * so a re-read reflects writes (#847). `.subscribe(...)` never uses it: it
+   * keeps the stale-while-revalidate cached view over `source`.
    */
-  private errors$?: Observable<unknown>;
+  private fetchFresh?: () => Promise<T>;
 
   then<R1 = T, R2 = never>(
     onfulfilled?: ((v: T) => R1 | PromiseLike<R1>) | null,
     onrejected?: ((e: unknown) => R2 | PromiseLike<R2>) | null,
   ): PromiseLike<R1 | R2> {
-    const value$ = this.pipe(
-      filter((v): v is T => v !== undefined),
-      map((value): { ok: true; value: T } => ({ ok: true, value })),
-    );
-    // Race first-defined-value against first-fetch-error. firstValueFrom
-    // takes the first emission and unsubscribes from both, so a later
-    // error (e.g. a subsequent failed refetch) can't produce a dangling
-    // rejection after the value already won.
-    const settled$ = this.errors$
-      ? merge(value$, this.errors$.pipe(map((error): { ok: false; error: unknown } => ({ ok: false, error }))))
-      : value$;
-    return firstValueFrom(settled$)
-      .then((r) => {
-        if (r.ok) return r.value;
-        throw r.error;
-      })
+    if (this.fetchFresh) {
+      // One-shot read: fetch fresh (rejects on failure), don't serve the memo.
+      return this.fetchFresh().then(onfulfilled, onrejected);
+    }
+    // Non-cache wrapper: resolve to the first non-undefined emission.
+    return firstValueFrom(this.pipe(filter((v): v is T => v !== undefined)))
       .then(onfulfilled, onrejected);
   }
 
   /**
    * Wrap an existing Observable's subscribe behavior in a `CacheObservable`.
    *
-   * `errors$`, when supplied, is the cache's per-key fetch-failure stream:
-   * it lets `await` reject on a lost/failed fetch instead of hanging
-   * forever, without erroring `.subscribe(...)` consumers (B6).
+   * `fetchFresh`, when supplied, backs the await path: `await` resolves to a
+   * freshly fetched value (rejecting on failure), so a one-shot read reflects
+   * writes without a scoped subscription (#847). `.subscribe(...)` consumers
+   * keep the SWR view over `source`.
    *
    * Memoizes on source identity: passing the same `source` returns the same
    * wrapper instance. The Browse cache primitive already returns a stable
@@ -108,11 +102,11 @@ export class CacheObservable<T> extends Observable<T | undefined> implements Pro
    *
    * Backed by a `WeakMap`, so wrappers are GC'd when their source is.
    */
-  static from<T>(source: Observable<T | undefined>, errors$?: Observable<unknown>): CacheObservable<T> {
+  static from<T>(source: Observable<T | undefined>, fetchFresh?: () => Promise<T>): CacheObservable<T> {
     let wrapper = wrapperCache.get(source) as CacheObservable<T> | undefined;
     if (!wrapper) {
       wrapper = new CacheObservable<T>((subscriber) => source.subscribe(subscriber));
-      wrapper.errors$ = errors$;
+      wrapper.fetchFresh = fetchFresh;
       wrapperCache.set(source, wrapper);
     }
     return wrapper;

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -7,45 +7,52 @@
  * `BrowseNamespace` to back its per-key stores, but equally usable from
  * CLI, MCP, or worker code.
  *
+ * Two consumption paths with different freshness semantics:
+ *   - `observe(key)` (the subscribe path) is a stale-while-revalidate live
+ *     view: it triggers a fetch on first subscription for a missing key,
+ *     dedup-joins any concurrent fetch, then emits the stored value and
+ *     re-emits on invalidation.
+ *   - `fetch(key)` (the one-shot await path) forces a fresh fetch, so a
+ *     re-read reflects writes rather than serving the memo.
+ *
  * Shape:
- *   - `observe(key)`: returns an Observable<V | undefined> that triggers
- *     a fetch on first subscription for a missing key, dedup-joins any
- *     concurrent fetch, and emits the stored value thereafter.
- *   - `invalidate(key)`: stale-while-revalidate — keeps the current
- *     value visible to observers, clears the in-flight guard, starts a
- *     fresh fetch. If the previous fetch was orphaned (SSE torn down,
- *     response lost), this is how the cache recovers.
- *   - `remove(key)`: drops the cache entry entirely. Used for entity
- *     deletions (B13a). No refetch.
- *   - `set(key, value)`: writes through without a fetch. Used when a
- *     bus event carries the new value inline (B13b).
- *   - `invalidateAll()`: per-key SWR refetch of every currently-cached
- *     entry. Used by gap-detection paths.
+ *   - `observe(key)`: Observable<V | undefined> — subscribe path (SWR).
+ *   - `fetch(key)`: force a fresh fetch (bypassing the memo), update the
+ *     store (so subscribers see it too), and resolve with the value —
+ *     rejecting if the fetch fails. Concurrent calls for the same key share
+ *     one in-flight fetch. Backs the one-shot `await` path.
+ *   - `invalidate(key)`: stale-while-revalidate — keeps the current value
+ *     visible to observers, clears the in-flight guard, starts a fresh
+ *     fetch. Recovers an orphaned fetch (SSE torn down, response lost).
+ *   - `remove(key)`: drops the cache entry entirely (B13a). No refetch.
+ *   - `set(key, value)`: write-through without a fetch (B13b).
+ *   - `invalidateAll()`: per-key SWR refetch of every currently-cached entry.
  *   - `dispose()`: completes the store so observers unsubscribe.
  *
  * What's deliberately out:
- *   - No subscriber ref-counting / GC of unobserved keys. The per-key
- *     observable memo grows with the set of observed keys for the cache's
- *     lifetime (B11). Acceptable given cache lifetime == client lifetime.
+ *   - No subscriber ref-counting / GC of unobserved keys (B11). Acceptable
+ *     given cache lifetime == client lifetime.
  *   - No TTL / cacheTime. Entries are evicted only by explicit remove.
- *   - No retry / backoff. A failing fetch leaves the cache unchanged
- *     (B6); the caller drives retry via invalidate.
+ *   - No retry / backoff. A failing fetch leaves the cache unchanged for
+ *     *subscribers* (B6); the `fetch`/await path surfaces the rejection so
+ *     the caller can retry.
  */
 
-import { BehaviorSubject, Observable, Subject, distinctUntilChanged, filter, map } from 'rxjs';
+import { BehaviorSubject, Observable, distinctUntilChanged, map } from 'rxjs';
 
 export interface Cache<K, V> {
-  /** Observable stream of the value at `key`. Triggers a fetch if not cached. */
+  /** Observable stream of the value at `key` (SWR). Triggers a fetch if not cached. */
   observe(key: K): Observable<V | undefined>;
 
   /**
-   * Per-key stream of fetch failures. Emits each time a fetch for `key`
-   * rejects. This is the await-path counterpart to B6: live-query
-   * *subscribers* of `observe(key)` never see these (they keep their
-   * stale value / loading state), but a one-shot awaiter can consume
-   * this to reject instead of hanging forever on a lost result.
+   * Force a fresh fetch for `key`, update the store (so subscribers see it),
+   * and resolve with the fetched value — rejecting if the fetch fails.
+   * Concurrent calls for the same key share one in-flight fetch. Backs the
+   * one-shot `await` path: a re-read reflects writes rather than serving the
+   * memoized value. Live-query *subscribers* (`observe`) keep B6 — a failed
+   * fetch leaves their value untouched.
    */
-  errors(key: K): Observable<unknown>;
+  fetch(key: K): Promise<V>;
 
   /** Synchronous snapshot of the current value, without triggering a fetch. */
   get(key: K): V | undefined;
@@ -74,45 +81,48 @@ export interface Cache<K, V> {
 
 export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> {
   const store$ = new BehaviorSubject<Map<K, V>>(new Map());
-  const inflight = new Set<K>();
+  /** In-flight fetch promise per key — dedups concurrent fetches (B3). */
+  const inflight = new Map<K, Promise<V>>();
   const obsCache = new Map<K, Observable<V | undefined>>();
-  const errCache = new Map<K, Observable<unknown>>();
-  /** Per-key fetch-failure channel. See `Cache.errors`. */
-  const fetchErrors$ = new Subject<{ key: K; error: unknown }>();
 
-  const doFetch = async (key: K): Promise<void> => {
-    // In-flight guard: concurrent first-observations deduplicate (B3).
-    // `invalidate` clears the guard before calling doFetch, which is the
-    // orphan-recovery mechanism documented in B7 and B9.
-    if (inflight.has(key)) return;
-    inflight.add(key);
-    try {
-      const value = await fetchFn(key);
-      // Atomic update: one `.next` with a fresh Map reference so
-      // downstream `distinctUntilChanged` sees the transition (B5).
-      const next = new Map(store$.value);
-      next.set(key, value);
-      store$.next(next);
-    } catch (error) {
-      // B6: fetch failure leaves the previous state intact for
-      // *subscribers* — an observer seeing `undefined` stays at
-      // `undefined`; one seeing a stale value keeps it. We do NOT error
-      // the store Subject (that would break every observer of every key).
-      //
-      // But surface the failure on the per-key error channel so a
-      // one-shot *awaiter* (CacheObservable.then) can reject instead of
-      // hanging forever on a lost result. Live-query subscribers never
-      // touch this stream.
-      fetchErrors$.next({ key, error });
-    } finally {
-      inflight.delete(key);
-    }
+  /**
+   * Run (or join) a fetch for `key`. Resolves with the value and updates the
+   * store on success; rejects on failure WITHOUT touching the store (B6 —
+   * subscribers keep their prior value / loading state). Concurrent callers
+   * share the same promise.
+   */
+  const runFetch = (key: K): Promise<V> => {
+    const existing = inflight.get(key);
+    if (existing) return existing;
+
+    // Definite-assignment: `p` is assigned synchronously below, before the
+    // async `finally` (which references it) can run.
+    let p!: Promise<V>;
+    p = (async () => {
+      try {
+        const value = await fetchFn(key);
+        // Atomic update: one `.next` with a fresh Map reference so
+        // downstream `distinctUntilChanged` sees the transition (B5).
+        const next = new Map(store$.value);
+        next.set(key, value);
+        store$.next(next);
+        return value;
+      } finally {
+        // Only clear if we're still the in-flight entry — an `invalidate`
+        // may have replaced us with a newer fetch (B9 orphan recovery).
+        if (inflight.get(key) === p) inflight.delete(key);
+      }
+    })();
+    inflight.set(key, p);
+    return p;
   };
 
   return {
     observe(key: K): Observable<V | undefined> {
       if (!store$.value.has(key) && !inflight.has(key)) {
-        void doFetch(key);
+        // Subscribe path: fire-and-forget, swallow failures so a subscriber
+        // stays at its last value (B6). The awaiter's `fetch` surfaces them.
+        void runFetch(key).catch(() => {});
       }
       // B4: return a stable Observable per key.
       let obs = obsCache.get(key);
@@ -126,17 +136,8 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
       return obs;
     },
 
-    errors(key: K): Observable<unknown> {
-      // Stable per-key error observable (mirrors B4 for the value path).
-      let obs = errCache.get(key);
-      if (!obs) {
-        obs = fetchErrors$.pipe(
-          filter((e) => e.key === key),
-          map((e) => e.error),
-        );
-        errCache.set(key, obs);
-      }
-      return obs;
+    fetch(key: K): Promise<V> {
+      return runFetch(key);
     },
 
     get(key: K): V | undefined {
@@ -152,7 +153,7 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
       // and trigger a fresh fetch. Observers keep seeing the stale value
       // until the new value replaces it.
       inflight.delete(key);
-      void doFetch(key);
+      void runFetch(key).catch(() => {});
     },
 
     remove(key: K): void {
@@ -175,15 +176,13 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
       // keeps its stale value until its refetch resolves.
       for (const key of store$.value.keys()) {
         inflight.delete(key);
-        void doFetch(key);
+        void runFetch(key).catch(() => {});
       }
     },
 
     dispose(): void {
       store$.complete();
-      fetchErrors$.complete();
       obsCache.clear();
-      errCache.clear();
       inflight.clear();
     },
   };

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -13,7 +13,7 @@
  * `client.bus`.
  */
 
-import type { ResourceId, BaseUrl, AccessToken } from '@semiont/core';
+import type { BaseUrl, AccessToken } from '@semiont/core';
 import { EventBus, accessToken, baseUrl } from '@semiont/core';
 import { BehaviorSubject } from 'rxjs';
 import { BrowseNamespace } from './namespaces/browse';
@@ -133,10 +133,6 @@ export class SemiontClient {
   /** Transport-level connection state. HTTP reflects SSE health; local is always 'connected'. */
   get state$() {
     return this.transport.state$;
-  }
-
-  subscribeToResource(resourceId: ResourceId): () => void {
-    return this.transport.subscribeToResource(resourceId);
   }
 
   dispose(): void {

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -81,6 +81,14 @@ export class BrowseNamespace implements IBrowseNamespace {
    */
   private readonly annotationListObs = new Map<ResourceId, Observable<Annotation[] | undefined>>();
 
+  /**
+   * Per-source memo for the scope-acquiring wrapper (#847 Phase 4), keyed by
+   * the underlying (stable, per-key) cache observable so the wrapped
+   * observable is itself stable per key — preserving B4/B11 referential
+   * identity through to `CacheObservable.from`'s own memo.
+   */
+  private readonly scopedSources = new WeakMap<Observable<unknown>, Observable<unknown>>();
+
   constructor(
     private readonly transport: ITransport,
     private readonly bus: EventBus,
@@ -188,6 +196,40 @@ export class BrowseNamespace implements IBrowseNamespace {
     this.subscribeToEvents();
   }
 
+  /**
+   * Wrap a resource-scoped live query's source so that *subscribing* acquires
+   * the resource's scope (via the transport's ref-counted
+   * `subscribeToResource`) and the last unsubscribe releases it (#847 Phase 4).
+   * Freshness follows observation: a `.subscribe()` keeps `rId`'s scoped
+   * events flowing — so `mark:*` / entity-tag invalidations reach this cache —
+   * with no separate `subscribeToResource` call from the consumer.
+   *
+   * The one-shot `await` path does NOT go through here (it resolves via the
+   * cache's `fetch` — see `CacheObservable.from`'s `fetchFresh`), so a
+   * one-shot read acquires no scope.
+   *
+   * Memoized per source so the wrapped observable is stable per key (B4/B11).
+   * Each subscription calls `subscribeToResource(rId)`; the transport
+   * ref-counts concurrent subscriptions for the same resource onto a single
+   * SSE scope. Single-scope model unchanged — multi-scope is deferred (see
+   * `.plans/MULTI-RESOURCE-SCOPE.md`).
+   */
+  private withScope<T>(rId: ResourceId, source: Observable<T | undefined>): Observable<T | undefined> {
+    let scoped = this.scopedSources.get(source) as Observable<T | undefined> | undefined;
+    if (!scoped) {
+      scoped = new Observable<T | undefined>((subscriber) => {
+        const release = this.transport.subscribeToResource(rId);
+        const inner = source.subscribe(subscriber);
+        return () => {
+          inner.unsubscribe();
+          release();
+        };
+      });
+      this.scopedSources.set(source, scoped);
+    }
+    return scoped;
+  }
+
   // ── Live queries ────────────────────────────────────────────────────────
   //
   // These return `CacheObservable<T>`: subscribers see `T | undefined`
@@ -195,7 +237,7 @@ export class BrowseNamespace implements IBrowseNamespace {
   // first non-undefined value.
 
   resource(resourceId: ResourceId): CacheObservable<ResourceDescriptor> {
-    return CacheObservable.from(this.resourceCache.observe(resourceId), () => this.resourceCache.fetch(resourceId));
+    return CacheObservable.from(this.withScope(resourceId, this.resourceCache.observe(resourceId)), () => this.resourceCache.fetch(resourceId));
   }
 
   resources(filters?: ResourceListFilters): CacheObservable<ResourceDescriptor[]> {
@@ -212,7 +254,7 @@ export class BrowseNamespace implements IBrowseNamespace {
       obs = this.annotationListCache.observe(resourceId).pipe(map((r) => r?.annotations as Annotation[] | undefined));
       this.annotationListObs.set(resourceId, obs);
     }
-    return CacheObservable.from(obs, () => this.annotationListCache.fetch(resourceId).then((r) => r.annotations as Annotation[]));
+    return CacheObservable.from(this.withScope(resourceId, obs), () => this.annotationListCache.fetch(resourceId).then((r) => r.annotations as Annotation[]));
   }
 
   annotation(resourceId: ResourceId, annotationId: AnnotationId): CacheObservable<Annotation> {
@@ -220,7 +262,7 @@ export class BrowseNamespace implements IBrowseNamespace {
     // the cache key, `annotationId`) can look up the resourceId it
     // needs for the bus request.
     this.annotationResources.set(annotationId, resourceId);
-    return CacheObservable.from(this.annotationDetailCache.observe(annotationId), () => this.annotationDetailCache.fetch(annotationId));
+    return CacheObservable.from(this.withScope(resourceId, this.annotationDetailCache.observe(annotationId)), () => this.annotationDetailCache.fetch(annotationId));
   }
 
   entityTypes(): CacheObservable<string[]> {
@@ -232,11 +274,11 @@ export class BrowseNamespace implements IBrowseNamespace {
   }
 
   referencedBy(resourceId: ResourceId): CacheObservable<ReferencedByEntry[]> {
-    return CacheObservable.from(this.referencedByCache.observe(resourceId), () => this.referencedByCache.fetch(resourceId));
+    return CacheObservable.from(this.withScope(resourceId, this.referencedByCache.observe(resourceId)), () => this.referencedByCache.fetch(resourceId));
   }
 
   events(resourceId: ResourceId): CacheObservable<StoredEventResponse[]> {
-    return CacheObservable.from(this.resourceEventsCache.observe(resourceId), () => this.resourceEventsCache.fetch(resourceId));
+    return CacheObservable.from(this.withScope(resourceId, this.resourceEventsCache.observe(resourceId)), () => this.resourceEventsCache.fetch(resourceId));
   }
 
   // ── One-shot reads ──────────────────────────────────────────────────────

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -195,7 +195,7 @@ export class BrowseNamespace implements IBrowseNamespace {
   // first non-undefined value.
 
   resource(resourceId: ResourceId): CacheObservable<ResourceDescriptor> {
-    return CacheObservable.from(this.resourceCache.observe(resourceId), this.resourceCache.errors(resourceId));
+    return CacheObservable.from(this.resourceCache.observe(resourceId), () => this.resourceCache.fetch(resourceId));
   }
 
   resources(filters?: ResourceListFilters): CacheObservable<ResourceDescriptor[]> {
@@ -203,7 +203,7 @@ export class BrowseNamespace implements IBrowseNamespace {
     // Remember the filter blob so `invalidateResourceLists` can drive
     // per-key SWR refetches without the caller re-passing filters.
     this.resourceListFilters.set(key, filters ?? {});
-    return CacheObservable.from(this.resourceListCache.observe(key), this.resourceListCache.errors(key));
+    return CacheObservable.from(this.resourceListCache.observe(key), () => this.resourceListCache.fetch(key));
   }
 
   annotations(resourceId: ResourceId): CacheObservable<Annotation[]> {
@@ -212,7 +212,7 @@ export class BrowseNamespace implements IBrowseNamespace {
       obs = this.annotationListCache.observe(resourceId).pipe(map((r) => r?.annotations as Annotation[] | undefined));
       this.annotationListObs.set(resourceId, obs);
     }
-    return CacheObservable.from(obs, this.annotationListCache.errors(resourceId));
+    return CacheObservable.from(obs, () => this.annotationListCache.fetch(resourceId).then((r) => r.annotations as Annotation[]));
   }
 
   annotation(resourceId: ResourceId, annotationId: AnnotationId): CacheObservable<Annotation> {
@@ -220,23 +220,23 @@ export class BrowseNamespace implements IBrowseNamespace {
     // the cache key, `annotationId`) can look up the resourceId it
     // needs for the bus request.
     this.annotationResources.set(annotationId, resourceId);
-    return CacheObservable.from(this.annotationDetailCache.observe(annotationId), this.annotationDetailCache.errors(annotationId));
+    return CacheObservable.from(this.annotationDetailCache.observe(annotationId), () => this.annotationDetailCache.fetch(annotationId));
   }
 
   entityTypes(): CacheObservable<string[]> {
-    return CacheObservable.from(this.entityTypesCache.observe(ENTITY_TYPES_KEY), this.entityTypesCache.errors(ENTITY_TYPES_KEY));
+    return CacheObservable.from(this.entityTypesCache.observe(ENTITY_TYPES_KEY), () => this.entityTypesCache.fetch(ENTITY_TYPES_KEY));
   }
 
   tagSchemas(): CacheObservable<TagSchema[]> {
-    return CacheObservable.from(this.tagSchemasCache.observe(TAG_SCHEMAS_KEY), this.tagSchemasCache.errors(TAG_SCHEMAS_KEY));
+    return CacheObservable.from(this.tagSchemasCache.observe(TAG_SCHEMAS_KEY), () => this.tagSchemasCache.fetch(TAG_SCHEMAS_KEY));
   }
 
   referencedBy(resourceId: ResourceId): CacheObservable<ReferencedByEntry[]> {
-    return CacheObservable.from(this.referencedByCache.observe(resourceId), this.referencedByCache.errors(resourceId));
+    return CacheObservable.from(this.referencedByCache.observe(resourceId), () => this.referencedByCache.fetch(resourceId));
   }
 
   events(resourceId: ResourceId): CacheObservable<StoredEventResponse[]> {
-    return CacheObservable.from(this.resourceEventsCache.observe(resourceId), this.resourceEventsCache.errors(resourceId));
+    return CacheObservable.from(this.resourceEventsCache.observe(resourceId), () => this.resourceEventsCache.fetch(resourceId));
   }
 
   // ── One-shot reads ──────────────────────────────────────────────────────

--- a/packages/sdk/src/namespaces/job.ts
+++ b/packages/sdk/src/namespaces/job.ts
@@ -26,32 +26,12 @@ export class JobNamespace implements IJobNamespace {
     return this.bus.get('job:report-progress');
   }
 
-  /**
-   * Live stream of `job:complete` events.
-   *
-   * **Dual-delivery — consumers must be idempotent.** The worker emits
-   * `job:complete` both globally (so a dispatching caller receives it on the
-   * always-on global bridge, keyed by `jobId`) and resource-scoped (so
-   * viewers of the resource react too). A client subscribed to *both* a
-   * resource scope and the global bus therefore sees each completion
-   * **twice**. This stream is a raw passthrough and does NOT dedupe.
-   *
-   * Key on `jobId` and keep the reaction idempotent — prefer naturally
-   * idempotent side effects; for a single job use
-   * `complete$.pipe(filter(e => e.jobId === id), take(1))`. The single-job
-   * consumers (`mark.assist`, `yield.fromAnnotation`, `pollUntilComplete`)
-   * already collapse the doubled delivery to one observed completion.
-   */
+  /** Live stream of `job:complete` events (global; filter by `jobId`). */
   get complete$(): Observable<EventMap['job:complete']> {
     return this.bus.get('job:complete');
   }
 
-  /**
-   * Live stream of `job:fail` events.
-   *
-   * Dual-delivered like {@link complete$} — see its note. Raw passthrough,
-   * not deduped; key on `jobId` and keep the reaction idempotent.
-   */
+  /** Live stream of `job:fail` events (global; filter by `jobId`). */
   get fail$(): Observable<EventMap['job:fail']> {
     return this.bus.get('job:fail');
   }


### PR DESCRIPTION
Fixes #847 