### PR TITLE
vectors: exclude resources by entity type from similarity search (EXCLUDE-VECTORS 1 + 2a)

### DIFF
--- a/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
+++ b/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
@@ -76,11 +76,12 @@ export function annotationEvent(resourceId: string, annotationId: string, exact:
   };
 }
 
-export function resourceDescriptor(id: string, mediaType = 'text/plain', checksum?: string): ResourceDescriptor {
+export function resourceDescriptor(id: string, mediaType = 'text/plain', checksum?: string, entityTypes: string[] = []): ResourceDescriptor {
   return {
     '@context': 'https://schema.org',
     '@id': id,
     name: id,
+    ...(entityTypes.length ? { entityTypes } : {}),
     representations: [{ mediaType, storageUri: `file://${id}.txt`, ...(checksum ? { checksum } : {}) }],
   };
 }
@@ -173,6 +174,12 @@ export function createFakeKsBus(
             offset,
             limit,
           },
+        }));
+      } else if (name === 'browse:resource-requested') {
+        const resource = resources.find((r) => r['@id'] === request.resourceId);
+        queueMicrotask(() => channel('browse:resource-result').next({
+          correlationId: request.correlationId,
+          response: { resource },
         }));
       } else if (name === 'browse:annotations-requested') {
         const annotations = annotationsByResource.get(request.resourceId as string) ?? [];

--- a/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
@@ -594,13 +594,13 @@ describe('Smelter axioms', () => {
             if (div.preIndexed[i]) {
               await h.store.upsertResourceVectors(makeResourceId(catalog[i].rid), [
                 { chunkIndex: 0, text: catalog[i].text, embedding: deterministicEmbed(catalog[i].text) },
-              ], calculateChecksum(catalog[i].text));
+              ], calculateChecksum(catalog[i].text), []);
             }
           }
           for (const rid of div.orphanRids) {
             await h.store.upsertResourceVectors(makeResourceId(rid), [
               { chunkIndex: 0, text: 'orphan', embedding: deterministicEmbed('orphan') },
-            ], calculateChecksum('orphan'));
+            ], calculateChecksum('orphan'), []);
           }
           for (const aid of div.orphanAids) {
             await h.store.upsertAnnotationVector(makeAnnotationId(aid), deterministicEmbed(aid), {

--- a/packages/make-meaning/src/__tests__/smelter.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter.test.ts
@@ -250,6 +250,28 @@ describe('Smelter.reconcile', () => {
   // equality cannot: no wasted re-embedding, the catalog page boundary,
   // and the failure state machine.
 
+  it('stamps a resource\'s entityTypes (read from the descriptor) onto its vectors', async () => {
+    const text = 'What is the capital of France?';
+    const checksum = calculateChecksum(text);
+    contentByResourceId.set('res-q', text);
+
+    // entityTypes live on the descriptor (the catalog), not the event payload —
+    // the smelter reads the authoritative current state, so reconcile stamps them.
+    const smelter = createSmelter([resourceDescriptor('res-q', 'text/plain', checksum, ['Question'])]);
+    await smelter.reconcile();
+
+    const queryVec = deterministicEmbed('capital of France');
+    const all = await vectorStore.searchResources(queryVec, { limit: 5 });
+    expect(all.find((r) => r.resourceId === 'res-q')?.entityTypes).toEqual(['Question']);
+
+    // And the discriminator is usable: excludeEntityTypes drops it from recall.
+    const excluded = await vectorStore.searchResources(queryVec, {
+      limit: 5,
+      filter: { excludeEntityTypes: ['Question'] },
+    });
+    expect(excluded.some((r) => r.resourceId === 'res-q')).toBe(false);
+  });
+
   it('leaves already-indexed resources alone', async () => {
     const text = 'Already indexed.';
     const checksum = calculateChecksum(text);
@@ -258,6 +280,7 @@ describe('Smelter.reconcile', () => {
       makeResourceId('res-indexed'),
       [{ chunkIndex: 0, text, embedding: deterministicEmbed(text) }],
       checksum,
+      [],
     );
 
     const smelter = createSmelter([resourceDescriptor('res-indexed', 'text/plain', checksum)]);

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -39,7 +39,7 @@ import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
 import { burstBuffer, errField } from '@semiont/core';
 import type { Logger, Annotation, ResourceId, AnnotationId, ResourceDescriptor, IContentTransport } from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId } from '@semiont/core';
-import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, decodeRepresentation, textExtractionOf } from '@semiont/core';
+import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, getResourceEntityTypes, decodeRepresentation, textExtractionOf } from '@semiont/core';
 import { calculateChecksum } from '@semiont/content';
 import type { VectorStore, EmbeddingChunk, AnnotationPayload } from '@semiont/vectors';
 import type { EmbeddingProvider, ChunkingConfig } from '@semiont/vectors';
@@ -322,6 +322,26 @@ export class Smelter {
     }
   }
 
+  /**
+   * Read a resource's current entity types from the materialized view — the
+   * authoritative source, updated before the EventBus fires to consumers — so
+   * its vectors carry the discriminator `searchResources` filters on (e.g.
+   * exclude `['Question']`). One read on every embed path, mirroring how the
+   * smelter already reads current content and annotations; a failed read
+   * propagates to the pipeline's per-resource error handler (reconcile heals),
+   * rather than silently stamping `[]` and letting the resource leak into recall.
+   */
+  private async resolveEntityTypes(resourceId: string): Promise<string[]> {
+    const { resource } = await busRequest<{ resource: ResourceDescriptor | undefined }>(
+      this.bus,
+      'browse:resource-requested',
+      { resourceId },
+      'browse:resource-result',
+      'browse:resource-failed',
+    );
+    return getResourceEntityTypes(resource);
+  }
+
   private async embedResource(event: SmelterInput, logMessage: string): Promise<void> {
     const rid = event.resourceId;
     if (!rid) return;
@@ -332,12 +352,13 @@ export class Smelter {
     const chunks = chunkText(fetched.text, this.chunkingConfig);
     if (chunks.length === 0) return;
 
+    const entityTypes = await this.resolveEntityTypes(rid);
     const embeddings = await this.embeddingProvider.embedBatch(chunks);
     const embeddingChunks: EmbeddingChunk[] = chunks.map((t, i) => ({
       chunkIndex: i, text: t, embedding: embeddings[i],
     }));
 
-    await this.vectorStore.upsertResourceVectors(makeResourceId(rid), embeddingChunks, fetched.checksum);
+    await this.vectorStore.upsertResourceVectors(makeResourceId(rid), embeddingChunks, fetched.checksum, entityTypes);
     this.logger.info(logMessage, { resourceId: rid, chunks: chunks.length });
   }
 
@@ -390,7 +411,7 @@ export class Smelter {
    * embedBatch() call, then index per resource.
    */
   private async batchResourceCreated(events: SmelterInput[]): Promise<number> {
-    const resourceData: { rid: ResourceId; chunks: string[]; checksum: string }[] = [];
+    const resourceData: { rid: ResourceId; chunks: string[]; checksum: string; entityTypes: string[] }[] = [];
     const allChunks: string[] = [];
 
     for (const event of events) {
@@ -403,7 +424,8 @@ export class Smelter {
       const chunks = chunkText(fetched.text, this.chunkingConfig);
       if (chunks.length === 0) continue;
 
-      resourceData.push({ rid: makeResourceId(rid), chunks, checksum: fetched.checksum });
+      const entityTypes = await this.resolveEntityTypes(rid);
+      resourceData.push({ rid: makeResourceId(rid), chunks, checksum: fetched.checksum, entityTypes });
       allChunks.push(...chunks);
     }
 
@@ -412,11 +434,11 @@ export class Smelter {
     const allEmbeddings = await this.embeddingProvider.embedBatch(allChunks);
 
     let offset = 0;
-    for (const { rid, chunks, checksum } of resourceData) {
+    for (const { rid, chunks, checksum, entityTypes } of resourceData) {
       const embeddingChunks: EmbeddingChunk[] = chunks.map((t, i) => ({
         chunkIndex: i, text: t, embedding: allEmbeddings[offset + i],
       }));
-      await this.vectorStore.upsertResourceVectors(rid, embeddingChunks, checksum);
+      await this.vectorStore.upsertResourceVectors(rid, embeddingChunks, checksum, entityTypes);
       this.logger.info('Batch-indexed resource', { resourceId: String(rid), chunks: chunks.length });
       offset += chunks.length;
     }

--- a/packages/vectors/src/__tests__/memory-store.test.ts
+++ b/packages/vectors/src/__tests__/memory-store.test.ts
@@ -29,7 +29,7 @@ describe('MemoryVectorStore', () => {
       const vec = await embedding.embed('Abraham Lincoln was the 16th president');
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'Abraham Lincoln was the 16th president', embedding: vec },
-      ], 'cs-lincoln');
+      ], 'cs-lincoln', []);
 
       const results = await store.searchResources(vec, { limit: 5 });
       expect(results).toHaveLength(1);
@@ -42,12 +42,12 @@ describe('MemoryVectorStore', () => {
       const vec1 = await embedding.embed('original text');
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'original text', embedding: vec1 },
-      ], 'cs-v1');
+      ], 'cs-v1', []);
 
       const vec2 = await embedding.embed('updated text');
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'updated text', embedding: vec2 },
-      ], 'cs-v2');
+      ], 'cs-v2', []);
 
       const results = await store.searchResources(vec2, { limit: 5 });
       expect(results).toHaveLength(1);
