### PR TITLE
YIELD-FROM-RESOURCE P5: semiont yield resource-anchored delegate mode (+ --output-media-type)

### DIFF
--- a/apps/cli/src/core/commands/__tests__/yield-command.test.ts
+++ b/apps/cli/src/core/commands/__tests__/yield-command.test.ts
@@ -16,9 +16,11 @@ const { mockYield, mockGather, mockLoadCachedClient } = vi.hoisted(() => {
   const mockYield = {
     resource: vi.fn(),
     fromAnnotation: vi.fn(),
+    fromResource: vi.fn(),
   };
   const mockGather = {
     annotation: vi.fn(),
+    resource: vi.fn(),
   };
   const mockLoadCachedClient = vi.fn();
   return { mockYield, mockGather, mockLoadCachedClient };
@@ -90,6 +92,15 @@ function makeDelegateOptions(overrides: Partial<YieldOptions> = {}): YieldOption
   });
 }
 
+// Resource-anchored delegate: --resource + --storage-uri, no --annotation.
+function makeResourceDelegateOptions(overrides: Partial<YieldOptions> = {}): YieldOptions {
+  return makeDelegateOptions({
+    annotation: undefined,
+    storageUri: 'file://generated/derived.md',
+    ...overrides,
+  });
+}
+
 // ── Schema tests ──────────────────────────────────────────────────────────────
 
 describe('YieldOptionsSchema', () => {
@@ -133,13 +144,13 @@ describe('YieldOptionsSchema', () => {
     expect(r.success).toBe(false);
   });
 
-  it('rejects delegate without --annotation', () => {
+  it('accepts delegate without --annotation (resource-anchored mode)', () => {
     const r = YieldOptionsSchema.safeParse({
       delegate: true,
       resource: 'doc-1',
       storageUri: 'file://out.md',
     });
-    expect(r.success).toBe(false);
+    expect(r.success).toBe(true);
   });
 
   it('rejects delegate without --storage-uri', () => {
@@ -271,6 +282,68 @@ describe('runYield', () => {
       mockYield.fromAnnotation.mockReset();
       mockYield.fromAnnotation.mockReturnValueOnce(throwError(() => new Error('Generation failed')));
       await expect(runYield(makeDelegateOptions())).rejects.toThrow('Generation failed');
+    });
+
+    it('passes outputMediaType through to yield.fromAnnotation', async () => {
+      await runYield(makeDelegateOptions({ outputMediaType: 'text/html' }));
+      const [, , opts] = mockYield.fromAnnotation.mock.calls[0];
+      expect(opts.outputMediaType).toBe('text/html');
+    });
+
+    it('rejects an unknown outputMediaType (membership guard)', async () => {
+      await expect(runYield(makeDelegateOptions({ outputMediaType: 'text/markdwn' })))
+        .rejects.toThrow(/text\/markdwn/);
+    });
+  });
+
+  describe('delegate mode — resource-anchored', () => {
+    beforeEach(() => {
+      // gather.resource is a Promise (resource-focus), unlike gather.annotation (Observable)
+      mockGather.resource.mockResolvedValue({
+        focus: { kind: 'resource', resource: {} },
+        graph: { nodes: [], edges: [] },
+        metadata: {},
+      });
+      mockYield.fromResource.mockReturnValue(of({
+        kind: 'complete',
+        data: {
+          jobId: 'j2',
+          resourceId: 'res-2',
+          jobType: 'generation',
+          result: { resourceId: 'urn:semiont:resource:derived-1', resourceName: 'Derived' },
+        },
+      }));
+    });
+
+    it('calls gather.resource then yield.fromResource (no annotation)', async () => {
+      await runYield(makeResourceDelegateOptions());
+      expect(mockGather.resource).toHaveBeenCalledOnce();
+      expect(mockYield.fromResource).toHaveBeenCalledOnce();
+      expect(mockGather.annotation).not.toHaveBeenCalled();
+      expect(mockYield.fromAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('grounds the gather (includeContent + includeSummary)', async () => {
+      await runYield(makeResourceDelegateOptions());
+      const [, opts] = mockGather.resource.mock.calls[0];
+      expect(opts).toMatchObject({ includeContent: true, includeSummary: true });
+    });
+
+    it('records the derived resourceId in result metadata', async () => {
+      const result = await runYield(makeResourceDelegateOptions());
+      expect(result.results[0]?.metadata?.resourceId).toBe('urn:semiont:resource:derived-1');
+    });
+
+    it('passes outputMediaType through to yield.fromResource', async () => {
+      await runYield(makeResourceDelegateOptions({ outputMediaType: 'text/plain' }));
+      const [, opts] = mockYield.fromResource.mock.calls[0];
+      expect(opts.outputMediaType).toBe('text/plain');
+    });
+
+    it('rejects when yield.fromResource errors', async () => {
+      mockYield.fromResource.mockReset();
+      mockYield.fromResource.mockReturnValueOnce(throwError(() => new Error('Derive failed')));
+      await expect(runYield(makeResourceDelegateOptions())).rejects.toThrow('Derive failed');
     });
   });
 });

--- a/apps/cli/src/core/commands/yield.ts
+++ b/apps/cli/src/core/commands/yield.ts
@@ -104,8 +104,9 @@ function resolveOutputMediaType(raw: string | undefined): SupportedMediaType | u
   return raw;
 }
 
-function extractResult(final: { kind: string; data?: { result?: unknown } }): { resourceId?: string; resourceName?: string } {
-  const r = ((final.kind === 'complete' ? final.data?.result : undefined) ?? {}) as { resourceId?: string; resourceName?: string };
+function extractResult(final: { kind: string; data?: unknown }): { resourceId?: string; resourceName?: string } {
+  if (final.kind !== 'complete') return {};
+  const r = (final.data as { result?: { resourceId?: string; resourceName?: string } } | undefined)?.result ?? {};
   return { resourceId: r.resourceId, resourceName: r.resourceName };
 }
 

--- a/apps/cli/src/core/commands/yield.ts
+++ b/apps/cli/src/core/commands/yield.ts
@@ -19,8 +19,8 @@ import * as path from 'path';
 import { promises as nodeFs } from 'fs';
 import { z } from 'zod';
 import { lastValueFrom } from 'rxjs';
-import { resourceId as toResourceId, annotationId as toAnnotationId, mediaTypeForExtension } from '@semiont/core';
-import type { GatheredContext } from '@semiont/core';
+import { resourceId as toResourceId, annotationId as toAnnotationId, mediaTypeForExtension, isSupportedMediaType } from '@semiont/core';
+import type { GatheredContext, SupportedMediaType } from '@semiont/core';
 import { CommandResults } from '../command-types.js';
 import { CommandBuilder } from '../command-definition.js';
 import { ApiOptionsSchema, withApiArgs } from '../base-options-schema.js';
@@ -58,6 +58,12 @@ export const YieldOptionsSchema = ApiOptionsSchema.extend({
   temperature: z.coerce.number().min(0).max(1).optional(),
   maxTokens: z.coerce.number().int().min(100).max(4000).optional(),
   contextWindow: z.coerce.number().int().min(100).max(5000).default(1000),
+  /**
+   * Media type of the generated resource (delegate mode). Validated for
+   * registry membership at the call site; the create route owns the
+   * authorable / role-appropriateness rejection (MEDIA-TYPES).
+   */
+  outputMediaType: z.string().optional(),
 }).superRefine((val, ctx) => {
   const hasUpload = val.upload.length > 0;
   const hasDelegate = val.delegate;
@@ -72,8 +78,8 @@ export const YieldOptionsSchema = ApiOptionsSchema.extend({
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: '--name can only be used when uploading a single file' });
   }
   if (hasDelegate) {
+    // --annotation is optional: present → annotation-anchored, absent → resource-anchored.
     if (!val.resource) ctx.addIssue({ code: z.ZodIssueCode.custom, message: '--resource <resourceId> is required with --delegate' });
-    if (!val.annotation) ctx.addIssue({ code: z.ZodIssueCode.custom, message: '--annotation <annotationId> is required with --delegate' });
     if (!val.storageUri) ctx.addIssue({ code: z.ZodIssueCode.custom, message: '--storage-uri is required with --delegate' });
   }
 });
@@ -84,13 +90,60 @@ export type YieldOptions = z.output<typeof YieldOptionsSchema>;
 // DELEGATE MODE HELPERS
 // =====================================================================
 
+/**
+ * Validate --output-media-type for registry membership (a typo is a CLI
+ * input error). The create route owns the authorable / role-appropriateness
+ * rejection — no parallel gate here (MEDIA-TYPES). Uses the core type guard,
+ * not a cast.
+ */
+function resolveOutputMediaType(raw: string | undefined): SupportedMediaType | undefined {
+  if (raw === undefined) return undefined;
+  if (!isSupportedMediaType(raw)) {
+    throw new Error(`Unknown output media type: ${raw}`);
+  }
+  return raw;
+}
+
+function extractResult(final: { kind: string; data?: { result?: unknown } }): { resourceId?: string; resourceName?: string } {
+  const r = ((final.kind === 'complete' ? final.data?.result : undefined) ?? {}) as { resourceId?: string; resourceName?: string };
+  return { resourceId: r.resourceId, resourceName: r.resourceName };
+}
+
 async function runDelegate(
   semiont: SemiontClient,
   options: YieldOptions,
 ): Promise<{ resourceId?: string; resourceName?: string }> {
   const rawResourceId = options.resource!;
-  const rawAnnotationId = options.annotation!;
   const rId = toResourceId(rawResourceId);
+  const outputMediaType = resolveOutputMediaType(options.outputMediaType);
+
+  // Resource-anchored mode: no --annotation. Derive a new resource from the
+  // whole source resource, grounded by a resource-focus GatheredContext.
+  if (!options.annotation) {
+    // gather.resource is a Promise (resource-focus), not an Observable.
+    // includeContent/includeSummary keep generation grounded (avoid the
+    // thin-context failure mode); the worker renders those sections.
+    const context = await semiont.gather.resource(rId, { includeContent: true, includeSummary: true });
+
+    if (!options.quiet) process.stderr.write(`Deriving from resource ${rawResourceId}...\n`);
+
+    const final = await lastValueFrom(
+      semiont.yield.fromResource(rId, {
+        title: options.title ?? rawResourceId,
+        storageUri: options.storageUri!,
+        context,
+        prompt: options.prompt,
+        language: options.language,
+        temperature: options.temperature,
+        maxTokens: options.maxTokens,
+        outputMediaType,
+      }),
+    );
+    return extractResult(final);
+  }
+
+  // Annotation-anchored mode.
+  const rawAnnotationId = options.annotation;
   const aId = toAnnotationId(rawAnnotationId);
 
   // Step 1: gather context
@@ -119,10 +172,10 @@ async function runDelegate(
       sourceLanguage: options.sourceLanguage ?? ctxSourceLanguage,
       temperature: options.temperature,
       maxTokens: options.maxTokens,
+      outputMediaType,
     }),
   );
-  const r = ((final.kind === 'complete' ? final.data.result : undefined) ?? {}) as { resourceId?: string; resourceName?: string };
-  return { resourceId: r.resourceId, resourceName: r.resourceName };
+  return extractResult(final);
 }
 
 // =====================================================================
@@ -211,7 +264,8 @@ export async function runYield(options: YieldOptions): Promise<CommandResults> {
 export const yieldCmd = new CommandBuilder()
   .name('yield')
   .description(
-    'Upload a local file as a resource (--upload), or generate a new resource from an annotation\'s gathered context (--delegate). ' +
+    'Upload a local file as a resource (--upload), or generate a new resource via --delegate: ' +
+    'from an annotation\'s gathered context (with --annotation), or derived from a whole source resource (without --annotation). ' +
     'Delegate mode outputs JSON { resourceId, resourceName, storageUri } to stdout.'
   )
   .requiresEnvironment(true)
@@ -223,6 +277,8 @@ export const yieldCmd = new CommandBuilder()
     'semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/paris.md',
     'semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/paris.md --title "Paris" --language en',
     'semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/paris.md --prompt "Write a brief encyclopedia entry" --temperature 0.3',
+    'semiont yield --delegate --resource <resourceId> --storage-uri file://generated/summary.md --prompt "Summarize this document"',
+    'semiont yield --delegate --resource <resourceId> --storage-uri file://generated/translated.html --prompt "Translate to French" --language fr --output-media-type text/html',
     'NEW_ID=$(semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/loc.md --quiet | jq -r \'.resourceId\') && semiont bind <resourceId> <annotationId> "$NEW_ID"',
   )
   .args({
@@ -275,6 +331,10 @@ export const yieldCmd = new CommandBuilder()
       '--context-window': {
         type: 'string',
         description: 'Delegate mode: characters of annotation context to gather (100–5000, default: 1000)',
+      },
+      '--output-media-type': {
+        type: 'string',
+        description: 'Delegate mode: media type of the generated resource (e.g. text/markdown, text/html; default: text/markdown)',
       },
     }, {
       '-n': '--name',


### PR DESCRIPTION
## YIELD-FROM-RESOURCE — Phase 5: `semiont yield` resource-anchored delegate mode

Surfaces the merged `yield.fromResource` SDK method (P4, #912) at the CLI: `yield --delegate` can now derive a new resource from a **whole source resource** (no annotation), alongside the existing annotation-anchored mode. Optional phase — the SDK method is the real deliverable; this is the ergonomic front door.

### What changed (`apps/cli/src/core/commands/yield.ts`)

- **Resource-anchored delegate mode.** `--delegate --resource <id> --storage-uri <uri>` **without `--annotation`** now routes through `gather.resource` → `yield.fromResource`. With `--annotation` it stays on the existing `gather.annotation` → `yield.fromAnnotation` path. The schema `superRefine` drops the "`--annotation` required with `--delegate`" rule (annotation present → annotation-anchored; absent → resource-anchored); `--resource` and `--storage-uri` remain required.
- **Grounded gather.** Resource mode calls `gather.resource(rId, { includeContent: true, includeSummary: true })` so generation isn't thin-context. (Note: `gather.resource` returns a `Promise` (resource-focus), unlike `gather.annotation`'s `Observable` — handled accordingly.)
- **`--output-media-type` flag** (both modes). Validated for **registry membership** via the core `isSupportedMediaType` type guard (not a cast) — a typo is a CLI input error. The create route still owns the authorable / role-appropriateness rejection (no parallel gate — MEDIA-TYPES).
- **Shared result extraction** factored into `extractResult(...)`, used by both modes (DRY, no duplication).
- Command **description + examples** updated — added resource-anchored summarize and translate-to-`text/html` examples.

### Tests (`yield-command.test.ts`)
- Flips the old "rejects delegate without `--annotation`" assertion to "accepts (resource-anchored mode)".
- New `delegate mode — resource-anchored` suite: calls `gather.resource` then `yield.fromResource` (and *not* the annotation path); grounds the gather (`includeContent`/`includeSummary`); records the derived `resourceId`; passes `outputMediaType` through; rejects on `yield.fromResource` error.
- `outputMediaType` passthrough + unknown-media-type rejection on the annotation path too.

### Plan
Plan: `.plans/YIELD-FROM-RESOURCE.md` (Phase 5 — optional, `apps/cli`). After this, only **P6** (docs — flip CHAT-SKILL D5 to whole-doc-chat-first-class) remains. Downstream, the whole-doc-chat path (`gather.resource` → `yield.fromResource`) is now reachable end-to-end from SDK *and* CLI; EXCLUDE-VECTORS Phase 3 (`my-chat`) consumes the same SDK method.
