### PR TITLE
feat(sdk): add StreamObservable/UploadObservable.run() + warn on cold…

### DIFF
--- a/packages/sdk/src/__tests__/awaitable.test.ts
+++ b/packages/sdk/src/__tests__/awaitable.test.ts
@@ -17,7 +17,8 @@
 import { describe, expect, it } from 'vitest';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { CacheObservable, StreamObservable } from '../awaitable';
+import { resourceId as toResourceId } from '@semiont/core';
+import { CacheObservable, StreamObservable, UploadObservable } from '../awaitable';
 
 describe('StreamObservable', () => {
   it('await resolves to the last emitted value', async () => {
@@ -144,5 +145,78 @@ describe('CacheObservable', () => {
     const wrapped = CacheObservable.from(source);
     expect(wrapped).toBeInstanceOf(CacheObservable);
     expect(await wrapped).toBe('hello');
+  });
+});
+
+describe('StreamObservable.run', () => {
+  it('subscribes the producer exactly ONCE — progress via callback, terminal via the promise (A2 fix)', async () => {
+    let subscribeCount = 0;
+    const stream = new StreamObservable<string>((subscriber) => {
+      subscribeCount += 1;
+      subscriber.next('progress');
+      subscriber.next('done');
+      subscriber.complete();
+    });
+    const seen: string[] = [];
+    const last = await stream.run((v) => seen.push(v));
+    expect(subscribeCount).toBe(1);
+    expect(seen).toEqual(['progress', 'done']);
+    expect(last).toBe('done');
+  });
+
+  it('rejects when the source errors', async () => {
+    const stream = new StreamObservable<number>((subscriber) => {
+      subscriber.next(1);
+      subscriber.error(new Error('boom'));
+    });
+    await expect(stream.run(() => {})).rejects.toThrow('boom');
+  });
+
+  it('rejects when the source completes without emitting (mirrors lastValueFrom)', async () => {
+    const stream = new StreamObservable<number>((subscriber) => {
+      subscriber.complete();
+    });
+    await expect(stream.run(() => {})).rejects.toThrow();
+  });
+
+  it('characterizes the A2 footgun: subscribe + await fires a COLD producer TWICE', async () => {
+    // The trap `run()` exists to avoid. Pinned so the MULTICAST-JOB-TRIGGERS
+    // redesign (which would make this 1) is a deliberate, tested flip — not a
+    // silent behavior change.
+    let subscribeCount = 0;
+    const stream = new StreamObservable<number>((subscriber) => {
+      subscribeCount += 1;
+      subscriber.next(1);
+      subscriber.complete();
+    });
+    stream.subscribe({ next: () => {} });
+    await stream;
+    expect(subscribeCount).toBe(2);
+  });
+});
+
+describe('UploadObservable.run', () => {
+  it('forwards each progress event and resolves { resourceId } from ONE subscription', async () => {
+    let subscribeCount = 0;
+    const upload = new UploadObservable((subscriber) => {
+      subscribeCount += 1;
+      subscriber.next({ phase: 'started', totalBytes: 10 });
+      subscriber.next({ phase: 'progress', bytesUploaded: 5, totalBytes: 10 });
+      subscriber.next({ phase: 'finished', resourceId: toResourceId('res-1') });
+      subscriber.complete();
+    });
+    const phases: string[] = [];
+    const result = await upload.run((e) => phases.push(e.phase));
+    expect(subscribeCount).toBe(1);
+    expect(phases).toEqual(['started', 'progress', 'finished']);
+    expect(result).toEqual({ resourceId: toResourceId('res-1') });
+  });
+
+  it('rejects if the terminal event is not "finished"', async () => {
+    const upload = new UploadObservable((subscriber) => {
+      subscriber.next({ phase: 'started', totalBytes: 0 });
+      subscriber.complete();
+    });
+    await expect(upload.run(() => {})).rejects.toThrow();
   });
 });

--- a/packages/sdk/src/awaitable.ts
+++ b/packages/sdk/src/awaitable.ts
@@ -9,6 +9,14 @@
  * `firstValueFrom` wrappers; reactive consumers keep using `.subscribe(...)`
  * and `.pipe(...)` exactly as before.
  *
+ * ⚠️ Pick ONE consumption per instance. These are **cold** Observables, so
+ * `await` and `.subscribe(...)` each re-run the producer — doing both on the
+ * same `StreamObservable`/`UploadObservable` fires the underlying job/upload
+ * *twice* (`.then` calls `lastValueFrom`, which subscribes again). To get
+ * progress *and* the terminal result from a single execution, use `.run(onNext)`.
+ * A hot/multicast redesign that removes the footgun is proposed in
+ * `.plans/MULTICAST-JOB-TRIGGERS.md`.
+ *
  * The asymmetric `.then()` semantics — last-value-on-completion for streams,
  * first-non-undefined-value for caches — is encoded by the subclass name. The
  * docstring on the namespace method tells the consumer which one applies.
@@ -18,7 +26,7 @@
  * RxJS land; `lastValueFrom` from `rxjs` is the right bridge there.
  */
 
-import { Observable, firstValueFrom, lastValueFrom } from 'rxjs';
+import { Observable, EmptyError, firstValueFrom, lastValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import type { ResourceId } from '@semiont/core';
 
@@ -28,7 +36,8 @@ import type { ResourceId } from '@semiont/core';
  * `mark.assist`, `gather.annotation`, `match.search`, `yield.fromAnnotation`.
  *
  * Awaiting resolves to the **last** emitted value (via `lastValueFrom`).
- * Subscribing yields every emission, ending in `complete`.
+ * Subscribing yields every emission, ending in `complete`. **Do not do both on
+ * one instance** (see the module note); use `run()` for progress + result.
  */
 export class StreamObservable<T> extends Observable<T> implements PromiseLike<T> {
   then<R1 = T, R2 = never>(
@@ -36,6 +45,33 @@ export class StreamObservable<T> extends Observable<T> implements PromiseLike<T>
     onrejected?: ((e: unknown) => R2 | PromiseLike<R2>) | null,
   ): PromiseLike<R1 | R2> {
     return lastValueFrom(this).then(onfulfilled, onrejected);
+  }
+
+  /**
+   * Subscribe **once**, delivering every emission to `onNext`, and resolve to
+   * the last emitted value on completion (rejects on error, or with rxjs
+   * `EmptyError` if the stream completes without emitting). The
+   * single-subscription way to consume progress *and* the terminal result from
+   * a job-triggering stream — unlike `.subscribe(...)` + `await`, which re-runs
+   * this cold Observable and fires the underlying job twice.
+   */
+  run(onNext: (value: T) => void): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let last!: T;
+      let hasValue = false;
+      this.subscribe({
+        next: (v) => {
+          hasValue = true;
+          last = v;
+          onNext(v);
+        },
+        error: reject,
+        complete: () => {
+          if (hasValue) resolve(last);
+          else reject(new EmptyError());
+        },
+      });
+    });
   }
 
   /** Wrap an existing Observable's subscribe behavior in a StreamObservable. */
@@ -148,5 +184,29 @@ export class UploadObservable extends Observable<UploadProgress> implements Prom
       const result = { resourceId: v.resourceId };
       return onfulfilled ? onfulfilled(result) : (result as unknown as R1);
     }, onrejected);
