### PR TITLE
Exclude Vectors, 2b & 3

### DIFF
--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -445,4 +445,57 @@ describe('LLM Context', () => {
       expect(resFocus(result).suggestedReferences).toBeDefined();
     });
   });
+
+  describe('semantic context (EXCLUDE-VECTORS Phase 2b)', () => {
+    // The fake vector store returns this pool from searchByResource, applying
+    // the excludeEntityTypes filter itself (the real store's job — already
+    // tested in @semiont/vectors). Here we verify getResourceContext forwards
+    // the filter, maps results, and records the exclusion as provenance.
+    const pool = [
+      { id: 'r-answer#0', score: 0.9, resourceId: 'r-answer', text: 'a prior answer', entityTypes: ['Answer'] },
+      { id: 'r-question#0', score: 0.8, resourceId: 'r-question', text: 'a prior question', entityTypes: ['Question'] },
+    ];
+    const baseOpts = { depth: 1, maxResources: 5, includeContent: false, includeSummary: false };
+
+    function kbWithVectors(capture?: (opts: any) => void): KnowledgeBase {
+      return {
+        ...kb,
+        vectors: {
+          searchByResource: vi.fn(async (_rid: any, opts: any) => {
+            capture?.(opts);
+            const exclude = new Set<string>(opts.filter?.excludeEntityTypes ?? []);
+            return pool.filter((p) => !p.entityTypes.some((t) => exclude.has(t)));
+          }),
+        } as any,
+      };
+    }
+
+    it('populates semanticContext from searchByResource', async () => {
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient);
+      expect(ctx.semanticContext?.similar.map((s) => s.resourceId).sort()).toEqual(['r-answer', 'r-question']);
+    });
+
+    it('omits excluded-entity-type resources and records the exclusion', async () => {
+      let seen: any;
+      const ctx = await LLMContext.getResourceContext(
+        resourceId(testResourceId),
+        { ...baseOpts, excludeEntityTypes: ['Question'] },
+        kbWithVectors((o) => { seen = o; }),
+        mockClient,
+      );
+      expect(seen.filter.excludeEntityTypes).toEqual(['Question']);             // filter forwarded
+      expect(ctx.semanticContext?.similar.map((s) => s.resourceId)).toEqual(['r-answer']); // Question omitted
+      expect(ctx.semanticContext?.excludedEntityTypes).toEqual(['Question']);   // provenance recorded
+    });
+
+    it('records no excludedEntityTypes when no exclusion is applied', async () => {
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient);
+      expect(ctx.semanticContext?.excludedEntityTypes).toBeUndefined();
+    });
+
+    it('leaves semanticContext absent when no vector store is configured', async () => {
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kb, mockClient);
+      expect(ctx.semanticContext).toBeUndefined();
+    });
+  });
 });