@@ -58,7 +58,7 @@ describe('MemoryVectorStore', () => {
       const vec = await embedding.embed('some text');
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'some text', embedding: vec },
-      ], 'cs-some');
+      ], 'cs-some', []);
 
       await store.deleteResourceVectors('res-1' as ResourceId);
 
@@ -72,11 +72,58 @@ describe('MemoryVectorStore', () => {
         { chunkIndex: 0, text: 'chunk one', embedding: vecs[0] },
         { chunkIndex: 1, text: 'chunk two', embedding: vecs[1] },
         { chunkIndex: 2, text: 'chunk three', embedding: vecs[2] },
-      ], 'cs-chunks');
+      ], 'cs-chunks', []);
 
       const results = await store.searchResources(vecs[0], { limit: 10 });
       expect(results.length).toBe(3);
       expect(results[0].text).toBe('chunk one'); // best match
+    });
+  });
+
+  describe('resource entity-type discrimination', () => {
+    it('stamps entityTypes onto resource vectors', async () => {
+      const vec = await embedding.embed('What is the capital of France?');
+      await store.upsertResourceVectors('q-1' as ResourceId, [
+        { chunkIndex: 0, text: 'What is the capital of France?', embedding: vec },
+      ], 'cs-q1', ['Question']);
+
+      const results = await store.searchResources(vec, { limit: 5 });
+      expect(results).toHaveLength(1);
+      expect(results[0].entityTypes).toEqual(['Question']);
+    });
+
+    it('excludes resources whose entityTypes intersect excludeEntityTypes', async () => {
+      const qVec = await embedding.embed('What is the capital of France?');
+      await store.upsertResourceVectors('q-1' as ResourceId, [
+        { chunkIndex: 0, text: 'What is the capital of France?', embedding: qVec },
+      ], 'cs-q1', ['Question']);
+
+      const dVec = await embedding.embed('Paris is the capital of France.');
+      await store.upsertResourceVectors('doc-1' as ResourceId, [
+        { chunkIndex: 0, text: 'Paris is the capital of France.', embedding: dVec },
+      ], 'cs-doc1', ['Article']);
+
+      // Query closest to the question itself, but questions must drop out of recall.
+      const results = await store.searchResources(qVec, {
+        limit: 10,
+        filter: { excludeEntityTypes: ['Question'] },
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].resourceId).toBe('doc-1');
+    });
+
+    it('keeps resources when excludeEntityTypes does not intersect', async () => {
+      const vec = await embedding.embed('Paris is the capital of France.');
+      await store.upsertResourceVectors('doc-1' as ResourceId, [
+        { chunkIndex: 0, text: 'Paris is the capital of France.', embedding: vec },
+      ], 'cs-doc1', ['Article']);
+
+      const results = await store.searchResources(vec, {
+        limit: 10,
+        filter: { excludeEntityTypes: ['Question'] },
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].resourceId).toBe('doc-1');
     });
   });
 
