### PR TITLE
fix: bus request empty error on dispose

### DIFF
--- a/packages/sdk/src/__tests__/bus-request.test.ts
+++ b/packages/sdk/src/__tests__/bus-request.test.ts
@@ -240,6 +240,49 @@ describe('busRequest', () => {
       process.off('unhandledRejection', onUnhandled);
     }
   });
+
+  it('does not leak an unhandled rejection when the bus is disposed while a fire-and-forget request is in flight', async () => {
+    // The reported crash (busrequest-emptyerror-on-dispose): a busRequest whose
+    // `emit` is still pending — so its internal `firstValueFrom` promise has no
+    // awaiter yet — and whose returned promise nobody awaits. When the bus
+    // completes (dispose), pre-fix `firstValueFrom` rejects `EmptyError` with no
+    // handler → unhandledRejection → process crash.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      const bus = makeBus(RESULT, FAILURE);
+      // emit never resolves → busRequest parks at `await bus.emit()`, so its
+      // `await resultPromise` is never reached (resultPromise has no awaiter).
+      bus.emit = vi.fn(() => new Promise<void>(() => {})) as BusRequestPrimitive['emit'];
+
+      // Fire-and-forget: do NOT await the returned promise.
+      void busRequest(bus, EMIT, {}, RESULT, FAILURE);
+      await Promise.resolve();
+
+      // Dispose: complete the underlying subjects, as `semiont.dispose()` does.
+      bus.resultSubject.complete();
+      bus.failureSubject.complete();
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('rejects an awaited request with BusRequestError(bus.closed) when the bus is disposed before a reply', async () => {
+    const bus = makeBus(RESULT, FAILURE);
+    const promise = busRequest(bus, EMIT, {}, RESULT, FAILURE);
+    await Promise.resolve(); // let emit resolve; busRequest now awaits the reply
+
+    // Dispose before any reply arrives.
+    bus.resultSubject.complete();
+    bus.failureSubject.complete();
+
+    await expect(promise).rejects.toMatchObject({ code: 'bus.closed' });
+  });
 });
 
 describe('BusRequestError', () => {

--- a/packages/sdk/src/bus-request.ts
+++ b/packages/sdk/src/bus-request.ts
@@ -1,10 +1,11 @@
 import { Observable, firstValueFrom, merge, throwError, TimeoutError } from 'rxjs';
-import { catchError, filter, map, take, timeout } from 'rxjs/operators';
+import { catchError, defaultIfEmpty, filter, map, take, timeout } from 'rxjs/operators';
 import { SemiontError, type EventMap } from '@semiont/core';
 
 export type BusRequestErrorCode =
   | 'bus.timeout'
   | 'bus.rejected'
+  | 'bus.closed'
   | 'bus.bad-payload'
   | 'bus.unauthorized'
   | 'bus.forbidden'
@@ -72,30 +73,32 @@ export async function busRequest<TResult>(
       }
       return throwError(() => err);
     }),
+    // If the stream completes with no value — the bus was disposed before a
+    // reply (e.g. during `semiont.dispose()` with a request in flight) —
+    // resolve to a typed `bus.closed` result instead of letting `firstValueFrom`
+    // throw rxjs `EmptyError`. An awaited caller then gets a clean
+    // BusRequestError; an in-flight promise nobody is awaiting simply resolves,
+    // so it can't surface as an unhandled rejection on dispose.
+    // See .plans/bugs/busrequest-emptyerror-on-dispose.md.
+    defaultIfEmpty({
+      ok: false as const,
+      error: new BusRequestError(
+        `Bus closed before a reply on ${resultChannel}`,
+        'bus.closed',
+        { channel: emitChannel, resultChannel, correlationId },
+      ),
+    }),
   );
 
   // Subscribe before emitting so we don't miss an instantaneous reply
   // (which can happen with an in-process LocalTransport bus).
   const resultPromise = firstValueFrom(result$);
 
