### PR TITLE
YIELD-FROM-RESOURCE P1–P4: yield.fromResource — annotation-optional generation + reference-annotation provenance

### DIFF
--- a/docs/protocol/flows/GATHER.md
+++ b/docs/protocol/flows/GATHER.md
@@ -39,24 +39,29 @@ const final = await lastValueFrom(
 );
 const context = (final as { context?: GatheredContext }).context;
 
-// Source context (passage text)
-console.log(context.sourceContext.selected);  // The exact text the annotation targets
-console.log(context.sourceContext.before);    // Surrounding passage before the selection
-console.log(context.sourceContext.after);     // Surrounding passage after the selection
+// gather.annotation returns an annotation-focus GatheredContext — narrow on focus.kind
+if (context.focus.kind === 'annotation') {
+  const focus = context.focus;
+  console.log(focus.selected?.text);      // The exact text the annotation targets
+  console.log(focus.selected?.before);    // Surrounding passage before the selection
+  console.log(focus.selected?.after);     // Surrounding passage after the selection
+  console.log(focus.sourceResource.name); // Source resource name
 
-// Graph context (knowledge graph neighborhood)
-console.log(context.graphContext.connections);       // Connected resources with scores
-console.log(context.graphContext.citedBy);           // Resources citing the source
-console.log(context.graphContext.citedByCount);      // Total citation count
-console.log(context.graphContext.siblingEntityTypes); // Entity types in neighborhood
-console.log(context.graphContext.entityTypeFrequencies); // IDF-weighted type frequencies
+  // The flattened neighborhood views derive from the shared graph backbone
+  // (deriveViews is exported from @semiont/core)
+  const views = deriveViews(context.graph, String(focus.sourceResource.id), focus.annotation.id);
+  console.log(views.connections);        // Connected resources with scores
+  console.log(views.citedBy);            // Resources citing the source
+  console.log(views.citedByCount);       // Total citation count
+  console.log(views.siblingEntityTypes); // Entity types in the neighborhood
+}
 