@@ -123,7 +170,7 @@ describe('MemoryVectorStore', () => {
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'chunk one', embedding: vecs[0] },
         { chunkIndex: 1, text: 'chunk two', embedding: vecs[1] },
-      ], 'cs-count');
+      ], 'cs-count', []);
 
       const annVec = await embedding.embed('an annotation');
       await store.upsertAnnotationVector('ann-1' as AnnotationId, annVec, {
@@ -146,10 +193,10 @@ describe('MemoryVectorStore', () => {
       const vecs = await embedding.embedBatch(['alpha', 'beta']);
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'alpha', embedding: vecs[0] },
-      ], 'cs-alpha');
+      ], 'cs-alpha', []);
       await store.upsertResourceVectors('res-2' as ResourceId, [
         { chunkIndex: 0, text: 'beta', embedding: vecs[1] },
-      ], 'cs-beta');
+      ], 'cs-beta', []);
 
       expect(await store.listResourceChecksums()).toEqual(new Map([
         ['res-1', 'cs-alpha'],
@@ -161,10 +208,10 @@ describe('MemoryVectorStore', () => {
       const vec = await embedding.embed('gamma');
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'gamma', embedding: vec },
-      ], 'cs-old');
+      ], 'cs-old', []);
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'gamma', embedding: vec },
-      ], 'cs-new');
+      ], 'cs-new', []);
 
       expect((await store.listResourceChecksums()).get('res-1')).toBe('cs-new');
     });

