### PR TITLE
resource level anchor test

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -21,7 +21,7 @@ container run --rm \
   -e E2E_FRONTEND_URL=http://<frontend-ip>:3000 \
   -e E2E_BACKEND_URL=http://<backend-ip>:4000 \
   -e CI=1 \
-  mcr.microsoft.com/playwright:v1.60.0-noble \
+  mcr.microsoft.com/playwright:v1.61.0-noble \
   npx playwright test
 ```
 
@@ -62,7 +62,7 @@ container run --rm \
   -e E2E_FRONTEND_URL=http://192.168.64.1:3000 \
   -e E2E_BACKEND_URL=http://192.168.64.1:4000 \
   -e CI=1 \
-  mcr.microsoft.com/playwright:v1.60.0-noble \
+  mcr.microsoft.com/playwright:v1.61.0-noble \
   npx playwright test
 ```
 

--- a/tests/e2e/docs/containers.md
+++ b/tests/e2e/docs/containers.md
@@ -138,7 +138,7 @@ its IP will change — re-grab it before re-running e2e.
 ## Playwright image tag must match `@playwright/test`
 
 The container invocation pins a specific tag:
-`mcr.microsoft.com/playwright:v1.60.0-noble`. If `npm install`
+`mcr.microsoft.com/playwright:v1.61.0-noble`. If `npm install`
 upgrades `@playwright/test`, pull the matching image:
 
 ```sh

--- a/tests/e2e/docs/running.md
+++ b/tests/e2e/docs/running.md
@@ -50,7 +50,7 @@ container run --rm \
   -e E2E_FRONTEND_URL=http://<frontend-ip>:3000 \
   -e E2E_BACKEND_URL=http://<backend-ip>:4000 \
   -e CI=1 \
-  mcr.microsoft.com/playwright:v1.60.0-noble \
+  mcr.microsoft.com/playwright:v1.61.0-noble \
   npx playwright test
 ```
 
@@ -82,7 +82,7 @@ container so its glibc matches what Playwright was built against):
 container run --rm \
   -v "$(git rev-parse --show-toplevel):/workspace" \
   -w /workspace/tests/e2e \