-// Inference enrichment (when InferenceClient is available)
-console.log(context.graphContext.inferredRelationshipSummary); // LLM-generated summary
-
-// Metadata
-console.log(context.metadata.entityTypes);   // Entity type tags on the annotation
-console.log(context.metadata.resourceName);  // Source resource name
+// Shared base (present on every GatheredContext, both focus kinds)
+console.log(context.graph.nodes);                    // KnowledgeGraph: resource + annotation nodes
+console.log(context.metadata.entityTypes);           // Entity type tags
+console.log(context.metadata.entityTypeFrequencies); // IDF-weighted type frequencies
+console.log(context.inferredRelationshipSummary);    // (optional) LLM-generated summary
+console.log(context.semanticContext?.similar);       // (optional) vector-similar passages
 ```
 
 Under the hood: the namespace emits `gather:annotation-request` via
@@ -86,14 +91,11 @@ The Gatherer actor assembles a `GatheredContext` by:
 7. Optionally generating an `inferredRelationshipSummary` via the InferenceClient
 
 The result is a `GatheredContext` containing:
-- **sourceContext** — `{ selected, before, after }` — the passage text
-- **metadata** — Entity types, annotation motivation, resource info
-- **graphContext** — Knowledge graph neighborhood:
-  - `connections` — Resources linked from/to the source resource, with `mutual` flag for bidirectional links
-  - `citedBy` / `citedByCount` — Resources that cite the source
-  - `siblingEntityTypes` — Entity types present in the graph neighborhood
-  - `entityTypeFrequencies` — IDF-weighted frequency map for entity types
-  - `inferredRelationshipSummary` — (optional) LLM-generated 1-2 sentence summary of how the passage relates to its graph neighborhood
+- **focus** (`kind: 'annotation'`) — `{ annotation, sourceResource, selected: { text, before, after }, userHint? }` — the annotation, its resource, and the passage text it targets
+- **graph** — a `KnowledgeGraph` (the shared backbone): resource **and** annotation nodes plus typed, directional edges (with a `bidirectional?` flag). The flattened neighborhood views — `connections`, `citedBy` / `citedByCount`, `siblingEntityTypes` — are **derived from `graph`** via `deriveViews` (`@semiont/core`), not stored
+- **metadata** — `{ entityTypes?, entityTypeFrequencies?, language?, resourceType? }` (the IDF-weighted frequency map is a global statistic kept here, not graph-derived)
+- **inferredRelationshipSummary** — (optional) LLM-generated 1-2 sentence summary of how the passage relates to its graph neighborhood
+- **semanticContext** — (optional) `{ similar }` — vector-similar passages, when embeddings are available
 
 ## Workflow
 

--- a/docs/protocol/flows/MATCHER.md
+++ b/docs/protocol/flows/MATCHER.md
@@ -61,7 +61,7 @@ The Matcher retrieves candidates in parallel from three sources, then deduplicat
 
 1. **Name match** — `graph.searchResources(searchTerm)` — text search against resource names
 2. **Entity type filter** — `graph.listResources({ entityTypes })` — resources sharing entity types with the annotation
-3. **Graph neighborhood** — resources connected to the source resource, from `context.graphContext.connections`
+3. **Graph neighborhood** — resources connected to the source resource, derived from the shared `context.graph` (`deriveViews(context.graph, mainResourceId).connections`, from `@semiont/core`)
 
 Candidates found by more than one source receive a multi-source bonus at scoring time.
 

--- a/packages/jobs/src/__tests__/generation-params.types.test.ts
+++ b/packages/jobs/src/__tests__/generation-params.types.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import type { GenerationParams } from '../types';
+
+/**
+ * tsc-enforced guard for the YIELD-FROM-RESOURCE P1 param contract: generation is
+ * annotation-OPTIONAL and carries `outputMediaType`. RED before P1 — `referenceId`/
+ * `sourceResourceId`/`sourceResourceName`/`annotation` were required and there was no
+ * `outputMediaType` (this file fails `tsc --noEmit` until the type is reshaped).
+ */
+describe('GenerationParams contract', () => {
+  it('accepts annotation-free params carrying outputMediaType', () => {
+    const p: GenerationParams = { prompt: 'Translate to French', outputMediaType: 'text/plain' };
+    expect(p.outputMediaType).toBe('text/plain');
+  });
+
+  it('requires no fields — referenceId is optional and the annotation fields are gone', () => {
+    const p: GenerationParams = {};
+    expect(p).toEqual({});
+  });
+});

--- a/packages/jobs/src/__tests__/job-queue.test.ts
+++ b/packages/jobs/src/__tests__/job-queue.test.ts
@@ -138,22 +138,6 @@ function createPendingGenerationJob(id: string): PendingJob<GenerationParams> {
     },
     params: {
       referenceId: annotationId('ann-1'),
-      sourceResourceId: resourceId('res-1'),
-      sourceResourceName: 'Test Resource',
-      annotation: {
-        '@context': 'http://www.w3.org/ns/anno.jsonld',
-        type: 'Annotation',
-        id: annotationId('test-anno-1'),
-        motivation: 'linking',
-        target: {
-          source: 'http://localhost:4100/resources/test-resource-1',
-          selector: [
-            { type: 'TextPositionSelector', start: 0, end: 10 },
-            { type: 'TextQuoteSelector', exact: 'test text' }
-          ]
-        },
-        body: [{ type: 'TextualBody', value: 'Person', purpose: 'tagging' }]
-      },
       prompt: 'Generate a summary',
     },
   };

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -347,6 +347,30 @@ describe('processGenerationJob', () => {
   });
 });
 
+describe('processGenerationJob — outputMediaType', () => {
+  beforeEach(() => {
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({ content: 'c', title: 'T' });
+  });
+
+  it('defaults the generated resource format to text/markdown', async () => {
+    const r = await processGenerationJob(makeInferenceClient(), { title: 'T' }, vi.fn(), LOGGER);
+    expect(r.format).toBe('text/markdown');
+  });
+
+  it('honors a requested text/plain outputMediaType', async () => {
+    const r = await processGenerationJob(makeInferenceClient(), { title: 'T', outputMediaType: 'text/plain' }, vi.fn(), LOGGER);
+    expect(r.format).toBe('text/plain');
+  });
+
+  it('throws for an unsupported outputMediaType — before the LLM call, no silent fallback', async () => {
+    vi.mocked(generateResourceFromTopic).mockClear();
+    await expect(
+      processGenerationJob(makeInferenceClient(), { title: 'T', outputMediaType: 'image/png' }, vi.fn(), LOGGER),
+    ).rejects.toThrow(/unsupported outputMediaType/i);
+    expect(generateResourceFromTopic).not.toHaveBeenCalled();
+  });
+});
+
 // ============================================================================
 // Attribution composition (creator / generator / wasAttributedTo)
 // ============================================================================
@@ -671,10 +695,10 @@ describe('locale threading', () => {
       );
 
       // Positional signature: topic, entityTypes, client, logger, prompt,
-      // locale, context, temperature, maxTokens, sourceLanguage.
+      // locale, context, temperature, maxTokens, sourceLanguage, outputMediaType.
       expect(generateResourceFromTopic).toHaveBeenCalledWith(
         'Topic', [], client, LOGGER, undefined, 'de', undefined,
-        undefined, undefined, 'fr',
+        undefined, undefined, 'fr', 'text/markdown',
       );
     });
   });

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -310,12 +310,8 @@ describe('processGenerationJob', () => {
       makeInferenceClient(),
       {
         referenceId: annotationId('ann-1'),
-        sourceResourceId: RID,
-        sourceResourceName: 'src',
         title: 'Initial',
         entityTypes: [],
-        context: {} as any,
-        annotation: {} as any,
       },
       progress,
       LOGGER,
@@ -339,12 +335,8 @@ describe('processGenerationJob', () => {
       makeInferenceClient(),
       {
         referenceId: annotationId('ann-1'),
-        sourceResourceId: RID,
-        sourceResourceName: 'src',
         title: 'Fallback Title',
         entityTypes: [],
-        context: {} as any,
-        annotation: {} as any,
       },
       vi.fn(),
       LOGGER,
@@ -669,12 +661,8 @@ describe('locale threading', () => {
         client,
         {
           referenceId: annotationId('ann-1'),
-          sourceResourceId: RID,
-          sourceResourceName: 'src',
           title: 'Topic',
           entityTypes: [],
-          context: {} as any,
-          annotation: {} as any,
           language: 'de',
           sourceLanguage: 'fr',
         },
@@ -685,7 +673,7 @@ describe('locale threading', () => {
       // Positional signature: topic, entityTypes, client, logger, prompt,
       // locale, context, temperature, maxTokens, sourceLanguage.
       expect(generateResourceFromTopic).toHaveBeenCalledWith(
-        'Topic', [], client, LOGGER, undefined, 'de', expect.any(Object),
+        'Topic', [], client, LOGGER, undefined, 'de', undefined,
         undefined, undefined, 'fr',
       );
     });

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -328,6 +328,36 @@ describe('handleJob orchestration', () => {
       expect(h.yieldResourceCalls).toHaveLength(1);
       expect(h.yieldResourceCalls[0]!.entityTypes).toBeUndefined();
     });
+
+    it('resource-focus generation (no referenceId) mints a source→derived reference annotation', async () => {
+      // YIELD-FROM-RESOURCE Fork 2b. Annotation-focus generation auto-binds via
+      // sourceAnnotationId; resource-focus has no triggering reference, so the worker
+      // mints a navigable reference: target = the whole source resource (resource-level,
+      // no selector), body = SpecificResource → the derived resource.
+      vi.mocked(processGenerationJob).mockResolvedValue({
+        content: 'body', title: 'Derived Doc', format: 'text/markdown', result: {} as never,
+      });
+      const h = makeFakeSessionAndAdapter();
+
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', {}));
+
+      expect(h.yieldResourceCalls[0]!.sourceAnnotationId).toBeUndefined(); // no auto-bind
+
+      const markCreate = h.busEmits.find(e => e.channel === 'mark:create');
+      expect(markCreate, 'resource-focus generation mints a navigable source→derived reference').toBeDefined();
+      expect(markCreate!.payload).toMatchObject({
+        annotation: {
+          motivation: 'linking',
+          target: { source: RID },
+          body: { type: 'SpecificResource', source: 'new-res-42', purpose: 'linking' },
+        },
+      });
+      // resource-level target — no selector
+      const ann = (markCreate!.payload as { annotation: { target: { selector?: unknown } } }).annotation;
+      expect(ann.target.selector).toBeUndefined();
+
+      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'job:complete']);
+    });
   });
 
   describe('unknown job type', () => {

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -458,6 +458,17 @@ export async function processGenerationJob(
   onProgress: OnProgress,
   logger: Logger,
 ): Promise<{ content: string; title: string; format: SupportedMediaType; result: GenerationResult }> {
+  // Generation produces text only for now. Refuse any other requested media type
+  // loudly (the throw propagates as job:fail) rather than silently emitting markdown
+  // under a mislabeled format. Validate before the LLM call so it fails fast.
+  const GENERATABLE_MEDIA_TYPES: readonly SupportedMediaType[] = ['text/markdown', 'text/plain'];
+  const outputMediaType: SupportedMediaType = params.outputMediaType ?? 'text/markdown';
+  if (!GENERATABLE_MEDIA_TYPES.includes(outputMediaType)) {
+    throw new Error(
+      `Unsupported outputMediaType for generation: ${outputMediaType}. Generation produces ${GENERATABLE_MEDIA_TYPES.join(' or ')}.`,
+    );
+  }
+
   onProgress(20, 'Fetching context...', 'fetching');
 
   const title = params.title ?? 'Untitled';
@@ -476,6 +487,7 @@ export async function processGenerationJob(
     params.temperature,
     params.maxTokens,
     params.sourceLanguage,
+    outputMediaType,
   );
 
   onProgress(85, 'Creating resource...', 'creating');
@@ -483,7 +495,7 @@ export async function processGenerationJob(
   return {
     content: generated.content,
     title: generated.title ?? title,
-    format: 'text/markdown',
+    format: outputMediaType,
     result: {
       resourceId: '' as ResourceId,
       resourceName: generated.title ?? title,

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -11,7 +11,7 @@
  * - State machine is explicit and type-safe
  */
 
-import type { Annotation, JobId, EntityType, ResourceId, UserId, AnnotationId, GatheredContext, TagSchema } from '@semiont/core';
+import type { JobId, EntityType, ResourceId, UserId, AnnotationId, GatheredContext, TagSchema, SupportedMediaType } from '@semiont/core';
 
 export type JobType = 'reference-annotation' | 'generation' | 'highlight-annotation' | 'assessment-annotation' | 'comment-annotation' | 'tag-annotation';
 export type JobStatus = 'pending' | 'running' | 'complete' | 'failed' | 'cancelled';
@@ -80,10 +80,13 @@ export interface DetectionParams {
  * Generation job parameters
  */
 export interface GenerationParams {
-  referenceId: AnnotationId;
-  sourceResourceId: ResourceId;
-  sourceResourceName: string;
-  annotation: Annotation;
+  /**
+   * The unresolved reference an annotation-focus generation was triggered from.
+   * Absent for resource-focus generation (`yield.fromResource`). When present, the
+   * worker auto-binds the new resource to it; when absent, provenance is a minted
+   * source→derived reference annotation (Fork 2b).
+   */
+  referenceId?: AnnotationId;
   prompt?: string;
   title?: string;
   entityTypes?: EntityType[];
@@ -99,6 +102,13 @@ export interface GenerationParams {
   temperature?: number;
   maxTokens?: number;
   storageUri?: string;
+  /**
+   * Requested media type of the generated resource's content. Default `text/markdown`.
+   * The generation worker produces `text/markdown` and `text/plain`; any other value
+   * fails the job (no silent fallback) — Semiont is multi-modal at the core, but
+   * generation coverage is text-only for now and the gap is surfaced, not hidden.
+   */
+  outputMediaType?: SupportedMediaType;
 }
 
 /**

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -18,7 +18,7 @@
 import { createJobClaimAdapter, type JobClaimAdapter, type ActiveJob } from './job-claim-adapter';
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
-import { getPrimaryMediaType, textExtractionOf, type EventMap } from '@semiont/core';
+import { getPrimaryMediaType, textExtractionOf, assembleAnnotation, type EventMap } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 import type { Logger, components } from '@semiont/core';
 import { deriveStorageUri } from '@semiont/content';
@@ -310,6 +310,23 @@ async function handleJobInner(
       ...(genParams.entityTypes && genParams.entityTypes.length > 0 ? { entityTypes: genParams.entityTypes } : {}),
       generator,
     });
+
+    // Resource-focus generation has no triggering reference — mint a navigable
+    // source→derived reference annotation (YIELD-FROM-RESOURCE Fork 2b) so the
+    // derivation is a first-class edge, targeting the whole source resource
+    // (resource-level, no selector). Annotation-focus generation instead auto-binds
+    // the triggering reference via `sourceAnnotationId` on the upload above.
+    if (!genParams.referenceId) {
+      const { annotation: provenanceRef } = assembleAnnotation(
+        {
+          motivation: 'linking',
+          target: { source: String(resourceId) },
+          body: { type: 'SpecificResource', source: String(newResourceId), purpose: 'linking' },
+        },
+        generator,
+      );
+      await emitEvent(session, 'mark:create', { annotation: provenanceRef, userId, resourceId });
+    }
 
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,

--- a/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
+++ b/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
@@ -542,5 +542,62 @@ describe('generateResourceFromTopic', () => {
       expect(prompt).not.toContain('Annotation motivation');
       expect(prompt).not.toContain('Source document context');
     });
+
+    it('grounds the prompt in the resource summary, suggested references, and content', async () => {
+      client.setResponses(['# X\n\nbody']);
+      const context: GatheredContext = {
+        focus: {
+          kind: 'resource',
+          resource: testSourceResource,
+          summary: 'A concise summary of the focal resource.',
+          suggestedReferences: ['Alpha', 'Beta'],
+          content: { main: 'MAIN-CONTENT-BODY', related: { r2: 'RELATED-CONTENT-BODY' } },
+        },
+        graph: buildGraph(),
+        metadata: {},
+      };
+
+      await generateResourceFromTopic('Topic', [], client, LOGGER, undefined, undefined, context);
+
+      const prompt = promptArg();
+      expect(prompt).toContain('A concise summary of the focal resource.');
+      expect(prompt).toContain('Alpha');
+      expect(prompt).toContain('MAIN-CONTENT-BODY');
+      expect(prompt).toContain('RELATED-CONTENT-BODY');
+      expect(prompt).not.toContain('Annotation motivation');
+    });
+
+    it('omits resource sections that are absent (omit-empty)', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic('Topic', [], client, LOGGER, undefined, undefined, makeResourceContext());
+
+      const prompt = promptArg();
+      expect(prompt).not.toContain('Summary:');
+      expect(prompt).not.toContain('Resource content:');
+    });
+  });
+
+  describe('output media type', () => {
+    it('text/markdown (default) instructs markdown formatting', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic('Topic', [], client, LOGGER);
+
+      expect(promptArg()).toMatch(/markdown/i);
+    });
+
+    it('text/plain drops the markdown scaffolding and asks for plain prose', async () => {
+      client.setResponses(['X\n\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined, undefined, undefined, undefined, undefined, 'text/plain',
+      );
+
+      const prompt = promptArg();
+      expect(prompt).not.toMatch(/markdown/i);
+      expect(prompt).not.toContain('# Title');
+      expect(prompt).toMatch(/plain text/i);
+    });
   });
 });

--- a/packages/jobs/src/workers/generation/resource-generation.ts
+++ b/packages/jobs/src/workers/generation/resource-generation.ts
@@ -5,7 +5,7 @@
  */
 
 import { getLocaleEnglishName, deriveViews } from '@semiont/core';
-import type { GatheredContext, Logger } from '@semiont/core';
+import type { GatheredContext, Logger, SupportedMediaType } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 
 
@@ -34,7 +34,8 @@ export async function generateResourceFromTopic(
   context?: GatheredContext,
   temperature?: number,
   maxTokens?: number,
-  sourceLanguage?: string
+  sourceLanguage?: string,
+  outputMediaType: SupportedMediaType = 'text/markdown'
 ): Promise<{ title: string; content: string }> {
   logger.debug('Generating resource from topic', {
     topicPreview: topic.substring(0, 100),
@@ -111,10 +112,28 @@ ${after ? `${after}...` : ''}
 ---
 `;
       }