--- a/packages/vectors/src/store/interface.ts
+++ b/packages/vectors/src/store/interface.ts
@@ -39,6 +39,13 @@ export interface SearchOptions {
     resourceId?: ResourceId;
     motivation?: string;
     excludeResourceId?: ResourceId;
+    /**
+     * Drop any point whose `entityTypes` intersect this set (any-of exclusion,
+     * the mirror of `entityTypes`). Lets a caller exclude a whole structural
+     * kind from recall — e.g. `['Question']` so answer-generation retrieval
+     * never surfaces prior questions.
+     */
+    excludeEntityTypes?: string[];
   };
 }
 
@@ -57,9 +64,11 @@ export interface VectorStore {
    * that shrinks to fewer chunks leaves no orphans. `contentChecksum` is
    * the checksum of the bytes the chunks were computed from; it is stamped
    * onto the points so reconciliation can detect stale-but-present
-   * resources (SMELTER-AXIOMS.md, S12).
+   * resources (SMELTER-AXIOMS.md, S12). `entityTypes` is the resource's
+   * entity-type set, stamped onto every point so `searchResources` can
+   * discriminate by kind (e.g. exclude `['Question']` from recall).
    */
-  upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string): Promise<void>;
+  upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[]): Promise<void>;
   upsertAnnotationVector(annotationId: AnnotationId, embedding: number[], payload: AnnotationPayload): Promise<void>;
   deleteResourceVectors(resourceId: ResourceId): Promise<void>;
   deleteAnnotationVector(annotationId: AnnotationId): Promise<void>;

--- a/packages/vectors/src/store/memory.ts
+++ b/packages/vectors/src/store/memory.ts
@@ -57,7 +57,7 @@ export class MemoryVectorStore implements VectorStore {
     return this.connected;
   }
 
-  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string): Promise<void> {
+  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[]): Promise<void> {
     // Remove existing vectors for this resource
     this.resources = this.resources.filter(p => p.payload.resourceId !== String(resourceId));
 
@@ -70,6 +70,7 @@ export class MemoryVectorStore implements VectorStore {
           chunkIndex: chunk.chunkIndex,
           text: chunk.text,
           contentChecksum,
+          entityTypes,
         },
       });
     }
@@ -148,6 +149,10 @@ export class MemoryVectorStore implements VectorStore {
         if (f.entityTypes && f.entityTypes.length > 0) {
           const pTypes = p.payload.entityTypes ?? [];
           if (!f.entityTypes.some(t => pTypes.includes(t))) return false;
+        }
+        if (f.excludeEntityTypes && f.excludeEntityTypes.length > 0) {
+          const pTypes = p.payload.entityTypes ?? [];
+          if (f.excludeEntityTypes.some(t => pTypes.includes(t))) return false;
         }
         return true;
       });

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -48,6 +48,8 @@ export class QdrantVectorStore implements VectorStore {
     // Ensure collections exist
     await this.ensureCollection('resources', this.config.dimensions);
     await this.ensureCollection('annotations', this.config.dimensions);
+    // Index the discriminator so excludeEntityTypes filtering scales.
+    await this.ensurePayloadIndex('resources', 'entityTypes');
   }
 
   async disconnect(): Promise<void> {
@@ -75,7 +77,18 @@ export class QdrantVectorStore implements VectorStore {
     }
   }
 