--- a/packages/make-meaning/src/llm-context.ts
+++ b/packages/make-meaning/src/llm-context.ts
@@ -21,6 +21,11 @@ export interface LLMContextOptions {
   maxResources: number;
   includeContent: boolean;
   includeSummary: boolean;
+  /**
+   * Entity types to exclude from the resource-gather semantic recall
+   * (caller-supplied; e.g. ['Question']). Optional; default none.
+   */
+  excludeEntityTypes?: string[];
 }
 
 export class LLMContext {
@@ -96,9 +101,33 @@ export class LLMContext {
     if (mainContent) content.main = mainContent;
     if (options.includeContent) content.related = relatedContent;
 
+    // Semantic recall over the resource's OWN already-indexed vectors (no
+    // re-embedding), excluding caller-supplied entity types. The applied filter
+    // is recorded on semanticContext as build provenance. EXCLUDE-VECTORS Phase 2b.
+    let semanticContext: GatheredContext['semanticContext'];
+    if (kb.vectors) {
+      const excludeEntityTypes = options.excludeEntityTypes ?? [];
+      const matches = await kb.vectors.searchByResource(resourceId, {
+        limit: options.maxResources,
+        scoreThreshold: 0.5,
+        ...(excludeEntityTypes.length ? { filter: { excludeEntityTypes } } : {}),
+      });
+      if (matches.length > 0) {
+        semanticContext = {
+          similar: matches.map((m) => ({
+            text: m.text,
+            resourceId: m.resourceId,
+            ...(m.annotationId ? { annotationId: m.annotationId } : {}),
+            score: m.score,
+            ...(m.entityTypes ? { entityTypes: m.entityTypes } : {}),
+          })),
+          ...(excludeEntityTypes.length ? { excludedEntityTypes: excludeEntityTypes } : {}),
+        };
+      }
+    }
+
     // Assemble the unified GatheredContext (focus.kind:'resource'). Related resources and
-    // annotations are graph nodes, not separate fields. semanticContext is left absent —
-    // EXCLUDE-VECTORS Phase 2b populates it (question-filtered).
+    // annotations are graph nodes, not separate fields.
     return {
       focus: {
         kind: 'resource',
@@ -108,6 +137,7 @@ export class LLMContext {
         ...(Object.keys(content).length > 0 ? { content } : {}),
       },
       graph,
+      ...(semanticContext ? { semanticContext } : {}),
       metadata: {
         resourceType: 'document',
         language: mainDoc.language as string | undefined,

--- a/packages/sdk/src/namespaces/gather.ts
+++ b/packages/sdk/src/namespaces/gather.ts
@@ -86,6 +86,9 @@ export class GatherNamespace implements IGatherNamespace {
       maxResources?: number;
       includeContent?: boolean;
       includeSummary?: boolean;
+      /** Entity types to exclude from the semantic recall built into the context
+       *  (e.g. ['Question'] so prior questions never ground answer generation). */
+      excludeEntityTypes?: string[];
     },
   ): Promise<GatheredContext> {
     return busRequest<GatheredContext>(
@@ -98,6 +101,7 @@ export class GatherNamespace implements IGatherNamespace {
           maxResources: options?.maxResources ?? 10,
           includeContent: options?.includeContent ?? true,
           includeSummary: options?.includeSummary ?? false,
+          ...(options?.excludeEntityTypes?.length ? { excludeEntityTypes: options.excludeEntityTypes } : {}),
         },
       },
       'gather:resource-complete',

--- a/packages/sdk/src/namespaces/types.ts
+++ b/packages/sdk/src/namespaces/types.ts
@@ -349,6 +349,9 @@ export interface GatherNamespace {
       maxResources?: number;
       includeContent?: boolean;
       includeSummary?: boolean;
+      /** Entity types to exclude from the semantic recall built into the context
+       *  (e.g. ['Question'] so prior questions never ground answer generation). */
+      excludeEntityTypes?: string[];
     },
   ): Promise<GatheredContext>;
 }

--- a/packages/vectors/src/__tests__/memory-store.test.ts
+++ b/packages/vectors/src/__tests__/memory-store.test.ts
@@ -127,6 +127,74 @@ describe('MemoryVectorStore', () => {
     });
   });
 
+  describe('searchByResource (per-chunk max-sim)', () => {
+    it('returns empty when the resource has no stored vectors', async () => {
+      const results = await store.searchByResource('ghost' as ResourceId, { limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it('finds resources similar to the source, excluding the source and excluded kinds', async () => {
+      await store.upsertResourceVectors('q-1' as ResourceId,
+        [{ chunkIndex: 0, text: 'capital of France?', embedding: [1, 0, 0] }], 'cs', ['Question']);
+      await store.upsertResourceVectors('q-2' as ResourceId,
+        [{ chunkIndex: 0, text: 'capital of France?', embedding: [1, 0, 0] }], 'cs', ['Question']);
+      await store.upsertResourceVectors('doc-paris' as ResourceId,
+        [{ chunkIndex: 0, text: 'Paris is the capital', embedding: [0.9, 0.1, 0] }], 'cs', ['Article']);
+      await store.upsertResourceVectors('doc-berlin' as ResourceId,
+        [{ chunkIndex: 0, text: 'Berlin is the capital', embedding: [0, 1, 0] }], 'cs', ['Article']);
+
+      const results = await store.searchByResource('q-1' as ResourceId, {
+        limit: 10,
+        filter: { excludeEntityTypes: ['Question'] },
+      });
+      const ids = results.map(r => r.resourceId);
+      expect(ids).not.toContain('q-1');  // source self-excluded
+      expect(ids).not.toContain('q-2');  // Question excluded
+      expect(ids).toContain('doc-paris');
+      expect(results[0].resourceId).toBe('doc-paris'); // most similar first
+    });
+
+    it('uses per-chunk max similarity, not a centroid average', async () => {
+      // Source has two orthogonal-topic chunks.
+      await store.upsertResourceVectors('multi' as ResourceId, [
+        { chunkIndex: 0, text: 'quantum', embedding: [1, 0] },
+        { chunkIndex: 1, text: 'cooking', embedding: [0, 1] },
+      ], 'cs', []);
+      // Each doc strongly matches ONE chunk; 'mid' matches the average of both.
+      await store.upsertResourceVectors('doc-quantum' as ResourceId,
+        [{ chunkIndex: 0, text: 'quantum doc', embedding: [1, 0] }], 'cs', ['Article']);
+      await store.upsertResourceVectors('doc-cooking' as ResourceId,
+        [{ chunkIndex: 0, text: 'cooking doc', embedding: [0, 1] }], 'cs', ['Article']);
+      await store.upsertResourceVectors('doc-mid' as ResourceId,
+        [{ chunkIndex: 0, text: 'mid doc', embedding: [0.7071, 0.7071] }], 'cs', ['Article']);
+
+      const results = await store.searchByResource('multi' as ResourceId, { limit: 10 });
+      const score = (id: string) => results.find(r => r.resourceId === id)!.score;
+
+      // Max-sim: each single-topic doc peaks at 1.0 on its chunk; 'mid' peaks at ~0.707.
+      expect(score('doc-quantum')).toBeCloseTo(1.0, 3);
+      expect(score('doc-cooking')).toBeCloseTo(1.0, 3);
+      expect(score('doc-mid')).toBeCloseTo(0.7071, 3);
+      // A centroid query would rank 'mid' top; max-sim ranks it last.
+      expect(results[results.length - 1].resourceId).toBe('doc-mid');
+    });
+
+    it('dedups multi-chunk targets to one result carrying the best-matching chunk', async () => {
+      await store.upsertResourceVectors('src' as ResourceId,
+        [{ chunkIndex: 0, text: 'q', embedding: [1, 0] }], 'cs', []);
+      await store.upsertResourceVectors('doc' as ResourceId, [
+        { chunkIndex: 0, text: 'off-topic chunk', embedding: [0, 1] },
+        { chunkIndex: 1, text: 'on-topic chunk', embedding: [1, 0] },
+      ], 'cs', ['Article']);
+
+      const results = await store.searchByResource('src' as ResourceId, { limit: 10 });
+      const docResults = results.filter(r => r.resourceId === 'doc');
+      expect(docResults).toHaveLength(1);                 // deduped to one
+      expect(docResults[0].score).toBeCloseTo(1.0, 3);    // best chunk's score
+      expect(docResults[0].text).toBe('on-topic chunk');  // best-matching chunk's text
+    });
+  });
+
   describe('annotation vectors', () => {
     it('upserts and searches annotation vectors', async () => {
       const vec = await embedding.embed('Lincoln delivered the Gettysburg Address');

--- a/packages/vectors/src/store/interface.ts
+++ b/packages/vectors/src/store/interface.ts
@@ -79,6 +79,21 @@ export interface VectorStore {
   searchResources(embedding: number[], opts: SearchOptions): Promise<VectorSearchResult[]>;
   searchAnnotations(embedding: number[], opts: SearchOptions): Promise<VectorSearchResult[]>;
   /**
+   * Find resources similar to a resource's own stored chunk vectors ("more like
+   * this resource"), without re-embedding any text.
+   *
+   * Per-chunk top-K + **max-sim merge** (not a centroid/average): searches by
+   * each of the resource's stored chunk vectors, then merges by `resourceId`
+   * keeping the **maximum** similarity any query chunk had to any target chunk.
+   * Each result's `score` is that max and its `text` is the best-matching target
+   * chunk, so callers see the passage that matched. The source resource's own
+   * points are excluded; `opts.filter.excludeEntityTypes` drops excluded kinds.
+   *
+   * Returns `[]` if the resource has no stored vectors yet (it must be indexed
+   * first — callers own that ordering).
+   */
+  searchByResource(resourceId: ResourceId, opts: SearchOptions): Promise<VectorSearchResult[]>;
+  /**
    * Total point count across all collections (resources + annotations).
    * Feeds the `semiont.vector.index.size` gauge.
    */

--- a/packages/vectors/src/store/memory.ts
+++ b/packages/vectors/src/store/memory.ts
@@ -137,26 +137,59 @@ export class MemoryVectorStore implements VectorStore {
     return this.search(this.annotations, embedding, opts);
   }
 
-  private search(points: StoredPoint[], embedding: number[], opts: SearchOptions): VectorSearchResult[] {
-    let filtered = points;
+  async searchByResource(resourceId: ResourceId, opts: SearchOptions): Promise<VectorSearchResult[]> {
+    const rid = String(resourceId);
+    const queryPoints = this.resources.filter(p => p.payload.resourceId === rid);
+    if (queryPoints.length === 0) return [];
 
-    if (opts.filter) {
-      const f = opts.filter;
-      filtered = points.filter(p => {
-        if (f.resourceId && p.payload.resourceId !== String(f.resourceId)) return false;
-        if (f.excludeResourceId && p.payload.resourceId === String(f.excludeResourceId)) return false;
-        if (f.motivation && p.payload.motivation !== f.motivation) return false;
-        if (f.entityTypes && f.entityTypes.length > 0) {
-          const pTypes = p.payload.entityTypes ?? [];
-          if (!f.entityTypes.some(t => pTypes.includes(t))) return false;
-        }
-        if (f.excludeEntityTypes && f.excludeEntityTypes.length > 0) {
-          const pTypes = p.payload.entityTypes ?? [];
-          if (f.excludeEntityTypes.some(t => pTypes.includes(t))) return false;
-        }
-        return true;
-      });
+    // Self-exclude the source; carry the caller's filter (e.g. excludeEntityTypes).
+    const filter: SearchOptions['filter'] = { ...opts.filter, excludeResourceId: resourceId };
+
+    // Per-chunk max-sim, merged by resource: each candidate point scores as the
+    // best similarity to any of the source's query chunks; keep, per target
+    // resource, the single best-matching point (its score and its text).
+    const bestByResource = new Map<string, StoredPoint & { score: number }>();
+    for (const cand of this.resources) {
+      if (!this.passesFilter(cand, filter)) continue;
+      let best = -Infinity;
+      for (const q of queryPoints) {
+        const score = cosineSimilarity(q.vector, cand.vector);
+        if (score > best) best = score;
+      }
+      const prev = bestByResource.get(cand.payload.resourceId);
+      if (!prev || best > prev.score) {
+        bestByResource.set(cand.payload.resourceId, { ...cand, score: best });
+      }
     }
+
+    let merged = [...bestByResource.values()];
+    if (opts.scoreThreshold !== undefined) {
+      const threshold = opts.scoreThreshold;
+      merged = merged.filter(s => s.score >= threshold);
+    }
+    merged.sort((a, b) => b.score - a.score);
+    return merged.slice(0, opts.limit).map(s => this.toResult(s));
+  }
+
+  private passesFilter(p: StoredPoint, filter: SearchOptions['filter']): boolean {
+    if (!filter) return true;
+    const f = filter;
+    if (f.resourceId && p.payload.resourceId !== String(f.resourceId)) return false;
+    if (f.excludeResourceId && p.payload.resourceId === String(f.excludeResourceId)) return false;
+    if (f.motivation && p.payload.motivation !== f.motivation) return false;
+    if (f.entityTypes && f.entityTypes.length > 0) {
+      const pTypes = p.payload.entityTypes ?? [];
+      if (!f.entityTypes.some(t => pTypes.includes(t))) return false;
+    }
+    if (f.excludeEntityTypes && f.excludeEntityTypes.length > 0) {
+      const pTypes = p.payload.entityTypes ?? [];
+      if (f.excludeEntityTypes.some(t => pTypes.includes(t))) return false;
+    }
+    return true;
+  }
+
+  private search(points: StoredPoint[], embedding: number[], opts: SearchOptions): VectorSearchResult[] {
+    const filtered = points.filter(p => this.passesFilter(p, opts.filter));
 
     const scored = filtered.map(p => ({
       ...p,

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -212,6 +212,69 @@ export class QdrantVectorStore implements VectorStore {
     return this.search('annotations', embedding, opts);
   }
 
+  async searchByResource(resourceId: ResourceId, opts: SearchOptions): Promise<VectorSearchResult[]> {
+    // Fetch the resource's stored chunk vectors (page through all of them so a
+    // long resource isn't silently truncated).
+    const queryVectors: number[][] = [];
+    let offset: Schemas['ScrollRequest']['offset'] = undefined;
+    do {
+      const page = await this.qdrant.scroll('resources', {
+        filter: { must: [{ key: 'resourceId', match: { value: String(resourceId) } }] },
+        with_vector: true,
+        with_payload: false,
+        limit: 256,
+        offset,
+      });
+      for (const point of page.points) {
+        if (Array.isArray(point.vector)) queryVectors.push(point.vector as number[]);
+      }
+      offset = page.next_page_offset ?? undefined;
+    } while (offset !== undefined && offset !== null);
+
+    if (queryVectors.length === 0) return [];
+
+    // Self-exclude the source; carry the caller's filter (e.g. excludeEntityTypes).
+    const filter = this.buildFilter({ ...opts.filter, excludeResourceId: resourceId });
+
+    // One batched search per query chunk (single round-trip), top-`limit` each;
+    // over-fetch beyond `limit` is unnecessary because the max-sim merge only
+    // needs a target in some chunk's top-K to surface.
+    const searches = queryVectors.map((vector) => ({
+      vector,
+      limit: opts.limit,
+      score_threshold: opts.scoreThreshold,
+      filter: filter ?? undefined,
+      with_payload: true,
+    }));
+    const batches = await this.qdrant.searchBatch('resources', { searches });
+
+    // Max-sim merge: dedup by resourceId, keep the best (query-chunk × target-chunk)
+    // score and the best-matching target chunk's payload.
+    const bestByResource = new Map<string, { id: string; score: number; payload: Record<string, unknown> }>();
+    for (const batch of batches) {
+      for (const r of batch) {
+        const payload = r.payload ?? {};
+        const tid = String(payload.resourceId);
+        const prev = bestByResource.get(tid);
+        if (!prev || r.score > prev.score) {
+          bestByResource.set(tid, { id: String(r.id), score: r.score, payload });
+        }
+      }
+    }
+
+    return [...bestByResource.values()]
+      .sort((a, b) => b.score - a.score)
+      .slice(0, opts.limit)
+      .map((m) => ({
+        id: m.id,
+        score: m.score,
+        resourceId: m.payload.resourceId as ResourceId,
+        annotationId: m.payload.annotationId as AnnotationId | undefined,
+        text: m.payload.text as string,
+        entityTypes: m.payload.entityTypes as string[] | undefined,
+      }));
+  }
+
   private async search(collection: string, embedding: number[], opts: SearchOptions): Promise<VectorSearchResult[]> {
     const filter = this.buildFilter(opts.filter);
 

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -48,8 +48,14 @@ export class QdrantVectorStore implements VectorStore {
     // Ensure collections exist
     await this.ensureCollection('resources', this.config.dimensions);
     await this.ensureCollection('annotations', this.config.dimensions);
-    // Index the discriminator so excludeEntityTypes filtering scales.
+    // Payload indexes so filtered operations scale:
+    //  - entityTypes: the excludeEntityTypes recall filter.
+    //  - resourceId: searchByResource's by-resource scroll + self-exclusion, and
+    //    the per-resource delete paths (deleteResourceVectors /
+    //    deleteAnnotationVectorsForResource).
     await this.ensurePayloadIndex('resources', 'entityTypes');
+    await this.ensurePayloadIndex('resources', 'resourceId');
+    await this.ensurePayloadIndex('annotations', 'resourceId');
   }
 
   async disconnect(): Promise<void> {

--- a/specs/src/components/schemas/GatherResourceRequest.json
+++ b/specs/src/components/schemas/GatherResourceRequest.json
@@ -28,6 +28,11 @@
         "includeSummary": {
           "type": "boolean",
           "description": "Whether to include resource summaries in the gathered result"
+        },
+        "excludeEntityTypes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Entity types to exclude from the semantic recall built into this context (caller-supplied; e.g. a chat consumer passes ['Question'] so prior questions never ground answer generation). Optional; default none."
         }
       },
       "required": ["depth", "maxResources", "includeContent", "includeSummary"],

--- a/specs/src/components/schemas/GatheredContext.json
+++ b/specs/src/components/schemas/GatheredContext.json
@@ -117,6 +117,11 @@
             "$ref": "./SemanticMatch.json"
           },
           "description": "Passages ranked by cosine similarity to the focal text"
+        },
+        "excludedEntityTypes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Entity types excluded from this recall — a record of how `similar` was filtered (e.g. ['Question'] so answer-generation never surfaces prior questions). Absent when no exclusion was applied."
         }
       },
       "required": ["similar"]


### PR DESCRIPTION
## EXCLUDE-VECTORS — Phase 2b: resource-gather semantic recall, with caller-supplied exclusion

Introduces resource-level semantic recall on the `gather.resource` path, with an entity-type
exclusion baked in from the start — so a consumer can keep prior questions out of
answer-generation recall (by passing `entityTypes: ['Question']`) without any
question-special-casing in core.

### Changes

**`@semiont/vectors` — `searchByResource`**
- New `searchByResource(resourceId, opts)` on `VectorStore` (interface / memory / qdrant): queries
  by a resource's *own* already-indexed chunk vectors — no re-embedding, no `EmbeddingProvider` in
  the gather path.
- **Per-chunk top-K + max-sim merge** (not a centroid/`recommend` average): dedup by `resourceId`,
  keep the max (query-chunk × target-chunk) similarity, return the top-`limit` carrying the
  best-matching chunk's text. Both backends rank identically.
- Self-excludes the source resource; applies `opts.filter.excludeEntityTypes`. Qdrant: scroll the
  resource's vectors → one `searchBatch` → client-side merge; memory: cosine-per-chunk + the same
  merge. Returns `[]` when the resource isn't indexed yet (the deferred ordering gap, below).

**Qdrant `resourceId` payload indexes**
- `ensurePayloadIndex('resources'/'annotations', 'resourceId')` so `searchByResource`'s
  by-resource scroll + self-exclusion scale.

**`@semiont/make-meaning` — fill the reserved `semanticContext` slot**
- `getResourceContext` now populates the `semanticContext` slot CONTEXT-UNIFICATION reserved, via
  `searchByResource(..., { filter: { excludeEntityTypes } })`, maps results to `SemanticMatch[]`,
  and records `excludedEntityTypes` (retrieval provenance) when a filter was applied. Omit-empty.

**`@semiont/sdk`**
- `gather.resource` gains `excludeEntityTypes?: string[]`, forwarded omit-empty into
  `GatherResourceRequest.options`.

**Specs (`@semiont/core`)**
- `GatherResourceRequest.options.excludeEntityTypes?` (caller-supplied filter) and
  `GatheredContext.semanticContext.excludedEntityTypes?` (the applied-filter provenance — on
  `semanticContext`, since it describes how `similar` was filtered).

### Out of scope / deferred
- Matcher-path exclusion + the react-ui match-modal multi-select — deferred.
- `searchByResource` read-after-write ordering guarantee — deferred (recall is best-effort on
  freshly-created resources).
- Phase 3 (the external `my-chat` consumer) lives in a separate repo.

### Notes
- No hardcoded `'Question'` in core — exclusion is purely caller-supplied (`'Question'` appears
  only in test fixtures).
- Verified on `node:24-alpine`: vectors build + tests, make-meaning typecheck + `llm-context`
  tests, sdk + cli typecheck — all green.