-    } else if (focus.resource.name) {
-      // Minimal resource anchor — YIELD-FROM-RESOURCE Gap B fleshes out the
-      // grounded resource section (summary / suggestedReferences / content).
-      resourceSection = `\n\nFocal resource: ${focus.resource.name}`;
+    } else {
+      // Resource focus — ground in the focal resource's summary, suggested
+      // references, and content (omit-empty). Content is capped per resource to
+      // bound prompt size; the caller already chose breadth via gather.resource.
+      const RESOURCE_CONTENT_CAP = 4000;
+      const parts = [`- Resource: ${focus.resource.name}`];
+      if (focus.summary) parts.push(`- Summary: ${focus.summary}`);
+      if (focus.suggestedReferences && focus.suggestedReferences.length > 0) {
+        parts.push(`- Suggested references: ${focus.suggestedReferences.join(', ')}`);
+      }
+      resourceSection = `\n\nResource context:\n${parts.join('\n')}`;
+
+      if (focus.content?.main) {
+        resourceSection += `\n\nResource content:\n---\n${focus.content.main.slice(0, RESOURCE_CONTENT_CAP)}\n---`;
+      }
+      const related = Object.entries(focus.content?.related ?? {});
+      if (related.length > 0) {
+        const blocks = related
+          .map(([id, text]) => `[${id}]\n${text.slice(0, RESOURCE_CONTENT_CAP)}`)
+          .join('\n\n');
+        resourceSection += `\n\nRelated resource content:\n---\n${blocks}\n---`;
+      }
     }
 
     // Shared base: graph-derived neighborhood (connections / citedBy / siblings)