-  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string): Promise<void> {
+  /**
+   * Idempotently create a keyword payload index. Qdrant accepts a repeat call
+   * for an already-indexed field, so this runs safely on every connect and
+   * back-fills the index on collections created before the field was indexed.
+   */
+  private async ensurePayloadIndex(collection: string, field: string): Promise<void> {
+    try {
+      await this.qdrant.createPayloadIndex(collection, { field_name: field, field_schema: 'keyword' });
+    } catch { /* already indexed, or created concurrently */ }
+  }
+
+  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[]): Promise<void> {
     // Replace semantics: purge existing chunks first, or a resource that
     // shrinks leaves orphan points at the higher chunk indices.
     await this.deleteResourceVectors(resourceId);
@@ -89,6 +102,7 @@ export class QdrantVectorStore implements VectorStore {
         chunkIndex: chunk.chunkIndex,
         text: chunk.text,
         contentChecksum,
+        entityTypes,
       },
     }));
 
@@ -246,6 +260,11 @@ export class QdrantVectorStore implements VectorStore {
 
     if (filter.excludeResourceId) {
       must_not.push({ key: 'resourceId', match: { value: String(filter.excludeResourceId) } });
+    }
+
+    if (filter.excludeEntityTypes && filter.excludeEntityTypes.length > 0) {
+      // any-of exclusion: drop points whose entityTypes contain any of these.
+      must_not.push({ key: 'entityTypes', match: { any: filter.excludeEntityTypes } });
     }
 
     if (must.length === 0 && must_not.length === 0) return null;


### PR DESCRIPTION
## Summary

Adds the ability to **exclude a structural kind of resource from vector similarity search** by entity type — e.g. exclude `['Question']` so resource-level recall (and answer generation built on it) never surfaces prior questions. This is **Phases 1 + 2a** of the EXCLUDE-VECTORS plan; the consuming gather/SDK wiring (Phase 2b+) and the chat consumer land separately.

## Phase 1 — `@semiont/vectors`: discriminator + exclusion filter

- `SearchOptions.filter.excludeEntityTypes?: string[]` — **any-of exclusion** (the mirror of the existing `entityTypes` include filter): a point is dropped if its entity types contain **any** of the listed values.
- `upsertResourceVectors(resourceId, chunks, contentChecksum, entityTypes)` — resource vectors now carry the resource's **full entity-type array**, stamped on **every** chunk point (so excluding a type drops the whole resource).
- **Qdrant** (`qdrant.ts`): stamps `entityTypes`, adds a `must_not` clause, and creates an idempotent **keyword payload index** on `resources.entityTypes` so the filter scales (and back-fills pre-existing collections).
- **Memory** (`memory.ts`): stamps `entityTypes`; the exclude predicate runs before scoring.
- All call sites and tests updated (no overloads/defaults — required arg).

## Phase 2a — `@semiont/make-meaning`: smelter stamps entity types

- The smelter reads a resource's **current** entity types from the materialized descriptor (`browse:resource-requested` → `getResourceEntityTypes`) and stamps them on embed — one unconditional read, mirroring how it already reads current content and annotations. Wired through `embedResource`, `batchResourceCreated`, and reconcile (`smelt:embed`).
- Entity types are read **at embed time**, not threaded from reconcile planning, so a vector's content and its entity-type tag come from one coherent point-in-time snapshot (consistent with the S2 axiom). The reconcile cold-path reads the descriptor again rather than carry a planning-time snapshot — a deliberate coherence-over-RPC tradeoff.

## Deliberately out of scope

- **Checksum dedup of byte-identical resources** is deferred. The exclude filter is the actual answer-generation guarantee; dedup is hygiene for a future "retrieve prior questions" path, and it changes the smelter's S7/S11 axiom model and needs a composite `(entityTypes, contentChecksum)` key — a separate effort.
- No spec/core/SDK changes — purely `@semiont/vectors` + the smelter.

## Verification

`node:24-alpine` container: `@semiont/vectors` build + 33 tests green; `@semiont/make-meaning` typecheck green; `smelter` + `smelter-axioms` 29 tests green (axioms S1–S12 intact — S5/S7 confirm stamping leaves the reconcile id-set model untouched).