+  }
+
+  /**
+   * Subscribe **once**, delivering every `UploadProgress` event to `onNext`, and
+   * resolve to `{ resourceId }` from the `finished` event (rejects on error, or
+   * if the terminal event isn't `finished`). The single-subscription way to
+   * track upload progress *and* get the resource id — unlike `.subscribe(...)` +
+   * `await`, which re-runs this cold Observable and uploads twice.
+   */
+  run(onNext: (event: UploadProgress) => void): Promise<{ resourceId: ResourceId }> {
+    return new Promise<{ resourceId: ResourceId }>((resolve, reject) => {
+      let last: UploadProgress | undefined;
+      this.subscribe({
+        next: (e) => {
+          last = e;
+          onNext(e);
+        },
+        error: reject,
+        complete: () => {
+          if (last?.phase === 'finished') resolve({ resourceId: last.resourceId });
+          else reject(new Error(`UploadObservable completed on a non-finished event: ${last?.phase ?? '<none>'}`));
+        },
+      });
+    });
   }
 }


### PR DESCRIPTION
… double-fire

Subscribing AND awaiting the same StreamObservable/UploadObservable fires the underlying job/upload twice: they're cold Observables, and `.then` calls lastValueFrom, which subscribes again — so a duplicate LLM generation or upload per call, silently (reported externally: my-chat SDK-FRICTION-LOG A2).
- run(onNext): subscribe once; deliver every emission to onNext and resolve the terminal (StreamObservable → last value / EmptyError on empty; UploadObservable → { resourceId } from the finished event). The single-subscription way to get progress + result.
- Docstrings: warn that await + subscribe on one instance double-fires; point to run() and the multicast proposal. awaitable.test.ts: run() single-subscription + last-value/error/empty cases for both classes, plus a characterization test pinning the cold subscribe+await = 2-subscription footgun (the ledger entry the root multicast fix will flip). sdk tsc clean; awaitable.test.ts 17/17.

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Infrastructure/DevOps changes