@@ -164,21 +183,27 @@ ${after ? `${after}...` : ''}
     semanticContextSection = `\n\nRelated passages from the knowledge base:\n${lines.join('\n')}`;
   }
 
-  const structureGuidance = finalMaxTokens >= 1000
+  // Format instructions branch on the requested output media type. Markdown is the
+  // default; text/plain drops the markup scaffolding so the result is clean prose.
+  const isPlainText = outputMediaType === 'text/plain';
+  const structureGuidance = !isPlainText && finalMaxTokens >= 1000
     ? 'organized into titled sections (## Section) with well-structured paragraphs'
     : 'organized into well-structured paragraphs';
+  const formatRequirements = isPlainText
+    ? `- Write the response as plain text — no formatting markup (no #, *, backticks, headings, or links)
+- Begin with the title on its own first line`
+    : `- Start with a clear heading (# Title)
+- Use markdown formatting
+- Write the response as markdown`;
 
-  // Simple, direct prompt - just ask for markdown content
   const prompt = `Generate a concise, informative resource about "${topic}".
 ${entityTypes.length > 0 ? `Focus on these entity types: ${entityTypes.join(', ')}.` : ''}
 ${userPrompt ? `Additional context: ${userPrompt}` : ''}${annotationSection}${contextSection}${resourceSection}${graphSection}${semanticContextSection}${sourceLanguageInstruction}${languageInstruction}
 
 Requirements:
-- Start with a clear heading (# Title)
 - Aim for approximately ${finalMaxTokens} tokens of content, ${structureGuidance}
 - Be factual and informative
-- Use markdown formatting
-- Write the response as markdown`;
+${formatRequirements}`;
 
   // Simple parser - just use the response directly as markdown
   const parseResponse = (response: string): { title: string; content: string } => {

--- a/packages/make-meaning/docs/api-reference.md
+++ b/packages/make-meaning/docs/api-reference.md
@@ -251,10 +251,10 @@ static async buildLLMContext(
   inferenceClient?: InferenceClient,
   logger?: Logger,
   embeddingProvider?: EmbeddingProvider,
-): Promise<AnnotationLLMContextResponse>
+): Promise<GatheredContext>
 ```
 
