### PR TITLE
feat(sdk): add mark.updateEntityTypes to tag a resource after creation

### DIFF
--- a/packages/core/src/__tests__/bus-invariants.test.ts
+++ b/packages/core/src/__tests__/bus-invariants.test.ts
@@ -38,6 +38,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { BRIDGED_CHANNELS } from '../bridged-channels';
+import { BUS_OPERATIONS } from '../bus-operations';
 import { PERSISTED_EVENT_TYPES } from '../persisted-events';
 
 /**
@@ -65,6 +66,7 @@ const FROZEN_BRIDGED = [
   'mark:create-ok', 'mark:create-failed',
   'mark:archive-ok', 'mark:archive-failed',
   'mark:unarchive-ok', 'mark:unarchive-failed',
+  'mark:update-entity-types-ok', 'mark:update-entity-types-failed',
   'match:search-results', 'match:search-failed',
   'gather:complete', 'gather:failed',
   'gather:resource-complete', 'gather:resource-failed',
@@ -89,6 +91,21 @@ const FROZEN_BRIDGED = [
 ];
 
 describe('bus channel-classification invariants', () => {
+  it('mark:update-entity-types is a registered operation with correlated -ok/-failed replies', () => {
+    // A resource's own entity-type classification is a confirmed backend write —
+    // registered like its sibling metadata mutations (mark:delete/archive) so the
+    // SDK's busRequest awaits the correlation-keyed reply and rejects on failure,
+    // NOT a fire-and-forget local emit whose failure has nowhere to go
+    // (.plans/bugs/BRIDGE-GAPS.md). Widened to a plain Record so this reads as a
+    // runtime registry assertion (RED before the operation is registered) rather
+    // than a compile error on a missing `as const` key.
+    const ops = BUS_OPERATIONS as Record<string, { result: string; failure: string }>;
+    expect(ops['mark:update-entity-types']).toEqual({
+      result: 'mark:update-entity-types-ok',
+      failure: 'mark:update-entity-types-failed',
+    });
+  });
+
   it('the derived BRIDGED_CHANNELS equals the frozen registry snapshot', () => {
     expect(new Set(BRIDGED_CHANNELS)).toEqual(new Set(FROZEN_BRIDGED));
     // guard against an accidental duplicate inflating the array length without

--- a/packages/core/src/bus-operations.ts
+++ b/packages/core/src/bus-operations.ts
@@ -69,6 +69,7 @@ export const BUS_OPERATIONS = {
   'mark:delete':                         { result: 'mark:delete-ok',                 failure: 'mark:delete-failed' },
   'mark:archive':                        { result: 'mark:archive-ok',                failure: 'mark:archive-failed' },
   'mark:unarchive':                      { result: 'mark:unarchive-ok',              failure: 'mark:unarchive-failed' },
+  'mark:update-entity-types':            { result: 'mark:update-entity-types-ok',    failure: 'mark:update-entity-types-failed' },
 
   // ── MATCH ───────────────────────────────────────────────────────
   // take-1 dressed as an Observable in the SDK; no progress channel

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -137,6 +137,11 @@ export type EventMap = {
   'mark:archive-failed': components['schemas']['CommandError'];
   'mark:unarchive-ok': { correlationId?: string };
   'mark:unarchive-failed': components['schemas']['CommandError'];
+  // update-entity-types confirmed-write reply (bridged) — correlation-keyed ack
+  // the SDK's busRequest awaits; failure routes the real outcome back rather than
+  // the old fire-and-forget silence (.plans/bugs/BRIDGE-GAPS.md).
+  'mark:update-entity-types-ok': { correlationId?: string };
+  'mark:update-entity-types-failed': components['schemas']['CommandError'];
   'mark:body-update-failed': components['schemas']['CommandError'];
 
   // UI events
@@ -479,6 +484,8 @@ export const CHANNEL_SCHEMAS = {
   'mark:archive-failed':              'CommandError',
   'mark:unarchive-ok':                null,
   'mark:unarchive-failed':            'CommandError',
+  'mark:update-entity-types-ok':      null,
+  'mark:update-entity-types-failed':  'CommandError',
   'mark:body-update-failed':          'CommandError',
   'frame:entity-type-add-ok':          null,
   'frame:entity-type-add-failed':      'CommandError',

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -820,11 +820,13 @@ describe('AnnotationOperations', () => {
   });
 
   describe('updateEntityTypes (Stower)', () => {
-    it('emits a correlated mark:update-entity-types-ok and appends the entity-tag events', async () => {
+    it('diffs the sets — appends entity-tag-added AND entity-tag-removed — then acks with a correlated -ok', async () => {
       // The SDK's `mark.updateEntityTypes` is a confirmed busRequest write: it
       // awaits this correlation-keyed reply. Before the reply was wired, the
       // handler appended the mark:entity-tag-* events but never acked, so the
       // request would hang to timeout (.plans/bugs/BRIDGE-GAPS.md shape).
+      // Passing a non-empty `current` that differs from `updated` exercises both
+      // diff branches: 'Person' is added, 'Legacy' is removed.
       const correlationId = 'uet-cid-1';
       const ok$ = firstValueFrom(
         eventBus.get('mark:update-entity-types-ok').pipe(
@@ -837,19 +839,55 @@ describe('AnnotationOperations', () => {
         correlationId,
         _userId: 'user-1',
         resourceId: testResourceId,
-        currentEntityTypes: [],
+        currentEntityTypes: ['Legacy'],
         updatedEntityTypes: ['Person'],
       });
 
       await ok$;
 
       const events = await testEventStore.log.getEvents(resourceId(testResourceId));
-      const added = events.filter(
-        (e) =>
-          e.type === 'mark:entity-tag-added' &&
-          (e.payload as { entityType?: string }).entityType === 'Person',
+      const tag = (type: string, entityType: string) =>
+        events.some(
+          (e) => e.type === type && (e.payload as { entityType?: string }).entityType === entityType,
+        );
+      expect(tag('mark:entity-tag-added', 'Person')).toBe(true);
+      expect(tag('mark:entity-tag-removed', 'Legacy')).toBe(true);
+    });
+
+    it('routes an append failure to a correlated mark:update-entity-types-failed (not silently dropped)', async () => {
+      // The confirmed-write guarantee: if the backend write throws, the failure
+      // must come back on the correlated reply channel so the SDK's busRequest
+      // rejects — the "failure has nowhere to go" bug BRIDGE-GAPS.md removed.
+      // Isolated Stower over a KB whose eventStore.appendEvent rejects, so the
+      // catch branch runs without disturbing the shared real-KB harness.
+      const failBus = new EventBus();
+      const failingKb = {
+        eventStore: { appendEvent: vi.fn().mockRejectedValue(new Error('disk full')) },
+      } as unknown as KnowledgeBase;
+      const failStower = new Stower(failingKb, failBus, mockLogger);
+      await failStower.initialize();
+
+      const correlationId = 'uet-cid-fail';
+      const failed$ = firstValueFrom(
+        failBus.get('mark:update-entity-types-failed').pipe(
+          filter((e) => e.correlationId === correlationId),
+          take(1),
+        ),
       );
-      expect(added.length).toBeGreaterThan(0);
+
+      failBus.get('mark:update-entity-types').next({
+        correlationId,
+        _userId: 'user-1',
+        resourceId: testResourceId,
+        currentEntityTypes: [],
+        updatedEntityTypes: ['Person'],
+      });
+
+      const failure = await failed$;
+      expect(failure.message).toContain('disk full');
+
+      await failStower.stop();
+      failBus.destroy();
     });
   });
 });

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -818,4 +818,38 @@ describe('AnnotationOperations', () => {
       ).rejects.toThrow('Annotation not found in resource');
     });
   });
+
+  describe('updateEntityTypes (Stower)', () => {
+    it('emits a correlated mark:update-entity-types-ok and appends the entity-tag events', async () => {
+      // The SDK's `mark.updateEntityTypes` is a confirmed busRequest write: it
+      // awaits this correlation-keyed reply. Before the reply was wired, the
+      // handler appended the mark:entity-tag-* events but never acked, so the
+      // request would hang to timeout (.plans/bugs/BRIDGE-GAPS.md shape).
+      const correlationId = 'uet-cid-1';
+      const ok$ = firstValueFrom(
+        eventBus.get('mark:update-entity-types-ok').pipe(
+          filter((e) => e.correlationId === correlationId),
+          take(1),
+        ),
+      );
+
+      eventBus.get('mark:update-entity-types').next({
+        correlationId,
+        _userId: 'user-1',
+        resourceId: testResourceId,
+        currentEntityTypes: [],
+        updatedEntityTypes: ['Person'],
+      });
+
+      await ok$;
+
+      const events = await testEventStore.log.getEvents(resourceId(testResourceId));
+      const added = events.filter(
+        (e) =>
+          e.type === 'mark:entity-tag-added' &&
+          (e.payload as { entityType?: string }).entityType === 'Person',
+      );
+      expect(added.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/packages/make-meaning/src/stower.ts
+++ b/packages/make-meaning/src/stower.ts
@@ -447,23 +447,35 @@ export class Stower {
     const added = event.updatedEntityTypes.filter(et => !event.currentEntityTypes.includes(et));
     const removed = event.currentEntityTypes.filter(et => !event.updatedEntityTypes.includes(et));
 
-    for (const entityType of added) {
-      await this.kb.eventStore.appendEvent({
-        type: 'mark:entity-tag-added',
-        resourceId: resourceId(event.resourceId),
-        userId: uid,
-        version: 1,
-        payload: { entityType },
-      });
-    }
+    try {
+      for (const entityType of added) {
+        await this.kb.eventStore.appendEvent({
+          type: 'mark:entity-tag-added',
+          resourceId: resourceId(event.resourceId),
+          userId: uid,
+          version: 1,
+          payload: { entityType },
+        });
+      }
 
-    for (const entityType of removed) {
-      await this.kb.eventStore.appendEvent({
-        type: 'mark:entity-tag-removed',
-        resourceId: resourceId(event.resourceId),
-        userId: uid,
-        version: 1,
-        payload: { entityType },
+      for (const entityType of removed) {
+        await this.kb.eventStore.appendEvent({
+          type: 'mark:entity-tag-removed',
+          resourceId: resourceId(event.resourceId),
+          userId: uid,
+          version: 1,
+          payload: { entityType },
+        });
+      }
+
+      // Correlation-keyed ack for the SDK's busRequest (the persisted
+      // mark:entity-tag-* domain events remain the system-of-record signal).
+      this.eventBus.get('mark:update-entity-types-ok').next({ correlationId: event.correlationId });
+    } catch (error) {
+      this.logger.error('Failed to update entity types', { error: errField(error) });
+      this.eventBus.get('mark:update-entity-types-failed').next({
+        correlationId: event.correlationId,
+        message: error instanceof Error ? error.message : String(error),
       });
     }
   }

--- a/packages/react-ui/docs/COMPONENTS.md
+++ b/packages/react-ui/docs/COMPONENTS.md
@@ -115,33 +115,27 @@ import { AnnotationHistory } from '@semiont/react-ui';
 
 ### SignInForm
 
-Sign-in form with Google OAuth and optional credentials-based authentication.
+Sign-in form with Google OAuth and optional credentials-based auth. The sign-in callbacks
+receive the target `backendUrl` (the form can prompt for it, or you can pre-fill + lock it via
+the `backendUrl` prop).
 
 ```tsx
 import { SignInForm } from '@semiont/react-ui';
-import Link from 'next/link'; // Or your router's Link
+import Link from 'next/link'; // or your router's Link
 
 <SignInForm
-  onGoogleSignIn={async () => signIn('google')}
-  onCredentialsSignIn={async (email, password) => signIn('credentials', { email, password })}
-  showCredentialsAuth={true}
+  onGoogleSignIn={async (backendUrl) => signIn('google', { backendUrl })}
+  onCredentialsSignIn={async (backendUrl, email, password) => signIn('credentials', { backendUrl, email, password })}
+  backendUrl={lockedBackendUrl}   // optional: pre-fill + lock the backend-URL field
+  showCredentialsAuth
+  isLoading={submitting}
   error={errorMessage}
   Link={Link}
-  translations={{
-    pageTitle: 'Sign In',
-    welcomeBack: 'Welcome back to Semiont',
-    // ... other translation keys
-  }}
+  translations={strings}
 />
 ```
 
-**Props:**
-- `onGoogleSignIn` - Callback for Google OAuth sign-in
-- `onCredentialsSignIn?` - Optional callback for email/password sign-in
-- `showCredentialsAuth?` - Whether to show credentials auth form (default: false)
-- `error?` - Error message to display
-- `Link` - Link component from your router
-- `translations` - Translation strings for all UI text
+**Required:** `onGoogleSignIn(backendUrl)`, `Link`, `translations`. **Optional:** `onCredentialsSignIn(backendUrl, email, password)`, `backendUrl`, `showCredentialsAuth`, `isLoading`, `error`. The full `translations` shape (21 keys) is the exported `SignInFormProps` type.
 
 ### SignUpForm
 
@@ -204,89 +198,89 @@ import Link from 'next/link';
 
 ### WelcomePage
 
-Welcome page for new users after sign-up.
+Terms-acceptance / welcome screen for new users. Driven by an explicit `status` and
+accept/decline callbacks; the host injects its own `PageLayout`.
 
 ```tsx
 import { WelcomePage } from '@semiont/react-ui';
 import Link from 'next/link';
 
 <WelcomePage
+  status="form"            // 'loading' | 'accepted' | 'form'
+  isProcessing={processing}
+  onAccept={acceptTerms}
+  onDecline={declineTerms}
   userName={user.name}
+  PageLayout={PageLayout}
   Link={Link}
-  translations={{
-    // ... translation keys
-  }}
+  translations={strings}
 />
 ```
+
+**Required:** `status`, `isProcessing`, `onAccept`, `onDecline`, `PageLayout`, `Link`, `translations`. **Optional:** `userName`, `termsAcceptedAt`, `isNewUser`. Full shape: the exported `WelcomePageProps` type.
 
 ---
 
 ## Layout Components
 
+These compose the app chrome and are **framework-agnostic**: instead of importing
+`next/navigation` or a translation library, they take the host's primitives as props — `Link`
+(your router's link component), `routes` (a `RouteBuilder`), and translation functions (`t`,
+`tNav`, `tHome`). Wire them once from your shell. Each component's own `Props` interface is the
+source of truth for the full (and evolving) list; the essentials are below.
+
 ### PageLayout
 
-Standard page layout with header, sidebar, and content.
+The standard page shell — composes `UnifiedHeader` + `Footer` around your content. (It does
+*not* take `header` / `sidebar` slots.)
 
 ```tsx
 import { PageLayout } from '@semiont/react-ui';
 
-<PageLayout
-  header={<Header />}
-  sidebar={<Sidebar />}
-  showSidebar={true}
->
+<PageLayout Link={Link} routes={routes} t={t} tNav={tNav} tHome={tHome}>
   {content}
 </PageLayout>
 ```
 
+Also optional: `className`, `showAuthLinks`, `CookiePreferences`, `onOpenKeyboardHelp`.
+
 ### UnifiedHeader
 
-Application header with navigation and user menu.
+Application header (branding + nav + user menu). Presentation via `variant`
+(`'standalone' | 'embedded' | 'floating'`) and the `isAuthenticated` / `isAdmin` /
+`isModerator` flags. No `userName` prop — the user menu resolves identity from the session.
 
 ```tsx
-import { UnifiedHeader } from '@semiont/react-ui';
-
-<UnifiedHeader
-  showUserMenu={isAuthenticated}
-  userName={user?.name}
-/>
+<UnifiedHeader Link={Link} routes={routes} t={t} tHome={tHome} variant="standalone" isAuthenticated={isAuthenticated} />
 ```
 
 ### LeftSidebar
 
-Collapsible sidebar navigation.
+Collapsible sidebar; it manages its own collapse state (persisted to `localStorage`). `children`
+may be a render function `(isCollapsed, toggleCollapsed, navigationMenu) => ReactNode`.
 
 ```tsx
-import { LeftSidebar } from '@semiont/react-ui';
-
-<LeftSidebar isOpen={sidebarOpen} onToggle={toggleSidebar}>
-  <NavigationMenu />
+<LeftSidebar Link={Link} routes={routes} t={t} tHome={tHome} collapsible isAuthenticated={isAuthenticated}>
+  {(isCollapsed, toggle, navigationMenu) => navigationMenu(() => {})}
 </LeftSidebar>
 ```
 
 ### NavigationMenu
 
-Main navigation menu.
+The Know / Moderate / Administer nav. `isAdmin` / `isModerator` gate the privileged entries;
+`currentPath` highlights the active one.
 
 ```tsx
-import { NavigationMenu } from '@semiont/react-ui';
-
-<NavigationMenu />
+<NavigationMenu Link={Link} routes={routes} t={t} isAdmin={isAdmin} currentPath={currentPath} />
 ```
-
-**Features:**
-- Keyboard navigation
-- Active route highlighting
-- Responsive design
 
 ### Footer
 
-Application footer with links.
+Application footer; rendered for you inside `PageLayout`. Optional: `showPolicyLinks`,
+`sourceCodeUrl`, `CookiePreferences`, `onOpenKeyboardHelp`.
 
 ```tsx
-import { Footer } from '@semiont/react-ui';
-
-<Footer />
+<Footer Link={Link} routes={routes} t={t} showPolicyLinks />
 ```
 
 ---
@@ -297,36 +291,41 @@ See [ANNOTATIONS.md](ANNOTATIONS.md) for detailed annotation documentation.
 
 ### AnnotateToolbar
 
-Toolbar for annotation tools.
+The tool bar `ResourceViewer` composes in annotate mode — selection / click / shape tool state,
+driven over the session bus. Composed for you by `ResourceViewer`; use it directly only for a
+custom annotate surface.
 
 ```tsx
 import { AnnotateToolbar } from '@semiont/react-ui';
 
 <AnnotateToolbar
-  currentTool={tool}
-  onToolChange={setTool}
+  selectedMotivation={selectedMotivation}   // 'linking' | 'highlighting' | 'assessing' | 'commenting' | 'tagging' | null
+  selectedClick={selectedClick}             // 'detail' | 'follow' | 'jsonld' | 'deleting'
+  annotateMode
+  annotators={annotators}
+  session={session}
 />
 ```
 
+Optional: `showSelectionGroup`, `showDeleteButton`, `showShapeGroup`, `selectedShape`, `mediaType`. See the `AnnotateToolbarProps` interface for the rest.
+
 ### Annotation Panels
 
+The side-panel renderers for each annotation motivation. They take the **grouped annotation
+arrays + UI state** (from `useResourceLoader` / the page state unit) — not a `resourceId`; they
+render what you pass and emit edits on the session bus.
+
 ```tsx
-import {
-  HighlightPanel,
-  CommentsPanel,
-  TaggingPanel,
-  ReferencesPanel,
-  AssessmentPanel,
-  JsonLdPanel,
-  UnifiedAnnotationsPanel
-} from '@semiont/react-ui';
+import { HighlightPanel, UnifiedAnnotationsPanel } from '@semiont/react-ui';
 
-// Use specific panel
-<HighlightPanel resourceId={rId} />
+// One motivation:
+<HighlightPanel annotations={highlights} pendingAnnotation={pending} annotateMode />
 
-// Or unified panel for all annotations
-<UnifiedAnnotationsPanel resourceId={rId} />
+// All motivations in one panel:
+<UnifiedAnnotationsPanel annotations={annotations} annotators={annotators} pendingAnnotation={pending} annotateMode />
 ```
+
+Also exported: `CommentsPanel`, `TaggingPanel`, `ReferencesPanel`, `AssessmentPanel`, `JsonLdPanel`. Each panel's `Props` interface lists its state inputs.
 
 ---
 
@@ -366,20 +365,17 @@ import { KeyboardShortcutsHelpModal } from '@semiont/react-ui';
 
 ### Toolbar
 
-Customizable toolbar container.
+The panel-switcher rail — toggles the resource side panels (annotations, info, history,
+json-ld, collaboration, knowledge-base, user, settings). Not a generic container.
 
 ```tsx
 import { Toolbar } from '@semiont/react-ui';
 
-<Toolbar>
-  <Toolbar.Section>
-    <button>Action 1</button>
-    <button>Action 2</button>
-  </Toolbar.Section>
-  <Toolbar.Section align="right">
-    <button>Settings</button>
-  </Toolbar.Section>
-</Toolbar>
+<Toolbar
+  context="document"        // 'document' | 'simple'
+  activePanel={activePanel} // the open panel key, or null
+  isArchived={false}
+/>
 ```
 
 ### Toast
@@ -471,17 +467,13 @@ import { UserMenuSkeleton } from '@semiont/react-ui';
 
 ### SkipLinks
 
-Skip navigation links for keyboard users.
+Skip-navigation links for keyboard users. Takes no props — it renders the standard skip targets
+(main content, navigation).
 
 ```tsx
 import { SkipLinks } from '@semiont/react-ui';
 
-<SkipLinks
-  links={[
-    { href: '#main-content', label: 'Skip to main content' },
-    { href: '#navigation', label: 'Skip to navigation' }
-  ]}
-/>
+<SkipLinks />
 ```
 
 ---
@@ -490,13 +482,15 @@ import { SkipLinks } from '@semiont/react-ui';
 
 ### SemiontBranding
 
-Semiont logo and branding.
+Semiont logo + tagline. Takes a translation function `t` for the tagline text.
 
 ```tsx
 import { SemiontBranding } from '@semiont/react-ui';
 
-<SemiontBranding size="large" />
+<SemiontBranding t={t} size="lg" showTagline />
 ```
+
+`size` is `'sm' | 'md' | 'lg' | 'xl'`; also optional: `showTagline`, `animated`, `compactTagline`, `className`.
 
 ---
 
@@ -516,55 +510,37 @@ import { ErrorBoundary } from '@semiont/react-ui';
 
 ### CodeMirrorRenderer
 
-CodeMirror-based code viewer.
+CodeMirror-based renderer for text/markdown content with the annotation overlay (used internally
+by `BrowseView` / `AnnotateView`). Editability is controlled by `editable` (not `readOnly`), and
+it always renders markdown — there is no `language` prop.
 
 ```tsx
 import { CodeMirrorRenderer } from '@semiont/react-ui';
 
-<CodeMirrorRenderer
-  content={code}
-  language="javascript"
-  readOnly={true}
-/>
+<CodeMirrorRenderer content={text} editable={false} showLineNumbers hoverDelayMs={200} />
 ```
 
-### DetectionProgressWidget
-
-Progress indicator for entity detection.
-
-```tsx
-import { DetectionProgressWidget } from '@semiont/react-ui';
-
-<DetectionProgressWidget
-  progress={0.5}
-  status="Processing..."
-/>
-```
+`content` and `hoverDelayMs` are required; also optional: `segments`, `onTextSelect`, `onChange`, `session`, `newAnnotationIds`, `hoveredAnnotationId`, `scrollToAnnotationId`, `sourceView`, `enableWidgets`, `getTargetResourceName`, `generatingReferenceId`.
 
 ### StatusDisplay
 
-Display system status messages.
+Renders the backend-connection / auth health indicator. Takes the current auth flags (not a
+free-form status/message).
 
 ```tsx
 import { StatusDisplay } from '@semiont/react-ui';
 
-<StatusDisplay
-  status="info" // or "success", "warning", "error"
-  message="System is running normally"
-/>
+<StatusDisplay isAuthenticated={isAuthenticated} isFullyAuthenticated={isFullyAuthed} hasValidBackendToken={tokenValid} />
 ```
 
 ### ResourceTagsInline
 
-Display resource tags inline.
+Renders a resource's tags inline (read-only display).
 
 ```tsx
 import { ResourceTagsInline } from '@semiont/react-ui';
 
-<ResourceTagsInline
-  tags={['important', 'review', 'draft']}
-  onTagClick={(tag) => filterByTag(tag)}
-/>
+<ResourceTagsInline resourceId={rId} tags={['important', 'review']} isEditing={false} onUpdate={async () => {}} />
 ```
 
 ---

--- a/packages/sdk/src/namespaces/__tests__/commands.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/commands.test.ts
@@ -159,6 +159,29 @@ describe('MarkNamespace', () => {
     await assertion;
   });
 
+  it('updateEntityTypes() emits mark:update-entity-types (diff payload) and resolves on -ok', async () => {
+    const mock = createMockTransport({
+      'mark:update-entity-types': () => ({ resultChannel: 'mark:update-entity-types-ok', response: {} }),
+    });
+    const m = new MarkNamespace(mock.transport, eventBus);
+    await m.updateEntityTypes(RID, ['A'], ['A', 'B']);
+    expect(mock.emitSpy).toHaveBeenCalledWith('mark:update-entity-types', expect.objectContaining({
+      resourceId: RID,
+      currentEntityTypes: ['A'],
+      updatedEntityTypes: ['A', 'B'],
+    }));
+  });
+
+  it('updateEntityTypes() REJECTS on mark:update-entity-types-failed — a tag write failure is not silently dropped', async () => {
+    const mock = createMockTransport();
+    const m = new MarkNamespace(mock.transport, eventBus);
+    const assertion = expect(m.updateEntityTypes(RID, [], ['Person'])).rejects.toThrow(/rejected/);
+    await new Promise((r) => setTimeout(r, 10));
+    const cid = mock.emitSpy.mock.calls[0]?.[1]?.correlationId as string;
+    (mock.transportBus.get('mark:update-entity-types-failed' as never) as { next(v: unknown): void }).next({ correlationId: cid, message: 'rejected by handler' });
+    await assertion;
+  });
+
   it('assist() returns Observable that emits on job:report-progress', async () => {
     const progress: any[] = [];
     const completed = new Promise<void>((resolve) => {

--- a/packages/sdk/src/namespaces/mark.ts
+++ b/packages/sdk/src/namespaces/mark.ts
@@ -70,6 +70,26 @@ export class MarkNamespace implements IMarkNamespace {
     );
   }
 
+  /**
+   * Replace a resource's own entity-type classification. The backend diffs
+   * `current` vs `updated` and folds the changes into `resource.entityTypes`
+   * (mark:entity-tag-added/-removed → graph consumer), so the change surfaces in
+   * `browse.resources({ entityType })` and `getResourceEntityTypes`. A
+   * **replace/diff** operation: pass the resource's current types as `current`,
+   * the desired full set as `updated`.
+   *
+   * Confirmed write (like `delete`/`archive`): awaits the backend's
+   * correlation-keyed reply and REJECTS on failure rather than fire-and-forget an
+   * emit whose failure had nowhere to go (.plans/bugs/BRIDGE-GAPS.md).
+   */
+  async updateEntityTypes(resourceId: ResourceId, current: string[], updated: string[]): Promise<void> {
+    await busRequest(
+      this.transport,
+      'mark:update-entity-types',
+      { resourceId, currentEntityTypes: current, updatedEntityTypes: updated },
+    );
+  }
+
   assist(resourceId: ResourceId, motivation: Motivation, options: MarkAssistOptions): StreamObservable<MarkAssistEvent> {
     return new StreamObservable<MarkAssistEvent>((subscriber) => {
       let done = false;

--- a/packages/sdk/src/namespaces/types.ts
+++ b/packages/sdk/src/namespaces/types.ts
@@ -281,6 +281,16 @@ export interface MarkNamespace {
   archive(resourceId: ResourceId): Promise<void>;
   unarchive(resourceId: ResourceId): Promise<void>;
 
+  /**
+   * Replace a resource's own entity-type classification. A **diff/replace**
+   * operation: pass the resource's current types as `current` and the desired
+   * full set as `updated`. The backend folds the difference into
+   * `resource.entityTypes`, so the change surfaces in
+   * `browse.resources({ entityType })` and `getResourceEntityTypes`. Awaitable +
+   * rejects on failure, like `delete`/`archive`.
+   */
+  updateEntityTypes(resourceId: ResourceId, current: string[], updated: string[]): Promise<void>;
+
   // AI-assisted annotation (long-running; emits progress, completes with the final event)
   assist(resourceId: ResourceId, motivation: Motivation, options: MarkAssistOptions): StreamObservable<MarkAssistEvent>;
 

--- a/scripts/compliance/audit-fire-and-forget-promise-void.sh
+++ b/scripts/compliance/audit-fire-and-forget-promise-void.sh
@@ -22,7 +22,7 @@ cd "$REPO_ROOT"
 
 # Legit ack methods — each awaits a backend HTTP round-trip and correctly returns
 # Promise<void>. Add a method name here only when it genuinely awaits a backend ack.
-ACK_ALLOWLIST='[^A-Za-z](body|addEntityType|addEntityTypes|addTagSchema|delete|archive|unarchive|logout|acceptTerms)\('
+ACK_ALLOWLIST='[^A-Za-z](body|addEntityType|addEntityTypes|addTagSchema|delete|archive|unarchive|updateEntityTypes|logout|acceptTerms)\('
 
 VIOLATIONS=$(grep -rnE ":[[:space:]]*Promise<void>" \
   packages/sdk/src/namespaces \

--- a/specs/src/components/schemas/MarkUpdateEntityTypesCommand.json
+++ b/specs/src/components/schemas/MarkUpdateEntityTypesCommand.json
@@ -2,6 +2,10 @@
   "type": "object",
   "description": "Bus command to replace the entity types on a resource.",
   "properties": {
+    "correlationId": {
+      "type": "string",
+      "description": "Correlation id for request/reply matching, set by the SDK's busRequest so the confirmed-write ack/failure routes back."
+    },
     "resourceId": {
       "type": "string"
     },


### PR DESCRIPTION
## Summary

Adds **`client.mark.updateEntityTypes(rid, current, updated)`** — the SDK method to change a resource's own entity-type classification *after* creation, so an untagged document can be tagged `Person`/`Place`/… and then surface in entity-type filters (`browse.resources({ entityType })`) and metadata (`getResourceEntityTypes`).

The backend capability already existed end-to-end (stower diffs current vs updated → `mark:entity-tag-added/-removed` → graph consumer folds into `resource.entityTypes`), but there was **no client method and no working client path**: the command was typed but not a registered operation, so a local bus emit never reached stower. This wires it as a first-class request/reply operation — an awaitable `busRequest` that rejects on failure, exactly like `mark.delete`/`archive` — **not** a fire-and-forget local emit whose failure has nowhere to go (`.plans/bugs/BRIDGE-GAPS.md`).

Design/rationale: `.plans/SDK-RESOURCE-ENTITY-TAGS.md`.

## Commits

| Commit | What |
| --- | --- |
| `8a03f70` — update react-ui components doc | Doc-vs-code sweep of `packages/react-ui/docs/COMPONENTS.md`: corrected stale prop signatures across the component reference to match current code (Resource cluster + Layout/Nav/auth/toolbar/panels/branding sections), removed a phantom widget entry. Docs-only. |
| `2b8e66f` — feat(sdk): add mark.updateEntityTypes to tag a resource after creation | The feature, TDD-first across three layers (below). |

## The feature, layer by layer (`2b8e66f`)

**core** — register the operation:
- `bus-operations.ts` — add `mark:update-entity-types` with `-ok`/`-failed` replies (`BRIDGED_CHANNELS` derives the bridging automatically).
- `bus-protocol.ts` — the two reply channels in `EventMap` + `CHANNEL_SCHEMAS`, mirroring `mark:archive-ok` (inline `{ correlationId? }` / `CommandError`, no new reply schema).
- `MarkUpdateEntityTypesCommand.json` — add `correlationId?` (regenerated types are gitignored).
- `bus-invariants.test.ts` — refresh the `FROZEN_BRIDGED` snapshot for the two new replies.

**make-meaning (backend)** — `stower.handleUpdateEntityTypes` now wraps its diff loop in try/catch and emits the correlated `mark:update-entity-types-ok` / `-failed`, identical in shape to `handleMarkArchive`. The persisted `mark:entity-tag-*` events remain the system-of-record.

**sdk** — `MarkNamespace.updateEntityTypes(rid, current, updated)` (interface + impl) issues the diff `busRequest` and resolves on `-ok`. A **replace/diff** op: pass the current set as `current`, the desired full set as `updated`.

## Testing (TDD-first — each layer RED before GREEN)

| Layer | RED | GREEN |
| --- | --- | --- |
| core | registry test: *expected undefined to equal {…}* | bus-invariants + bus-request 17/17 |
| backend | stower test **timed out at 10s** (no ack) | annotation-operations 20/20 |
| sdk (keystone) | *m.updateEntityTypes is not a function* | commands 44/44 |

`tsc --noEmit` clean for core / make-meaning / sdk. The cross-package http-transport `bus-invariants` guard (BRIDGED vs RESOURCE_SCOPED disjoint) stays 2/2 — the new replies are bridged, not scoped, so no http-transport change was needed. Full suites run in CI.

## Not built (deliberate, logged in the plan)

- `add/removeEntityTypes` sugar — would couple `MarkNamespace` to `browse` to read the current set, for a fetch the consumer already avoids (it holds `resource.entityTypes`). The primitive covers the stated need.
- A `-failed`-on-missing-`_userId` test — that guard is a hard gateway-injection invariant that throws *outside* try/catch (like every sibling handler), not a routed reply.

## Areas changed

- **Core** (`packages/core`) — operation registry + reply channels
- **Backend** (`packages/make-meaning`) — stower reply
- **SDK** (`packages/sdk`) — the new method
- **OpenAPI Specs** (`specs/`) — `correlationId` on the command
- **Documentation** (`packages/react-ui/docs`) — COMPONENTS.md sweep
