### PR TITLE
CI: switch test/build jobs to npm ci — fail-fast on lockfile drift

### DIFF
--- a/.github/workflows/accessibility-tests.yml
+++ b/.github/workflows/accessibility-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build dependencies
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run openapi:bundle
           npm run build --workspace=@semiont/core
           npm run build --workspace=@semiont/http-transport
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build dependencies
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run openapi:bundle
           npm run build --workspace=@semiont/core
           npm run build --workspace=@semiont/http-transport
@@ -166,7 +166,7 @@ jobs:
 
       - name: Build dependencies
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run openapi:bundle
           npm run build --workspace=@semiont/core
           npm run build --workspace=@semiont/http-transport

--- a/.github/workflows/architecture-compliance.yml
+++ b/.github/workflows/architecture-compliance.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install --include=optional
+        run: npm ci --include=optional
 
       - name: Run Raw Bus Access Audit
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build packages
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
 
       - name: Build CLI
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install dependencies and CLI
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
           cd apps/cli && npm run build && npm link
 
@@ -158,7 +158,7 @@ jobs:
 
       - name: Install dependencies and CLI
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
           cd apps/cli && npm run build && npm link
 
@@ -230,7 +230,7 @@ jobs:
 
       - name: Install dependencies and CLI
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
           cd apps/cli && npm run build && npm link
 
@@ -282,7 +282,7 @@ jobs:
 
       - name: Install dependencies and CLI
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
           cd apps/cli && npm run build && npm link
 
@@ -310,7 +310,7 @@ jobs:
 
       - name: Install dependencies and CLI
         run: |
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
           cd apps/cli && npm run build && npm link
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
         cache: 'npm'
 
     - name: Install all dependencies
-      run: npm install --include=optional
+      run: npm ci --include=optional
       continue-on-error: true
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -43,7 +43,7 @@ jobs:
           cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        run: npm install --include=optional
+        run: npm ci --include=optional
 
       - name: Build package dependencies only
         run: |

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies and build packages
         run: |
           cd ../..
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
 
       - name: Build and install CLI
@@ -233,7 +233,7 @@ jobs:
       - name: Install dependencies and build packages
         run: |
           cd ../..
-          npm install --include=optional
+          npm ci --include=optional
           npm run build:packages
 
       - name: Build and install CLI

--- a/docs/development/RELEASE.md
+++ b/docs/development/RELEASE.md
@@ -116,10 +116,17 @@ The bump regenerates `package-lock.json` (`npm install --package-lock-only
 --include=optional`, run in a `node:24` container — the release host has no
 Node) and stages it in the same commit, so the committed lock always records
 the bumped versions. This keeps `npm ci` usable for reproducible/clean installs
-(release seed builds, Docker images). Without it the lock stays one version
-behind after every bump and `npm ci` fails on the lock↔`package.json` mismatch;
-CI hides this because it installs with `npm install`, which silently re-resolves
-and heals the drift. Do not hand-edit the lock to "fix" a version: a
+(release seed builds, Docker images) — and the **CI test/build jobs run
+`npm ci --include=optional`**, so any lockfile drift fails the build loudly at
+install instead of being silently healed by `npm install`. (The publish workflow
+intentionally stays on `npm install` — it stamps `"*"`→exact versions, after
+which the tree no longer matches the committed lock.)
+
+**Contributor rule:** any dependency change must commit the regenerated
+`package-lock.json` — regenerate with `npm install --package-lock-only
+--include=optional` in a `node:24` container; `npm ci` now rejects an out-of-sync
+lock, so an uncommitted lock turns CI red. Do not hand-edit the lock to "fix" a
+version: a
 lockfileVersion-3 file records each workspace version in several interlinked
 places (the `packages` map, app dependency pins, `link: true` entries), and only
 npm rewrites it consistently. `--include=optional` is required so the


### PR DESCRIPTION
## What

Flip the six **test/build** workflows from `npm install --include=optional` to `npm ci --include=optional` — 14 sites:

`ci.yml` (×6), `package-tests.yml`, `security-tests.yml` (×2), `accessibility-tests.yml` (×3), `architecture-compliance.yml`, `codeql-analysis.yml`.

The **publish/release** workflows are deliberately left on `npm install` — they stamp internal `"*"` ranges to exact versions before publishing, after which the tree no longer matches the committed lock, so `npm ci` can't run there.

## Why

`npm install` silently **re-resolves and heals** a drifted lockfile, so CI stays green even when `package-lock.json` is out of sync with the workspace `package.json`s — a stale or uncommitted lock goes unnoticed. `npm ci` instead **fails at install** on any mismatch, so drift surfaces loudly and immediately.

This is safe because the lock is kept honest: the version bump regenerates `package-lock.json` in the same commit, so the precondition `npm ci` needs holds (verified here — every workspace `version` matches the lockfile record).

## Verification

- **RED** — with a deliberately drifted lock (an app pinned to a published `@semiont/*` version the lock doesn't carry), `npm ci` fails at install: `EUSAGE`, *"package.json and package-lock.json … in sync … Missing … from lock file."*
- **GREEN** — clean tree: `npm ci --include=optional` exits 0 with no nested real-dir `@semiont/*` under `apps/*`; confirmed locally in a `node:24` container and across this PR's jobs.

## For contributors

Any dependency change must **commit the regenerated `package-lock.json`** (`npm install --package-lock-only --include=optional` in a `node:24` container) — `npm ci` now rejects an out-of-sync lock, so an uncommitted lock turns CI red. See `docs/development/RELEASE.md` → *Lockfile policy*.