-  try {
-    await bus.emit(emitChannel as keyof EventMap, fullPayload as EventMap[keyof EventMap]);
-  } catch (err) {
-    // If emit threw, control is about to leave this function without
-    // anyone awaiting `resultPromise`. Its subscription stays open
-    // until the bus completes (e.g. during `semiont.dispose()`), at
-    // which point firstValueFrom throws EmptyError with no consumer —
-    // surfacing as an uncaught rejection in skill scripts as a
-    // cosmetic stack trace after `Done.`.
-    //
-    // Attach a no-op handler so the eventual rejection has somewhere
-    // to land. We can't actively cancel the firstValueFrom
-    // subscription (its Promise type exposes no handle), but
-    // suppressing its unhandled-rejection is enough; the bus's
-    // natural lifecycle tears the subscription down whenever it ends.
-    resultPromise.catch(() => {});
-    throw err;
-  }
+  // No guard around emit: an emit rejection propagates to the caller
+  // naturally, and `result$`'s `defaultIfEmpty` guarantees `resultPromise`
+  // *resolves* (never rejects) when the bus is disposed before a reply — so it
+  // cannot leak an unhandled rejection regardless of whether anyone awaits it.
+  await bus.emit(emitChannel as keyof EventMap, fullPayload as EventMap[keyof EventMap]);
 
   const result = await resultPromise;
   if (!result.ok) {

--- a/specs/src/paths/api_resources_{id}.json
+++ b/specs/src/paths/api_resources_{id}.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "summary": "Get a resource's stored representation (browser-friendly alias)",
-    "description": "Identical pipe to GET /resources/{id} — verbatim bytes, stored media type in Content-Type, Accept never read. Exists only as the auth affordance for `<img>` / PDF.js / download links, which cannot carry Authorization headers: the `?token=` media token or the httpOnly semiont-token cookie ride along automatically.\n\nResponses carry `Cache-Control: public, max-age=31536000, immutable` — `public` is safe here, unlike the bearer-authenticated main route, because the `?token=` is part of the cache key.",
+    "description": "Identical pipe to GET /resources/{id} — verbatim bytes, stored media type in Content-Type, Accept never read. Exists only as the auth affordance for `<img>` / PDF.js / download links, which cannot carry Authorization headers: the `?token=` media token rides along automatically.\n\nResponses carry `Cache-Control: public, max-age=31536000, immutable` — `public` is safe here, unlike the bearer-authenticated main route, because the `?token=` is part of the cache key.",
     "tags": ["Resources"],
     "security": [
       { "bearerAuth": [] }


### PR DESCRIPTION
## Summary

Fixes an intermittent teardown race where an in-flight `busRequest` could turn a routine `dispose()` into an **uncatchable process crash**, plus a small OpenAPI doc correction.

## `fix(sdk)`: `busRequest` resolves on dispose instead of throwing `EmptyError`

A `busRequest` still in flight when the bus is disposed had its internal `firstValueFrom(result$)` reject with rxjs `EmptyError` (*"no elements in sequence"*). With no awaiter (the `emit` was still pending, so `await resultPromise` was never reached), that surfaced as an **unhandled rejection raised inside `events$.complete()` during `client.dispose()`** — outside any caller `try/catch` — which intermittently failed e2e specs (e.g. spec 12, and a cold-backend `globalSetup`).

**Fix** — `packages/sdk/src/bus-request.ts`:
- Append `defaultIfEmpty(<sentinel>)` to the `result$` pipe so an empty completion (bus disposed before a reply) makes `firstValueFrom` **resolve** to a typed `{ ok: false, error: BusRequestError('bus.closed') }` instead of throwing `EmptyError`.
- Add `'bus.closed'` to `BusRequestErrorCode`.
- Remove the old `try/catch`-around-`emit` guard (`resultPromise.catch(() => {})`) — now subsumed: with `defaultIfEmpty`, `resultPromise` resolves rather than rejects on dispose-empty, so it can't leak regardless of whether anyone awaits it.

**Behavior after the fix:**
- An **awaited** caller gets a clean `BusRequestError` with `code: 'bus.closed'`.
- An in-flight request nobody is awaiting (emit pending) simply **resolves** — no unhandled rejection on dispose.

**Tests** — `packages/sdk/src/__tests__/bus-request.test.ts` (TDD, RED→GREEN):
- Crash repro: fire-and-forget request with `emit` pending → bus disposed → assert **no** `process` `unhandledRejection`.
- Awaited ergonomic: awaited request, bus disposed before reply → rejects with `BusRequestError(bus.closed)`.
- The existing emit-threw regression stays green.

**Verification:** sdk `tsc --noEmit` clean; `bus-request.test.ts` **13/13**.

> Known residual (out of scope here, tracked separately): a *fire-and-forget* caller whose `emit` has already resolved still throws `bus.closed` on its returned promise. No SDK-internal call site hits this (all `await`/`return`/`.then().catch()`); it's reachable only by a consumer that fires-and-forgets a busRequest-backed SDK promise.

## `docs(specs)`: drop the cookie reference from the resources alias route

`specs/src/paths/api_resources_{id}.json` — the `GET /api/resources/{id}` ("browser-friendly alias") description previously said the `?token=` media token **or the httpOnly `semiont-token` cookie** rides along. Removed the cookie mention so the only stated auth affordance is the `?token=` media token, aligning the doc with the cookie-removal direction. Description text only — no schema/shape change, so no generated-types regeneration required.

## Areas changed

- Core SDK (`packages/sdk`) — bug fix + tests
- OpenAPI Specs (`specs/`) — description-only doc fix
