### PR TITLE
fix(react-ui): build integration entrypoints

### DIFF
--- a/packages/react-ui/rollup.dts.config.mjs
+++ b/packages/react-ui/rollup.dts.config.mjs
@@ -44,6 +44,14 @@ function isExternal(id) {
 const entries = [
   { input: 'dist-types/index.d.ts', file: 'dist/index.d.ts' },
   { input: 'dist-types/test-utils.d.ts', file: 'dist/test-utils.d.ts' },
+  {
+    input: 'dist-types/integrations/css-modules-helper.d.ts',
+    file: 'dist/integrations/css-modules-helper.d.ts',
+  },
+  {
+    input: 'dist-types/integrations/styled-components-theme.d.ts',
+    file: 'dist/integrations/styled-components-theme.d.ts',
+  },
 ];
 
 export default entries.map(({ input, file }) => ({

--- a/packages/react-ui/tsup.config.ts
+++ b/packages/react-ui/tsup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/test-utils.tsx'],
+  entry: {
+    index: 'src/index.ts',
+    'test-utils': 'src/test-utils.tsx',
+    'integrations/css-modules-helper': 'src/integrations/css-modules-helper.tsx',
+    'integrations/styled-components-theme': 'src/integrations/styled-components-theme.ts',
+  },
   format: ['esm'],
   dts: false,
   sourcemap: true,


### PR DESCRIPTION
## Summary
- add the exported React UI integration modules to the tsup entry map
- bundle declaration files for those integration exports
- keep package exports aligned with generated runtime and type files

## Why
`@semiont/react-ui` publishes package exports for `./integrations/css-modules` and `./integrations/styled-components`, but the current build only emits `index` and `test-utils` entrypoints. The published `0.5.7` tarball is missing the corresponding `dist/integrations/*` files, so those subpath exports resolve to missing files.

## Validation
- inspected the published `@semiont/react-ui@0.5.7` tarball and confirmed `dist/integrations/css-modules-helper.{js,d.ts}` and `dist/integrations/styled-components-theme.{js,d.ts}` are missing
- confirmed the source modules exist under `packages/react-ui/src/integrations/`
- attempted `npm run build -w @semiont/react-ui`; local dependency installation is currently blocked by the repo lockfile being out of sync / peer resolution issues in this environment