### PR TITLE
entity extraction silent drop

### DIFF
--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -111,7 +111,7 @@ const items = JSON.parse(json); // guaranteed to be an array
 
 Each implementation honors the contract with its provider's mechanism:
 - **Ollama**: grammar-constrained sampling — the request's `format` field carries a minimal array schema.
-- **Anthropic**: assistant-turn prefill (`[`); the prefix is re-attached to the returned text so callers always see a complete JSON document.
+- **Anthropic**: forced structured tool-use — a single tool is offered and forced via `tool_choice`, so the model answers by filling the tool's input, which the API serializes as escaped JSON. The array is carried under an `items` property (tool inputs must be objects) and unwrapped to a top-level array on return.
 
 Current callers all expect arrays (entity extraction, motivation detection). If an object-emitting caller appears, the option grows a `root: 'array' | 'object'` field — see the notes in [src/interface.ts](src/interface.ts).
 

--- a/packages/inference/docs/API.md
+++ b/packages/inference/docs/API.md
@@ -84,7 +84,7 @@ interface InferenceOptions {
 `format: 'json'` constrains output to a **parseable top-level JSON array**, regardless of provider:
 
 - **Ollama** uses grammar-constrained sampling: the request's `format` field carries a minimal array schema (`{ type: 'array', items: {} }`). The bare `"json"` string would allow any JSON value, including a wrapping object, which would break callers that `.map` over the result.
-- **Anthropic** has no native JSON mode, so the client adds an assistant-turn prefill (`[`). Claude continues from the bracket, syntactically committed to an array. The prefill characters don't appear in the API response, so the client re-attaches the `[` before returning — callers always receive a complete JSON document.
+- **Anthropic** uses forced structured **tool-use**. The client offers a single tool and forces it via `tool_choice: { type: 'tool', name }`, so the model must answer by filling the tool's input — which the API serializes as **properly-escaped** JSON. This eliminates both free-text failure modes at the source: trailing prose after the `]`, and an unescaped `"` inside a string. Because a tool's input must be an object, the array is carried under an `items` property and unwrapped (`JSON.stringify(input.items)`) so callers still receive a top-level array in `text`.
 
 Element shape is **not** constrained — the prompt carries the per-element schema; only the outer array is enforced.
 

--- a/packages/inference/src/__tests__/anthropic.test.ts
+++ b/packages/inference/src/__tests__/anthropic.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the Anthropic SDK so we can assert the exact request shape and feed
+// canned responses. `vi.hoisted` makes `createMock` available inside the
+// (hoisted) mock factory.
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: createMock };
+  },
+}));
+
+import { AnthropicInferenceClient } from '../implementations/anthropic.js';
+import { OllamaInferenceClient } from '../implementations/ollama.js';
+
+describe('AnthropicInferenceClient - JSON mode is tool-use, not prefill', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('forces a schema-typed tool call (no assistant prefill) for { format: "json" }', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'tool_use', id: 'toolu_1', name: 'emit', input: { items: [{ exact: 'Paris' }] } }],
+      stop_reason: 'tool_use',
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    const client = new AnthropicInferenceClient('test-key', 'claude-x');
+    const text = await client.generateText('Extract locations', 1000, 0, { format: 'json' });
+
+    const req = createMock.mock.calls[0][0];
+
+    // A single tool is offered and the model is forced to call exactly it.
+    expect(Array.isArray(req.tools)).toBe(true);
+    expect(req.tools).toHaveLength(1);
+    expect(req.tool_choice).toMatchObject({ type: 'tool' });
+    expect(req.tool_choice.name).toBe(req.tools[0].name);
+
+    // The tool input is a schema-typed object wrapping an array (tool inputs
+    // must be objects); the array lives under `items`.
+    expect(req.tools[0].input_schema.type).toBe('object');
+    expect(req.tools[0].input_schema.properties.items.type).toBe('array');
+
+    // No prefill: the request must not carry an assistant turn.
+    expect(req.messages.some((m: { role: string }) => m.role === 'assistant')).toBe(false);
+
+    // The returned text is a parseable top-level JSON ARRAY (the array is
+    // re-serialized out of the tool_use input wrapper).
+    const parsed = JSON.parse(text);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toEqual([{ exact: 'Paris' }]);
+  });
+
+  it('round-trips an entity whose `exact` span contains a quote', async () => {
+    // The variant-2 failure: an unescaped `"` inside a verbatim span. Tool-use
+    // makes the API serialize properly-escaped JSON, so it round-trips cleanly.
+    createMock.mockResolvedValue({
+      content: [{ type: 'tool_use', id: 't', name: 'emit', input: { items: [{ exact: 'the "best" café', prefix: 'a' }] } }],
+      stop_reason: 'tool_use',
+      usage: {},
+    });
+
+    const client = new AnthropicInferenceClient('test-key', 'claude-x');
+    const text = await client.generateText('p', 1000, 0, { format: 'json' });
+
+    const parsed = JSON.parse(text);
+    expect(parsed[0].exact).toBe('the "best" café');
+  });
+
+  it('preserves the real stop_reason and yields an empty array for an empty extraction', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'tool_use', id: 't', name: 'emit', input: { items: [] } }],
+      stop_reason: 'tool_use',
+      usage: {},
+    });
+
+    const client = new AnthropicInferenceClient('test-key', 'claude-x');
+    const res = await client.generateTextWithMetadata('p', 1000, 0, { format: 'json' });
+
+    expect(res.stopReason).toBe('tool_use');
+    expect(JSON.parse(res.text)).toEqual([]);
+  });
+});
+
+describe('AnthropicInferenceClient - plain text mode unchanged', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('returns the text block and offers no tools when format is unset', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'text', text: 'hello world' }],
+      stop_reason: 'end_turn',
+      usage: {},
+    });
+
+    const client = new AnthropicInferenceClient('test-key', 'claude-x');
+    const text = await client.generateText('p', 100, 0);
+
+    expect(text).toBe('hello world');
+    const req = createMock.mock.calls[0][0];
+    expect(req.tools).toBeUndefined();
+    expect(req.tool_choice).toBeUndefined();
+  });
+});
+
+describe('OllamaInferenceClient - grammar path unchanged (guard)', () => {
+  it('sends the array-schema format for { format: "json" }', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: '[]', done: true, done_reason: 'stop' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new OllamaInferenceClient('llama3', 'http://localhost:11434');
+    await client.generateText('p', 100, 0, { format: 'json' });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.format).toEqual({ type: 'array', items: {} });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/inference/src/implementations/anthropic.ts
+++ b/packages/inference/src/implementations/anthropic.ts
@@ -5,6 +5,32 @@ import type { Logger } from '@semiont/core';
 import { recordInferenceUsage } from '@semiont/observability';
 import { InferenceClient, InferenceOptions, InferenceResponse } from '../interface.js';
 
+// Forced-tool channel for JSON mode. Anthropic has no grammar-constrained
+// sampling like Ollama's `format`; the equivalent hard guarantee is a *tool
+// call*. We offer exactly one tool and force it via `tool_choice`, so the model
+// must answer by filling the tool's input — which the API serializes as
+// properly-escaped JSON. That kills both free-text failure modes at the source:
+// trailing prose after the `]` (variant 1) and an unescaped `"` inside a string
+// (variant 2), neither of which a prefill could prevent.
+//
+// A tool's input must be an *object*, so the array is carried under `items`
+// and unwrapped on return (see generateTextWithMetadata) — the caller still
+// receives a top-level JSON array in `text`, exactly as on Ollama.
+const JSON_ARRAY_TOOL: Anthropic.Tool = {
+  name: 'emit_json_array',
+  description:
+    'Return your entire answer by calling this tool. Put the JSON array of results under the "items" property, and emit no prose.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      // Element shape is unconstrained here — the prompt carries the per-element
+      // schema; the tool only enforces that the top-level result is an array.
+      items: { type: 'array', items: {} },
+    },
+    required: ['items'],
+  },
+};
+
 export class AnthropicInferenceClient implements InferenceClient {
   readonly type = 'anthropic' as const;
   readonly modelId: string;
@@ -26,20 +52,7 @@ export class AnthropicInferenceClient implements InferenceClient {
   }
 
   async generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number, options?: InferenceOptions): Promise<InferenceResponse> {
-    // Anthropic has no grammar-constrained sampling layer like Ollama's
-    // `format: "json"`. The closest equivalent is *prefill*: add an
-    // assistant turn whose content is the opening bracket of the
-    // expected structure. Claude continues from there, syntactically
-    // committed to producing valid JSON. The prefill characters don't
-    // appear in the response, so we prepend them ourselves on return.
-    //
-    // We assume `[` (array) — every current caller of the inference
-    // layer that asks for JSON expects an array (entity extraction,
-    // motivation detection). If an object-emitting caller appears, the
-    // option needs to grow a `root: 'array' | 'object'` field; for now
-    // a single shape keeps the contract small.
     const jsonMode = options?.format === 'json';
-    const prefill = jsonMode ? '[' : undefined;
 
     this.logger?.debug('Generating text with inference client', {
       model: this.modelId,
@@ -49,13 +62,6 @@ export class AnthropicInferenceClient implements InferenceClient {
       format: options?.format,
     });
 
-    const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [
-      { role: 'user', content: prompt },
-    ];
-    if (prefill) {
-      messages.push({ role: 'assistant', content: prefill });
-    }
-
     const start = performance.now();
     let response: Awaited<ReturnType<typeof this.client.messages.create>>;
     try {
@@ -63,7 +69,12 @@ export class AnthropicInferenceClient implements InferenceClient {
         model: this.modelId,
         max_tokens: maxTokens,
         temperature,
-        messages,
+        messages: [{ role: 'user', content: prompt }],
+        // JSON mode → force the structured-output tool. No prefill assistant
+        // turn: the constraint now lives in the tool call, not in free text.
+        ...(jsonMode
+          ? { tools: [JSON_ARRAY_TOOL], tool_choice: { type: 'tool' as const, name: JSON_ARRAY_TOOL.name } }
+          : {}),
       });
     } catch (err) {
       recordInferenceUsage({
@@ -81,22 +92,51 @@ export class AnthropicInferenceClient implements InferenceClient {
       stopReason: response.stop_reason
     });
 
-    const textContent = response.content.find(c => c.type === 'text');
-
-    if (!textContent || textContent.type !== 'text') {
-      recordInferenceUsage({
-        provider: this.type,
-        model: this.modelId,
-        durationMs: performance.now() - start,
-        outcome: 'error',
-        inputTokens: response.usage?.input_tokens,
-        outputTokens: response.usage?.output_tokens,
-      });
-      this.logger?.error('No text content in inference response', {
-        model: this.modelId,
-        contentTypes: response.content.map(c => c.type)
-      });
-      throw new Error('No text content in inference response');
+    let text: string;
+    if (jsonMode) {
+      // The answer arrives as a tool_use block, not text. Unwrap the `items`
+      // array and re-serialize it so `text` is a complete, parseable top-level
+      // JSON array — the cross-provider contract every consumer reads.
+      const toolUse = response.content.find(c => c.type === 'tool_use');
+      if (!toolUse || toolUse.type !== 'tool_use') {
+        recordInferenceUsage({
+          provider: this.type,
+          model: this.modelId,
+          durationMs: performance.now() - start,
+          outcome: 'error',
+          inputTokens: response.usage?.input_tokens,
+          outputTokens: response.usage?.output_tokens,
+        });
+        this.logger?.error('No tool_use content in inference response', {
+          model: this.modelId,
+          contentTypes: response.content.map(c => c.type)
+        });
+        throw new Error('No tool_use content in inference response');
+      }
+      // `input` is typed `unknown` by the SDK. A truncated (`max_tokens`)
+      // response may carry partial or absent `items` — fall back to the partial
+      // array, or `[]` if absent; the consumer flags truncation via stopReason.
+      const input = toolUse.input as { items?: unknown };
+      const items = Array.isArray(input.items) ? input.items : [];
+      text = JSON.stringify(items);
+    } else {
+      const textContent = response.content.find(c => c.type === 'text');
+      if (!textContent || textContent.type !== 'text') {
+        recordInferenceUsage({
+          provider: this.type,
+          model: this.modelId,
+          durationMs: performance.now() - start,
+          outcome: 'error',
+          inputTokens: response.usage?.input_tokens,
+          outputTokens: response.usage?.output_tokens,
+        });
+        this.logger?.error('No text content in inference response', {
+          model: this.modelId,
+          contentTypes: response.content.map(c => c.type)
+        });
+        throw new Error('No text content in inference response');
+      }
+      text = textContent.text;
     }
 
     recordInferenceUsage({
@@ -107,13 +147,6 @@ export class AnthropicInferenceClient implements InferenceClient {
       inputTokens: response.usage?.input_tokens,
       outputTokens: response.usage?.output_tokens,
     });
-
-    // Re-attach the prefill prefix so the returned text is what the caller
-    // *would have seen* if Anthropic had a native JSON mode — a complete,
-    // parseable JSON document. Without this, the consumer would get the
-    // tail (`{...}, {...}]`) and parse-fail trying to read it as a top-
-    // level array.
-    const text = prefill ? prefill + textContent.text : textContent.text;
 
     this.logger?.info('Text generation completed', {
       model: this.modelId,

--- a/packages/inference/src/interface.ts
+++ b/packages/inference/src/interface.ts
@@ -15,10 +15,11 @@ export interface InferenceOptions {
    * Constrain output to a parseable JSON array. Every implementation
    * MUST satisfy this contract using whatever mechanism its provider
    * supports — Ollama uses grammar-constrained sampling
-   * (`format: "json"`); Anthropic uses assistant-turn prefill (`[`)
-   * and re-attaches the prefix on return. Callers can rely on the
-   * returned `text` being a top-level JSON array regardless of
-   * provider.
+   * (`format: "json"`); Anthropic uses forced structured tool-use (a
+   * single tool, forced via `tool_choice`, whose array result the API
+   * serializes as escaped JSON) and unwraps the array on return.
+   * Callers can rely on the returned `text` being a top-level JSON
+   * array regardless of provider.
    *
    * Current callers all expect arrays (entity extraction, motivation
    * detection). If an object-emitting caller appears, this option

--- a/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
+++ b/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
@@ -334,10 +334,11 @@ describe('AnnotationDetection', () => {
   });
 
   describe('error handling', () => {
-    it('should handle AI inference errors gracefully', async () => {
-      // Mock client to throw error
+    it('should propagate AI inference errors', async () => {
+      // detectComments now reads metadata (stopReason) via
+      // generateTextWithMetadata, so the failure is injected there.
       const errorClient = new MockInferenceClient(['']);
-      errorClient.generateText = vi.fn().mockRejectedValue(new Error('AI service unavailable'));
+      errorClient.generateTextWithMetadata = vi.fn().mockRejectedValue(new Error('AI service unavailable'));
 
       await expect(
         AnnotationDetection.detectComments(
@@ -347,17 +348,28 @@ describe('AnnotationDetection', () => {
       ).rejects.toThrow('AI service unavailable');
     });
 
-    it('should handle malformed AI responses gracefully', async () => {
-      // Mock invalid JSON response - parsers handle this gracefully and return empty array
+    it('throws on malformed AI responses instead of silently returning []', async () => {
+      // Phase 2b: a parse failure is silent data loss — it must surface as a
+      // thrown error (→ job:failed), not a graceful empty array.
       mockClient.setResponses(['invalid json']);
 
-      const result = await AnnotationDetection.detectHighlights(
-        testContent,
-        mockClient
+      await expect(
+        AnnotationDetection.detectHighlights(testContent, mockClient)
+      ).rejects.toThrow();
+    });
+
+    it('throws on a truncated (max_tokens) response instead of under-reporting', async () => {
+      // Phase 2b truncation parity with 2a: the motivation path now reads
+      // stopReason via generateTextWithMetadata and fails the job loudly
+      // rather than parsing a valid-but-incomplete array as a partial success.
+      mockClient.setResponses(
+        [JSON.stringify([{ exact: 'Climate change', start: 0, end: 14 }])],
+        ['max_tokens'],
       );
 
-      // Invalid JSON should result in empty results (graceful failure)
-      expect(result).toBeInstanceOf(Array);
+      await expect(
+        AnnotationDetection.detectHighlights(testContent, mockClient)
+      ).rejects.toThrow(/truncat/i);
     });
   });
 

--- a/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
@@ -106,50 +106,20 @@ describe('extractEntities', () => {
     expect(result[1].exact).toBe('Bob');
   });
 
-  it('should handle markdown-wrapped JSON response', async () => {
+  it('throws on truncation (max_tokens) instead of silently dropping annotations', async () => {
+    // Phase 2a: a truncated response is data loss, not "no entities". The
+    // truncation check runs BEFORE parse, so even a syntactically-valid but
+    // incomplete array must fail the job loudly rather than return [].
     const text = 'Alice went to Paris.';
     const mockResponse = [
-      {
-        exact: 'Alice',
-        entityType: 'Person',
-        startOffset: 0,
-        endOffset: 5
-      }
+      { exact: 'Alice', entityType: 'Person', prefix: '', suffix: ' went to' },
     ];
 
-    mockInferenceClient.setResponses(['```json\n' + JSON.stringify(mockResponse) + '\n```']);
-
-    const result = await extractEntities(text, ['Person'], mockInferenceClient, false, LOGGER);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].exact).toBe('Alice');
-  });
-
-  it('should log error and return empty array when response is truncated', async () => {
-    const text = 'Alice went to Paris.';
-    const mockResponse = [
-      {
-        exact: 'Alice',
-        entityType: 'Person',
-        startOffset: 0,
-        endOffset: 5,
-        prefix: '',
-        suffix: ' went to'
-      }
-    ];
-
-    // Set response with max_tokens stop reason to simulate truncation
     mockInferenceClient.setResponses([JSON.stringify(mockResponse)], ['max_tokens']);
 
-    // When truncated, extractEntities throws but catch block returns []
-    try {
-      const result = await extractEntities(text, ['Person'], mockInferenceClient, false, LOGGER);
-      expect(result).toEqual([]);
-    } catch (error) {
-      // If it throws, that's also acceptable - the catch block should return []
-      // But the test expects [] to be returned, not thrown
-      throw error;
-    }
+    await expect(
+      extractEntities(text, ['Person'], mockInferenceClient, false, LOGGER),
+    ).rejects.toThrow(/truncat/i);
   });
 
   it('should handle entity types with examples', async () => {
@@ -206,12 +176,14 @@ describe('extractEntities', () => {
     expect(result[1].exact).toBe('The Nobel laureate');
   });
 
-  it('should handle malformed JSON gracefully', async () => {
+  it('throws on unparseable response instead of silently returning []', async () => {
+    // Phase 2a: parse failure is silent data loss in disguise — it must
+    // surface as a thrown error (→ job:failed) rather than an empty success.
     mockInferenceClient.setResponses(['This is not JSON']);
 
-    const result = await extractEntities('Alice went to Paris.', ['Person'], mockInferenceClient, false, LOGGER);
-
-    expect(result).toEqual([]);
+    await expect(
+      extractEntities('Alice went to Paris.', ['Person'], mockInferenceClient, false, LOGGER),
+    ).rejects.toThrow(/parse/i);
   });
 
   describe('source language', () => {

--- a/packages/jobs/src/__tests__/workers/detection/motivation-parsers.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/motivation-parsers.test.ts
@@ -3,10 +3,17 @@
  *
  * Tests the MotivationParsers class which parses and validates AI responses
  * for different annotation motivations.
+ *
+ * Phase 2b (de-silence): the parsers no longer tolerate malformed output or
+ * swallow parse failures into an empty array. Post-Phase-1 both providers emit
+ * syntactically-valid, fence-free JSON arrays, so a parse failure is a real
+ * failure and must throw (→ job:failed) rather than silently return zero
+ * annotations. A legitimately-empty `[]` still parses to a success with no
+ * matches. The former tolerant `extractObjectsFromArray` walker is gone.
  */
 
 import { describe, it, expect } from 'vitest';
-import { MotivationParsers, extractObjectsFromArray } from '../../../workers/detection/motivation-parsers';
+import { MotivationParsers } from '../../../workers/detection/motivation-parsers';
 
 // No `@semiont/core` mock — the real `reconcileSelector` runs against the
 // synthetic test content. Tests that exercise hallucinated text (offsets
@@ -36,22 +43,6 @@ describe('MotivationParsers', () => {
         end: 5,
         comment: 'This is a test comment'
       });
-    });
-
-    it('should handle markdown-wrapped JSON', () => {
-      const response = '```json\n' + JSON.stringify([
-        {
-          exact: 'Paris',
-          start: 14,
-          end: 19,
-          comment: 'A city'
-        }
-      ]) + '\n```';
-
-      const result = MotivationParsers.parseComments(response, testContent);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].exact).toBe('Paris');
     });
 
     it('drops comments whose exact does not appear in the source', () => {
@@ -90,18 +81,17 @@ describe('MotivationParsers', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('should handle malformed JSON gracefully', () => {
-      const result = MotivationParsers.parseComments('not valid json', testContent);
-
-      expect(result).toEqual([]);
+    it('parses a legitimately-empty array as a success with no matches', () => {
+      expect(MotivationParsers.parseComments('[]', testContent)).toEqual([]);
     });
 
-    it('should handle non-array response', () => {
+    it('throws on unparseable response instead of silently returning []', () => {
+      expect(() => MotivationParsers.parseComments('not valid json', testContent)).toThrow();
+    });
+
+    it('throws on a non-array response instead of silently returning []', () => {
       const response = JSON.stringify({ exact: 'Alice', start: 0, end: 5 });
-
-      const result = MotivationParsers.parseComments(response, testContent);
-
-      expect(result).toEqual([]);
+      expect(() => MotivationParsers.parseComments(response, testContent)).toThrow(/array/i);
     });
   });
 
@@ -125,21 +115,6 @@ describe('MotivationParsers', () => {
       });
     });
 
-    it('should handle markdown code fence variants', () => {
-      const response = '```\n' + JSON.stringify([
-        {
-          exact: 'Paris',
-          start: 14,
-          end: 19
-        }
-      ]) + '\n```';
-
-      const result = MotivationParsers.parseHighlights(response, testContent);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].exact).toBe('Paris');
-    });
-
     it('should filter out invalid highlights', () => {
       const response = JSON.stringify([
         { exact: 'Alice' },
@@ -152,10 +127,12 @@ describe('MotivationParsers', () => {
       expect(result[0]!.exact).toBe('Alice');
     });
 
-    it('should handle malformed JSON gracefully', () => {
-      const result = MotivationParsers.parseHighlights('{invalid', testContent);
+    it('parses a legitimately-empty array as a success with no matches', () => {
+      expect(MotivationParsers.parseHighlights('[]', testContent)).toEqual([]);
+    });
 
-      expect(result).toEqual([]);
+    it('throws on unparseable response instead of silently returning []', () => {
+      expect(() => MotivationParsers.parseHighlights('{invalid', testContent)).toThrow();
     });
   });
 
@@ -181,22 +158,6 @@ describe('MotivationParsers', () => {
       });
     });
 
-    it('should handle markdown-wrapped JSON', () => {
-      const response = '```json\n' + JSON.stringify([
-        {
-          exact: 'Paris',
-          start: 14,
-          end: 19,
-          assessment: 'Capital of France'
-        }
-      ]) + '\n```';
-
-      const result = MotivationParsers.parseAssessments(response, testContent);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].exact).toBe('Paris');
-    });
-
     it('drops assessments whose exact does not appear in the source', () => {
       const response = JSON.stringify([
         { exact: 'Bob', assessment: 'Valid' },
@@ -209,40 +170,22 @@ describe('MotivationParsers', () => {
       expect(result[0]!.exact).toBe('Bob');
     });
 
-    it('should handle malformed JSON gracefully', () => {
-      const result = MotivationParsers.parseAssessments('not json', testContent);
-
-      expect(result).toEqual([]);
+    it('throws on unparseable response instead of silently returning []', () => {
+      expect(() => MotivationParsers.parseAssessments('not json', testContent)).toThrow();
     });
 
-    it('should recover valid objects when LLM emits stray tokens between array elements', () => {
-      // Regression: gemma4:26b hallucinated a bare `wide: 0,` line between
-      // two well-formed objects, breaking strict JSON.parse. The tolerant
-      // parser must still surface the recoverable objects so the user sees
-      // partial results rather than a silent zero-count "success".
-      const response = `\`\`\`json
-[
-  {
-    "exact": "Alice",
-    "start": 0,
-    "end": 5,
-    "assessment": "First assessment"
-  },
+    it('throws on stray tokens between array elements instead of partially recovering', () => {
+      // Pre-Phase-2 the tolerant walker recovered the two well-formed objects
+      // around a hallucinated `wide: 0,` line. Post-Phase-1 such output cannot
+      // come from a constrained provider, so it is a real parse failure that
+      // must fail the job loudly rather than silently surface partial results.
+      const response = `[
+  { "exact": "Alice", "start": 0, "end": 5, "assessment": "First assessment" },
   wide: 0,
-  {
-    "exact": "Bob",
-    "start": 21,
-    "end": 24,
-    "assessment": "Second assessment"
-  }
-]
-\`\`\``;
+  { "exact": "Bob", "start": 21, "end": 24, "assessment": "Second assessment" }
+]`;
 
-      const result = MotivationParsers.parseAssessments(response, testContent);
-
-      expect(result).toHaveLength(2);
-      expect(result[0].exact).toBe('Alice');
-      expect(result[1].exact).toBe('Bob');
+      expect(() => MotivationParsers.parseAssessments(response, testContent)).toThrow();
     });
   });
 
@@ -266,21 +209,6 @@ describe('MotivationParsers', () => {
       });
     });
 
-    it('should handle markdown-wrapped JSON', () => {
-      const response = '```json\n' + JSON.stringify([
-        {
-          exact: 'Bob stayed home',
-          start: 21,
-          end: 36
-        }
-      ]) + '\n```';
-
-      const result = MotivationParsers.parseTags(response);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].exact).toBe('Bob stayed home');
-    });
-
     it('should filter out tags with empty exact text', () => {
       const response = JSON.stringify([
         {
@@ -295,18 +223,17 @@ describe('MotivationParsers', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('should handle malformed JSON gracefully', () => {
-      const result = MotivationParsers.parseTags('invalid json');
-
-      expect(result).toEqual([]);
+    it('parses a legitimately-empty array as a success with no matches', () => {
+      expect(MotivationParsers.parseTags('[]')).toEqual([]);
     });
 
-    it('should handle non-array response', () => {
+    it('throws on unparseable response instead of silently returning []', () => {
+      expect(() => MotivationParsers.parseTags('invalid json')).toThrow();
+    });
+
+    it('throws on a non-array response instead of silently returning []', () => {
       const response = JSON.stringify({ exact: 'test', start: 0, end: 4 });
-
-      const result = MotivationParsers.parseTags(response);
-
-      expect(result).toEqual([]);
+      expect(() => MotivationParsers.parseTags(response)).toThrow(/array/i);
     });
   });
 
@@ -354,101 +281,5 @@ describe('MotivationParsers', () => {
 
       expect(result).toEqual([]);
     });
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────
-// extractObjectsFromArray — the tolerant array extractor used by every
-// parser above. Shipped with minimal coverage (one end-to-end case via
-// parseAssessments); these direct tests pin the state-machine contract
-// so future edits don't silently break nested-brace / escape handling.
-// ─────────────────────────────────────────────────────────────────────
-
-describe('extractObjectsFromArray', () => {
-  it('parses a well-formed JSON array (fast path)', () => {
-    const result = extractObjectsFromArray('[{"a":1},{"b":2}]');
-    expect(result).toEqual([{ a: 1 }, { b: 2 }]);
-  });
-
-  it('strips ```json markdown fences', () => {
-    const result = extractObjectsFromArray('```json\n[{"a":1}]\n```');
-    expect(result).toEqual([{ a: 1 }]);
-  });
-
-  it('strips plain ``` fences', () => {
-    const result = extractObjectsFromArray('```\n[{"a":1}]\n```');
-    expect(result).toEqual([{ a: 1 }]);
-  });
-
-  it('returns [] for empty input', () => {
-    expect(extractObjectsFromArray('')).toEqual([]);
-    expect(extractObjectsFromArray('   \n\t  ')).toEqual([]);
-  });
-
-  it('returns [] when response has no array brackets at all', () => {
-    expect(extractObjectsFromArray('not json')).toEqual([]);
-    expect(extractObjectsFromArray('{"a":1}')).toEqual([]); // object, not array
-  });
-
-  it('parses an empty JSON array', () => {
-    expect(extractObjectsFromArray('[]')).toEqual([]);
-  });
-
-  it('recovers well-formed objects when stray tokens sit between them (the wide:0 case)', () => {
-    // Regression: gemma4:26b emitted `wide: 0,` between two valid objects.
-    const response = '[{"a":1},\n  wide: 0,\n{"b":2}]';
-    const result = extractObjectsFromArray(response);
-    expect(result).toEqual([{ a: 1 }, { b: 2 }]);
-  });
-
-  it('skips malformed objects but keeps surrounding valid ones', () => {
-    const response = '[{"a":1}, {broken: "no quotes"}, {"c":3}]';
-    const result = extractObjectsFromArray(response);
-    expect(result).toEqual([{ a: 1 }, { c: 3 }]);
-  });
-
-  it('treats braces inside string values as literal, not as object delimiters', () => {
-    // The `}` inside "ugly: }junk" must not close the outer object.
-    const response = '[{"note":"ugly: }junk"},{"b":2}]';
-    const result = extractObjectsFromArray(response);
-    expect(result).toEqual([{ note: 'ugly: }junk' }, { b: 2 }]);
-  });
-
-  it('handles escaped quotes inside strings without losing object boundaries', () => {
-    const response = '[{"quote":"she said \\"hi\\""},{"b":2}]';
-    const result = extractObjectsFromArray(response);
-    expect(result).toEqual([{ quote: 'she said "hi"' }, { b: 2 }]);
-  });
-
-  it('handles multi-line objects across newlines', () => {
-    const response = `[
-  {
-    "a": 1,
-    "b": "two"
-  },
-  {
-    "c": 3
-  }
-]`;
-    const result = extractObjectsFromArray(response);
-    expect(result).toEqual([{ a: 1, b: 'two' }, { c: 3 }]);
-  });
-
-  it('tolerates prose before and after the array', () => {
-    const response = 'Here is the answer:\n[{"a":1}]\n\nThat is all.';
-    const result = extractObjectsFromArray(response);
-    expect(result).toEqual([{ a: 1 }]);
-  });
-
-  it('returns [] when brackets exist but contain nothing recoverable', () => {
-    expect(extractObjectsFromArray('[garbage, more garbage]')).toEqual([]);
-  });
-
-  it('skips an unclosed object at the end but keeps earlier valid ones', () => {
-    // Worker saw a response where the final object was cut off mid-stream.
-    // The tolerant parser should still return whatever closed cleanly.
-    const response = '[{"a":1},{"b":2},{"c":';
-    const result = extractObjectsFromArray(response);
-    expect(result).toEqual([{ a: 1 }, { b: 2 }]);
   });
 });

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -10,7 +10,7 @@
  * fetches it and hands it in.
  */
 
-import type { InferenceClient } from '@semiont/inference';
+import type { InferenceClient, InferenceResponse } from '@semiont/inference';
 import { MotivationPrompts } from './detection/motivation-prompts';
 import {
   MotivationParsers,
@@ -20,6 +20,19 @@ import {
   type TagMatch,
 } from './detection/motivation-parsers';
 import type { TagSchema } from '@semiont/core';
+
+/**
+ * A `max_tokens` stop reason means the model's JSON was cut off mid-stream.
+ * Post-Phase-1 that still yields a syntactically-valid but incomplete array
+ * (structured output serializes whatever was generated), so it would parse
+ * cleanly and silently under-report. Fail the job loudly instead — parity
+ * with the entity-extractor path.
+ */
+function assertNotTruncated(response: InferenceResponse, motivation: string): void {
+  if (response.stopReason === 'max_tokens') {
+    throw new Error(`${motivation} detection response truncated (max_tokens) — increase max_tokens or reduce resource size; failing the job rather than under-reporting annotations.`);
+  }
+}
 
 export class AnnotationDetection {
 
@@ -41,8 +54,9 @@ export class AnnotationDetection {
     sourceLanguage?: string
   ): Promise<CommentMatch[]> {
     const prompt = MotivationPrompts.buildCommentPrompt(content, instructions, tone, density, language, sourceLanguage);
-    const response = await client.generateText(prompt, 3000, 0.4, { format: 'json' });
-    return MotivationParsers.parseComments(response, content);
+    const response = await client.generateTextWithMetadata(prompt, 3000, 0.4, { format: 'json' });
+    assertNotTruncated(response, 'comment');
+    return MotivationParsers.parseComments(response.text, content);
   }
 
   /**
@@ -60,8 +74,9 @@ export class AnnotationDetection {
     sourceLanguage?: string
   ): Promise<HighlightMatch[]> {
     const prompt = MotivationPrompts.buildHighlightPrompt(content, instructions, density, sourceLanguage);
-    const response = await client.generateText(prompt, 2000, 0.3, { format: 'json' });
-    return MotivationParsers.parseHighlights(response, content);
+    const response = await client.generateTextWithMetadata(prompt, 2000, 0.3, { format: 'json' });
+    assertNotTruncated(response, 'highlight');
+    return MotivationParsers.parseHighlights(response.text, content);
   }
 
   /**
@@ -81,8 +96,9 @@ export class AnnotationDetection {
     sourceLanguage?: string
   ): Promise<AssessmentMatch[]> {
     const prompt = MotivationPrompts.buildAssessmentPrompt(content, instructions, tone, density, language, sourceLanguage);
-    const response = await client.generateText(prompt, 3000, 0.3, { format: 'json' });
-    return MotivationParsers.parseAssessments(response, content);
+    const response = await client.generateTextWithMetadata(prompt, 3000, 0.3, { format: 'json' });
+    assertNotTruncated(response, 'assessment');
+    return MotivationParsers.parseAssessments(response.text, content);
   }
 
   /**
@@ -120,8 +136,9 @@ export class AnnotationDetection {
       sourceLanguage
     );
 
-    const response = await client.generateText(prompt, 4000, 0.2, { format: 'json' });
-    const parsedTags = MotivationParsers.parseTags(response);
+    const response = await client.generateTextWithMetadata(prompt, 4000, 0.2, { format: 'json' });
+    assertNotTruncated(response, 'tag');
+    const parsedTags = MotivationParsers.parseTags(response.text);
     return MotivationParsers.validateTagOffsets(parsedTags, content, category);
   }
 }

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -1,5 +1,5 @@
 import type { InferenceClient } from '@semiont/inference';
-import { getLocaleEnglishName, type Logger } from '@semiont/core';
+import { getLocaleEnglishName, isArray, isObject, isString, type Logger } from '@semiont/core';
 
 /**
  * Entity reference extracted from text — pre-reconciliation.
@@ -123,44 +123,53 @@ Example output:
   );
   logger.debug('Got entity extraction response', { responseLength: response.text.length });
 
+  // Truncation is data loss, not "no entities" — check it BEFORE parsing.
+  // Post-Phase-1 a truncated response is a syntactically-valid but incomplete
+  // array (the structured-output path serializes whatever was generated), so
+  // JSON.parse would succeed and the loss would be invisible. Fail loudly.
+  if (response.stopReason === 'max_tokens') {
+    const errorMsg = 'Entity extraction response truncated (max_tokens) — increase max_tokens or reduce resource size; failing the job rather than dropping annotations.';
+    logger.error(errorMsg, { responseLength: response.text.length });
+    throw new Error(errorMsg);
+  }
+
+  // A parse failure used to be swallowed as `[]` — silent data loss
+  // indistinguishable from a legitimately-empty extraction. Surface it as a
+  // thrown error so the job fails (job:failed) and `withSpan` marks the span.
+  let entities: unknown;
   try {
-    // Clean up response if wrapped in markdown
-    let jsonStr = response.text.trim();
-    if (jsonStr.startsWith('```')) {
-      jsonStr = jsonStr.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
-    }
-
-    const entities = JSON.parse(jsonStr);
-    logger.debug('Parsed entities from AI response', { count: entities.length });
-
-    // Check if response was truncated - this is an ERROR condition
-    if (response.stopReason === 'max_tokens') {
-      const errorMsg = `AI response truncated: Found ${entities.length} entities but response hit max_tokens limit. Increase max_tokens or reduce resource size.`;
-      logger.error(errorMsg);
-      throw new Error(errorMsg);
-    }
-
-    return entities
-      .filter((e: any) => {
-        const ok =
-          e && typeof e === 'object' &&
-          typeof e.exact === 'string' &&
-          typeof e.entityType === 'string';
-        if (!ok) {
-          logger.debug('Dropped malformed LLM entity', { entity: e });
-        }
-        return ok;
-      })
-      .map((entity: any): ExtractedEntity => ({
-        exact: entity.exact,
-        entityType: entity.entityType,
-        ...(typeof entity.prefix === 'string' ? { prefix: entity.prefix } : {}),
-        ...(typeof entity.suffix === 'string' ? { suffix: entity.suffix } : {}),
-      }));
+    entities = JSON.parse(response.text.trim());
   } catch (error) {
     logger.error('Failed to parse entity extraction response', {
-      error: error instanceof Error ? error.message : String(error)
+      error: error instanceof Error ? error.message : String(error),
+      response: response.text.slice(0, 500),
     });
-    return [];
+    throw new Error('Failed to parse entity extraction response', {
+      cause: error instanceof Error ? error : new Error(String(error)),
+    });
   }
+
+  if (!isArray(entities)) {
+    logger.error('Failed to parse entity extraction response: expected a JSON array', {
+      response: response.text.slice(0, 500),
+    });
+    throw new Error('Failed to parse entity extraction response: expected a JSON array');
+  }
+
+  logger.debug('Parsed entities from AI response', { count: entities.length });
+
+  return entities
+    .filter((e): e is Record<string, unknown> & { exact: string; entityType: string } => {
+      const ok = isObject(e) && isString(e.exact) && isString(e.entityType);
+      if (!ok) {
+        logger.debug('Dropped malformed LLM entity', { entity: e });
+      }
+      return ok;
+    })
+    .map((entity): ExtractedEntity => ({
+      exact: entity.exact,
+      entityType: entity.entityType,
+      ...(isString(entity.prefix) ? { prefix: entity.prefix } : {}),
+      ...(isString(entity.suffix) ? { suffix: entity.suffix } : {}),
+    }));
 }

--- a/packages/jobs/src/workers/detection/motivation-parsers.ts
+++ b/packages/jobs/src/workers/detection/motivation-parsers.ts
@@ -9,79 +9,36 @@
  * Console statements kept for debugging - consider adding logger parameter in future.
  */
 
-import { reconcileSelector, type AnchorMethod } from '@semiont/core';
+import { reconcileSelector, isObject, isString, type AnchorMethod } from '@semiont/core';
+
 /**
- * Best-effort extractor that pulls a JSON array of objects out of a raw
- * LLM response. Tolerates:
- *   - markdown code fences (``` / ```json)
- *   - prose before/after the array
- *   - stray non-JSON tokens between array elements (a common
- *     hallucination: e.g. a line like `wide: 0,` inserted between two
- *     well-formed objects).
+ * Strict parse of an LLM JSON-array response.
  *
- * Strategy: try strict `JSON.parse` first (fast path); on failure, walk
- * between the outermost `[` and `]` and parse each balanced `{ ... }`
- * object independently, skipping any that don't parse. Returns the
- * recovered objects — callers should still filter/validate fields.
+ * Post-Phase-1 both providers emit syntactically-valid, fence-free JSON
+ * arrays — Anthropic via forced structured tool-use, Ollama via
+ * grammar-constrained sampling — so there is nothing to tolerate. A parse
+ * failure, or a non-array, is a real failure and is surfaced as a throw so
+ * the job fails loudly (`job:failed`) instead of silently returning zero
+ * annotations. A legitimately-empty `[]` parses to an empty array (a success
+ * with no matches).
  *
- * Exported for direct unit testing of the state machine edge cases
- * (nested braces in strings, escape sequences, empty/garbage input).
+ * Replaces the former tolerant `extractObjectsFromArray` walker, deleted
+ * along with the silent-drop policy it served.
  */
-export function extractObjectsFromArray(response: string): unknown[] {
-  let cleaned = response.trim();
-
-  // Strip markdown code fences if present
-  if (cleaned.startsWith('```')) {
-    cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
-  }
-
-  // Fast path: well-formed JSON
+function parseJsonArray(response: string, motivation: string): unknown[] {
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(cleaned);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    // fall through to tolerant parse
+    parsed = JSON.parse(response.trim());
+  } catch (error) {
+    console.error(`[MotivationParsers] Failed to parse AI ${motivation} response:`, error);
+    console.error('Raw response:', response);
+    throw error instanceof Error ? error : new Error(String(error));
   }
-
-  // Tolerant path: extract each top-level `{ ... }` from within the
-  // first `[` / last `]`, parse independently. If the response was
-  // truncated mid-stream (no closing `]`), fall back to end-of-string
-  // so we still recover whatever closed cleanly before the cutoff.
-  const start = cleaned.indexOf('[');
-  if (start === -1) return [];
-  const endBracket = cleaned.lastIndexOf(']');
-  const end = endBracket > start ? endBracket : cleaned.length;
-
-  const inner = cleaned.slice(start + 1, end);
-  const objects: unknown[] = [];
-  let depth = 0;
-  let objStart = -1;
-  let inString = false;
-  let escape = false;
-
-  for (let i = 0; i < inner.length; i++) {
-    const ch = inner[i];
-    if (escape) { escape = false; continue; }
-    if (ch === '\\') { escape = true; continue; }
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
-    if (ch === '{') {
-      if (depth === 0) objStart = i;
-      depth++;
-    } else if (ch === '}') {
-      depth--;
-      if (depth === 0 && objStart !== -1) {
-        try {
-          objects.push(JSON.parse(inner.slice(objStart, i + 1)));
-        } catch {
-          // Skip malformed object
-        }
-        objStart = -1;
-      }
-    }
+  if (!Array.isArray(parsed)) {
+    console.error(`[MotivationParsers] Expected a JSON array for ${motivation} detection, got ${typeof parsed}:`, response);
+    throw new Error(`Expected a JSON array for ${motivation} detection, got ${typeof parsed}`);
   }
-
-  return objects;
+  return parsed;
 }
 
 /**
@@ -135,166 +92,144 @@ export class MotivationParsers {
   /**
    * Parse and validate AI response for comment detection
    *
-   * @param response - Raw AI response string (may include markdown code fences)
+   * @param response - Raw AI response text (a JSON array)
    * @param content - Original content to validate offsets against
    * @returns Array of validated comment matches
+   * @throws if the response is not a parseable JSON array
    */
   static parseComments(response: string, content: string): CommentMatch[] {
-    try {
-      const parsed = extractObjectsFromArray(response);
+    const parsed = parseJsonArray(response, 'comment');
 
-      const valid = parsed.filter((c): c is { exact: string; prefix?: string; suffix?: string; comment: string } =>
-        !!c && typeof c === 'object' &&
-        typeof (c as any).exact === 'string' &&
-        typeof (c as any).comment === 'string' &&
-        (c as any).comment.trim().length > 0
-      );
+    const valid = parsed.filter((c): c is { exact: string; prefix?: string; suffix?: string; comment: string } =>
+      isObject(c) &&
+      isString(c.exact) &&
+      isString(c.comment) &&
+      c.comment.trim().length > 0
+    );
 
-      console.log(`[MotivationParsers] Parsed ${valid.length} valid comments from ${parsed.length} total`);
+    console.log(`[MotivationParsers] Parsed ${valid.length} valid comments from ${parsed.length} total`);
 
-      const validatedComments: CommentMatch[] = [];
-      for (const comment of valid) {
-        const reconciled = reconcileSelector(content, {
-          exact: comment.exact,
-          ...(typeof comment.prefix === 'string' ? { prefix: comment.prefix } : {}),
-          ...(typeof comment.suffix === 'string' ? { suffix: comment.suffix } : {}),
-        });
-        if (!reconciled) {
-          console.warn(`[MotivationParsers] Dropped hallucinated comment "${comment.exact}"`);
-          continue;
-        }
-        logAnchorMethod('comment', comment.exact, reconciled.anchorMethod);
-        validatedComments.push({
-          comment: comment.comment,
-          exact: reconciled.exact,
-          start: reconciled.start,
-          end: reconciled.end,
-          ...(reconciled.prefix !== undefined ? { prefix: reconciled.prefix } : {}),
-          ...(reconciled.suffix !== undefined ? { suffix: reconciled.suffix } : {}),
-        });
+    const validatedComments: CommentMatch[] = [];
+    for (const comment of valid) {
+      const reconciled = reconcileSelector(content, {
+        exact: comment.exact,
+        ...(typeof comment.prefix === 'string' ? { prefix: comment.prefix } : {}),
+        ...(typeof comment.suffix === 'string' ? { suffix: comment.suffix } : {}),
+      });
+      if (!reconciled) {
+        console.warn(`[MotivationParsers] Dropped hallucinated comment "${comment.exact}"`);
+        continue;
       }
-
-      return validatedComments;
-    } catch (error) {
-      console.error('[MotivationParsers] Failed to parse AI comment response:', error);
-      return [];
+      logAnchorMethod('comment', comment.exact, reconciled.anchorMethod);
+      validatedComments.push({
+        comment: comment.comment,
+        exact: reconciled.exact,
+        start: reconciled.start,
+        end: reconciled.end,
+        ...(reconciled.prefix !== undefined ? { prefix: reconciled.prefix } : {}),
+        ...(reconciled.suffix !== undefined ? { suffix: reconciled.suffix } : {}),
+      });
     }
+
+    return validatedComments;
   }
 
   /**
    * Parse and validate AI response for highlight detection
    *
-   * @param response - Raw AI response string (may include markdown code fences)
+   * @param response - Raw AI response text (a JSON array)
    * @param content - Original content to validate offsets against
    * @returns Array of validated highlight matches
+   * @throws if the response is not a parseable JSON array
    */
   static parseHighlights(response: string, content: string): HighlightMatch[] {
-    try {
-      const parsed = extractObjectsFromArray(response);
+    const parsed = parseJsonArray(response, 'highlight');
 
-      const highlights = parsed.filter((h): h is { exact: string; prefix?: string; suffix?: string } =>
-        !!h && typeof h === 'object' &&
-        typeof (h as any).exact === 'string'
-      );
+    const highlights = parsed.filter((h): h is { exact: string; prefix?: string; suffix?: string } =>
+      isObject(h) && isString(h.exact)
+    );
 
-      const validatedHighlights: HighlightMatch[] = [];
-      for (const highlight of highlights) {
-        const reconciled = reconcileSelector(content, {
-          exact: highlight.exact,
-          ...(typeof highlight.prefix === 'string' ? { prefix: highlight.prefix } : {}),
-          ...(typeof highlight.suffix === 'string' ? { suffix: highlight.suffix } : {}),
-        });
-        if (!reconciled) {
-          console.warn(`[MotivationParsers] Dropped hallucinated highlight "${highlight.exact}"`);
-          continue;
-        }
-        logAnchorMethod('highlight', highlight.exact, reconciled.anchorMethod);
-        validatedHighlights.push({
-          exact: reconciled.exact,
-          start: reconciled.start,
-          end: reconciled.end,
-          ...(reconciled.prefix !== undefined ? { prefix: reconciled.prefix } : {}),
-          ...(reconciled.suffix !== undefined ? { suffix: reconciled.suffix } : {}),
-        });
+    const validatedHighlights: HighlightMatch[] = [];
+    for (const highlight of highlights) {
+      const reconciled = reconcileSelector(content, {
+        exact: highlight.exact,
+        ...(typeof highlight.prefix === 'string' ? { prefix: highlight.prefix } : {}),
+        ...(typeof highlight.suffix === 'string' ? { suffix: highlight.suffix } : {}),
+      });
+      if (!reconciled) {
+        console.warn(`[MotivationParsers] Dropped hallucinated highlight "${highlight.exact}"`);
+        continue;
       }
-
-      return validatedHighlights;
-    } catch (error) {
-      console.error('[MotivationParsers] Failed to parse AI highlight response:', error);
-      console.error('Raw response:', response);
-      return [];
+      logAnchorMethod('highlight', highlight.exact, reconciled.anchorMethod);
+      validatedHighlights.push({
+        exact: reconciled.exact,
+        start: reconciled.start,
+        end: reconciled.end,
+        ...(reconciled.prefix !== undefined ? { prefix: reconciled.prefix } : {}),
+        ...(reconciled.suffix !== undefined ? { suffix: reconciled.suffix } : {}),
+      });
     }
+
+    return validatedHighlights;
   }
 
   /**
    * Parse and validate AI response for assessment detection
    *
-   * @param response - Raw AI response string (may include markdown code fences)
+   * @param response - Raw AI response text (a JSON array)
    * @param content - Original content to validate offsets against
    * @returns Array of validated assessment matches
+   * @throws if the response is not a parseable JSON array
    */
   static parseAssessments(response: string, content: string): AssessmentMatch[] {
-    try {
-      const parsed = extractObjectsFromArray(response);
+    const parsed = parseJsonArray(response, 'assessment');
 
-      const assessments = parsed.filter((a): a is { exact: string; prefix?: string; suffix?: string; assessment: string } =>
-        !!a && typeof a === 'object' &&
-        typeof (a as any).exact === 'string' &&
-        typeof (a as any).assessment === 'string'
-      );
+    const assessments = parsed.filter((a): a is { exact: string; prefix?: string; suffix?: string; assessment: string } =>
+      isObject(a) && isString(a.exact) && isString(a.assessment)
+    );
 
-      const validatedAssessments: AssessmentMatch[] = [];
-      for (const assessment of assessments) {
-        const reconciled = reconcileSelector(content, {
-          exact: assessment.exact,
-          ...(typeof assessment.prefix === 'string' ? { prefix: assessment.prefix } : {}),
-          ...(typeof assessment.suffix === 'string' ? { suffix: assessment.suffix } : {}),
-        });
-        if (!reconciled) {
-          console.warn(`[MotivationParsers] Dropped hallucinated assessment "${assessment.exact}"`);
-          continue;
-        }
-        logAnchorMethod('assessment', assessment.exact, reconciled.anchorMethod);
-        validatedAssessments.push({
-          assessment: assessment.assessment,
-          exact: reconciled.exact,
-          start: reconciled.start,
-          end: reconciled.end,
-          ...(reconciled.prefix !== undefined ? { prefix: reconciled.prefix } : {}),
-          ...(reconciled.suffix !== undefined ? { suffix: reconciled.suffix } : {}),
-        });
+    const validatedAssessments: AssessmentMatch[] = [];
+    for (const assessment of assessments) {
+      const reconciled = reconcileSelector(content, {
+        exact: assessment.exact,
+        ...(typeof assessment.prefix === 'string' ? { prefix: assessment.prefix } : {}),
+        ...(typeof assessment.suffix === 'string' ? { suffix: assessment.suffix } : {}),
+      });
+      if (!reconciled) {
+        console.warn(`[MotivationParsers] Dropped hallucinated assessment "${assessment.exact}"`);
+        continue;
       }
-
-      return validatedAssessments;
-    } catch (error) {
-      console.error('[MotivationParsers] Failed to parse AI assessment response:', error);
-      console.error('Raw response:', response);
-      return [];
+      logAnchorMethod('assessment', assessment.exact, reconciled.anchorMethod);
+      validatedAssessments.push({
+        assessment: assessment.assessment,
+        exact: reconciled.exact,
+        start: reconciled.start,
+        end: reconciled.end,
+        ...(reconciled.prefix !== undefined ? { prefix: reconciled.prefix } : {}),
+        ...(reconciled.suffix !== undefined ? { suffix: reconciled.suffix } : {}),
+      });
     }
+
+    return validatedAssessments;
   }
 
   /**
    * Parse the LLM's tag response into raw, pre-reconciliation tag inputs.
    * Reconciliation happens in `validateTagOffsets`, which adds `start`/`end`
    * by anchoring `exact` against the source content.
+   *
+   * @throws if the response is not a parseable JSON array
    */
   static parseTags(response: string): RawTagInput[] {
-    try {
-      const parsed = extractObjectsFromArray(response);
+    const parsed = parseJsonArray(response, 'tag');
 
-      const valid = parsed.filter((t): t is RawTagInput =>
-        !!t && typeof t === 'object' &&
-        typeof (t as any).exact === 'string' &&
-        (t as any).exact.trim().length > 0
-      );
+    const valid = parsed.filter((t): t is RawTagInput =>
+      isObject(t) && isString(t.exact) && t.exact.trim().length > 0
+    );
 
-      console.log(`[MotivationParsers] Parsed ${valid.length} valid tags from ${parsed.length} total`);
+    console.log(`[MotivationParsers] Parsed ${valid.length} valid tags from ${parsed.length} total`);
 
-      return valid;
-    } catch (error) {
-      console.error('[MotivationParsers] Failed to parse AI tag response:', error);
-      return [];
-    }
+    return valid;
   }
 
   /**

--- a/tests/e2e/specs/06-assisted-reference.spec.ts
+++ b/tests/e2e/specs/06-assisted-reference.spec.ts
@@ -2,123 +2,117 @@ import { test, expect } from '../fixtures/auth';
 
 /**
  * Smoke test: the AI-assisted "Annotate References" flow dispatches a
- * job-create request with the selected entity types.
+ * reference-annotation job **and the resulting reference annotations are
+ * actually persisted.**
  *
  * The production chain is:
  *
- *   ReferencesPanel assist widget
- *     → click "Annotate" (✨)
+ *   ReferencesPanel assist widget → click "Annotate" (✨)
  *     → eventBus `mark:assist-request` (local)
- *     → mark-state-unit catches it, calls `client.mark.assist(...)`
+ *     → mark-state-unit → `client.mark.assist(...)`
  *     → namespaces/mark.ts `dispatchAssist`
- *     → bus `job:create` (with jobType="reference-annotation" +
- *       `params.entityTypes`)
- *     → bus `job:created` (with jobId)
- *     → progress polled / forwarded via `mark:progress` /
- *       `mark:assist-finished`.
+ *     → bus `job:create` (jobType="reference-annotation" + params.entityTypes)
+ *     → bus `job:created` (jobId)
+ *     → worker entity-extraction → `mark:added` per entity
+ *     → SSE → BrowseNamespace cache invalidation → references render.
  *
- * We stop at the `job:create` / `job:created` pair. Waiting for
- * completion requires a real LLM response and would make the test
- * slow and flaky; dispatch-level correctness is what we're guarding
- * here (entity-types selected in the UI make it into the params).
+ * Two assertion levels:
+ *   1. **Dispatch** (fast, original regression target): `job:create` →
+ *      `job:created` — the chip-selected entity type reaches the wire.
+ *   2. **Outcome** (Phase 3 of `entity-extraction-silent-drop.md`): after
+ *      the assist runs, ≥1 reference annotation is **persisted** and
+ *      survives a reload.
  *
- * Regression target: the UI's selected entity types failing to reach
- * the wire — e.g. the chip-selection state not being threaded into
- * `mark:assist-request` payload, or the state unit not forwarding to the
- * http-transport. Protocol-level assertion on `job:create` catches
- * either break.
+ * Why the outcome assertion matters: the *previous* version of this spec
+ * stopped at the dispatch pair, so a worker that silently dropped every
+ * extracted entity (the `entity-extraction-silent-drop` bug — JSON parse
+ * failure → `return []`) still passed. This spec is the system-level
+ * guard for that fix (P1 tool-use + P2 de-silence); the deterministic RED
+ * lives in the `@semiont/jobs` unit tests.
  *
- * Requires the seeded KB to have ≥1 entity type defined.
+ * Entity-type choice: **Concept**, not the "first chip" (= `Person`).
+ * The seeded first resource (Photosynthesis) is Concept-dense, so the
+ * extraction reliably yields references; Person/Location would
+ * legitimately return zero on that doc and make the outcome flaky.
+ *
+ * Requires the seeded KB to have the default entity types (incl. Concept).
  */
 test.describe('assisted reference detection', () => {
-  test('selecting entity types and clicking Annotate emits job:create with reference-annotation', async ({ signedInPage: page, bus }) => {
+  test('selecting an entity type and clicking Annotate dispatches the job AND persists reference annotations', async ({ signedInPage: page, bus }) => {
+    test.setTimeout(120_000);  // includes a real LLM entity-extraction round-trip
+
     await page.goto('/en/know/discover');
     const firstCard = page.getByRole('button', { name: /^open resource:/i }).first();
     await expect(firstCard).toBeVisible({ timeout: 15_000 });
     await firstCard.click();
     await expect(page.getByText(/loading resource/i)).toBeHidden({ timeout: 30_000 });
 
+    // Baseline reference count — the KB accumulates across runs, so assert
+    // growth, not an absolute. (Same property test 05 relies on.)
+    const referenceEntries = page.locator('[data-type="reference"]');
+    const refsBefore = await referenceEntries.count();
+
     // Enter annotate mode. The References-panel's "Annotate References"
-    // assist section is only rendered in annotate mode (see ReferencesPanel's
-    // `annotateMode && (...)` guard).
+    // assist section only renders in annotate mode.
     await page.getByRole('button', { name: /^mode$/i }).click();
     await page.getByRole('menuitem', { name: /^annotate$/i }).click();
+    await expect(page.locator('.cm-content').first()).toBeVisible({ timeout: 15_000 });
 
-    const cmContent = page.locator('.cm-content').first();
-    await expect(cmContent).toBeVisible({ timeout: 15_000 });
-
-    // The right sidebar defaults to "Knowledge Base" on a fresh session.
-    // Switch it to "Annotations" so UnifiedAnnotationsPanel mounts and
-    // the References tab becomes reachable. Without this the
-    // "Annotate References" assist section isn't in the DOM at all.
+    // Right sidebar → Annotations → References sub-tab, so the assist
+    // section is in the DOM.
     await page.getByRole('button', { name: /^annotations$/i }).click();
-
-    // Within the annotations panel, select the References sub-tab.
-    // The tab button is just the 🔵 emoji. Use the exact-name match.
     const referencesTab = page.getByRole('button', { name: '🔵', exact: true });
     await expect(referencesTab).toBeVisible({ timeout: 10_000 });
     if ((await referencesTab.getAttribute('aria-pressed')) !== 'true') {
       await referencesTab.click();
     }
 
-    // Expand the "Annotate References" collapsible section. The button
-    // label has a trailing "›" chevron (e.g. "Annotate References ›"),
-    // so match with a substring regex not an anchored one.
+    // Expand the "Annotate References" collapsible (label has a trailing "›").
     const main = page.getByRole('main');
     const assistToggle = main.getByRole('button', { name: /annotate references/i }).first();
     await expect(assistToggle).toBeVisible({ timeout: 10_000 });
-    // If the section is already expanded, `aria-expanded` is "true" and
-    // a subsequent click would collapse it. Only toggle if collapsed.
-    const alreadyOpen = (await assistToggle.getAttribute('aria-expanded')) === 'true';
-    if (!alreadyOpen) await assistToggle.click();
+    if ((await assistToggle.getAttribute('aria-expanded')) !== 'true') await assistToggle.click();
 
-    // The assist widget's entity-type picker uses
-    // `.semiont-chip.semiont-chip--selectable`. Pick the first available
-    // type. This is a distinct picker from the manual-reference
-    // prompt's `.semiont-tag-selector__item` — two different surfaces,
-    // same underlying `entityTypes()` cache.
-    const assistChips = page.locator('.semiont-assist-widget__chips .semiont-chip--selectable');
-    await expect(assistChips.first()).toBeVisible({ timeout: 10_000 });
-    const firstChip = assistChips.first();
-    await firstChip.click();
-    await expect(firstChip).toHaveAttribute('data-selected', 'true');
+    // Select the **Concept** entity-type chip (reliably present in the
+    // Photosynthesis seed text — see docstring). Among the default types
+    // only "Concept" matches /concept/i, so the filter is unambiguous.
+    const conceptChip = page
+      .locator('.semiont-assist-widget__chips .semiont-chip--selectable')
+      .filter({ hasText: /concept/i });
+    await expect(conceptChip).toBeVisible({ timeout: 10_000 });
+    await conceptChip.click();
+    await expect(conceptChip).toHaveAttribute('data-selected', 'true');
 
     bus.clear();
 
-    // Submit button is the ReferencesPanel assist widget's "Annotate" (✨)
-    // action. Scope it by its data attributes (`data-variant="assist"`
-    // + `data-type="reference"`) so we don't hit the identically-labeled
-    // button in another annotation panel.
+    // Click "Annotate" (✨) — scoped by data attrs to the reference assist
+    // so we don't hit an identically-labeled button elsewhere.
     const submitBtn = page.locator('button[data-variant="assist"][data-type="reference"]');
     await expect(submitBtn).toBeVisible({ timeout: 5_000 });
     await expect(submitBtn).toBeEnabled();
     await submitBtn.click();
 
-    // Protocol-level proof: the assist dispatch crossed the wire as a
-    // `job:create` request and the backend acked with `job:created`.
-    // The jobType for `linking` motivation is `reference-annotation`
-    // (see namespaces/mark.ts jobTypeMap).
+    // (1) Dispatch — the assist crossed the wire as a reference-annotation
+    // job and the backend acked. (jobType for `linking` is
+    // `reference-annotation`; see namespaces/mark.ts jobTypeMap.)
     const { request } = await bus.expectRequestResponse('job:create', 'job:created', 30_000);
-
-    // Additional sanity: the emitted request should carry the entity
-    // types we selected. We can't inspect the payload from the bus-log
-    // capture directly, but the emit-count invariant and the fact that
-    // `dispatchAssist` throws synchronously if entityTypes is empty
-    // both combine to tell us the chip-selection state reached the
-    // namespace layer. A dispatch with empty entity types would not
-    // have produced this request at all.
     expect(request.channel).toBe('job:create');
 
-    // UI-level: the progress widget for an in-flight assist appears.
-    // We don't wait for completion — the LLM round-trip is beyond the
-    // scope of a smoke test.
-    const progressWidget = page.locator('[data-testid="annotate-references-progress-widget"], .semiont-assist-progress');
-    // Soft-assert: either the progress widget appears within a short
-    // window, OR the backend completed instantly (edge case). Either is
-    // acceptable for dispatch-level coverage.
-    await Promise.race([
-      progressWidget.first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {}),
-      bus.waitForRecv('mark:assist-finished', { timeout: 10_000 }).catch(() => {}),
-    ]);
+    // (2) Outcome — wait for the extracted references to actually persist
+    // and render. Poll (rather than wait on a finish event) so we tolerate
+    // the LLM round-trip + SSE delivery latency. PRE-FIX this stayed at the
+    // baseline (silent drop → return []); that is the regression guarded.
+    await expect
+      .poll(async () => referenceEntries.count(), { timeout: 90_000 })
+      .toBeGreaterThan(refsBefore);
+
+    // Persistence across reload.
+    const url = page.url();
+    await page.reload();
+    await expect(page).toHaveURL(url);
+    await expect(page.getByText(/loading resource/i)).toBeHidden({ timeout: 30_000 });
+    await expect
+      .poll(async () => referenceEntries.count(), { timeout: 30_000 })
+      .toBeGreaterThan(refsBefore);
   });
 });


### PR DESCRIPTION
## Summary

Fixes **silent data loss** in AI annotation detection. When an LLM response wasn't strictly-parseable JSON, the parse failure was swallowed (`return []`) and the job reported **success with zero annotations** — dropping reference/comment/highlight annotations while `job:complete` fired, with nothing surfaced to the user. Entity-rich documents failed worst: the whole array was parsed in one `JSON.parse`, so a single bad element discarded the entire batch. The e2e suite stayed green over it because spec 06 only asserted the `job:create` emit, not the resulting annotation.

Two trigger variants were confirmed live, both on the Anthropic path:
- **Variant 1** — trailing prose after the JSON array (`stop_reason: end_turn`).
- **Variant 2** — an unescaped `"` inside a verbatim span, malforming the JSON mid-array (near-deterministic for location/entity-dense documents).

**Type of Change:** Bug fix · **Areas:** `packages/inference`, `packages/jobs`, `tests/e2e`

## What changed

**1. `@semiont/inference` — a hard JSON guarantee on Anthropic (source fix).**
`{ format: 'json' }` on the Anthropic client moved from a free-text **prefill** (which only anchored the *start* of the output and couldn't stop trailing prose or bad escaping) to **forced structured tool-use** — a single tool forced via `tool_choice`, whose array result the API serializes as properly-escaped JSON. This eliminates both trigger variants at the source. The array is unwrapped and returned as a top-level JSON array in `.text`, so the cross-provider contract (matching Ollama's grammar-constrained path) is unchanged.

**2. `@semiont/jobs` — stop swallowing parse failures (the actual silent-drop bug).**
Both detection consumers (`entity-extractor.ts`, and `annotation-detection.ts` → `motivation-parsers.ts`) now:
- check for truncation (`stopReason === 'max_tokens'`) **before** parsing, and fail the job loudly rather than under-reporting a cut-off response;
- `throw` on an unparseable / non-array response instead of `return []`, so the failure propagates to a real `job:failed` — counted by the existing `semiont.job.outcome{outcome:failed}` metric — instead of a fake `completed`;
- keep distinguishing a legitimately-empty extraction (success) from a parse failure.
`annotation-detection.ts` now reads `stopReason` via `generateTextWithMetadata`, and the now-superseded tolerant `extractObjectsFromArray` walker is deleted (strict `JSON.parse` on the now-clean source).

**3. `tests/e2e` — close the blind spot.**
Spec 06 (`assisted-reference`) now asserts the run **persists an annotation**, not just that `job:create` crosses the wire — so a regression of this class is caught at the system level.

## Testing

- Unit tests added/updated per package, RED→GREEN: Anthropic tool-use JSON mode (`packages/inference`); fail-loud + truncation behavior for the entity extractor and motivation parsers (`packages/jobs`).
- e2e spec 06 extended to assert annotation persistence.
- Full suite via CI.

## Notes / out of scope

- **Truncation** (`max_tokens`) is now a visible `job:failed` rather than a silent drop, but the underlying remedy (chunking / scaling the token budget) is deliberately out of scope here. It is **not** self-healing — a doc that exceeds the cap re-truncates on retry — so the honest failure is the fix for now.
- **No new telemetry** was added: failure-rate is already visible via the existing job-outcome counter once the drop becomes a real failure. The `truncated` / `unparseable` reason lives in the diagnosability log, not as a metric dimension.
- Annotation **yield/quality dashboards** remain tracked separately in #854, which this fix unblocks — it makes "0 annotations" a trustworthy signal instead of a masked failure.