## Areas Changed

- [ ] Frontend (`apps/frontend`)
- [ ] Backend (`apps/backend`)
- [ ] CLI (`apps/cli`)
- [ ] HTTP Transport (`packages/http-transport`)
- [ ] Core (`packages/core`)
- [ ] MCP Server (`packages/mcp-server`)
- [ ] Test Utils (`packages/test-utils`)
- [ ] OpenAPI Specs (`specs/`)
- [ ] Demo Scripts (`demo/`)
- [ ] Documentation (`docs/`)
- [ ] GitHub Actions (`.github/workflows/`)
- [ ] Scripts (`scripts/`)
- [ ] Infrastructure/Deployment

## Security Checklist

**Required for all PRs that modify authentication, authorization, or admin functionality:**

### Authentication & Authorization

- [ ] No authentication logic moved to client-side
- [ ] All admin routes properly protected with server-side checks
- [ ] JWT tokens validated server-side only
- [ ] Session data comes from secure sources (database, not client claims)
- [ ] No hardcoded secrets or credentials

### Admin Route Security (Frontend)

- [ ] Admin/moderate routes protected by middleware (proxy.ts)
- [ ] No admin content rendered for unauthorized users
- [ ] No sensitive information in error responses

### API Security (Backend)

- [ ] Admin endpoints protected with `adminMiddleware`
- [ ] All endpoints return proper HTTP status codes (401/403/500)
- [ ] Error messages don't leak sensitive information
- [ ] Database queries protected behind authentication
- [ ] Input validation implemented

### Information Disclosure Prevention

- [ ] No database connection strings in error messages
- [ ] No file paths or stack traces exposed to clients
- [ ] No user emails or personal data in unauthorized responses
- [ ] No API keys or secrets in client-accessible responses
- [ ] Error messages are generic and safe

## Testing

- [ ] Added tests for new functionality
- [ ] All existing tests pass
- [ ] Security tests pass (`npm run test:security`)
- [ ] Manual testing completed for authentication flows
- [ ] Tested with different user roles (unauthenticated, non-admin, admin)

## Security Test Results

Please run and paste results:

### Frontend Security Tests

```bash
cd apps/frontend && npm run test:security
# Paste results here
```

### Backend Security Tests

```bash
cd apps/backend && npm run test:security
# Paste results here
```

### Manual Security Verification

If you modified admin routes, please verify:

```bash
# Start the application and test:
curl -I http://localhost:3000/admin
# Should return: HTTP/1.1 200 OK (not 307)

# Verify no admin content leakage:
curl -s http://localhost:3000/admin | grep -i "admin\|dashboard\|management"
# Should return no results
```

## Performance Impact

- [ ] No significant performance degradation
- [ ] Database queries optimized
- [ ] No N+1 query problems introduced
- [ ] Bundle size impact considered (for frontend changes)

## Breaking Changes

If this PR introduces breaking changes, please describe:

- What breaks
- Migration path for users
- Documentation updates needed

## Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] API documentation updated (if applicable)
- [ ] Security documentation updated (if security-related)

## Additional Context

Add any other context, screenshots, or information about the pull request here.

---

## For Reviewers

### Security Review Required

- [ ] Authentication/authorization changes reviewed
- [ ] No security regressions introduced
- [ ] Error handling doesn't leak sensitive data
- [ ] All security tests passing
- [ ] Manual security verification completed

### Code Review

- [ ] Code follows project conventions
- [ ] No obvious bugs or issues
- [ ] Performance considerations addressed
- [ ] Tests provide adequate coverage
- [ ] Documentation is clear and accurate

### Final Checks

- [ ] All CI checks passing
- [ ] Security tests passing
- [ ] No merge conflicts
- [ ] Ready for deployment

---

**⚠️ SECURITY NOTICE:** If any security tests fail or if this PR modifies authentication/authorization logic, **DO NOT MERGE** until security issues are resolved and all tests pass.
