### PR TITLE
Embeddable resource viewer: bring-your-own-session (provider-free)

### DIFF
--- a/packages/react-ui/src/__tests__/embeddable-surface.test.ts
+++ b/packages/react-ui/src/__tests__/embeddable-surface.test.ts
@@ -1,0 +1,22 @@
+/**
+ * EMBEDDABLE-RESOURCE-VIEWER step 5 — packaging gate.
+ *
+ * The bring-your-own-session consumer surface must be importable straight from
+ * the barrel, so `import { ResourceViewer, useResourceLoader, useMediaToken,
+ * useSessionEventSubscriptions } from '@semiont/react-ui'` works in a plain
+ * Vite/Electron host with no app framework. (The "no `next/*` on the viewer path"
+ * half of the gate is a static grep in the plan's step-5 log.)
+ */
+import { describe, it, expect } from 'vitest';
+import * as reactUi from '../index';
+
+describe('@semiont/react-ui — embeddable consumer surface', () => {
+  it('exports the bring-your-own-session viewer pieces from the barrel', () => {
+    expect(typeof reactUi.ResourceViewer).toBe('function');
+    expect(typeof reactUi.useResourceLoader).toBe('function');
+    expect(typeof reactUi.useMediaToken).toBe('function');
+    expect(typeof reactUi.useSessionEventSubscriptions).toBe('function');
+    expect(typeof reactUi.setPdfWorkerSrc).toBe('function');
+    expect(typeof reactUi.defaultBrowseRenderers).toBe('object');
+  });
+});

--- a/packages/react-ui/src/components/annotation/AnnotateToolbar.tsx
+++ b/packages/react-ui/src/components/annotation/AnnotateToolbar.tsx
@@ -2,8 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { useTranslations } from '../../contexts/TranslationContext';
-import { useSemiont } from '../../session/SemiontProvider';
-import { useObservable } from '../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import { getSupportedShapes } from '../../lib/media-shapes';
 import type { Annotator } from '../../lib/annotation-registry';
 import './annotations.css';