-Builds rich context for AI processing including the annotation, surrounding text, resource metadata, and knowledge graph neighborhood (`graphContext`). When an `InferenceClient` is provided, also generates an `inferredRelationshipSummary` describing how the passage relates to its graph neighborhood; when an `EmbeddingProvider` is provided (and the KB has vectors), adds `semanticContext` from vector search.
+Builds rich context for AI processing: an annotation-focus `GatheredContext` carrying the annotation, surrounding text, resource metadata, and the shared knowledge-graph backbone (`graph` / `KnowledgeGraph`). When an `InferenceClient` is provided, also generates an `inferredRelationshipSummary` describing how the passage relates to its graph neighborhood; when an `EmbeddingProvider` is provided (and the KB has vectors), adds `semanticContext` from vector search.
 
 #### getResourceAnnotations()
 
@@ -336,7 +336,7 @@ static async getResourceContext(
   options: LLMContextOptions,
   kb: KnowledgeBase,
   inferenceClient: InferenceClient,
-): Promise<ResourceLLMContextResponse>
+): Promise<GatheredContext>
 ```
 
 ---

--- a/packages/make-meaning/docs/examples.md
+++ b/packages/make-meaning/docs/examples.md
@@ -124,16 +124,19 @@ const allAnnotations = await AnnotationContext.getAllAnnotations(resourceId, kb)
 ```typescript
 import { AnnotationContext } from '@semiont/make-meaning';
 