-  mcr.microsoft.com/playwright:v1.60.0-noble \
+  mcr.microsoft.com/playwright:v1.61.0-noble \
   npm install
 ```
 

--- a/tests/e2e/specs/15-resource-level-anchor.spec.ts
+++ b/tests/e2e/specs/15-resource-level-anchor.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { SemiontClient } from '@semiont/sdk';
+import { getTargetSource, getTargetSelector, getBodySource } from '@semiont/core';
+import { BACKEND_URL, E2E_EMAIL, E2E_PASSWORD } from '../playwright.config';
+
+/**
+ * Smoke test — RESOURCE-LEVEL-ANCHOR.md Phase 5 (verify): a whole-resource
+ * (source-only, *selectorless*) annotation is a first-class target — it is
+ * created, served by `browse.annotations`, and its `SpecificResource` body
+ * edge resolves to the linked resource.
+ *
+ * This is a pure **SDK round-trip** (no browser): the feature has no UI
+ * affordance; its consumers are the SDK and fleet skills (e.g. the newsroom
+ * Claim→Source binder). The edge shape mirrors the canonical pattern in
+ * `semiont-newsroom-kb/skills/bind-claim-to-source` — a source-only `target`
+ * with a `SpecificResource` body.
+ *
+ * RED→GREEN: before P2 (#908), `@semiont/core`'s `assembleAnnotation` hard-threw
+ * "Either TextPositionSelector, SvgSelector, or FragmentSelector is required" on
+ * a selectorless target, so the `mark.annotation` below would reject. P2 deleted
+ * that throw — a successful create + serve IS the verification that whole-resource
+ * targets are now first-class. (Deterministic RED lives in the `@semiont/core`
+ * unit test; this is the system-level guard against the live stack.)
+ *
+ * Self-seeding: creates its own two resources, so it doesn't depend on the
+ * global seed's fixtures.
+ */
+test.describe('resource-level anchor', () => {
+  test('a source-only (whole-resource) annotation is created, served, and its edge resolves', async () => {
+    test.setTimeout(60_000);
+
+    const client = await SemiontClient.signInHttp({
+      baseUrl: BACKEND_URL,
+      email: E2E_EMAIL,
+      password: E2E_PASSWORD,
+    });
+
+    try {
+      // Two resources: "claim" A (the annotation target) and "source" B (the edge target).
+      const a = (
+        await client.yield.resource({
+          name: 'P5 Claim',
+          storageUri: 'file://e2e/p5-claim.txt',
+          file: Buffer.from('A claim that needs a supporting source.', 'utf-8'),
+          format: 'text/plain',
+          language: 'en',
+        })
+      ).resourceId;
+      const b = (
+        await client.yield.resource({
+          name: 'P5 Source',
+          storageUri: 'file://e2e/p5-source.txt',
+          file: Buffer.from('The supporting source document.', 'utf-8'),
+          format: 'text/plain',
+          language: 'en',
+        })
+      ).resourceId;
+
+      // Whole-resource edge A→B: a source-only target (no selector) with a
+      // SpecificResource body. Pre-P2 this threw "selector required"; that it
+      // returns an id at all is the core assertion of the feature.
+      const { annotationId } = await client.mark.annotation({
+        target: { source: a },
+        motivation: 'linking',
+        body: [
+          { type: 'SpecificResource', source: b, purpose: 'linking' },
+          { type: 'TextualBody', purpose: 'tagging', value: 'supports' },
+        ],
+      });
+      expect(annotationId, 'source-only annotation was created (not rejected)').toBeTruthy();
+
+      // Served by browse.annotations(A) — poll for SSE/cache delivery.
+      await expect
+        .poll(async () => (await client.browse.annotations(a)).some((x) => x.id === annotationId), {
+          timeout: 30_000,
+        })
+        .toBe(true);
+
+      const created = (await client.browse.annotations(a)).find((x) => x.id === annotationId);
+      expect(created, 'annotation served by browse.annotations').toBeTruthy();
+
+      // Source-only: target points at A with NO selector.
+      expect(getTargetSource(created!.target)).toBe(a);
+      expect(getTargetSelector(created!.target), 'whole-resource target carries no selector').toBeFalsy();
+
+      // The SpecificResource body edge resolves to B.
+      expect(getBodySource(created!.body)).toBe(b);
+    } finally {
+      client.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## RESOURCE-LEVEL-ANCHOR — Phase 5: e2e verification of whole-resource annotation targets

System-level guard for the feature landed in [#908](https://github.com/The-AI-Alliance/semiont/pull/908) (P1–P3): a **source-only (selectorless) annotation** — a whole resource as a first-class target — is created, served, and its body edge resolves against the live stack.

### New e2e spec — `tests/e2e/specs/15-resource-level-anchor.spec.ts`

A pure **SDK round-trip** (no browser — the feature has no UI affordance; its consumers are the SDK and fleet skills like the newsroom Claim→Source binder). Self-seeding, so it doesn't depend on the global seed fixtures. It:

1. Creates two resources — a "claim" A (the annotation target) and a "source" B (the edge target).
2. Creates a whole-resource edge **A→B**: `mark.annotation` with a **source-only `target` (no selector)** and a `SpecificResource` body pointing at B (mirroring `semiont-newsroom-kb/skills/bind-claim-to-source`).
3. Asserts the annotation is created (returns an id — not rejected), is served by `browse.annotations(A)` (polled for SSE/cache delivery), that its **target carries no selector**, and that the `SpecificResource` **body edge resolves to B**.

**RED→GREEN:** before P2, `@semiont/core`'s `assembleAnnotation` hard-threw *"Either TextPositionSelector, SvgSelector, or FragmentSelector is required"* on a selectorless target, so this `mark.annotation` would have rejected. P2 deleted that throw — a successful create + serve **is** the verification. The deterministic RED lives in the `@semiont/core` unit test; this is the system-level guard against a running stack.

### Playwright image bump — e2e docs

Bumps the pinned container image `mcr.microsoft.com/playwright:v1.60.0-noble` → `v1.61.0-noble` in `tests/e2e/{README.md,docs/containers.md,docs/running.md}`, keeping the container tag matched to the installed `@playwright/test` (the glibc-match requirement those docs call out).