@@ -28,6 +27,9 @@ interface AnnotateToolbarProps {
 
   // Annotators for emoji lookup
   annotators: Record<string, Annotator>;
+
+  // Session — emits mark:* selection/click/shape/mode changes via its client.
+  session: SemiontSession | null;
 }
 
 interface DropdownGroupProps {
@@ -117,10 +119,10 @@ export function AnnotateToolbar({
   selectedShape = 'rectangle',
   mediaType,
   annotateMode = false,
-  annotators
+  annotators,
+  session,
 }: AnnotateToolbarProps) {
   const t = useTranslations('AnnotateToolbar');
-  const session = useObservable(useSemiont().activeSession$);
 
   // Helper to get emoji from annotators by motivation (with fallback for safety)
   const getMotivationEmoji = (motivation: SelectionMotivation): string => {

--- a/packages/react-ui/src/components/annotation/__tests__/AnnotateToolbar.test.tsx
+++ b/packages/react-ui/src/components/annotation/__tests__/AnnotateToolbar.test.tsx
@@ -7,6 +7,7 @@ import { TranslationProvider } from '../../../contexts/TranslationContext';
 import { createTestSemiontWrapper } from '../../../test-utils';
 import type { TranslationManager } from '../../../types/TranslationManager';
 import type { EventBus } from '@semiont/core';
+import type { SemiontClient, SemiontSession } from '@semiont/sdk';
 
 // Mock translations
 const messages: Record<string, Record<string, string>> = {
@@ -63,8 +64,20 @@ function createEventTracker() {
   };
 }
 
-const renderWithIntl = (component: React.ReactElement, tracker?: ReturnType<typeof createEventTracker>) => {
-  const { SemiontWrapper, eventBus } = createTestSemiontWrapper();
+// AnnotateToolbar takes its session as a prop now (step 1b). Wrap the fake client
+// so mark:* changes emit on the SAME bus the tracker listens on.
+function makeSession(client: SemiontClient): SemiontSession {
+  return {
+    client,
+    subscribe: (channel: string, handler: (p: never) => void) => {
+      const sub = (client.bus.get(channel as never) as { subscribe(fn: (p: never) => void): { unsubscribe(): void } }).subscribe(handler);
+      return () => sub.unsubscribe();
+    },
+  } as unknown as SemiontSession;
+}
+
+const renderWithIntl = (component: React.ReactElement<React.ComponentProps<typeof AnnotateToolbar>>, tracker?: ReturnType<typeof createEventTracker>) => {
+  const { SemiontWrapper, eventBus, client } = createTestSemiontWrapper();
   if (tracker) tracker._attach(eventBus);
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>
@@ -73,8 +86,15 @@ const renderWithIntl = (component: React.ReactElement, tracker?: ReturnType<type
       </TranslationProvider>
     </SemiontWrapper>
   );
-  const result = render(component, { wrapper: Wrapper });
-  return { ...result, eventBus };
+  const session = makeSession(client);
+  const result = render(React.cloneElement(component, { session }), { wrapper: Wrapper });
+  // Re-inject the same session on rerender — a bare rerender would drop it (→ session:null).
+  return {
+    ...result,
+    eventBus,
+    rerender: (next: React.ReactElement<React.ComponentProps<typeof AnnotateToolbar>>) =>
+      result.rerender(React.cloneElement(next, { session })),
+  };
 };
 
 describe('AnnotateToolbar', () => {
@@ -84,7 +104,9 @@ describe('AnnotateToolbar', () => {
     onSelectionChange: vi.fn(),
     onClickChange: vi.fn(),
     annotateMode: false,
-    annotators: ANNOTATORS
+    annotators: ANNOTATORS,
+    // Placeholder — renderWithIntl overrides with a session bound to the fake bus.
+    session: null as SemiontSession | null,
   };
 
   beforeEach(() => {

--- a/packages/react-ui/src/components/resource/AnnotateView.tsx
+++ b/packages/react-ui/src/components/resource/AnnotateView.tsx
@@ -7,16 +7,13 @@ import { segmentTextWithAnnotations } from '../../lib/text-segmentation';
 import { buildTextSelectors, fallbackTextPosition } from '../../lib/text-selection-handler';
 import { SvgDrawingCanvas } from '../image-annotation/SvgDrawingCanvas';
 
-import { useResourceAnnotations } from '../../contexts/ResourceAnnotationsContext';
-
 // Lazy load PDF component to avoid SSR issues with browser PDF.js loading
 const PdfAnnotationCanvas = lazy(() => import('../pdf-annotation/PdfAnnotationCanvas.client').then(mod => ({ default: mod.PdfAnnotationCanvas })));
 
 import { CodeMirrorRenderer } from '../CodeMirrorRenderer';
 import type { EditorView } from '@codemirror/view';
-import { useSemiont } from '../../session/SemiontProvider';
-import { useObservable } from '../../hooks/useObservable';
-import { useEventSubscriptions } from '../../contexts/useEventSubscription';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../hooks/useSessionEventSubscriptions';
 
 // Type augmentation for custom DOM properties
 interface EnrichedHTMLElement extends HTMLElement {
@@ -42,6 +39,10 @@ interface Props {
   showLineNumbers?: boolean;
   hoverDelayMs?: number;
   annotateMode: boolean;
+  /** Session for the shown resource — its client emits mark:* / mark.request; its bus feeds toolbar + beckon events. */
+  session: SemiontSession | null;
+  /** Recently-created annotation ids to sparkle (host-provided; was ResourceAnnotationsContext). */
+  newAnnotationIds?: Set<string>;
 }
 
 /**
@@ -65,11 +66,11 @@ export function AnnotateView({
   generatingReferenceId,
   showLineNumbers = false,
   hoverDelayMs = 150,
-  annotateMode
+  annotateMode,
+  session,
+  newAnnotationIds,
 }: Props) {
-  const { newAnnotationIds } = useResourceAnnotations();
   const containerRef = useRef<HTMLDivElement>(null);
-  const session = useObservable(useSemiont().activeSession$);
 
   const render = capabilitiesOf(mimeType)?.render ?? 'none';
 
@@ -103,7 +104,7 @@ export function AnnotateView({
   }, []);
 
   // Subscribe to toolbar events and annotation hover
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     'mark:selection-changed': handleToolbarSelectionChanged,
     'mark:click-changed': handleToolbarClickChanged,
     'mark:shape-changed': handleToolbarShapeChanged,
@@ -203,6 +204,7 @@ export function AnnotateView({
             mediaType={mimeType}
             annotateMode={annotateMode}
             annotators={ANNOTATORS}
+            session={session}
           />
           <div className="semiont-annotate-view__content">
             <CodeMirrorRenderer
@@ -237,6 +239,7 @@ export function AnnotateView({
             mediaType={mimeType}
             annotateMode={annotateMode}
             annotators={ANNOTATORS}
+            session={session}
           />
           <div className="semiont-annotate-view__content">
             {content && (
@@ -268,6 +271,7 @@ export function AnnotateView({
             mediaType={mimeType}
             annotateMode={annotateMode}
             annotators={ANNOTATORS}
+            session={session}
           />
           <div className="semiont-annotate-view__content">
             {content && (

--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import { useEffect, useRef, useCallback, useMemo, memo, lazy, Suspense } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import { useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { annotationId as toAnnotationId } from '@semiont/core';
 import { capabilitiesOf } from '@semiont/core';
 import { createHoverHandlers } from '@semiont/sdk';
 import { ANNOTATORS } from '../../lib/annotation-registry';
 import { scrollAnnotationIntoView } from '../../lib/scroll-utils';
-import { ImageViewer } from '../viewers';
 import { AnnotateToolbar, type ClickAction } from '../annotation/AnnotateToolbar';
 import type { AnnotationsCollection } from '../../types/annotation-props';
 import {
@@ -20,13 +17,9 @@ import {
   toOverlayAnnotations,
 } from '../../lib/annotation-overlay';
 
-// Lazy load PDF component to avoid SSR issues with browser PDF.js loading
-const PdfAnnotationCanvas = lazy(() => import('../pdf-annotation/PdfAnnotationCanvas.client').then(mod => ({ default: mod.PdfAnnotationCanvas })));
-
-import { useResourceAnnotations } from '../../contexts/ResourceAnnotationsContext';
-import { useSemiont } from '../../session/SemiontProvider';
-import { useObservable } from '../../hooks/useObservable';
-import { useEventSubscriptions } from '../../contexts/useEventSubscription';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../hooks/useSessionEventSubscriptions';
+import { defaultBrowseRenderers, type BrowseMediaRenderers } from './browse-renderers';
 
 interface Props {
   content: string;
@@ -37,25 +30,13 @@ interface Props {
   selectedClick?: ClickAction;
   annotateMode: boolean;
   hoverDelayMs?: number;
+  /** Session for the shown resource — emits browse:click / beckon:hover; its bus feeds beckon events. */
+  session: SemiontSession | null;
+  /** Recently-created annotation ids to sparkle (host-provided; was ResourceAnnotationsContext). */
+  newAnnotationIds?: Set<string>;
+  /** Override the read-only media renderers (render mode → renderer); merged over the defaults. */
+  renderers?: BrowseMediaRenderers;
 }
-
-/**
- * Memoized markdown renderer — only re-renders when content changes.
- * No annotation plugins: annotations are applied as a DOM overlay after paint.
- */
-const MemoizedMarkdown = memo(function MemoizedMarkdown({
-  content,
-}: {
-  content: string;
-}) {
-  return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-    >
-      {content}
-    </ReactMarkdown>
-  );
-});
 
 /**
  * View component for browsing annotated resources in read-only mode.
@@ -77,10 +58,11 @@ export const BrowseView = memo(function BrowseView({
   annotations,
   selectedClick = 'detail',
   annotateMode,
-  hoverDelayMs = 150
+  hoverDelayMs = 150,
+  session,
+  newAnnotationIds,
+  renderers,
 }: Props) {
-  const { newAnnotationIds } = useResourceAnnotations();
-  const session = useObservable(useSemiont().activeSession$);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const render = capabilitiesOf(mimeType)?.render ?? 'none';
@@ -202,94 +184,51 @@ export const BrowseView = memo(function BrowseView({
     scrollToAnnotation(annotationId ?? null, true);
   }, [scrollToAnnotation]);
 
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     'beckon:hover': handleAnnotationHover,
     'beckon:focus': handleAnnotationFocus,
   });
 
-  // Route to the viewer for this media type's render mode. The switch is
-  // exhaustive over RenderMode, so every path returns.
-  switch (render) {
-    case 'text':
-      return (
-        <div className="semiont-browse-view" data-mime-type="text">
-          <AnnotateToolbar
-            selectedMotivation={null}
-            selectedClick={selectedClick}
-            showSelectionGroup={false}
-            showDeleteButton={false}
-            annotateMode={annotateMode}
-            annotators={ANNOTATORS}
-          />
-          <div ref={containerRef} className="semiont-browse-view__content">
-            <MemoizedMarkdown content={content} />
-          </div>
-        </div>
-      );
+  // Route to the media renderer for this render mode. `text`/`image`/`pdf` share
+  // the shell (toolbar + annotation-overlay container); `none` (no preview, or an
+  // unknown type) has its own metadata+download structure. Callers can override
+  // any renderer via `renderers`.
+  const mediaRenderers: BrowseMediaRenderers = { ...defaultBrowseRenderers, ...renderers };
+  const Renderer = render === 'none' ? undefined : mediaRenderers[render];
 
-    case 'pdf':
-      return (
-        <div className="semiont-browse-view" data-mime-type="pdf">
-          <AnnotateToolbar
-            selectedMotivation={null}
-            selectedClick={selectedClick}
-            showSelectionGroup={false}
-            showDeleteButton={false}
-            annotateMode={annotateMode}
-            annotators={ANNOTATORS}
-          />
-          <div ref={containerRef} className="semiont-browse-view__content">
-            <Suspense fallback={<div className="semiont-browse-view__loading">Loading PDF viewer...</div>}>
-              <PdfAnnotationCanvas
-                pdfUrl={content}
-                existingAnnotations={allAnnotations}
-                drawingMode={null}
-                selectedMotivation={null}
-              />
-            </Suspense>
-          </div>
+  if (!Renderer) {
+    return (
+      <div ref={containerRef} className="semiont-browse-view semiont-browse-view--unsupported" data-mime-type="unsupported">
+        <div className="semiont-browse-view__empty">
+          <p className="semiont-browse-view__empty-message">
+            Preview not available for {mimeType}
+          </p>
+          <a
+            href={`/api/resources/${resourceUri}`}
+            download
+            className="semiont-button semiont-button--primary"
+          >
+            Download File
+          </a>
         </div>
-      );
-
-    case 'image':
-      return (
-        <div className="semiont-browse-view" data-mime-type="image">
-          <AnnotateToolbar
-            selectedMotivation={null}
-            selectedClick={selectedClick}
-            showSelectionGroup={false}
-            showDeleteButton={false}
-            annotateMode={annotateMode}
-            annotators={ANNOTATORS}
-          />
-          <div ref={containerRef} className="semiont-browse-view__content">
-            <ImageViewer
-              imageUrl={content}
-              mimeType={mimeType}
-              alt="Resource content"
-            />
-          </div>
-        </div>
-      );
-
-    case 'none':
-      // Catalogued type with no preview (render: 'none') or an imported
-      // foreign type the registry doesn't know — same UI: metadata + download.
-      return (
-        <div ref={containerRef} className="semiont-browse-view semiont-browse-view--unsupported" data-mime-type="unsupported">
-          <div className="semiont-browse-view__empty">
-            <p className="semiont-browse-view__empty-message">
-              Preview not available for {mimeType}
-            </p>
-            <a
-              href={`/api/resources/${resourceUri}`}
-              download
-              className="semiont-button semiont-button--primary"
-            >
-              Download File
-            </a>
-          </div>
-        </div>
-      );
+      </div>
+    );
   }
+
+  return (
+    <div className="semiont-browse-view" data-mime-type={render}>
+      <AnnotateToolbar
+        selectedMotivation={null}
+        selectedClick={selectedClick}
+        showSelectionGroup={false}
+        showDeleteButton={false}
+        annotateMode={annotateMode}
+        annotators={ANNOTATORS}
+        session={session}
+      />
+      <div ref={containerRef} className="semiont-browse-view__content">
+        <Renderer content={content} mimeType={mimeType} resourceUri={resourceUri} annotations={allAnnotations} />
+      </div>
+    </div>
+  );
 });

--- a/packages/react-ui/src/components/resource/ResourceViewer.tsx
+++ b/packages/react-ui/src/components/resource/ResourceViewer.tsx
@@ -6,12 +6,10 @@ import { AnnotateView, type SelectionMotivation, type ClickAction, type ShapeTyp
 import { BrowseView } from './BrowseView';
 import { PopupContainer } from '../annotation-popups/SharedPopupElements';
 import { JsonLdView } from '../annotation-popups/JsonLdView';
-import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, components } from '@semiont/core';
+import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, components, EventMap } from '@semiont/core';
 import { getExactText, getTargetSelector, isHighlight, isAssessment, isReference, isComment, isTag, getBodySource } from '@semiont/core';
-import { useEventSubscriptions } from '../../contexts/useEventSubscription';
-import { useSemiont } from '../../session/SemiontProvider';
-import { useObservable } from '../../hooks/useObservable';
-import { useObservableExternalNavigation } from '../../hooks/useObservableBrowse';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../hooks/useSessionEventSubscriptions';
 import { ANNOTATORS } from '../../lib/annotation-registry';
 import type { AnnotationsCollection } from '../../types/annotation-props';
 import { getSelectorType, getSelectedShapeForSelectorType, saveSelectedShapeForSelectorType } from '../../lib/media-shapes';
@@ -24,9 +22,11 @@ import { getSelectorType, getSelectedShapeForSelectorType, saveSelectedShapeForS
  * - Automatically invalidates cache when annotations change
  * - No manual refetch needed - events handle cache invalidation
  *
- * Requirements:
- * - Must be wrapped in SemiontProvider (which owns the session's event bus)
- * - Must be wrapped in CacheContext (provides cache manager)
+ * Bring-your-own-session: the `session` (SemiontSession) and the host's
+ * navigation / panel callbacks come in as props — no SemiontProvider required.
+ * Every event it subscribes to is session-scoped (mark:*, browse:click) and
+ * reaches it via `session.subscribe`. Translations fall back to built-in English
+ * when no TranslationProvider is mounted; caching flows through `session.client.browse.*`.
  *
  * Event flow:
  *   make-meaning → EventLog → SSE → EventBus → ResourceViewer → Cache invalidation
@@ -37,6 +37,14 @@ import { getSelectorType, getSelectedShapeForSelectorType, saveSelectedShapeForS
 interface Props {
   resource: SemiontResource & { content: string };
   annotations: AnnotationsCollection;
+  /** Session for the shown resource — its client mutates/invalidates, its bus feeds annotation events. */
+  session: SemiontSession | null;
+  /** Host-owned navigation: a resolved reference was followed. Omit for a view with no follow behavior. */
+  onOpenResource?: (resourceId: string) => void;
+  /** Host-owned panel control (annotation clicks open a panel). Omit for hosts without side panels. */
+  onOpenPanel?: (event: EventMap['panel:open']) => void;
+  /** Recently-created annotation ids to sparkle (threaded to the browse/annotate subtree). */
+  newAnnotationIds?: Set<string>;
   generatingReferenceId?: string | null;
   showLineNumbers?: boolean;
   hoverDelayMs?: number;
@@ -59,6 +67,10 @@ interface Props {
 export function ResourceViewer({
   resource,
   annotations,
+  session,
+  onOpenResource,
+  onOpenPanel,
+  newAnnotationIds,
   generatingReferenceId,
   showLineNumbers = false,
   hoverDelayMs,
@@ -66,12 +78,6 @@ export function ResourceViewer({
 }: Props) {
   const t = useTranslations('ResourceViewer');
   const documentViewerRef = useRef<HTMLDivElement>(null);
-
-  const browser = useSemiont();
-  const session = useObservable(browser.activeSession$);
-
-  // Get observable navigation for event-driven routing
-  const navigate = useObservableExternalNavigation();
 
   const { highlights, references, assessments, comments, tags } = annotations;
 
@@ -267,8 +273,8 @@ export function ResourceViewer({
     if (selectedClick === 'follow' && isReference(annotation)) {
       const bodySource = getBodySource(annotation.body);
       if (bodySource) {
-        // bodySource is already a bare resource ID
-        navigate(`/know/resource/${bodySource}`, { resourceId: bodySource });
+        // bodySource is already a bare resource ID — the host owns navigation
+        onOpenResource?.(bodySource);
       }
       return;
     }
@@ -293,7 +299,7 @@ export function ResourceViewer({
       setDeleteConfirmation({ annotation, position });
       return;
     }
-  }, [annotateMode, selectedClick, focusAnnotation]);
+  }, [annotateMode, selectedClick, focusAnnotation, onOpenResource]);
 
   // Annotation click coordinator - handles panel opening and scrolling
   const handleAnnotationClickEvent = useCallback(({ annotationId, motivation }: {
@@ -323,14 +329,14 @@ export function ResourceViewer({
       return;
     }
 
-    // All annotations open the unified annotations panel
+    // All annotations open the unified annotations panel — the host owns the panel.
     // The panel internally switches tabs based on the motivation → tab mapping in UnifiedAnnotationsPanel
-    browser.emit('panel:open', { panel: 'annotations', scrollToAnnotationId: annotationId, motivation });
-  }, [highlights, references, assessments, comments, tags, handleAnnotationClick, selectedClick, session]);
+    onOpenPanel?.({ panel: 'annotations', scrollToAnnotationId: annotationId, motivation });
+  }, [highlights, references, assessments, comments, tags, handleAnnotationClick, selectedClick, onOpenPanel]);
 
   // Event subscriptions - Combined into single useEventSubscriptions call to prevent hook ordering issues
   // IMPORTANT: All event subscriptions MUST be in a single call to maintain consistent hook order between renders
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     // View mode
     'mark:mode-toggled': handleViewModeToggle,
 
@@ -390,6 +396,8 @@ export function ResourceViewer({
           showLineNumbers={showLineNumbers}
           hoverDelayMs={hoverDelayMs}
           annotateMode={annotateMode}
+          session={session}
+          newAnnotationIds={newAnnotationIds}
         />
       ) : (
         <BrowseView
@@ -400,6 +408,8 @@ export function ResourceViewer({
           selectedClick={selectedClick}
           hoverDelayMs={hoverDelayMs}
           annotateMode={annotateMode}
+          session={session}
+          newAnnotationIds={newAnnotationIds}
         />
       )}
 

--- a/packages/react-ui/src/components/resource/__tests__/AnnotateView.embeddable.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/AnnotateView.embeddable.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * EMBEDDABLE-RESOURCE-VIEWER step 1b — AnnotateView + AnnotateToolbar provider-free.
+ *
+ * AnnotateView takes `session` + `newAnnotationIds` as props; the REAL
+ * AnnotateToolbar (not mocked — its decoupling is the crux of 1b) takes `session`
+ * as a prop. CodeMirrorRenderer is mocked (heavy; already prop-based).
+ *
+ * Started RED (tsc: no `session` prop) and GREEN once step 1b lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { AnnotationUIState } from '../../../types/annotation-props';
+import { AnnotateView } from '../AnnotateView';
+
+vi.mock('../../CodeMirrorRenderer', () => ({ CodeMirrorRenderer: () => <div>cm-mock</div> }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+const uiState: AnnotationUIState = {
+  selectedMotivation: 'linking',
+  selectedClick: 'detail',
+  selectedShape: 'rectangle',
+  hoveredAnnotationId: null,
+  scrollToAnnotationId: null,
+};
+
+function fakeSession(): SemiontSession {
+  return {
+    client: {
+      mark: {
+        changeSelection: vi.fn(), changeClick: vi.fn(), changeShape: vi.fn(),
+        toggleMode: vi.fn(), request: vi.fn(),
+      },
+    },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+describe('AnnotateView — embeddable (session prop, no providers)', () => {
+  it('renders (incl. the real AnnotateToolbar) fed only a session, no providers', () => {
+    render(
+      <AnnotateView
+        content="hello"
+        mimeType="text/plain"
+        annotations={emptyAnnotations}
+        uiState={uiState}
+        annotateMode={true}
+        session={fakeSession()}
+      />,
+    );
+    // The tree (real AnnotateToolbar + mocked CodeMirror) rendered without a provider.
+    expect(screen.getByText('cm-mock')).toBeInTheDocument();
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.embeddable.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.embeddable.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * EMBEDDABLE-RESOURCE-VIEWER step 1a — BrowseView renders provider-free.
+ *
+ * BrowseView takes its `session` + `newAnnotationIds` as props (not
+ * `useSemiont()` / `useResourceAnnotations()`), and subscribes to session-scoped
+ * beckon events via `session.subscribe`. `AnnotateToolbar` is mocked here — its
+ * own provider decoupling is step 1b — so this spec isolates BrowseView's body.
+ *
+ * Started RED (tsc: no `session` prop) and GREEN once step 1a lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import { BrowseView } from '../BrowseView';
+
+// AnnotateToolbar still calls useSemiont() (step 1b) — stub it out so this spec
+// exercises only BrowseView's own provider-freedom.
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: {
+      browse: { click: vi.fn() },
+      beckon: { hover: vi.fn() },
+    },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+describe('BrowseView — embeddable (session prop, no providers)', () => {
+  it('renders content fed only a session, with NO providers mounted', () => {
+    render(
+      <BrowseView
+        content="Embeddable browse content."
+        mimeType="text/plain"
+        resourceUri="res-1"
+        annotations={emptyAnnotations}
+        annotateMode={false}
+        session={fakeSession()}
+      />,
+    );
+    expect(screen.getByText('Embeddable browse content.')).toBeInTheDocument();
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.registry.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.registry.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * EMBEDDABLE-RESOURCE-VIEWER step 3 — overridable browse media-renderer registry.
+ *
+ * A consumer can swap a media renderer via the `renderers` prop (e.g. its own PDF
+ * viewer) without forking BrowseView. AnnotateToolbar is mocked (unrelated here).
+ *
+ * Started RED (tsc: no `renderers` prop) and GREEN once step 3 lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import { BrowseView } from '../BrowseView';
+import type { MediaRendererProps } from '../browse-renderers';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+describe('BrowseView — media-renderer registry', () => {
+  it('uses a custom renderer from the `renderers` override', () => {
+    const CustomText = ({ content }: MediaRendererProps) => <div>custom-render: {content}</div>;
+    render(
+      <BrowseView
+        content="the-body"
+        mimeType="text/plain"
+        resourceUri="res-1"
+        annotations={emptyAnnotations}
+        annotateMode={false}
+        session={fakeSession()}
+        renderers={{ text: CustomText }}
+      />,
+    );
+    expect(screen.getByText(/custom-render: the-body/)).toBeInTheDocument();
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
@@ -3,17 +3,15 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowseView } from '../BrowseView';
 import type { EventBus } from '@semiont/core';
+import type { SemiontClient, SemiontSession } from '@semiont/sdk';
 import { createTestSemiontWrapper } from '../../../test-utils';
 
 import type { Annotation, AnnotationId } from '@semiont/core';
 
-// Mock ResourceAnnotationsContext - keep this simple
-let mockNewAnnotationIds = new Set<string>();
-vi.mock('../../../contexts/ResourceAnnotationsContext', () => ({
-  useResourceAnnotations: vi.fn(() => ({
-    newAnnotationIds: mockNewAnnotationIds,
-  })),
-}));
+// BrowseView takes its `session` + `newAnnotationIds` as props now (step 1a) — no
+// ResourceAnnotationsContext / SemiontProvider reach-in. `makeSession` (below)
+// wraps the fake client so browse:click / beckon:hover land on the bus the
+// trackers listen on, and session.subscribe registers beckon:* on that bus.
 
 // Mock @semiont/core utilities. The media-type registry (`capabilitiesOf`)
 // is NOT mocked — BrowseView dispatches on the real registry's render mode,
@@ -116,34 +114,47 @@ function createEventTracker() {
   };
 }
 
+// BrowseView now takes its session as a prop. Wrap the fake client so
+// browse:click / beckon:hover emit on the SAME bus the trackers listen on, and
+// session.subscribe registers beckon:* there (mirrors test-utils' fake session).
+function makeSession(client: SemiontClient): SemiontSession {
+  return {
+    client,
+    subscribe: (channel: string, handler: (p: never) => void) => {
+      const sub = (client.bus.get(channel as never) as { subscribe(fn: (p: never) => void): { unsubscribe(): void } }).subscribe(handler);
+      return () => sub.unsubscribe();
+    },
+  } as unknown as SemiontSession;
+}
+
 const renderWithProviders = (
-  component: React.ReactElement,
+  component: React.ReactElement<React.ComponentProps<typeof BrowseView>>,
   options: { newAnnotationIds?: Set<string> } = {}
 ) => {
-  if (options.newAnnotationIds) {
-    mockNewAnnotationIds = options.newAnnotationIds;
-  }
-  const { SemiontWrapper } = createTestSemiontWrapper();
+  const { SemiontWrapper, client } = createTestSemiontWrapper();
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
   );
-  return render(component, { wrapper: Wrapper });
+  return render(
+    React.cloneElement(component, { session: makeSession(client), newAnnotationIds: options.newAnnotationIds }),
+    { wrapper: Wrapper },
+  );
 };
 
 const renderWithEventTracking = (
-  component: React.ReactElement,
+  component: React.ReactElement<React.ComponentProps<typeof BrowseView>>,
   tracker: ReturnType<typeof createEventTracker>,
   options: { newAnnotationIds?: Set<string> } = {}
 ) => {
-  if (options.newAnnotationIds) {
-    mockNewAnnotationIds = options.newAnnotationIds;
-  }
-  const { SemiontWrapper, eventBus } = createTestSemiontWrapper();
+  const { SemiontWrapper, eventBus, client } = createTestSemiontWrapper();
   tracker._attach(eventBus);
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
   );
-  return render(component, { wrapper: Wrapper });
+  return render(
+    React.cloneElement(component, { session: makeSession(client), newAnnotationIds: options.newAnnotationIds }),
+    { wrapper: Wrapper },
+  );
 };
 
 // Test data fixtures
@@ -179,11 +190,13 @@ describe('BrowseView Component', () => {
     hoveredAnnotationId: null,
     selectedClick: 'detail' as const,
     annotateMode: false,
+    // Placeholder — the render helpers override this with a session bound to the
+    // fake client's bus (so emits/subscriptions land where the trackers listen).
+    session: null as SemiontSession | null,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockNewAnnotationIds = new Set();
 
     // Mock scrollIntoView for jsdom
     if (typeof Element !== 'undefined') {
@@ -499,7 +512,7 @@ describe('BrowseView Component', () => {
         tags: [],
       };
 
-      const { SemiontWrapper, eventBus } = createTestSemiontWrapper();
+      const { SemiontWrapper, eventBus, client } = createTestSemiontWrapper();
       eventBus.get('beckon:hover').subscribe((payload: any) => {
         eventTracker.push({ event: 'beckon:hover', annotationId: payload?.annotationId ?? null });
       });
@@ -509,7 +522,7 @@ describe('BrowseView Component', () => {
 
       const { container } = render(
         <SemiontWrapper>
-          <BrowseView {...defaultProps} annotations={manyAnnotations} />
+          <BrowseView {...defaultProps} annotations={manyAnnotations} session={makeSession(client)} />
         </SemiontWrapper>
       );
 

--- a/packages/react-ui/src/components/resource/__tests__/ResourceViewer.embeddable.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/ResourceViewer.embeddable.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * EMBEDDABLE-RESOURCE-VIEWER — keystone acceptance spec.
+ *
+ * The consumer's (my-chat) actual requirement: render + interact with a resource
+ * fed ONLY a `SemiontSession`, with NO SemiontProvider / TranslationProvider /
+ * cache context mounted. This is the definition of done for provider-free
+ * rendering — the "an external host can import the pieces" half of the plan's
+ * dual acceptance test.
+ *
+ * GREEN as of step 1c: the browse-mode subtree (ResourceViewer → BrowseView →
+ * AnnotateToolbar) renders provider-free from a bare session. The annotate-mode
+ * subtree is covered by AnnotateView.embeddable.test.tsx.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { ResourceViewer } from '../ResourceViewer';
+
+// Minimal bring-your-own-session double: just the surface ResourceViewer + its
+// subtree touch — `client.browse` / `client.mark` and generic-channel `subscribe`.
+function fakeSession(): SemiontSession {
+  const client = {
+    baseUrl: 'http://localhost:4000',
+    browse: { invalidateAnnotationList: vi.fn(), click: vi.fn() },
+    mark: { delete: vi.fn() },
+  };
+  return {
+    client,
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+const resource: SemiontResource & { content: string } = {
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  '@id': 'res-1' as ResourceId,
+  name: 'Doc',
+  created: '2024-01-01T00:00:00Z',
+  entityTypes: [],
+  archived: false,
+  representations: [{ mediaType: 'text/plain', byteSize: 10 }],
+  content: 'Embeddable content.',
+};
+
+const annotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+describe('ResourceViewer — embeddable (bring-your-own-session, no providers)', () => {
+  // GREEN: the whole browse-mode subtree (ResourceViewer → BrowseView →
+  // AnnotateToolbar) renders provider-free from a bare session.
+  it('renders content fed only a session, with NO providers mounted', () => {
+    render(
+      <ResourceViewer
+        session={fakeSession()}
+        resource={resource}
+        annotations={annotations}
+        onOpenResource={vi.fn()}
+        onOpenPanel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Embeddable content.')).toBeInTheDocument();
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/ResourceViewer.mode-switch.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/ResourceViewer.mode-switch.test.tsx
@@ -19,14 +19,10 @@ import { TranslationProvider } from '../../../contexts/TranslationContext';
 import { ResourceAnnotationsProvider } from '../../../contexts/ResourceAnnotationsContext';
 import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
 
-// Mock dependencies
-vi.mock('../../../hooks/useObservableBrowse', () => ({
-  useObservableExternalNavigation: () => vi.fn(),
-}));
-
-// ResourceViewer (and ResourceAnnotationsContext) now resolve the client via
+// ResourceViewer now takes its session as a prop; its children (BrowseView /
+// AnnotateView) and ResourceAnnotationsContext still resolve the client via
 // useSemiont(). Mock useSemiont to emit a minimal session carrying a stub
-// client with the methods the subject component touches. The session also
+// client with the methods those children touch. The session also
 // exposes `on` and `emit` stubs so useEventSubscription(s) don't explode.
 const stubClient = {
   browse: { invalidateAnnotationList: vi.fn() },
@@ -115,6 +111,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -128,6 +125,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -144,6 +142,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -158,6 +157,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -169,6 +169,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -181,6 +182,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -193,6 +195,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -209,6 +212,7 @@ describe('ResourceViewer - Mode Switching', () => {
         <ResourceViewer
           resource={mockResource}
           annotations={mockAnnotations}
+          session={null}
         />
       </TestWrapper>
     );
@@ -221,6 +225,7 @@ describe('ResourceViewer - Mode Switching', () => {
           <ResourceViewer
             resource={mockResource}
             annotations={mockAnnotations}
+            session={null}
           />
         </TestWrapper>
       );

--- a/packages/react-ui/src/components/resource/browse-renderers.tsx
+++ b/packages/react-ui/src/components/resource/browse-renderers.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { lazy, Suspense, memo, type ComponentType } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Annotation } from '@semiont/core';
+import { ImageViewer } from '../viewers';
+
+// Lazy-load the PDF component to avoid SSR issues with browser PDF.js loading.
+const PdfAnnotationCanvas = lazy(() => import('../pdf-annotation/PdfAnnotationCanvas.client').then(mod => ({ default: mod.PdfAnnotationCanvas })));
+
+/**
+ * Common props for a read-only ("browse") media renderer. `content` is decoded
+ * text for the text renderer, or a media URL for the image / PDF renderers.
+ * A consumer can implement this interface to swap in a custom renderer.
+ */
+export interface MediaRendererProps {
+  content: string;
+  mimeType: string;
+  resourceUri: string;
+  annotations: Annotation[];
+}
+
+/** Read-only media dispatch, keyed by the registry render mode. */
+export type BrowseMediaRenderers = Partial<Record<string, ComponentType<MediaRendererProps>>>;
+
+const MemoizedMarkdown = memo(function MemoizedMarkdown({ content }: { content: string }) {
+  // No annotation plugins: annotations are applied as a DOM overlay after paint.
+  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>;
+});
+
+export function TextBrowseRenderer({ content }: MediaRendererProps) {
+  return <MemoizedMarkdown content={content} />;
+}
+
+export function ImageBrowseRenderer({ content, mimeType }: MediaRendererProps) {
+  return <ImageViewer imageUrl={content} mimeType={mimeType} alt="Resource content" />;
+}
+
+export function PdfBrowseRenderer({ content, annotations }: MediaRendererProps) {
+  return (
+    <Suspense fallback={<div className="semiont-browse-view__loading">Loading PDF viewer...</div>}>
+      <PdfAnnotationCanvas
+        pdfUrl={content}
+        existingAnnotations={annotations}
+        drawingMode={null}
+        selectedMotivation={null}
+      />
+    </Suspense>
+  );
+}
+
+/**
+ * Default read-only media renderers. `BrowseView` merges a caller's `renderers`
+ * override on top of these, so a host can swap one renderer (e.g. its own PDF
+ * viewer) or add a mode without forking the view.
+ */
+export const defaultBrowseRenderers: Record<'text' | 'image' | 'pdf', ComponentType<MediaRendererProps>> = {
+  text: TextBrowseRenderer,
+  image: ImageBrowseRenderer,
+  pdf: PdfBrowseRenderer,
+};

--- a/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
+++ b/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
@@ -28,6 +28,7 @@ import { useTheme } from '../../../contexts/ThemeContext';
 import { useLineNumbers } from '../../../hooks/useLineNumbers';
 import { useHoverDelay } from '../../../hooks/useHoverDelay';
 import { useEventSubscriptions } from '../../../contexts/useEventSubscription';
+import { useObservableExternalNavigation } from '../../../hooks/useObservableBrowse';
 import { useResourceAnnotations } from '../../../contexts/ResourceAnnotationsContext';
 import { useSemiont } from '../../../session/SemiontProvider';
 import { createResourceViewerPageStateUnit } from '../state/resource-viewer-page-state-unit';
@@ -135,13 +136,24 @@ export function ResourceViewerPage({
   const browser = useSemiont();
   const session = useObservable(browser.activeSession$);
   const semiont = session?.client;
+  const navigateExternal = useObservableExternalNavigation();
+
+  // ResourceViewer is bring-your-own-session: feed it the active session plus
+  // host-owned navigation (reference follow) and panel control (app-scoped bus).
+  const handleViewerOpenResource = useCallback((id: string) => {
+    navigateExternal(`/know/resource/${id}`, { resourceId: id });
+  }, [navigateExternal]);
+
+  const handleViewerOpenPanel = useCallback((event: EventMap['panel:open']) => {
+    browser.emit('panel:open', event);
+  }, [browser]);
 
   // UI state hooks
   const { showError, showSuccess, showInfo } = useToast();
   const { theme, setTheme } = useTheme();
   const { showLineNumbers, toggleLineNumbers } = useLineNumbers();
   const { hoverDelayMs } = useHoverDelay();
-  const { triggerSparkleAnimation, clearNewAnnotationId } = useResourceAnnotations();
+  const { triggerSparkleAnimation, clearNewAnnotationId, newAnnotationIds } = useResourceAnnotations();
 
   // Render mode chooses the content path: 'text' decodes inline; 'image'
   // and 'pdf' go through the media-token (binary) path. 'none'/registry-miss
@@ -154,7 +166,7 @@ export function ResourceViewerPage({
   const { content: textContent, loading: textLoading } = useResourceContent(rUri, resource, !isBinary);
 
   // Binary path: fetch short-lived media token, construct URL
-  const { token: mediaToken, loading: mediaTokenLoading } = useMediaToken(rUri);
+  const { token: mediaToken, loading: mediaTokenLoading } = useMediaToken(semiont ?? null, rUri);
   const binaryContent = (isBinary && mediaToken && semiont)
     ? `${semiont.baseUrl}/api/resources/${rUri}?token=${mediaToken}`
     : '';
@@ -516,6 +528,10 @@ export function ResourceViewerPage({
                 <ResourceViewer
                   resource={resourceWithContent}
                   annotations={groups ?? { highlights: [], comments: [], assessments: [], references: [], tags: [] }}
+                  session={session ?? null}
+                  onOpenResource={handleViewerOpenResource}
+                  onOpenPanel={handleViewerOpenPanel}
+                  newAnnotationIds={newAnnotationIds}
                   generatingReferenceId={generationProgress?.annotationId ?? null}
                   showLineNumbers={showLineNumbers}
                   hoverDelayMs={hoverDelayMs}

--- a/packages/react-ui/src/features/resource-viewer/state/resource-viewer-page-state-unit.ts
+++ b/packages/react-ui/src/features/resource-viewer/state/resource-viewer-page-state-unit.ts
@@ -10,7 +10,7 @@ import { createMatchStateUnit } from '@semiont/sdk';
 import { createYieldStateUnit, type YieldStateUnit } from '@semiont/sdk';
 import type { SemiontClient } from '@semiont/sdk';
 import { decodeWithCharset, textExtractionOf } from '@semiont/core';
-import { isHighlight, isComment, isAssessment, isReference, isTag } from '@semiont/core';
+import { groupAnnotations } from '../../../lib/annotation-groups';
 import type { ReferencedByEntry } from '@semiont/sdk';
 
 import type { Annotation } from '@semiont/core';
@@ -85,19 +85,7 @@ export function createResourceViewerPageStateUnit(
     map((a) => a ?? []),
   );
 
-  const annotationGroups$: Observable<AnnotationGroups> = annotations$.pipe(
-    map((anns) => {
-      const groups: AnnotationGroups = { highlights: [], comments: [], assessments: [], references: [], tags: [] };
-      for (const ann of anns) {
-        if (isHighlight(ann)) groups.highlights.push(ann);
-        else if (isComment(ann)) groups.comments.push(ann);
-        else if (isAssessment(ann)) groups.assessments.push(ann);
-        else if (isReference(ann)) groups.references.push(ann);
-        else if (isTag(ann)) groups.tags.push(ann);
-      }
-      return groups;
-    }),
-  );
+  const annotationGroups$: Observable<AnnotationGroups> = annotations$.pipe(map(groupAnnotations));
 
   const entityTypes$: Observable<string[]> = client.browse.entityTypes().pipe(
     map((e) => e ?? []),

--- a/packages/react-ui/src/hooks/__tests__/useMediaToken.test.tsx
+++ b/packages/react-ui/src/hooks/__tests__/useMediaToken.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * EMBEDDABLE-RESOURCE-VIEWER step 4 — session-level media token.
+ *
+ * `useMediaToken` takes the client explicitly (not `useSemiont()`), so a
+ * bring-your-own-session host can mint authed `<img>` / PDF URLs from a bare
+ * session — no provider.
+ *
+ * Started RED (old signature was `useMediaToken(id)`) and GREEN once step 4 lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { resourceId } from '@semiont/core';
+import type { SemiontClient } from '@semiont/sdk';
+import { useMediaToken } from '../useMediaToken';
+
+function makeClient(token: string): SemiontClient {
+  return { auth: { mediaToken: vi.fn(async () => ({ token })) } } as unknown as SemiontClient;
+}
+
+describe('useMediaToken', () => {
+  it('resolves the media token from a bare client', async () => {
+    const client = makeClient('tok-123');
+    const rid = resourceId('res-1');
+    const { result } = renderHook(() => useMediaToken(client, rid));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.token).toBe('tok-123');
+    expect(client.auth!.mediaToken).toHaveBeenCalledWith(rid);
+  });
+
+  it('stays token-less (not loading) without a client', async () => {
+    const { result } = renderHook(() => useMediaToken(null, resourceId('res-1')));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.token).toBeUndefined();
+  });
+});

--- a/packages/react-ui/src/hooks/__tests__/useResourceLoader.test.tsx
+++ b/packages/react-ui/src/hooks/__tests__/useResourceLoader.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * EMBEDDABLE-RESOURCE-VIEWER step 2 — useResourceLoader.
+ *
+ * A standalone loader: given a bare client, it fetches the resource + its
+ * annotations (grouped into an AnnotationsCollection) and reports loading/error —
+ * no page, no composite state unit, no providers. The lightweight alternative to
+ * ResourceViewerPage that a bring-your-own-session host can feed into ResourceViewer.
+ *
+ * Started RED (the hook does not exist) and GREEN once step 2 lands.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import { resourceId } from '@semiont/core';
+import type { SemiontClient } from '@semiont/sdk';
+import { useResourceLoader } from '../useResourceLoader';
+
+const RES = { '@id': 'res-1', name: 'Doc' };
+
+function makeClient(resource$: BehaviorSubject<unknown>, annotations$: BehaviorSubject<unknown>): SemiontClient {
+  return { browse: { resource: () => resource$, annotations: () => annotations$ } } as unknown as SemiontClient;
+}
+
+describe('useResourceLoader', () => {
+  it('loads the resource + grouped annotations from a bare client', () => {
+    const resource$ = new BehaviorSubject<unknown>(undefined);
+    const annotations$ = new BehaviorSubject<unknown>(undefined);
+    const client = makeClient(resource$, annotations$);
+    const rid = resourceId('res-1');
+
+    const { result } = renderHook(() => useResourceLoader(client, rid));
+
+    // Nothing emitted yet → loading.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    act(() => {
+      resource$.next(RES);
+      annotations$.next([{ motivation: 'highlighting' }, { motivation: 'linking' }, { motivation: 'linking' }]);
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.resource).toEqual(RES);
+    expect(result.current.annotations.highlights).toHaveLength(1);
+    expect(result.current.annotations.references).toHaveLength(2);
+    expect(result.current.annotations.comments).toHaveLength(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('stays loading (no subscription) without a client', () => {
+    const { result } = renderHook(() => useResourceLoader(null, resourceId('res-1')));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.resource).toBeUndefined();
+  });
+});

--- a/packages/react-ui/src/hooks/useMediaToken.ts
+++ b/packages/react-ui/src/hooks/useMediaToken.ts
@@ -1,23 +1,27 @@
 import { useEffect, useState } from 'react';
 import type { ResourceId } from '@semiont/core';
-import { useSemiont } from '../session/SemiontProvider';
-import { useObservable } from './useObservable';
+import type { SemiontClient } from '@semiont/sdk';
 
 export interface UseMediaTokenResult {
   token: string | undefined;
   loading: boolean;
 }
 
-export function useMediaToken(id: ResourceId): UseMediaTokenResult {
-  const semiont = useObservable(useSemiont().activeSession$)?.client;
+/**
+ * Mint (and periodically refresh) a short-lived authed media token for a
+ * resource — the query param that makes `<img>` / PDF URLs load. Takes the
+ * client explicitly (not `useSemiont()`), so a bring-your-own-session host can
+ * use it with a bare session; the batteries-included page passes `session.client`.
+ */
+export function useMediaToken(client: SemiontClient | null, id: ResourceId): UseMediaTokenResult {
   const [token, setToken] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!semiont || !id) { setLoading(false); return; }
+    if (!client || !id) { setLoading(false); return; }
     let cancelled = false;
     setLoading(true);
-    semiont.auth!.mediaToken(id)
+    client.auth!.mediaToken(id)
       .then(({ token: t }) => {
         if (cancelled) return;
         setToken(t);
@@ -29,7 +33,7 @@ export function useMediaToken(id: ResourceId): UseMediaTokenResult {
       });
 
     const refreshInterval = setInterval(() => {
-      semiont.auth!.mediaToken(id)
+      client.auth!.mediaToken(id)
         .then(({ token: t }) => { if (!cancelled) setToken(t); })
         .catch(() => {});
     }, 4 * 60 * 1000);
@@ -38,7 +42,7 @@ export function useMediaToken(id: ResourceId): UseMediaTokenResult {
       cancelled = true;
       clearInterval(refreshInterval);
     };
-  }, [semiont, id]);
+  }, [client, id]);
 
   return { token, loading };
 }

--- a/packages/react-ui/src/hooks/useResourceLoader.ts
+++ b/packages/react-ui/src/hooks/useResourceLoader.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import type { Annotation, ResourceDescriptor, ResourceId } from '@semiont/core';
+import type { SemiontClient } from '@semiont/sdk';
+import { groupAnnotations } from '../lib/annotation-groups';
+import type { AnnotationsCollection } from '../types/annotation-props';
+
+export interface UseResourceLoaderResult {
+  resource: ResourceDescriptor | undefined;
+  annotations: AnnotationsCollection;
+  loading: boolean;
+  error: Error | null;
+}
+
+const EMPTY: AnnotationsCollection = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+/**
+ * Load a resource + its annotations from a bare client — no page, no composite
+ * state unit, no providers. The lightweight alternative to `ResourceViewerPage`
+ * for a bring-your-own-session host; feed the result straight into `<ResourceViewer>`.
+ *
+ * `loading` is true until BOTH the resource and its annotation list have first
+ * emitted; `annotations` is bucketed via the shared `groupAnnotations`. A null
+ * client subscribes to nothing (stays loading) and re-subscribes when one arrives.
+ */
+export function useResourceLoader(client: SemiontClient | null, resourceId: ResourceId): UseResourceLoaderResult {
+  const [resource, setResource] = useState<ResourceDescriptor | undefined>(undefined);
+  const [rawAnnotations, setRawAnnotations] = useState<Annotation[] | undefined>(undefined);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    setResource(undefined);
+    setRawAnnotations(undefined);
+    setError(null);
+    const onError = (e: unknown) => setError(e instanceof Error ? e : new Error(String(e)));
+    const subs = [
+      client.browse.resource(resourceId).subscribe({ next: setResource, error: onError }),
+      client.browse.annotations(resourceId).subscribe({ next: setRawAnnotations, error: onError }),
+    ];
+    return () => { for (const s of subs) s.unsubscribe(); };
+  }, [client, resourceId]);
+
+  const annotations = useMemo(() => (rawAnnotations ? groupAnnotations(rawAnnotations) : EMPTY), [rawAnnotations]);
+  const loading = resource === undefined || rawAnnotations === undefined;
+
+  return { resource, annotations, loading, error };
+}

--- a/packages/react-ui/src/hooks/useSessionEventSubscriptions.ts
+++ b/packages/react-ui/src/hooks/useSessionEventSubscriptions.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useRef, useMemo } from 'react';
+import type { EventMap } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
+
+/**
+ * Subscribe to session-scoped bus events on an explicit `SemiontSession` — the
+ * provider-free counterpart to `useEventSubscriptions`. The embeddable viewer
+ * path takes its session as a prop (bring-your-own-session), so it can't reach
+ * the app-scoped `SemiontBrowser` bus; every channel it needs (`mark:*`,
+ * `browse:click`) is session-scoped anyway and reaches it via `session.subscribe`.
+ *
+ * Same stable-handler / stable-key semantics as `useEventSubscriptions`:
+ * handlers may change every render without re-subscribing; re-subscription
+ * happens only when the set of channel names or the session changes. A null
+ * session subscribes to nothing, and cleanly re-subscribes when one arrives.
+ */
+export function useSessionEventSubscriptions(
+  session: SemiontSession | null,
+  subscriptions: {
+    [K in keyof EventMap]?: (payload: EventMap[K]) => void;
+  },
+): void {
+  const handlersRef = useRef(subscriptions);
+  useEffect(() => { handlersRef.current = subscriptions; });
+
+  // Stable key derived from the subscribed event names; re-subscribe only when
+  // the set changes, not when handlers change.
+  const eventNames = useMemo(
+    () => Object.keys(subscriptions).sort(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [Object.keys(subscriptions).sort().join(',')],
+  );
+
+  useEffect(() => {
+    if (!session) return;
+    const unsubs: Array<() => void> = [];
+    for (const eventName of eventNames) {
+      const channel = eventName as keyof EventMap;
+      const fan = (payload: EventMap[keyof EventMap]) => {
+        const current = handlersRef.current[channel];
+        if (current) (current as (p: EventMap[keyof EventMap]) => void)(payload);
+      };
+      unsubs.push(session.subscribe(channel, fan));
+    }
+    return () => { for (const unsub of unsubs) unsub(); };
+  }, [eventNames, session]);
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -40,6 +40,9 @@ export * from './contexts/ThemeContext';
 export { useDropdown, useLoadingState, useLocalStorage } from './hooks/useUI';
 export * from './hooks/useResourceContent';
 export * from './hooks/useResourceGather';
+export * from './hooks/useResourceLoader';
+export * from './hooks/useMediaToken';
+export * from './hooks/useSessionEventSubscriptions';
 
 // Session (the React layer — provider + hook + browser storage adapter).
 // All session classes (`SemiontSession`, `SemiontBrowser`, `SessionSignals`,
@@ -91,6 +94,7 @@ export * from './components/modals/SessionExpiredModal';
 export * from './components/resource/AnnotateView';
 export * from './components/resource/AnnotationHistory';
 export * from './components/resource/BrowseView';
+export * from './components/resource/browse-renderers';
 export * from './components/resource/HistoryEvent';
 export * from './components/resource/ResourceViewer';
 

--- a/packages/react-ui/src/lib/annotation-groups.ts
+++ b/packages/react-ui/src/lib/annotation-groups.ts
@@ -1,0 +1,20 @@
+import type { Annotation } from '@semiont/core';
+import { isHighlight, isComment, isAssessment, isReference, isTag } from '@semiont/core';
+import type { AnnotationsCollection } from '../types/annotation-props';
+
+/**
+ * Bucket a flat annotation list into an `AnnotationsCollection` by motivation.
+ * Shared by the composite page state unit and the standalone `useResourceLoader`
+ * so the grouping lives in exactly one place.
+ */
+export function groupAnnotations(annotations: Annotation[]): AnnotationsCollection {
+  const groups: AnnotationsCollection = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+  for (const ann of annotations) {
+    if (isHighlight(ann)) groups.highlights.push(ann);
+    else if (isComment(ann)) groups.comments.push(ann);
+    else if (isAssessment(ann)) groups.assessments.push(ann);
+    else if (isReference(ann)) groups.references.push(ann);
+    else if (isTag(ann)) groups.tags.push(ann);
+  }
+  return groups;
+}


### PR DESCRIPTION
## Summary

Make `@semiont/react-ui`'s resource viewer consumable by a **bring-your-own-session** React host: render a resource — content + annotations, any media type — fed only a `SemiontSession`, with **no `SemiontProvider` / `SemiontBrowser` / cache / translation provider**. Built for an external consumer (`my-chat`, a thin Electron/Vite GUI over the SDK that holds several KB sessions at once); it also collapses the frontend and external hosts onto **one viewer code path**.

The consumer target now works:
```tsx
import { ResourceViewer, useResourceLoader } from '@semiont/react-ui';

const { resource, annotations, loading } = useResourceLoader(session.client, id);
<ResourceViewer session={session} resource={resource} annotations={annotations}
                onOpenResource={host.open} onOpenPanel={host.openPanel} />
```

## Motivation

Almost the entire resource-viewing experience already lived in `@semiont/react-ui`, but the components were wired to the **application-shell stack** — `SemiontProvider` (a process-wide `SemiontBrowser` singleton), a cache context, a translation context, and observable navigation. That shell's *single-active-session* model is incompatible with a host that manages several sessions (or none). This PR **demotes `SemiontBrowser` from a requirement to one possible host**: the viewer depends on the small thing (a session/client) passed as props.

## What's in it (all `@semiont/react-ui`)

- **Provider-free viewer subtree** — `ResourceViewer`, `BrowseView`, `AnnotateView`, `AnnotateToolbar` take `session` + host callbacks (`onOpenResource`, `onOpenPanel`) as **props** instead of `useSemiont()` / `useEventSubscriptions` / `useObservableExternalNavigation`. All the events they subscribe to are session-scoped (`mark:*`, `browse:click`, `beckon:*`) and now arrive via a new **`useSessionEventSubscriptions(session, …)`** hook. `useTranslations` already falls back to built-in English with no provider.
- **Standalone loader** — **`useResourceLoader(client, id) → { resource, annotations, loading, error }`** loads a resource + its grouped annotations from a bare client. The annotation grouping was extracted to a shared `lib/annotation-groups.ts`, and the composite page state-unit re-pointed at it (one grouping in the codebase).
- **Overridable media renderers** — new `components/resource/browse-renderers.tsx`: self-contained `MediaRendererProps` renderers behind a `defaultBrowseRenderers` registry. `BrowseView`'s dispatch `switch` became a registry lookup with a `renderers` override prop, so a host can swap one renderer (e.g. its own PDF viewer) without forking the view.
- **Session-level media token** — `useMediaToken(client, id)` takes the client explicitly, so authed `<img>` / PDF URLs work from a bare session.
- **Packaging** — the consumer surface (`ResourceViewer`, `useResourceLoader`, `useMediaToken`, `useSessionEventSubscriptions`, `defaultBrowseRenderers`, `setPdfWorkerSrc`) is barrel-exported; no `next/*` on the viewer path.

## Built test-first (TDD)

Every step led with a failing spec. The keystone — `ResourceViewer.embeddable.test.tsx`, render fed only a session with no providers — started **RED** and exposed a *false* "provider-free" claim (the subtree still called `useSemiont()`); it only flipped `it.fails → it` once the whole subtree was genuinely decoupled. A **running** test (not `tsc`) also caught a `rerender`-drops-session regression that a type check can't see. RED-first specs cover each piece: `BrowseView` / `AnnotateView` embeddable, the registry override, `useResourceLoader`, `useMediaToken`, and a barrel-surface import gate.

## Testing

react-ui `tsc --noEmit` clean; the touched + new suites pass (final combined gate: **14 files / 87 tests**). Frontend behavior is unchanged — `ResourceViewerPage` (the batteries-included composition) still feeds the same props from the shell, so the app renders identically.

## Notes
- **Preserved / non-goals:** `SemiontBrowser` and `ResourceViewerPage` stay unchanged as the frontend's app shell and batteries-included path. No annotation-semantics or media-visual changes — only *what the components require to be mounted*.
- **Deferred:** the symmetric annotate-path media registry (CodeMirror / PDF / SVG) — lower value, since annotate isn't the consumer's read path.
- No authentication / authorization changes — the security checklist is N/A.
- Design rationale + phase-by-phase execution log: `.plans/EMBEDDABLE-RESOURCE-VIEWER.md`.