-const response = await AnnotationContext.buildLLMContext(
+const context = await AnnotationContext.buildLLMContext(
   annotationId,
   resourceId,
   kb,
   { contextWindow: 1000 },
 );
 
-console.log(`Selected: "${response.context?.sourceContext?.selected}"`);
-console.log(`Before: "${response.context?.sourceContext?.before}"`);
-console.log(`After: "${response.context?.sourceContext?.after}"`);
+// buildLLMContext returns an annotation-focus GatheredContext
+if (context.focus.kind === 'annotation') {
+  console.log(`Selected: "${context.focus.selected?.text}"`);
+  console.log(`Before: "${context.focus.selected?.before}"`);
+  console.log(`After: "${context.focus.selected?.after}"`);
+}
 ```
 
 ## Using the SDK (Recommended)

--- a/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
@@ -238,6 +238,28 @@ describe('registerJobCommandHandlers — tag-annotation dispatcher', () => {
     expect(queuedJob.params.schema, 'generation jobs must not get a TagSchema injected').toBeUndefined();
     expect(queuedJob.params.schemaId).toBeUndefined();
   });
+
+  it('sets maxRetries to 0 for generation (non-idempotent) and 1 for detection', async () => {
+    const gen$ = (eventBus.get('job:created') as never as import('rxjs').Observable<JobCreatedEvent>)
+      .pipe(filter((e) => e.correlationId === 'cid-retry-gen'), take(1));
+    eventBus.get('job:create').next({
+      correlationId: 'cid-retry-gen', jobType: 'generation', resourceId: 'rid-test',
+      params: { title: 'T' }, _userId: TEST_USER_DID,
+    } as never);
+    await firstValueFrom(race(gen$, timer(2_000)));
+    const genJob = jobQueue.createJob.mock.calls.at(-1)![0] as { metadata: { maxRetries: number } };
+    expect(genJob.metadata.maxRetries, 'generation must not retry — re-rolling is not a replay').toBe(0);
+
+    const ref$ = (eventBus.get('job:created') as never as import('rxjs').Observable<JobCreatedEvent>)
+      .pipe(filter((e) => e.correlationId === 'cid-retry-ref'), take(1));
+    eventBus.get('job:create').next({
+      correlationId: 'cid-retry-ref', jobType: 'reference-annotation', resourceId: 'rid-test',
+      params: {}, _userId: TEST_USER_DID,
+    } as never);
+    await firstValueFrom(race(ref$, timer(2_000)));
+    const refJob = jobQueue.createJob.mock.calls.at(-1)![0] as { metadata: { maxRetries: number } };
+    expect(refJob.metadata.maxRetries, 'detection keeps one self-heal retry').toBe(1);
+  });
 });
 
 describe('registerJobCommandHandlers — entity-type validation', () => {

--- a/packages/make-meaning/src/handlers/job-commands.ts
+++ b/packages/make-meaning/src/handlers/job-commands.ts
@@ -47,7 +47,11 @@ export function registerJobCommandHandlers(
           userDomain: user.domain,
           created: new Date().toISOString(),
           retryCount: 0,
-          maxRetries: jobType === 'generation' ? 3 : 1,
+          // Generation is non-idempotent — a retry re-runs the LLM and produces
+          // *different* content (not a replay) — and expensive. Surface the failure
+          // to the caller rather than silently re-rolling. Detection jobs re-scan the
+          // same content (≈idempotent) and keep one self-heal retry.
+          maxRetries: jobType === 'generation' ? 0 : 1,
         },
         params: {
           resourceId: resourceId(resId as string),

--- a/packages/sdk/src/namespaces/__tests__/commands.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/commands.test.ts
@@ -6,7 +6,7 @@ import { BindNamespace } from '../bind';
 import { GatherNamespace } from '../gather';
 import { MatchNamespace } from '../match';
 import { YieldNamespace } from '../yield';
-import type { ITransport, IContentTransport } from '@semiont/core';
+import type { ITransport, IContentTransport, GatheredContext } from '@semiont/core';
 
 const RID = resourceId('res-1');
 const AID = annotationId('ann-1');
@@ -477,6 +477,38 @@ describe('YieldNamespace', () => {
       expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
         jobType: 'generation',
         resourceId: RID,
+      }));
+      resolve();
+    }, 20));
+  });
+
+  it('fromResource() emits job:create (generation) with no referenceId', () => {
+    yld.fromResource(RID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
+        jobType: 'generation',
+        resourceId: RID,
+        params: expect.not.objectContaining({ referenceId: expect.anything() }),
+      }));
+      resolve();
+    }, 20));
+  });
+
+  it('fromResource({ outputMediaType }) carries outputMediaType into job:create params', () => {
+    yld.fromResource(RID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext, outputMediaType: 'text/plain' }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
+        params: expect.objectContaining({ outputMediaType: 'text/plain' }),
+      }));
+      resolve();
+    }, 20));
+  });
+
+  it('fromAnnotation({ outputMediaType }) carries outputMediaType into job:create params', () => {
+    yld.fromAnnotation(RID, AID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext, outputMediaType: 'text/plain' }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
+        params: expect.objectContaining({ outputMediaType: 'text/plain' }),
       }));
       resolve();
     }, 20));

--- a/packages/sdk/src/namespaces/types.ts
+++ b/packages/sdk/src/namespaces/types.ts
@@ -53,6 +53,7 @@ type GatherProgress = components['schemas']['GatherProgress'];
 type MatchSearchResult = components['schemas']['MatchSearchResult'];
 type JobProgress = components['schemas']['JobProgress'];
 type GatherAnnotationComplete = components['schemas']['GatherAnnotationComplete'];
+type SupportedMediaType = components['schemas']['SupportedMediaType'];
 type JobStatusResponse = components['schemas']['JobStatusResponse'];
 type AuthResponse = components['schemas']['AuthResponse'];
 type TokenRefreshResponse = components['schemas']['TokenRefreshResponse'];
@@ -93,7 +94,7 @@ export interface CreateResourceInput {
   isDraft?: boolean;
 }
 
-/** Options for yield.fromAnnotation() */
+/** Options for yield.fromAnnotation() and yield.fromResource(). */
 export interface GenerationOptions {
   title: string;
   storageUri: string;
@@ -107,6 +108,12 @@ export interface GenerationOptions {
   sourceLanguage?: string;
   temperature?: number;
   maxTokens?: number;
+  /**
+   * Media type of the generated resource (the role's output format). Defaults to
+   * `text/markdown` at the worker, which validates it against its supported output
+   * set and **fails the job** for anything it can't write — not a silent fallback.
+   */
+  outputMediaType?: SupportedMediaType;
 }
 
 /** Options for mark.assist() */
@@ -387,6 +394,14 @@ export interface YieldNamespace {
   fromAnnotation(
     resourceId: ResourceId,
     annotationId: AnnotationId,
+    options: GenerationOptions,
+  ): StreamObservable<YieldGenerationEvent>;
+
+  // Generation derived from a whole resource (no annotation anchor). Same lifecycle
+  // and options as fromAnnotation; ground it with a resource-focus `context` from
+  // gather.resource. The worker mints a source→derived reference annotation.
+  fromResource(
+    resourceId: ResourceId,
     options: GenerationOptions,
   ): StreamObservable<YieldGenerationEvent>;
 

--- a/packages/sdk/src/namespaces/yield.ts
+++ b/packages/sdk/src/namespaces/yield.ts
@@ -98,6 +98,63 @@ export class YieldNamespace implements IYieldNamespace {
     annotationId: AnnotationId,
     options: GenerationOptions,
   ): StreamObservable<YieldGenerationEvent> {
+    return this.runGeneration(resourceId, {
+      referenceId: annotationId,
+      title: options.title,
+      prompt: options.prompt,
+      entityTypes: options.entityTypes,
+      language: options.language,
+      sourceLanguage: options.sourceLanguage,
+      temperature: options.temperature,
+      maxTokens: options.maxTokens,
+      storageUri: options.storageUri,
+      outputMediaType: options.outputMediaType,
+      context: options.context as unknown as Record<string, unknown>,
+    });
+  }
+
+  /**
+   * Generate a new resource *derived from* a whole source resource — translate,
+   * summarize, transform, extract, synthesize, rewrite; the role is carried by
+   * `options.prompt` (+ `language`, `outputMediaType`). No annotation anchor — pass a
+   * resource-focus `GatheredContext` (from `gather.resource`) as `options.context` to
+   * ground it. Long-running/LLM-based; on completion the worker mints a navigable
+   * source→derived reference annotation (provenance).
+   *
+   * ⚠️ Cold `StreamObservable`: do NOT both `.subscribe(...)` and `await` the same
+   * instance — that fires the job twice. Use `.run(onNext)` for progress + result.
+   * See `.plans/MULTICAST-JOB-TRIGGERS.md`.
+   */
+  fromResource(
+    resourceId: ResourceId,
+    options: GenerationOptions,
+  ): StreamObservable<YieldGenerationEvent> {
+    return this.runGeneration(resourceId, {
+      title: options.title,
+      prompt: options.prompt,
+      entityTypes: options.entityTypes,
+      language: options.language,
+      sourceLanguage: options.sourceLanguage,
+      temperature: options.temperature,
+      maxTokens: options.maxTokens,
+      storageUri: options.storageUri,
+      outputMediaType: options.outputMediaType,
+      context: options.context as unknown as Record<string, unknown>,
+    });
+  }
+
+  /**
+   * Shared job-lifecycle driver for `fromAnnotation`/`fromResource`. Emits
+   * `job:create` (jobType `generation`) with the supplied `params`, then streams the
+   * unified `job:report-progress`/`job:complete`/`job:fail` lifecycle (with a polled
+   * `job:status` fallback) as `YieldGenerationEvent`s, resolving on the terminal
+   * `complete`. The two public methods differ only in `params` (fromAnnotation sets
+   * `referenceId`; fromResource doesn't).
+   */
+  private runGeneration(
+    resourceId: ResourceId,
+    params: Record<string, unknown>,
+  ): StreamObservable<YieldGenerationEvent> {
     return new StreamObservable<YieldGenerationEvent>((subscriber) => {
       let done = false;
       let pollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -192,18 +249,7 @@ export class YieldNamespace implements IYieldNamespace {
         {
           jobType: 'generation',
           resourceId,
-          params: {
-            referenceId: annotationId,
-            title: options.title,
-            prompt: options.prompt,
-            entityTypes: options.entityTypes,
-            language: options.language,
-            sourceLanguage: options.sourceLanguage,
-            temperature: options.temperature,
-            maxTokens: options.maxTokens,
-            storageUri: options.storageUri,
-            context: options.context as unknown as Record<string, unknown>,
-          },
+          params,
         },
         'job:created',
         'job:create-failed',


### PR DESCRIPTION
## YIELD-FROM-RESOURCE — Phases 1–4: `yield.fromResource`, a general derive-from-resource generation primitive

Makes generation **annotation-optional** so a new resource can be derived from a *source resource* (grounded in caller-chosen context), with chat (Q→A) as the first consumer rather than the shape of the API. Builds on the merged CONTEXT-UNIFICATION work (`yield.fromResource` consumes a resource-focus `GatheredContext`) and RESOURCE-LEVEL-ANCHOR (the provenance edge targets a whole resource).

### What changed, by phase

**P1 — param contract (`@semiont/jobs`).** `GenerationParams` is now annotation-optional: `referenceId` is optional and the vestigial `sourceResourceId` / `sourceResourceName` / `annotation` fields (never read by the runtime) are **deleted** (no-compat). Added `outputMediaType?: SupportedMediaType`. A `tsc`-enforced guard pins that `{ }` and `{ prompt, outputMediaType }` are both valid `GenerationParams`.

**P2 — output format + resource grounding (`@semiont/jobs`).**
- `outputMediaType` flows to the created resource's `format` (was hardcoded `text/markdown`). `processGenerationJob` validates it against the generatable set (`text/markdown`, `text/plain`) and **throws loudly** on anything else — no silent fallback to markdown under a mislabeled format. The prompt builder branches on it (plain-text drops the markdown scaffolding).
- The resource-focus prompt branch is fleshed out (the half CONTEXT-UNIFICATION P5 handed back): it now renders `focus.{summary, suggestedReferences, content.{main, related}}` as **omit-empty** sections (content capped at 4000 chars/resource), replacing the placeholder anchor line.

**P3 — provenance (Fork 2b, `@semiont/jobs`).** Resource-focus generation has no triggering reference, so the worker **mints a navigable source→derived reference-annotation** (`mark:create` via `assembleAnnotation`): target = the **whole source resource** (resource-level, no selector — per RESOURCE-LEVEL-ANCHOR), body = a `SpecificResource` → the derived resource. Annotation-focus generation still auto-binds its triggering reference via `sourceAnnotationId`. The navigable annotation is the sole provenance record (no separate `generatedFrom` stamp).

**P4 — SDK (`@semiont/sdk`).** `yield.fromResource(resourceId, { title, storageUri, context, outputMediaType?, … })` emits `job:create` (`jobType: 'generation'`, **no** `referenceId`); the StreamObservable job-lifecycle tracking is factored into a helper shared with `fromAnnotation` (refactor, no compat shim). `outputMediaType` is plumbed through both `fromResource` and `fromAnnotation`.

### Notable build-time decision (beyond the worklist)
Generation `maxRetries` changed **3 → 0** (`make-meaning/job-commands.ts`): generation is **non-idempotent** — a retry re-runs the LLM and produces *different* content, not a replay — and expensive, so the failure is surfaced to the caller rather than silently re-rolled. Detection jobs (≈idempotent re-scan) keep their one self-heal retry.

### Docs
Protocol flow docs (`GATHER.md`, `MATCHER.md`) and `@semiont/make-meaning` API docs/examples updated to the unified `GatheredContext` shape (discriminated `focus`, the shared `KnowledgeGraph` backbone, `deriveViews`) — carrying forward the CONTEXT-UNIFICATION documentation.

### Plan & remaining work
Plan: `.plans/YIELD-FROM-RESOURCE.md`. This PR is **P1–P4** (the `@semiont/jobs` lane + SDK). Remaining: **P5** (`apps/cli` — optional `yield resource <id>` subcommand) and **P6** (docs — flip CHAT-SKILL D5 to whole-doc-chat-first-class). Downstream, this is the half of whole-doc chat that EXCLUDE-VECTORS Phase 3 (`my-chat`) depends on.
