### PR TITLE
Embeddable viewer completion: inline embedding, content-link + reference-hover callbacks, compact annotate bar

### DIFF
--- a/packages/react-ui/src/components/annotation/AnnotateToolbar.tsx
+++ b/packages/react-ui/src/components/annotation/AnnotateToolbar.tsx
@@ -30,6 +30,10 @@ interface AnnotateToolbarProps {
 
   // Session — emits mark:* selection/click/shape/mode changes via its client.
   session: SemiontSession | null;
+
+  // Compact display form (display-only): icon-only, tight, chromeless — for inline
+  // embeds. The bar's functionality is identical; only its form changes.
+  compact?: boolean;
 }
 
 interface DropdownGroupProps {
@@ -121,6 +125,7 @@ export function AnnotateToolbar({
   annotateMode = false,
   annotators,
   session,
+  compact = false,
 }: AnnotateToolbarProps) {
   const t = useTranslations('AnnotateToolbar');
 
@@ -291,7 +296,7 @@ export function AnnotateToolbar({
   const shapeTypes = allShapeTypes.filter(st => supportedShapes.includes(st.shape));
 
   return (
-    <div className="semiont-annotate-toolbar">
+    <div className={`semiont-annotate-toolbar${compact ? ' semiont-annotate-toolbar--compact' : ''}`}>
       {/* Click Group */}
       <DropdownGroup
         label={t('clickGroup')}

--- a/packages/react-ui/src/components/annotation/__tests__/AnnotateToolbar.display.test.tsx
+++ b/packages/react-ui/src/components/annotation/__tests__/AnnotateToolbar.display.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 3 — Annotate Bar display forms.
+ *
+ * Behavior is mostly fixed (the bar IS the annotation capability); the host
+ * gets freedom over its display form. `compact` is a display-only variant:
+ * icon-only, tight, chromeless — the functional groups stay present and wired.
+ * BrowseView's `inline` embed shows the compact bar automatically. Theming
+ * (semiont-* classes + CSS vars) and labels (i18n) already exist — no new API
+ * for those.
+ *
+ * Started RED (no `compact` prop) and GREEN once Phase 3 lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SemiontSession } from '@semiont/sdk';
+import { AnnotateToolbar } from '../AnnotateToolbar';
+import { ANNOTATORS } from '../../../lib/annotation-registry';
+import { BrowseView } from '../../resource/BrowseView';
+
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() }, mark: { toggleMode: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+const toolbarProps = {
+  selectedMotivation: null,
+  selectedClick: 'detail' as const,
+  annotateMode: false,
+  annotators: ANNOTATORS,
+  session: null,
+};
+
+describe('Annotate Bar display forms (Phase 3)', () => {
+  it('`compact` adds the display modifier; default does not', () => {
+    const { container: normal } = render(<AnnotateToolbar {...toolbarProps} />);
+    expect(normal.querySelector('.semiont-annotate-toolbar')).not.toHaveClass('semiont-annotate-toolbar--compact');
+
+    const { container } = render(<AnnotateToolbar {...toolbarProps} compact />);
+    expect(container.querySelector('.semiont-annotate-toolbar')).toHaveClass('semiont-annotate-toolbar--compact');
+  });
+
+  it('compact is display-only: the functional groups are still present', () => {
+    render(<AnnotateToolbar {...toolbarProps} compact />);
+    // Groups render with their aria labels (default-English translations, no provider).
+    expect(screen.getByLabelText(/mode/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/click/i)).toBeInTheDocument();
+  });
+
+  it('BrowseView inline embeds show the compact bar automatically', () => {
+    const props = {
+      content: 'x', mimeType: 'text/plain', resourceUri: 'res-1',
+      annotations: emptyAnnotations, annotateMode: false, session: fakeSession(),
+    };
+    const { container: pane } = render(<BrowseView {...props} />);
+    expect(pane.querySelector('.semiont-annotate-toolbar')).not.toHaveClass('semiont-annotate-toolbar--compact');
+
+    const { container } = render(<BrowseView {...props} inline />);
+    expect(container.querySelector('.semiont-annotate-toolbar')).toHaveClass('semiont-annotate-toolbar--compact');
+  });
+
+  it('stylesheet carries the compact form (static gate — icon-only, chromeless)', () => {
+    const css = readFileSync(resolve(process.cwd(), 'src/components/toolbar/Toolbar.css'), 'utf8');
+    expect(css).toMatch(/\.semiont-annotate-toolbar--compact\s*\{/);
+    expect(css).toMatch(/\.semiont-annotate-toolbar--compact\s+\.semiont-dropdown-label\s*\{[^}]*display:\s*none/);
+  });
+});

--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback, useMemo, memo } from 'react';
-import { annotationId as toAnnotationId } from '@semiont/core';
-import { capabilitiesOf } from '@semiont/core';
+import { useEffect, useRef, useCallback, useMemo, memo, type MouseEvent as ReactMouseEvent } from 'react';
+import { annotationId as toAnnotationId, resourceId as toResourceId } from '@semiont/core';
+import { capabilitiesOf, getBodySource, isResolvedReference } from '@semiont/core';
+import type { Annotation, ResourceDescriptor } from '@semiont/core';
 import { createHoverHandlers } from '@semiont/sdk';
 import { ANNOTATORS } from '../../lib/annotation-registry';
 import { scrollAnnotationIntoView } from '../../lib/scroll-utils';
@@ -36,6 +37,22 @@ interface Props {
   newAnnotationIds?: Set<string>;
   /** Override the read-only media renderers (render mode → renderer); merged over the defaults. */
   renderers?: BrowseMediaRenderers;
+  /** A content link (`<a href>` in the rendered content) was clicked. The viewer preventDefaults and
+   *  delegates; it never navigates on its own. Omit → the click is still blocked (nothing happens). */
+  onLinkClick?: (link: { href: string; event: ReactMouseEvent }) => void;
+  /** A RESOLVED reference span is hovered: fires after the dwell AND the referent's cached descriptor
+   *  resolves; `null` on leave (only if a hover fired — stubs stay silent). Host renders its own preview. */
+  onReferenceHover?: (hover: ReferenceHover | null) => void;
+  /** Inline display variant: auto-height to content, no inner scroll container, no pane chrome —
+   *  drops into a chat bubble / card / list item. Default: fill-the-pane (unchanged). */
+  inline?: boolean;
+}
+
+/** Payload for `onReferenceHover` — the hovered linking annotation, its resolved referent, and where the span is. */
+export interface ReferenceHover {
+  annotation: Annotation;
+  referent: ResourceDescriptor;
+  anchorRect: DOMRect;
 }
 
 /**
@@ -62,8 +79,12 @@ export const BrowseView = memo(function BrowseView({
   session,
   newAnnotationIds,
   renderers,
+  onLinkClick,
+  onReferenceHover,
+  inline = false,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const inlineMod = inline ? ' semiont-browse-view--inline' : '';
 
   const render = capabilitiesOf(mimeType)?.render ?? 'none';
 
@@ -124,8 +145,50 @@ export const BrowseView = memo(function BrowseView({
       }
     };
 
+    // Reference-hover delegation (host-facing event surface): after the dwell,
+    // resolve the referent's cached descriptor and hand the host
+    // { annotation, referent, anchorRect }; `null` on leave — but only if a hover
+    // fired, so stubs stay silent. Rides the SAME dwell emitter as beckon:hover —
+    // one state machine, two consumers.
+    let hoveredElement: HTMLElement | null = null;
+    let referentSub: { unsubscribe(): void } | null = null;
+    let referenceHoverFired = false;
+
+    const startReferenceHover = (id: string) => {
+      if (!onReferenceHover) return; // no handler → no referent load
+      const annotation = allAnnotations.find(a => a.id === id);
+      if (!annotation || !isResolvedReference(annotation)) return; // stub / non-reference: fires nothing
+      const referentId = getBodySource(annotation.body);
+      const element = hoveredElement;
+      if (!referentId || !element) return;
+      referentSub?.unsubscribe();
+      referentSub = session.client.browse.resource(toResourceId(referentId)).subscribe({
+        next: (referent) => {
+          if (referent === undefined) return; // cache still loading
+          referentSub?.unsubscribe();
+          referentSub = null;
+          referenceHoverFired = true;
+          // anchorRect taken at fire time so it reflects current layout.
+          onReferenceHover({ annotation, referent, anchorRect: element.getBoundingClientRect() });
+        },
+        error: () => { referentSub = null; }, // failed load: never fires
+      });
+    };
+
+    const endReferenceHover = () => {
+      referentSub?.unsubscribe(); // leave-before-resolve: cancel, no fire
+      referentSub = null;
+      if (referenceHoverFired) {
+        referenceHoverFired = false;
+        onReferenceHover?.(null);
+      }
+    };
+
     const { handleMouseEnter, handleMouseLeave, cleanup: cleanupHover } = createHoverHandlers(
-      (id) => session.client.beckon.hover(id),
+      (id) => {
+        session.client.beckon.hover(id);
+        if (id) startReferenceHover(id); else endReferenceHover();
+      },
       hoverDelayMs
     );
 
@@ -134,7 +197,10 @@ export const BrowseView = memo(function BrowseView({
       const target = e.target as HTMLElement;
       const annotationElement = target.closest('[data-annotation-id]');
       const annotationId = annotationElement?.getAttribute('data-annotation-id');
-      if (annotationId) handleMouseEnter(toAnnotationId(annotationId));
+      if (annotationId) {
+        hoveredElement = annotationElement as HTMLElement; // anchor for onReferenceHover
+        handleMouseEnter(toAnnotationId(annotationId));
+      }
     };
 
     // Single mouseout handler for the container - fires once on exit
@@ -164,8 +230,9 @@ export const BrowseView = memo(function BrowseView({
       container.removeEventListener('mouseover', handleMouseOver);
       container.removeEventListener('mouseout', handleMouseOut);
       cleanupHover();
+      referentSub?.unsubscribe(); // in-flight referent load dies with the effect
     };
-  }, [content, allAnnotations, newAnnotationIds, hoverDelayMs, session]);
+  }, [content, allAnnotations, newAnnotationIds, hoverDelayMs, session, onReferenceHover]);
 
   // Helper to scroll annotation into view with pulse effect
   const scrollToAnnotation = useCallback((annotationId: string | null, removePulse = false) => {
@@ -189,6 +256,16 @@ export const BrowseView = memo(function BrowseView({
     'beckon:focus': handleAnnotationFocus,
   });
 
+  // A content link inside the rendered output (react-markdown / HTML `<a href>`) must never navigate
+  // on its own (embedded/Electron security): always preventDefault, then delegate to the host if it cares.
+  const handleContentClick = useCallback((e: ReactMouseEvent) => {
+    const anchor = (e.target as HTMLElement).closest('a[href]');
+    if (!anchor) return;
+    e.preventDefault();
+    const href = anchor.getAttribute('href');
+    if (href) onLinkClick?.({ href, event: e });
+  }, [onLinkClick]);
+
   // Route to the media renderer for this render mode. `text`/`image`/`pdf` share
   // the shell (toolbar + annotation-overlay container); `none` (no preview, or an
   // unknown type) has its own metadata+download structure. Callers can override
@@ -198,7 +275,7 @@ export const BrowseView = memo(function BrowseView({
 
   if (!Renderer) {
     return (
-      <div ref={containerRef} className="semiont-browse-view semiont-browse-view--unsupported" data-mime-type="unsupported">
+      <div ref={containerRef} className={`semiont-browse-view semiont-browse-view--unsupported${inlineMod}`} data-mime-type="unsupported">
         <div className="semiont-browse-view__empty">
           <p className="semiont-browse-view__empty-message">
             Preview not available for {mimeType}
@@ -216,7 +293,7 @@ export const BrowseView = memo(function BrowseView({
   }
 
   return (
-    <div className="semiont-browse-view" data-mime-type={render}>
+    <div className={`semiont-browse-view${inlineMod}`} data-mime-type={render}>
       <AnnotateToolbar
         selectedMotivation={null}
         selectedClick={selectedClick}
@@ -225,8 +302,9 @@ export const BrowseView = memo(function BrowseView({
         annotateMode={annotateMode}
         annotators={ANNOTATORS}
         session={session}
+        compact={inline}
       />
-      <div ref={containerRef} className="semiont-browse-view__content">
+      <div ref={containerRef} className="semiont-browse-view__content" onClick={handleContentClick}>
         <Renderer content={content} mimeType={mimeType} resourceUri={resourceUri} annotations={allAnnotations} />
       </div>
     </div>

--- a/packages/react-ui/src/components/resource/ResourceViewer.tsx
+++ b/packages/react-ui/src/components/resource/ResourceViewer.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useTranslations } from '../../contexts/TranslationContext';
 import { AnnotateView, type SelectionMotivation, type ClickAction, type ShapeType } from './AnnotateView';
-import { BrowseView } from './BrowseView';
+import { BrowseView, type ReferenceHover } from './BrowseView';
 import { PopupContainer } from '../annotation-popups/SharedPopupElements';
 import { JsonLdView } from '../annotation-popups/JsonLdView';
 import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, components, EventMap } from '@semiont/core';
@@ -43,6 +43,12 @@ interface Props {
   onOpenResource?: (resourceId: string) => void;
   /** Host-owned panel control (annotation clicks open a panel). Omit for hosts without side panels. */
   onOpenPanel?: (event: EventMap['panel:open']) => void;
+  /** A content link in the rendered content was clicked — the viewer preventDefaults and delegates; it never navigates on its own. */
+  onLinkClick?: (link: { href: string; event: React.MouseEvent }) => void;
+  /** A resolved reference span is hovered (after dwell + referent descriptor resolve); `null` on leave. Host renders its own preview. */
+  onReferenceHover?: (hover: ReferenceHover | null) => void;
+  /** Inline display variant: auto-height, no inner scroll, no pane chrome (browse path). Default: fill-the-pane. */
+  inline?: boolean;
   /** Recently-created annotation ids to sparkle (threaded to the browse/annotate subtree). */
   newAnnotationIds?: Set<string>;
   generatingReferenceId?: string | null;
@@ -70,6 +76,9 @@ export function ResourceViewer({
   session,
   onOpenResource,
   onOpenPanel,
+  onLinkClick,
+  onReferenceHover,
+  inline = false,
   newAnnotationIds,
   generatingReferenceId,
   showLineNumbers = false,
@@ -376,7 +385,7 @@ export function ResourceViewer({
   }, [references]);
 
   return (
-    <div ref={documentViewerRef} className="semiont-resource-viewer">
+    <div ref={documentViewerRef} className={`semiont-resource-viewer${inline ? ' semiont-resource-viewer--inline' : ''}`}>
       {/* Content */}
       {activeView === 'annotate' ? (
         <AnnotateView
@@ -410,6 +419,9 @@ export function ResourceViewer({
           annotateMode={annotateMode}
           session={session}
           newAnnotationIds={newAnnotationIds}
+          onLinkClick={onLinkClick}
+          onReferenceHover={onReferenceHover}
+          inline={inline}
         />
       )}
 

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.links.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.links.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 2 — content-link delegation.
+ *
+ * A content link (`<a href>` rendered inside the resource content) must be
+ * intercepted: the viewer `preventDefault`s (never navigates on its own — an
+ * embedded/Electron security requirement) and delegates to `onLinkClick({href,
+ * event})`. With no handler, the click is still cancelled (nothing happens).
+ *
+ * Started RED (no `onLinkClick` prop) and GREEN once Phase 2 lands. Real
+ * react-markdown (not the mock) so the `<a>` is a genuine rendered content link.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import { BrowseView } from '../BrowseView';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+const MD = 'see [the link](https://example.test/x) here';
+
+describe('BrowseView — content link delegation (Phase 2)', () => {
+  it('intercepts a content <a> click: preventDefault + onLinkClick(href)', () => {
+    const onLinkClick = vi.fn();
+    render(
+      <BrowseView
+        content={MD} mimeType="text/markdown" resourceUri="res-1"
+        annotations={emptyAnnotations} annotateMode={false}
+        session={fakeSession()} onLinkClick={onLinkClick}
+      />,
+    );
+    const anchor = screen.getByText('the link').closest('a')!;
+    // fireEvent.click returns false when the event was cancelled (preventDefault).
+    const notCancelled = fireEvent.click(anchor);
+    expect(notCancelled).toBe(false); // navigation blocked
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+    expect(onLinkClick.mock.calls[0]![0]).toMatchObject({ href: 'https://example.test/x' });
+  });
+
+  it('blocks navigation even with no handler (never navigates on its own)', () => {
+    render(
+      <BrowseView
+        content={MD} mimeType="text/markdown" resourceUri="res-1"
+        annotations={emptyAnnotations} annotateMode={false}
+        session={fakeSession()}
+      />,
+    );
+    const anchor = screen.getByText('the link').closest('a')!;
+    expect(fireEvent.click(anchor)).toBe(false); // still cancelled — nothing happens, but no navigation
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.reference-hover.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.reference-hover.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 2b — `onReferenceHover`.
+ *
+ * Hovering a RESOLVED reference span fires `onReferenceHover({annotation,
+ * referent, anchorRect})` once — after the viewer's dwell AND the referent's
+ * cached descriptor resolves. A stub fires nothing (not even null); leaving
+ * before the descriptor resolves cancels (no fire, and no stray null); leaving
+ * after a fire sends `null`; the beckon:hover panel-highlight emit is untouched.
+ *
+ * Started RED (no `onReferenceHover` prop) and GREEN once Phase 2b lands.
+ * Test mechanics mirror BrowseView.test.tsx: mock target with `closest()`,
+ * fake timers for the dwell, a BehaviorSubject standing in for the cached
+ * `browse.resource` observable so the test controls resolve timing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BehaviorSubject } from 'rxjs';
+import type { Annotation, AnnotationId, ResourceDescriptor } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
+import { BrowseView } from '../BrowseView';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+// jsdom has no Range API — the overlay is not under test here.
+vi.mock('../../../lib/annotation-overlay', () => ({
+  buildSourceToRenderedMap: vi.fn(() => new Map()),
+  buildTextNodeIndex: vi.fn(() => []),
+  resolveAnnotationRanges: vi.fn(() => new Map()),
+  applyHighlights: vi.fn(),
+  clearHighlights: vi.fn(),
+  toOverlayAnnotations: vi.fn(() => []),
+}));
+
+const REFERENT = { '@id': 'res-target', name: 'Target Doc' } as unknown as ResourceDescriptor;
+const DWELL = 100;
+
+const makeAnnotation = (id: string, body: Annotation['body']): Annotation => ({
+  '@context': 'http://www.w3.org/ns/anno.jsonld',
+  id: id as AnnotationId,
+  type: 'Annotation',
+  motivation: 'linking',
+  creator: { '@type': 'Person', name: 'u' },
+  created: '2024-01-01T00:00:00Z',
+  target: { source: 'res-1', selector: { type: 'TextPositionSelector', start: 0, end: 4 } },
+  body,
+});
+
+const resolvedRef = makeAnnotation('ref-resolved', [{ type: 'SpecificResource', source: 'res-target', purpose: 'linking' }]);
+const stubRef = makeAnnotation('ref-stub', []);
+
+function setup(onReferenceHover?: (h: unknown) => void) {
+  const referent$ = new BehaviorSubject<ResourceDescriptor | undefined>(undefined);
+  const beckonHover = vi.fn();
+  const browseResource = vi.fn(() => referent$);
+  const session = {
+    client: {
+      browse: { click: vi.fn(), resource: browseResource },
+      beckon: { hover: beckonHover },
+    },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+
+  const { container } = render(
+    <BrowseView
+      content="some text"
+      mimeType="text/plain"
+      resourceUri="res-1"
+      annotations={{ highlights: [], references: [resolvedRef, stubRef], assessments: [], comments: [], tags: [] }}
+      annotateMode={false}
+      hoverDelayMs={DWELL}
+      session={session}
+      {...(onReferenceHover ? { onReferenceHover } : {})}
+    />,
+  );
+  const content = container.querySelector('.semiont-browse-view__content')!;
+
+  const hoverTarget = (id: string) => {
+    const el = document.createElement('span');
+    el.setAttribute('data-annotation-id', id);
+    return { el, target: { closest: vi.fn(() => el) } as unknown as Element };
+  };
+
+  return { content, referent$, beckonHover, browseResource, hoverTarget };
+}
+
+describe('BrowseView — onReferenceHover (Phase 2b)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('fires once after dwell + descriptor resolve, with {annotation, referent, anchorRect}', () => {
+    const onReferenceHover = vi.fn();
+    const { content, referent$, hoverTarget } = setup(onReferenceHover);
+
+    fireEvent.mouseOver(content, { target: hoverTarget('ref-resolved').target });
+    vi.advanceTimersByTime(DWELL + 10);        // dwell fires → subscribe starts
+    expect(onReferenceHover).not.toHaveBeenCalled(); // descriptor not resolved yet
+
+    referent$.next(REFERENT);                  // descriptor lands
+    expect(onReferenceHover).toHaveBeenCalledTimes(1);
+    const hover = onReferenceHover.mock.calls[0]![0];
+    expect(hover.annotation.id).toBe('ref-resolved');
+    expect(hover.referent).toBe(REFERENT);
+    expect(typeof hover.anchorRect.top).toBe('number'); // DOMRect from the hovered span
+
+    referent$.next({ ...REFERENT });           // later cache emissions must NOT re-fire
+    expect(onReferenceHover).toHaveBeenCalledTimes(1);
+  });
+
+  it('a stub reference fires nothing — not even null on leave', () => {
+    const onReferenceHover = vi.fn();
+    const { content, beckonHover, hoverTarget } = setup(onReferenceHover);
+
+    const { target } = hoverTarget('ref-stub');
+    fireEvent.mouseOver(content, { target });
+    vi.advanceTimersByTime(DWELL + 10);
+    fireEvent.mouseOut(content, { target });
+
+    expect(onReferenceHover).not.toHaveBeenCalled();
+    expect(beckonHover).toHaveBeenCalledWith('ref-stub'); // panel-highlight path unaffected
+  });
+
+  it('leaving before the descriptor resolves cancels: no fire, and a late resolve stays silent', () => {
+    const onReferenceHover = vi.fn();
+    const { content, referent$, hoverTarget } = setup(onReferenceHover);
+
+    const { target } = hoverTarget('ref-resolved');
+    fireEvent.mouseOver(content, { target });
+    vi.advanceTimersByTime(DWELL + 10);        // dwell fired, load in flight
+    fireEvent.mouseOut(content, { target });   // leave first
+
+    referent$.next(REFERENT);                  // late resolve
+    expect(onReferenceHover).not.toHaveBeenCalled(); // cancelled — and no stray null either
+  });
+
+  it('leaving after a fire sends null', () => {
+    const onReferenceHover = vi.fn();
+    const { content, referent$, hoverTarget } = setup(onReferenceHover);
+
+    const { target } = hoverTarget('ref-resolved');
+    fireEvent.mouseOver(content, { target });
+    vi.advanceTimersByTime(DWELL + 10);
+    referent$.next(REFERENT);
+    expect(onReferenceHover).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseOut(content, { target });
+    expect(onReferenceHover).toHaveBeenCalledTimes(2);
+    expect(onReferenceHover).toHaveBeenLastCalledWith(null);
+  });
+
+  it('without onReferenceHover, hover still emits beckon:hover and loads nothing', () => {
+    const { content, beckonHover, browseResource, hoverTarget } = setup();
+
+    fireEvent.mouseOver(content, { target: hoverTarget('ref-resolved').target });
+    vi.advanceTimersByTime(DWELL + 10);
+
+    expect(beckonHover).toHaveBeenCalledWith('ref-resolved');
+    expect(browseResource).not.toHaveBeenCalled(); // no handler → no referent load
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/browse-renderers.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/browse-renderers.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 0 — regression: the browse `text` default
+ * renders markdown as **formatted prose**, not raw source.
+ *
+ * The other BrowseView suites mock `react-markdown` away for simplicity, so
+ * nothing currently pins that the default text renderer actually *formats*
+ * markdown. This spec uses the real renderer and guards against a regression to
+ * raw/source rendering.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TextBrowseRenderer, defaultBrowseRenderers } from '../browse-renderers';
+
+const base = { mimeType: 'text/markdown', resourceUri: 'res-1', annotations: [] };
+
+describe('browse-renderers — markdown-as-prose (Phase 0 regression)', () => {
+  it('TextBrowseRenderer is the default `text` renderer', () => {
+    expect(defaultBrowseRenderers.text).toBe(TextBrowseRenderer);
+  });
+
+  it('renders markdown as formatted HTML, not raw source', () => {
+    const { container } = render(
+      <TextBrowseRenderer content={'# Big Heading\n\nsome **bold** and a [link](https://x.test).'} {...base} />,
+    );
+    // Formatted: heading / strong / anchor elements exist (react-markdown output).
+    expect(container.querySelector('h1')?.textContent).toBe('Big Heading');
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://x.test');
+    // NOT raw: the literal markdown syntax must not survive to the text content.
+    expect(container.textContent).not.toContain('# Big Heading');
+    expect(container.textContent).not.toContain('**bold**');
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/inline-embedding.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/inline-embedding.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 1 — inline embedding.
+ *
+ * `inline` is a display variant (default: today's pane behavior, frontend
+ * untouched): the viewer renders at content height in a bare container — no
+ * inner scroll container, no pane chrome. jsdom can't compute stylesheet
+ * layout, so this spec pins the two testable seams: (1) the components emit
+ * the `--inline` modifier classes; (2) the stylesheet contains the inline
+ * overrides (height:auto / overflow:visible / padding drop). The visual
+ * auto-height check is the plan's live smoke-test.
+ *
+ * Started RED (no `inline` prop) and GREEN once Phase 1 lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SemiontSession } from '@semiont/sdk';
+import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { BrowseView } from '../BrowseView';
+import { ResourceViewer } from '../ResourceViewer';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+const resource: SemiontResource & { content: string } = {
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  '@id': 'res-1' as ResourceId,
+  name: 'Doc',
+  created: '2024-01-01T00:00:00Z',
+  entityTypes: [],
+  archived: false,
+  representations: [{ mediaType: 'text/plain', byteSize: 10 }],
+  content: 'Inline content.',
+};
+
+describe('inline embedding (Phase 1)', () => {
+  it('BrowseView: `inline` adds the modifier class; default does not', () => {
+    const props = {
+      content: 'x', mimeType: 'text/plain', resourceUri: 'res-1',
+      annotations: emptyAnnotations, annotateMode: false, session: fakeSession(),
+    };
+    const { container: pane } = render(<BrowseView {...props} />);
+    expect(pane.querySelector('.semiont-browse-view')).not.toHaveClass('semiont-browse-view--inline');
+
+    const { container } = render(<BrowseView {...props} inline />);
+    expect(container.querySelector('.semiont-browse-view')).toHaveClass('semiont-browse-view--inline');
+  });
+
+  it('ResourceViewer: `inline` marks its root and threads to BrowseView', () => {
+    const { container } = render(
+      <ResourceViewer
+        resource={resource} annotations={emptyAnnotations}
+        session={fakeSession()} inline
+      />,
+    );
+    expect(container.querySelector('.semiont-resource-viewer')).toHaveClass('semiont-resource-viewer--inline');
+    expect(container.querySelector('.semiont-browse-view')).toHaveClass('semiont-browse-view--inline');
+  });
+
+  it('stylesheet carries the inline overrides (static gate — layout itself is the live check)', () => {
+    // vitest runs with cwd = the package root (same in CI's per-workspace run).
+    const css = readFileSync(resolve(process.cwd(), 'src/styles/features/resource-viewer.css'), 'utf8');
+    // Auto-height roots, and the content area stops being a scroll container / drops the pane gutter.
+    expect(css).toMatch(/\.semiont-resource-viewer--inline\s*\{[^}]*height:\s*auto/);
+    expect(css).toMatch(/\.semiont-browse-view--inline\s*\{[^}]*height:\s*auto/);
+    expect(css).toMatch(/\.semiont-browse-view--inline\s+\.semiont-browse-view__content\s*\{[^}]*overflow:\s*visible/);
+    expect(css).toMatch(/\.semiont-browse-view--inline\s+\.semiont-browse-view__content\s*\{[^}]*padding:\s*0/);
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/media-completeness.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/media-completeness.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 4 — media-completeness sweep.
+ *
+ * ONE mounted component (`ResourceViewer`, inline, bare session, no providers)
+ * renders every standard media type from the DEFAULTS — text, markdown, image,
+ * pdf — with the annotation-overlay container present and zero per-type wiring.
+ * (Formatted-markdown correctness is pinned by browse-renderers.test; visual
+ * overlay alignment is the plan's live smoke-test. This sweep pins the routing
+ * parity: every type reaches its renderer from one component.)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { ResourceViewer } from '../ResourceViewer';
+
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div data-testid="md">{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+// pdfjs can't load in jsdom — the sweep pins ROUTING to the pdf renderer, not pdf.js itself.
+vi.mock('../../pdf-annotation/PdfAnnotationCanvas.client', () => ({
+  PdfAnnotationCanvas: ({ pdfUrl }: { pdfUrl: string }) => <div data-testid="pdf-canvas">{pdfUrl}</div>,
+}));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+function makeResource(mediaType: string, content: string): SemiontResource & { content: string } {
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    '@id': 'res-1' as ResourceId,
+    name: 'Doc',
+    created: '2024-01-01T00:00:00Z',
+    entityTypes: [],
+    archived: false,
+    representations: [{ mediaType, byteSize: 10 }],
+    content,
+  };
+}
+
+function mount(mediaType: string, content: string) {
+  return render(
+    <ResourceViewer
+      resource={makeResource(mediaType, content)}
+      annotations={emptyAnnotations}
+      session={fakeSession()}
+      inline
+    />,
+  );
+}
+
+describe('media-completeness sweep (Phase 4) — one component, all types, inline, defaults only', () => {
+  it.each([
+    ['text/plain', 'plain body'],
+    ['text/markdown', '# md body'],
+  ])('%s renders via the text default with the overlay container', (mt, content) => {
+    const { container } = mount(mt, content);
+    expect(container.querySelector('.semiont-browse-view[data-mime-type="text"]')).toBeInTheDocument();
+    expect(screen.getByTestId('md')).toHaveTextContent(content.replace('# ', '# ').trim());
+    expect(container.querySelector('.semiont-browse-view__content')).toBeInTheDocument(); // overlay anchor
+    expect(container.querySelector('.semiont-browse-view')).toHaveClass('semiont-browse-view--inline');
+  });
+
+  it('image/png renders via the image default', () => {
+    const { container } = mount('image/png', 'https://media.test/img.png?token=t');
+    expect(container.querySelector('.semiont-browse-view[data-mime-type="image"]')).toBeInTheDocument();
+    expect(container.querySelector('img')).toBeInTheDocument();
+    expect(container.querySelector('.semiont-browse-view__content')).toBeInTheDocument();
+  });
+
+  it('application/pdf routes to the pdf default', async () => {
+    const { container } = mount('application/pdf', 'https://media.test/doc.pdf?token=t');
+    expect(container.querySelector('.semiont-browse-view[data-mime-type="pdf"]')).toBeInTheDocument();
+    expect(await screen.findByTestId('pdf-canvas')).toHaveTextContent('https://media.test/doc.pdf?token=t');
+  });
+
+  it('an unknown type degrades to metadata + download (no crash, no per-type wiring)', () => {
+    const { container } = mount('application/octet-stream', '');
+    expect(container.querySelector('[data-mime-type="unsupported"]')).toBeInTheDocument();
+    expect(screen.getByText(/Preview not available/)).toBeInTheDocument();
+  });
+});

--- a/packages/react-ui/src/components/toolbar/Toolbar.css
+++ b/packages/react-ui/src/components/toolbar/Toolbar.css
@@ -219,3 +219,17 @@
 }
 
 /* Popup Components */
+
+/* ── Compact display form ────────────────────────────────────────────────────
+ * Display-only variant for inline embeds: icon-only, tight, chromeless. The
+ * bar's functionality is identical — only its form changes. */
+.semiont-annotate-toolbar--compact {
+  gap: 0.375rem;
+  padding: 0.25rem 0;
+  background: transparent; /* the host container owns the background */
+  border-bottom: none;
+}
+
+.semiont-annotate-toolbar--compact .semiont-dropdown-label {
+  display: none; /* icon-only collapsed triggers; expanded menus keep labels */
+}

--- a/packages/react-ui/src/styles/features/resource-viewer.css
+++ b/packages/react-ui/src/styles/features/resource-viewer.css
@@ -111,6 +111,25 @@
   padding: 0 1.5rem; /* Move padding from parent to scrollable content */
 }
 
+/* ── Inline embed variant ────────────────────────────────────────────────────
+ * Auto-height to content, no inner scroll container, no pane chrome — the
+ * viewer drops into a chat bubble / card / list item and the HOST page
+ * scrolls. Default (no modifier) keeps the fill-the-pane behavior above. */
+.semiont-resource-viewer--inline {
+  height: auto;
+}
+
+.semiont-browse-view--inline {
+  height: auto;
+  background-color: transparent; /* the host container owns the background */
+}
+
+.semiont-browse-view--inline .semiont-browse-view__content {
+  flex: none; /* size to content, not to a pane */
+  overflow: visible; /* no inner scrollbar — the host page is the scroll context */
+  padding: 0; /* no pane gutter — the host owns spacing */
+}
+
 /* ── Markdown prose typography ──────────────────────────────────────────────
  * The global CSS reset zeroes margins/padding on all block elements and
  * removes list styles. Re-apply semantic typographic defaults scoped to the


### PR DESCRIPTION
## Summary

Completes the embeddable resource viewer ([#942](https://github.com/The-AI-Alliance/semiont/pull/942), 0.5.11): the bring-your-own-session `ResourceViewer` can now embed **inline** (a chat bubble, a card, a list item), exposes the rest of its **host-facing event surface** (content-link clicks + resolved-reference hovers), and shows a **compact annotate bar** that hosts can restyle — so a consumer mounts one component per resource, any media type, with zero per-type wiring.

The consumer target (`adampingel/chat`, rendering every chat message through one viewer) now works end-to-end:

```tsx
<ResourceViewer inline session={session} resource={r} annotations={a}
  onOpenResource={host.open} onOpenPanel={host.panel}
  onLinkClick={({ href }) => host.route(href)}     // viewer never navigates on its own
  onReferenceHover={(h) => setPreview(h)} />        // host renders its own hovercard
```

## What's in it (all `@semiont/react-ui`)

- **`inline` display variant** (`ResourceViewer` / `BrowseView`) — auto-height to content, no inner scroll container (the host page scrolls), no pane gutter, transparent background. Default is unchanged (fill-the-pane), so the frontend is byte-identical.
- **`onLinkClick({ href, event })`** — content links (`<a href>` in rendered markdown/HTML) are **always** `preventDefault`ed and delegated; the viewer **never navigates on its own** (embedded/Electron security). No handler → the click is still blocked.
- **`onReferenceHover(hover | null)`** — hovering a **resolved** reference span fires once, after the existing dwell **and** the referent's cached `ResourceDescriptor` resolves, with `{ annotation, referent, anchorRect }`; the host positions and renders whatever preview it wants. Stubs fire nothing (not even null); leave-before-resolve cancels; leave-after-fire sends `null`; no handler → zero referent loads. Rides the **same** dwell emitter as `beckon:hover` (one state machine, two consumers — no new timers or handlers), so panel-highlight behavior is untouched. Exported `ReferenceHover` type.
- **Compact annotate bar** — `AnnotateToolbar` gains a display-only `compact` form (icon-only, tight, chromeless); inline embeds show it automatically. Behavior and wiring are fixed — no prop removes or rewires the bar; hosts change how it *looks* (this + the existing `semiont-*` classes / CSS vars / i18n labels), not what it *does*.
- **Media-completeness + markdown regression pins** — new specs pin: the browse `text` default renders markdown as formatted prose (real `react-markdown`, which other suites mock away), and one mounted viewer routes text / markdown / image / pdf from the defaults with the overlay container present (sweep passed on first run — no gaps; now pinned).

## Built test-first

Every phase led with a failing spec (RED observed, then GREEN): content-link interception, all five reference-hover lifecycle cases (fire-once, stub-silence, cancel-on-leave, null-after-fire, no-handler-no-load), inline modifier classes + a static CSS gate, compact-bar display + an 18-test toolbar regression suite. One process find worth noting: a **conditional JSX spread bypasses TS excess-property checks**, so a new-prop spec's RED must be observed by *running* it, not by `tsc` alone.

## Testing

react-ui `tsc --noEmit` clean; final combined gate **19 files / 143 tests** across all resource, annotation, page, and packaging suites (`node:24-alpine`). Frontend behavior unchanged (pane default; `ResourceViewerPage` untouched by the new props). Live-verified in the consumer.

## Notes
- Design + phased execution log: `.plans/EMBEDDABLE-VIEWER-COMPLETION.md` (unifies and retires the `EMBEDDABLE-VIEWER-ALL-MEDIA` and `REFERENCE-HOVERCARD` proposals).
- Deliberately **not** included: an exported `ReferenceHovercard` component (the callback gives hosts full freedom; available on demand), annotation *authoring* over rendered markdown (authoring stays on raw source), and any annotate-bar behavior changes.
- No authentication / authorization changes — the security checklist is N/A.
