### PR TITLE
Fix permanent starvation of concurrent browse.resource loaders; make its silent paths observable

### DIFF
--- a/docs/protocol/TRANSPORT-HTTP.md
+++ b/docs/protocol/TRANSPORT-HTTP.md
@@ -214,13 +214,19 @@ The client-side `ActorStateUnit` handles three reconnect triggers:
    `DEGRADED_THRESHOLD_MS`, state enters `degraded`.
 2. **Channel-set change** (`addChannels` / `removeChannels`). A new SSE
    is opened with the updated query string and, **only once it is
-   `open`, the old one is aborted** — make-before-break (#847), so an
-   ephemeral result in flight during the swap is delivered on the still-
-   live old connection instead of dropped in a gap. Reconnects are
-   **debounced 100 ms** so React Strict Mode's mount → cleanup → mount
-   sequence collapses into one reconnect. State cycles `open →
-   reconnecting → connecting → open` without reaching `degraded` (the
-   round-trip is sub-second).
+   `open`, the old one is marked superseded and LINGERS — still
+   draining — for `LINGER_MS` (1 s) before being aborted** —
+   make-before-break (#847) plus drain (starvation fix), so an
+   ephemeral result in flight during the swap is delivered on the
+   still-live old connection instead of dropped in a gap, and replies
+   already written to the old socket but not yet read survive the
+   handoff. Reconnects are **debounced 100 ms** so React Strict Mode's
+   mount → cleanup → mount sequence collapses into one reconnect. State
+   cycles `open → reconnecting → connecting → open` without reaching
+   `degraded` (the round-trip is sub-second). A superseded connection's
+   read loop ending — naturally or via the linger abort — does NOT
+   restart the reconnect machinery; that belongs to the live connection
+   only.
 3. **Explicit `stop()` / `dispose()`.** State transitions to `closed`;
    the observable completes. No retry.
 
@@ -231,14 +237,48 @@ Consumers should NOT revalidate caches on the `reconnecting → open`
 transition — that work is driven by `bus:resume-gap`, which the server
 emits only when it genuinely can't cover the gap.
 
-**Connection handoff (make-before-break).** On a channel-set change the
-client keeps the previous connection(s) live and aborts them only after
-the new fetch resolves (#847) — closing the reconnect gap. A genuine
+**Connection handoff (make-before-break + linger-drain).** On a
+channel-set change the client keeps the previous connection(s) live
+until the new fetch resolves (#847), then supersedes them and keeps
+them **draining for `LINGER_MS` before the abort** — aborting at the
+instant of handover discarded replies already buffered on the old
+socket but not yet read by the client's read loop (the
+N-concurrent-loaders starvation,
+`.plans/bugs/concurrent-browse-resource-starvation.md`). A genuine
 disconnect or the initial connect has nothing live to preserve, so it
-aborts up front. Either way the client tracks SSE fetch controllers as a
-set and converges to a single live stream: when the newest connection
-opens it aborts every prior controller, so rapid channel-set changes
-racing each other can't accumulate orphaned streams.
+aborts up front. Either way the client tracks SSE fetch controllers as
+a set and converges to a single live stream within the drain window:
+the newest connection supersedes every prior controller, so rapid
+channel-set changes racing each other can't accumulate orphaned
+streams.
+
+### Abort discipline (drain-over-abort)
+
+`abort()` means "discard these bytes" — any buffered-but-unread event
+on the aborted stream is silently lost, and correlated replies are
+non-replayable by design (`e-*` ids). So the rule:
+
+> **A connection is retired by drain, never by a handover abort.
+> `abort()` is reserved for (a) explicit consumer cancellation and
+> (b) terminal teardown (`stop()`/`dispose()`), where no consumer
+> remains to receive the bytes.**
+
+Audit of every live `.abort()` site (2026-07-05):
+
+| Site | Class | Verdict |
+|---|---|---|
+| `actor-state-unit.ts` `disconnect()` | terminal teardown (`stop`/`dispose`) | sanctioned |
+| `actor-state-unit.ts` `connect(keepPrevious=false)` up-front abort | drop-recovery / orphan collapse — the pipe is already dead (read loop exited) or a raced orphan; resumption + the cache's bounded SWR retry cover the gap | sanctioned |
+| `actor-state-unit.ts` linger-expiry abort | the drain rule itself (drain-then-abort) | sanctioned |
+| `http-transport.ts` `sseProgressStream` unsubscribe | explicit consumer cancellation (progress is ephemeral UI feedback; the server-side operation completes regardless) | sanctioned |
+| `http-content-transport.ts` XHR `onAbort` | explicit consumer cancellation (caller's `AbortSignal`) | sanctioned |
+| `sdk/namespaces/yield.ts` upload teardown | explicit consumer cancellation (unsubscribe-before-finished is documented as cancel) | sanctioned |
+
+The one historical violator — the immediate handover abort in
+`connect(keepPrevious=true)` — was converted to linger-drain by the
+starvation fix. Any NEW `.abort()` call must be classifiable as
+consumer-cancel or terminal teardown; a lifecycle-handover abort is the
+buffered-loss bug class reintroduced.
 
 During the brief handoff overlap the same live event can arrive on both
 connections. The client dedups by event id (`seenEventIds` in the
@@ -435,6 +475,11 @@ the contract are visible.
   actor-state-unit now tracks all in-flight fetch controllers and aborts every
   previous one on new connect, closing an orphan-stream leak.
 - **2026-04-19** — connection-state machine landed.
+- **2026-07-05** — linger-drain handoff landed (starvation fix P2):
+  superseded connections drain `LINGER_MS` before abort; their read-loop
+  exit no longer restarts reconnect. New **Abort discipline
+  (drain-over-abort)** section with the site audit; the rule is the
+  contract for any future `.abort()` call.
   `actor.connected$: Observable<boolean>` replaced with
   `actor.state$: Observable<ConnectionState>` (initial / connecting /
   open / reconnecting / degraded / closed). Transitions are enforced;

--- a/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
+++ b/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
@@ -615,12 +615,13 @@ describe('createActorStateUnit', () => {
 
   // ── #847 Phase 3: make-before-break reconnect ─────────────────────────
 
-  it('retires the old connection only after the new one opens (make-before-break)', async () => {
+  it('retires the old connection only after the new one opens + the drain window (make-before-break + linger)', async () => {
     // Pre-#847 a scope-change reconnect aborted the live connection up front
     // (break-before-make), opening a gap in which an in-flight ephemeral
     // result was dropped. Now the old connection stays live until the new
-    // fetch resolves, then is retired — and rapid connects still converge to
-    // a single live stream (the orphan-stream guarantee).
+    // fetch resolves, then LINGERS for LINGER_MS (draining buffered replies)
+    // before being aborted — and rapid connects still converge to a single
+    // live stream (the orphan-stream guarantee).
     const c1 = mockConn();
     const stateUnit = createActorStateUnit({
       baseUrl: 'http://localhost:4000',
@@ -640,9 +641,44 @@ describe('createActorStateUnit', () => {
     // old one MUST remain live.
     expect(c1.aborted).toBe(false);
 
-    // Once the new connection opens, the old is retired.
+    // Once the new connection opens, the old lingers (still draining)…
     c2.open();
-    await vi.waitFor(() => expect(c1.aborted).toBe(true));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(c1.aborted).toBe(false);
+
+    // …and is aborted after the drain window — no connection leak.
+    await vi.waitFor(() => expect(c1.aborted).toBe(true), { timeout: 2_500 });
+
+    stateUnit.dispose();
+  });
+
+  it('a lingering connection ending naturally does not restart the reconnect machinery', async () => {
+    // During the drain window the superseded connection may end on its own
+    // (server teardown). That is expected — it must not transition the actor
+    // to `reconnecting` or schedule a retry connect for the live stream.
+    const c1 = mockConn();
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['test:event'],
+    });
+    const states: string[] = [];
+    stateUnit.state$.subscribe((s) => states.push(s));
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    const c2 = mockConn({ defer: true });
+    stateUnit.addChannels(['mark:added'], 'res-1');
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    c2.open();
+    await vi.waitFor(() => expect(states[states.length - 1]).toBe('open'));
+
+    // The lingering old connection ends naturally mid-drain.
+    c1.sse.close();
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(states[states.length - 1]).toBe('open'); // no reconnecting blip
+    expect(mockFetch).toHaveBeenCalledTimes(2); // no retry connect scheduled
 
     stateUnit.dispose();
   });
@@ -675,9 +711,110 @@ describe('createActorStateUnit', () => {
     await vi.waitFor(() => expect(received).toHaveLength(1));
     expect(received[0]).toEqual({ correlationId: 'x', annotations: [] });
 
-    // Let the handoff complete (old retired, new open) before teardown.
+    // Let the handoff complete (old retired after the drain window) before teardown.
     c2.open();
-    await vi.waitFor(() => expect(c1.aborted).toBe(true));
+    await vi.waitFor(() => expect(c1.aborted).toBe(true), { timeout: 2_500 });
+    stateUnit.dispose();
+  });
+
+  // ── Linger-drain: replies in flight on the old connection at handover ──
+  // (.plans/bugs/concurrent-browse-resource-starvation.md — ask 1)
+
+  it('delivers a reply still in flight on the old connection after the new one opens (linger-drain)', async () => {
+    // The starvation repro: N browse requests issued on the unscoped
+    // connection; their correlated results were written to the old socket
+    // around the handover and discarded when the old connection was aborted
+    // the instant the new fetch resolved (buffered-but-unread bytes are lost
+    // on abort). The old connection must LINGER (keep draining) after
+    // handover; the id-dedup absorbs the overlap.
+    const c1 = mockConn();
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['browse:resource-result'],
+    });
+    const received: unknown[] = [];
+    stateUnit.on$('browse:resource-result').subscribe((p) => received.push(p));
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    const c2 = mockConn({ defer: true });
+    stateUnit.addChannels(['mark:added'], 'res-1');
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+
+    // Handoff completes: the new connection opens.
+    c2.open();
+    await new Promise((r) => setTimeout(r, 20));
+
+    // A correlated reply the backend wrote to the old socket around the
+    // handover arrives on the OLD connection — it must still be delivered.
+    c1.sse.push(sseChunkId(
+      'bus-event',
+      JSON.stringify({ channel: 'browse:resource-result', payload: { correlationId: 'c-lost', response: {} } }),
+      'e-browse:resource-result:c-lost',
+    ));
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    expect(received[0]).toMatchObject({ correlationId: 'c-lost' });
+
+    stateUnit.dispose();
+  });
+
+  it('dedupes a deterministic-id reply delivered by both connections during the linger overlap', async () => {
+    // The backend stamps correlated replies with deterministic ephemeral ids
+    // (`e-<channel>:<correlationId>`, routes/bus.ts) precisely so both
+    // connections tag the same reply identically — one emission, not two.
+    const c1 = mockConn();
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['browse:resource-result'],
+    });
+    const received: unknown[] = [];
+    stateUnit.on$('browse:resource-result').subscribe((p) => received.push(p));
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    const c2 = mockConn({ defer: true });
+    stateUnit.addChannels(['mark:added'], 'res-1');
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    c2.open();
+    await new Promise((r) => setTimeout(r, 20));
+
+    const frame = sseChunkId(
+      'bus-event',
+      JSON.stringify({ channel: 'browse:resource-result', payload: { correlationId: 'c-dup', response: {} } }),
+      'e-browse:resource-result:c-dup',
+    );
+    c1.sse.push(frame);
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    c2.sse.push(frame);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(received).toHaveLength(1);
+
+    stateUnit.dispose();
+  });
+
+  it('collapses connect + several scope-adds into a single swap (debounced batch)', async () => {
+    // N scope-adds in one burst must produce ONE replacement connection,
+    // not a swap per call.
+    mockConn();
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['browse:resource-result'],
+    });
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    mockConn();
+    stateUnit.addChannels(['mark:added'], 'res-1');
+    stateUnit.addChannels(['mark:removed'], 'res-1');
+    stateUnit.addChannels(['job:complete'], 'res-1');
+
+    await new Promise((r) => setTimeout(r, 250));
+    expect(mockFetch).toHaveBeenCalledTimes(2); // initial + exactly one swap
+
     stateUnit.dispose();
   });
 
@@ -709,9 +846,10 @@ describe('createActorStateUnit', () => {
     c1.sse.push(frame);
     await vi.waitFor(() => expect(received).toHaveLength(1));
 
-    // New connection opens (old retired); it re-delivers the same id.
+    // New connection opens (old retired after the drain window); it
+    // re-delivers the same id.
     c2.open();
-    await vi.waitFor(() => expect(c1.aborted).toBe(true));
+    await vi.waitFor(() => expect(c1.aborted).toBe(true), { timeout: 2_500 });
     c2.sse.push(frame);
 
     // Give the parser time to process the second frame; it must be deduped.

--- a/packages/http-transport/src/transport/actor-state-unit.ts
+++ b/packages/http-transport/src/transport/actor-state-unit.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { filter, map, share } from 'rxjs/operators';
-import { busLog, type ConnectionState, type StateUnit } from '@semiont/core';
+import { busLog, busLogEnabled, type ConnectionState, type StateUnit } from '@semiont/core';
 import {
   SpanKind,
   extractTraceparent,
@@ -317,6 +317,16 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
               }
               const parsed = JSON.parse(currentData) as BusEvent;
               busLog('RECV', parsed.channel, parsed.payload, parsed.scope);
+              // Drain-window forensics: an event delivered by a SUPERSEDED
+              // (lingering) connection is one that an immediate handover abort
+              // would have discarded — the loss mode of
+              // .plans/bugs/concurrent-browse-resource-starvation.md. Gated
+              // (per-event, bursty during overlap); flip bus logging on to
+              // see how real the window is.
+              if (busLogEnabled() && superseded.has(controller)) {
+                // eslint-disable-next-line no-console
+                console.debug(`[bus LINGER] ${parsed.channel} delivered on superseded connection`);
+              }
               // Tier 2: lift trace context off the SSE payload (the
               // backend's writeBusEvent puts it there). The synchronous
               // fan-out to subscribers happens inside the bus.recv span,

--- a/packages/http-transport/src/transport/actor-state-unit.ts
+++ b/packages/http-transport/src/transport/actor-state-unit.ts
@@ -28,6 +28,19 @@ export interface ActorStateUnitOptions {
 /** Time in the `reconnecting` state before transitioning to `degraded`. */
 export const DEGRADED_THRESHOLD_MS = 3_000;
 
+/**
+ * How long a superseded connection keeps DRAINING after a make-before-break
+ * handoff before being aborted. Aborting the old connection the instant the
+ * new one opened discarded replies already written to the old socket but not
+ * yet read by the client (a freshly-hydrating page's main thread is busy —
+ * exactly the N-concurrent-loaders-at-connect repro in
+ * .plans/bugs/concurrent-browse-resource-starvation.md). The overlap is safe:
+ * persisted ids are stable and correlated-reply ids are deterministic
+ * (`e-<channel>:<cid>`, routes/bus.ts), so `seenEventIds` dedups double
+ * delivery.
+ */
+export const LINGER_MS = 1_000;
+
 export interface ActorStateUnit extends StateUnit {
   on$<T = Record<string, unknown>>(channel: string): Observable<T>;
   emit(channel: string, payload: Record<string, unknown>, emitScope?: string): Promise<void>;
@@ -119,6 +132,16 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
+   * Connections retired by a make-before-break handoff. A superseded
+   * connection lingers (still draining) for LINGER_MS before its abort; its
+   * read loop ending — naturally or via that abort — must NOT drive the
+   * actor-wide reconnect logic, which belongs to the live connection only.
+   */
+  const superseded = new WeakSet<AbortController>();
+  /** Pending linger-abort timers, cleared on stop/dispose. */
+  const lingerTimers = new Set<ReturnType<typeof setTimeout>>();
+
+  /**
    * `Last-Event-ID` of the most recently delivered SSE event from the
    * server. Sent as a request header on each connect so the server can
    * replay persisted events missed during the disconnect (see
@@ -170,6 +193,8 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
     }
     inflightControllers.clear();
     if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    for (const t of lingerTimers) clearTimeout(t);
+    lingerTimers.clear();
   };
 
   const connect = async (keepPrevious = false) => {
@@ -225,17 +250,26 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
 
       // Make-before-break handoff: the new connection is established (the
       // backend has subscribed it and any `Last-Event-ID` replay is flowing),
-      // so NOW retire the previous connection(s). Aborting only after the new
-      // fetch resolves is what closes the reconnect gap — an event in flight
-      // on the old connection during a scope change is delivered, not dropped
-      // (#847). A live event delivered by both during the overlap is deduped
-      // by id in the read loop below. Had the fetch failed, we'd have thrown
-      // above and never reached here, leaving the old connection live (no gap).
+      // so mark the previous connection(s) superseded and LINGER them — keep
+      // them draining for LINGER_MS before the abort. Aborting immediately
+      // here discarded replies already written to the old socket but not yet
+      // read (the buffered-bytes loss in
+      // .plans/bugs/concurrent-browse-resource-starvation.md); an event
+      // delivered by both connections during the overlap is deduped by id in
+      // the read loop below (persisted ids are stable; correlated-reply ids
+      // are deterministic per routes/bus.ts). Had the fetch failed, we'd have
+      // thrown above and never reached here, leaving the old connection live
+      // (no gap).
       if (keepPrevious) {
-        for (const c of previous) {
-          try { c.abort(); } catch { /* noop */ }
-          inflightControllers.delete(c);
-        }
+        for (const c of previous) superseded.add(c);
+        const lingerTimer = setTimeout(() => {
+          lingerTimers.delete(lingerTimer);
+          for (const c of previous) {
+            try { c.abort(); } catch { /* noop */ }
+            inflightControllers.delete(c);
+          }
+        }, LINGER_MS);
+        lingerTimers.add(lingerTimer);
       }
 
       transition('open');
@@ -319,8 +353,10 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
 
     // If we reached here without an AbortError, the connection dropped
     // or the fetch failed. Transition to reconnecting and schedule a
-    // retry after `reconnectMs`.
-    if (running) {
+    // retry after `reconnectMs` — unless this was a SUPERSEDED (lingering)
+    // connection ending: its termination is expected teardown, not a drop
+    // of the live stream, and must not restart the reconnect machinery.
+    if (running && !superseded.has(controller)) {
       transition('reconnecting');
       reconnectTimer = setTimeout(() => {
         if (running) connect();

--- a/packages/react-ui/src/components/annotation/AnnotateToolbar.tsx
+++ b/packages/react-ui/src/components/annotation/AnnotateToolbar.tsx
@@ -30,6 +30,10 @@ interface AnnotateToolbarProps {
 
   // Session — emits mark:* selection/click/shape/mode changes via its client.
   session: SemiontSession | null;
+
+  // Compact display form (display-only): icon-only, tight, chromeless — for inline
+  // embeds. The bar's functionality is identical; only its form changes.
+  compact?: boolean;
 }
 
 interface DropdownGroupProps {
@@ -121,6 +125,7 @@ export function AnnotateToolbar({
   annotateMode = false,
   annotators,
   session,
+  compact = false,
 }: AnnotateToolbarProps) {
   const t = useTranslations('AnnotateToolbar');
 
@@ -291,7 +296,7 @@ export function AnnotateToolbar({
   const shapeTypes = allShapeTypes.filter(st => supportedShapes.includes(st.shape));
 
   return (
-    <div className="semiont-annotate-toolbar">
+    <div className={`semiont-annotate-toolbar${compact ? ' semiont-annotate-toolbar--compact' : ''}`}>
       {/* Click Group */}
       <DropdownGroup
         label={t('clickGroup')}

--- a/packages/react-ui/src/components/annotation/__tests__/AnnotateToolbar.display.test.tsx
+++ b/packages/react-ui/src/components/annotation/__tests__/AnnotateToolbar.display.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 3 — Annotate Bar display forms.
+ *
+ * Behavior is mostly fixed (the bar IS the annotation capability); the host
+ * gets freedom over its display form. `compact` is a display-only variant:
+ * icon-only, tight, chromeless — the functional groups stay present and wired.
+ * BrowseView's `inline` embed shows the compact bar automatically. Theming
+ * (semiont-* classes + CSS vars) and labels (i18n) already exist — no new API
+ * for those.
+ *
+ * Started RED (no `compact` prop) and GREEN once Phase 3 lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SemiontSession } from '@semiont/sdk';
+import { AnnotateToolbar } from '../AnnotateToolbar';
+import { ANNOTATORS } from '../../../lib/annotation-registry';
+import { BrowseView } from '../../resource/BrowseView';
+
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() }, mark: { toggleMode: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+const toolbarProps = {
+  selectedMotivation: null,
+  selectedClick: 'detail' as const,
+  annotateMode: false,
+  annotators: ANNOTATORS,
+  session: null,
+};
+
+describe('Annotate Bar display forms (Phase 3)', () => {
+  it('`compact` adds the display modifier; default does not', () => {
+    const { container: normal } = render(<AnnotateToolbar {...toolbarProps} />);
+    expect(normal.querySelector('.semiont-annotate-toolbar')).not.toHaveClass('semiont-annotate-toolbar--compact');
+
+    const { container } = render(<AnnotateToolbar {...toolbarProps} compact />);
+    expect(container.querySelector('.semiont-annotate-toolbar')).toHaveClass('semiont-annotate-toolbar--compact');
+  });
+
+  it('compact is display-only: the functional groups are still present', () => {
+    render(<AnnotateToolbar {...toolbarProps} compact />);
+    // Groups render with their aria labels (default-English translations, no provider).
+    expect(screen.getByLabelText(/mode/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/click/i)).toBeInTheDocument();
+  });
+
+  it('BrowseView inline embeds show the compact bar automatically', () => {
+    const props = {
+      content: 'x', mimeType: 'text/plain', resourceUri: 'res-1',
+      annotations: emptyAnnotations, annotateMode: false, session: fakeSession(),
+    };
+    const { container: pane } = render(<BrowseView {...props} />);
+    expect(pane.querySelector('.semiont-annotate-toolbar')).not.toHaveClass('semiont-annotate-toolbar--compact');
+
+    const { container } = render(<BrowseView {...props} inline />);
+    expect(container.querySelector('.semiont-annotate-toolbar')).toHaveClass('semiont-annotate-toolbar--compact');
+  });
+
+  it('stylesheet carries the compact form (static gate — icon-only, chromeless)', () => {
+    const css = readFileSync(resolve(process.cwd(), 'src/components/toolbar/Toolbar.css'), 'utf8');
+    expect(css).toMatch(/\.semiont-annotate-toolbar--compact\s*\{/);
+    expect(css).toMatch(/\.semiont-annotate-toolbar--compact\s+\.semiont-dropdown-label\s*\{[^}]*display:\s*none/);
+  });
+});

--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback, useMemo, memo } from 'react';
-import { annotationId as toAnnotationId } from '@semiont/core';
-import { capabilitiesOf } from '@semiont/core';
+import { useEffect, useRef, useCallback, useMemo, memo, type MouseEvent as ReactMouseEvent } from 'react';
+import { annotationId as toAnnotationId, resourceId as toResourceId } from '@semiont/core';
+import { capabilitiesOf, getBodySource, isResolvedReference } from '@semiont/core';
+import type { Annotation, ResourceDescriptor } from '@semiont/core';
 import { createHoverHandlers } from '@semiont/sdk';
 import { ANNOTATORS } from '../../lib/annotation-registry';
 import { scrollAnnotationIntoView } from '../../lib/scroll-utils';
@@ -36,6 +37,22 @@ interface Props {
   newAnnotationIds?: Set<string>;
   /** Override the read-only media renderers (render mode → renderer); merged over the defaults. */
   renderers?: BrowseMediaRenderers;
+  /** A content link (`<a href>` in the rendered content) was clicked. The viewer preventDefaults and
+   *  delegates; it never navigates on its own. Omit → the click is still blocked (nothing happens). */
+  onLinkClick?: (link: { href: string; event: ReactMouseEvent }) => void;
+  /** A RESOLVED reference span is hovered: fires after the dwell AND the referent's cached descriptor
+   *  resolves; `null` on leave (only if a hover fired — stubs stay silent). Host renders its own preview. */
+  onReferenceHover?: (hover: ReferenceHover | null) => void;
+  /** Inline display variant: auto-height to content, no inner scroll container, no pane chrome —
+   *  drops into a chat bubble / card / list item. Default: fill-the-pane (unchanged). */
+  inline?: boolean;
+}
+
+/** Payload for `onReferenceHover` — the hovered linking annotation, its resolved referent, and where the span is. */
+export interface ReferenceHover {
+  annotation: Annotation;
+  referent: ResourceDescriptor;
+  anchorRect: DOMRect;
 }
 
 /**
@@ -62,8 +79,12 @@ export const BrowseView = memo(function BrowseView({
   session,
   newAnnotationIds,
   renderers,
+  onLinkClick,
+  onReferenceHover,
+  inline = false,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const inlineMod = inline ? ' semiont-browse-view--inline' : '';
 
   const render = capabilitiesOf(mimeType)?.render ?? 'none';
 
@@ -124,8 +145,50 @@ export const BrowseView = memo(function BrowseView({
       }
     };
 
+    // Reference-hover delegation (host-facing event surface): after the dwell,
+    // resolve the referent's cached descriptor and hand the host
+    // { annotation, referent, anchorRect }; `null` on leave — but only if a hover
+    // fired, so stubs stay silent. Rides the SAME dwell emitter as beckon:hover —
+    // one state machine, two consumers.
+    let hoveredElement: HTMLElement | null = null;
+    let referentSub: { unsubscribe(): void } | null = null;
+    let referenceHoverFired = false;
+
+    const startReferenceHover = (id: string) => {
+      if (!onReferenceHover) return; // no handler → no referent load
+      const annotation = allAnnotations.find(a => a.id === id);
+      if (!annotation || !isResolvedReference(annotation)) return; // stub / non-reference: fires nothing
+      const referentId = getBodySource(annotation.body);
+      const element = hoveredElement;
+      if (!referentId || !element) return;
+      referentSub?.unsubscribe();
+      referentSub = session.client.browse.resource(toResourceId(referentId)).subscribe({
+        next: (referent) => {
+          if (referent === undefined) return; // cache still loading
+          referentSub?.unsubscribe();
+          referentSub = null;
+          referenceHoverFired = true;
+          // anchorRect taken at fire time so it reflects current layout.
+          onReferenceHover({ annotation, referent, anchorRect: element.getBoundingClientRect() });
+        },
+        error: () => { referentSub = null; }, // failed load: never fires
+      });
+    };
+
+    const endReferenceHover = () => {
+      referentSub?.unsubscribe(); // leave-before-resolve: cancel, no fire
+      referentSub = null;
+      if (referenceHoverFired) {
+        referenceHoverFired = false;
+        onReferenceHover?.(null);
+      }
+    };
+
     const { handleMouseEnter, handleMouseLeave, cleanup: cleanupHover } = createHoverHandlers(
-      (id) => session.client.beckon.hover(id),
+      (id) => {
+        session.client.beckon.hover(id);
+        if (id) startReferenceHover(id); else endReferenceHover();
+      },
       hoverDelayMs
     );
 
@@ -134,7 +197,10 @@ export const BrowseView = memo(function BrowseView({
       const target = e.target as HTMLElement;
       const annotationElement = target.closest('[data-annotation-id]');
       const annotationId = annotationElement?.getAttribute('data-annotation-id');
-      if (annotationId) handleMouseEnter(toAnnotationId(annotationId));
+      if (annotationId) {
+        hoveredElement = annotationElement as HTMLElement; // anchor for onReferenceHover
+        handleMouseEnter(toAnnotationId(annotationId));
+      }
     };
 
     // Single mouseout handler for the container - fires once on exit
@@ -164,8 +230,9 @@ export const BrowseView = memo(function BrowseView({
       container.removeEventListener('mouseover', handleMouseOver);
       container.removeEventListener('mouseout', handleMouseOut);
       cleanupHover();
+      referentSub?.unsubscribe(); // in-flight referent load dies with the effect
     };
-  }, [content, allAnnotations, newAnnotationIds, hoverDelayMs, session]);
+  }, [content, allAnnotations, newAnnotationIds, hoverDelayMs, session, onReferenceHover]);
 
   // Helper to scroll annotation into view with pulse effect
   const scrollToAnnotation = useCallback((annotationId: string | null, removePulse = false) => {
@@ -189,6 +256,16 @@ export const BrowseView = memo(function BrowseView({
     'beckon:focus': handleAnnotationFocus,
   });
 
+  // A content link inside the rendered output (react-markdown / HTML `<a href>`) must never navigate
+  // on its own (embedded/Electron security): always preventDefault, then delegate to the host if it cares.
+  const handleContentClick = useCallback((e: ReactMouseEvent) => {
+    const anchor = (e.target as HTMLElement).closest('a[href]');
+    if (!anchor) return;
+    e.preventDefault();
+    const href = anchor.getAttribute('href');
+    if (href) onLinkClick?.({ href, event: e });
+  }, [onLinkClick]);
+
   // Route to the media renderer for this render mode. `text`/`image`/`pdf` share
   // the shell (toolbar + annotation-overlay container); `none` (no preview, or an
   // unknown type) has its own metadata+download structure. Callers can override
@@ -198,7 +275,7 @@ export const BrowseView = memo(function BrowseView({
 
   if (!Renderer) {
     return (
-      <div ref={containerRef} className="semiont-browse-view semiont-browse-view--unsupported" data-mime-type="unsupported">
+      <div ref={containerRef} className={`semiont-browse-view semiont-browse-view--unsupported${inlineMod}`} data-mime-type="unsupported">
         <div className="semiont-browse-view__empty">
           <p className="semiont-browse-view__empty-message">
             Preview not available for {mimeType}
@@ -216,7 +293,7 @@ export const BrowseView = memo(function BrowseView({
   }
 
   return (
-    <div className="semiont-browse-view" data-mime-type={render}>
+    <div className={`semiont-browse-view${inlineMod}`} data-mime-type={render}>
       <AnnotateToolbar
         selectedMotivation={null}
         selectedClick={selectedClick}
@@ -225,8 +302,9 @@ export const BrowseView = memo(function BrowseView({
         annotateMode={annotateMode}
         annotators={ANNOTATORS}
         session={session}
+        compact={inline}
       />
-      <div ref={containerRef} className="semiont-browse-view__content">
+      <div ref={containerRef} className="semiont-browse-view__content" onClick={handleContentClick}>
         <Renderer content={content} mimeType={mimeType} resourceUri={resourceUri} annotations={allAnnotations} />
       </div>
     </div>

--- a/packages/react-ui/src/components/resource/ResourceViewer.tsx
+++ b/packages/react-ui/src/components/resource/ResourceViewer.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useTranslations } from '../../contexts/TranslationContext';
 import { AnnotateView, type SelectionMotivation, type ClickAction, type ShapeType } from './AnnotateView';
-import { BrowseView } from './BrowseView';
+import { BrowseView, type ReferenceHover } from './BrowseView';
 import { PopupContainer } from '../annotation-popups/SharedPopupElements';
 import { JsonLdView } from '../annotation-popups/JsonLdView';
 import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, components, EventMap } from '@semiont/core';
@@ -43,6 +43,12 @@ interface Props {
   onOpenResource?: (resourceId: string) => void;
   /** Host-owned panel control (annotation clicks open a panel). Omit for hosts without side panels. */
   onOpenPanel?: (event: EventMap['panel:open']) => void;
+  /** A content link in the rendered content was clicked — the viewer preventDefaults and delegates; it never navigates on its own. */
+  onLinkClick?: (link: { href: string; event: React.MouseEvent }) => void;
+  /** A resolved reference span is hovered (after dwell + referent descriptor resolve); `null` on leave. Host renders its own preview. */
+  onReferenceHover?: (hover: ReferenceHover | null) => void;
+  /** Inline display variant: auto-height, no inner scroll, no pane chrome (browse path). Default: fill-the-pane. */
+  inline?: boolean;
   /** Recently-created annotation ids to sparkle (threaded to the browse/annotate subtree). */
   newAnnotationIds?: Set<string>;
   generatingReferenceId?: string | null;
@@ -70,6 +76,9 @@ export function ResourceViewer({
   session,
   onOpenResource,
   onOpenPanel,
+  onLinkClick,
+  onReferenceHover,
+  inline = false,
   newAnnotationIds,
   generatingReferenceId,
   showLineNumbers = false,
@@ -376,7 +385,7 @@ export function ResourceViewer({
   }, [references]);
 
   return (
-    <div ref={documentViewerRef} className="semiont-resource-viewer">
+    <div ref={documentViewerRef} className={`semiont-resource-viewer${inline ? ' semiont-resource-viewer--inline' : ''}`}>
       {/* Content */}
       {activeView === 'annotate' ? (
         <AnnotateView
@@ -410,6 +419,9 @@ export function ResourceViewer({
           annotateMode={annotateMode}
           session={session}
           newAnnotationIds={newAnnotationIds}
+          onLinkClick={onLinkClick}
+          onReferenceHover={onReferenceHover}
+          inline={inline}
         />
       )}
 

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.links.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.links.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 2 — content-link delegation.
+ *
+ * A content link (`<a href>` rendered inside the resource content) must be
+ * intercepted: the viewer `preventDefault`s (never navigates on its own — an
+ * embedded/Electron security requirement) and delegates to `onLinkClick({href,
+ * event})`. With no handler, the click is still cancelled (nothing happens).
+ *
+ * Started RED (no `onLinkClick` prop) and GREEN once Phase 2 lands. Real
+ * react-markdown (not the mock) so the `<a>` is a genuine rendered content link.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import { BrowseView } from '../BrowseView';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+const MD = 'see [the link](https://example.test/x) here';
+
+describe('BrowseView — content link delegation (Phase 2)', () => {
+  it('intercepts a content <a> click: preventDefault + onLinkClick(href)', () => {
+    const onLinkClick = vi.fn();
+    render(
+      <BrowseView
+        content={MD} mimeType="text/markdown" resourceUri="res-1"
+        annotations={emptyAnnotations} annotateMode={false}
+        session={fakeSession()} onLinkClick={onLinkClick}
+      />,
+    );
+    const anchor = screen.getByText('the link').closest('a')!;
+    // fireEvent.click returns false when the event was cancelled (preventDefault).
+    const notCancelled = fireEvent.click(anchor);
+    expect(notCancelled).toBe(false); // navigation blocked
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+    expect(onLinkClick.mock.calls[0]![0]).toMatchObject({ href: 'https://example.test/x' });
+  });
+
+  it('blocks navigation even with no handler (never navigates on its own)', () => {
+    render(
+      <BrowseView
+        content={MD} mimeType="text/markdown" resourceUri="res-1"
+        annotations={emptyAnnotations} annotateMode={false}
+        session={fakeSession()}
+      />,
+    );
+    const anchor = screen.getByText('the link').closest('a')!;
+    expect(fireEvent.click(anchor)).toBe(false); // still cancelled — nothing happens, but no navigation
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.reference-hover.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.reference-hover.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 2b — `onReferenceHover`.
+ *
+ * Hovering a RESOLVED reference span fires `onReferenceHover({annotation,
+ * referent, anchorRect})` once — after the viewer's dwell AND the referent's
+ * cached descriptor resolves. A stub fires nothing (not even null); leaving
+ * before the descriptor resolves cancels (no fire, and no stray null); leaving
+ * after a fire sends `null`; the beckon:hover panel-highlight emit is untouched.
+ *
+ * Started RED (no `onReferenceHover` prop) and GREEN once Phase 2b lands.
+ * Test mechanics mirror BrowseView.test.tsx: mock target with `closest()`,
+ * fake timers for the dwell, a BehaviorSubject standing in for the cached
+ * `browse.resource` observable so the test controls resolve timing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BehaviorSubject } from 'rxjs';
+import type { Annotation, AnnotationId, ResourceDescriptor } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
+import { BrowseView } from '../BrowseView';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+// jsdom has no Range API — the overlay is not under test here.
+vi.mock('../../../lib/annotation-overlay', () => ({
+  buildSourceToRenderedMap: vi.fn(() => new Map()),
+  buildTextNodeIndex: vi.fn(() => []),
+  resolveAnnotationRanges: vi.fn(() => new Map()),
+  applyHighlights: vi.fn(),
+  clearHighlights: vi.fn(),
+  toOverlayAnnotations: vi.fn(() => []),
+}));
+
+const REFERENT = { '@id': 'res-target', name: 'Target Doc' } as unknown as ResourceDescriptor;
+const DWELL = 100;
+
+const makeAnnotation = (id: string, body: Annotation['body']): Annotation => ({
+  '@context': 'http://www.w3.org/ns/anno.jsonld',
+  id: id as AnnotationId,
+  type: 'Annotation',
+  motivation: 'linking',
+  creator: { '@type': 'Person', name: 'u' },
+  created: '2024-01-01T00:00:00Z',
+  target: { source: 'res-1', selector: { type: 'TextPositionSelector', start: 0, end: 4 } },
+  body,
+});
+
+const resolvedRef = makeAnnotation('ref-resolved', [{ type: 'SpecificResource', source: 'res-target', purpose: 'linking' }]);
+const stubRef = makeAnnotation('ref-stub', []);
+
+function setup(onReferenceHover?: (h: unknown) => void) {
+  const referent$ = new BehaviorSubject<ResourceDescriptor | undefined>(undefined);
+  const beckonHover = vi.fn();
+  const browseResource = vi.fn(() => referent$);
+  const session = {
+    client: {
+      browse: { click: vi.fn(), resource: browseResource },
+      beckon: { hover: beckonHover },
+    },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+
+  const { container } = render(
+    <BrowseView
+      content="some text"
+      mimeType="text/plain"
+      resourceUri="res-1"
+      annotations={{ highlights: [], references: [resolvedRef, stubRef], assessments: [], comments: [], tags: [] }}
+      annotateMode={false}
+      hoverDelayMs={DWELL}
+      session={session}
+      {...(onReferenceHover ? { onReferenceHover } : {})}
+    />,
+  );
+  const content = container.querySelector('.semiont-browse-view__content')!;
+
+  const hoverTarget = (id: string) => {
+    const el = document.createElement('span');
+    el.setAttribute('data-annotation-id', id);
+    return { el, target: { closest: vi.fn(() => el) } as unknown as Element };
+  };
+
+  return { content, referent$, beckonHover, browseResource, hoverTarget };
+}
+
+describe('BrowseView — onReferenceHover (Phase 2b)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('fires once after dwell + descriptor resolve, with {annotation, referent, anchorRect}', () => {
+    const onReferenceHover = vi.fn();
+    const { content, referent$, hoverTarget } = setup(onReferenceHover);
+
+    fireEvent.mouseOver(content, { target: hoverTarget('ref-resolved').target });
+    vi.advanceTimersByTime(DWELL + 10);        // dwell fires → subscribe starts
+    expect(onReferenceHover).not.toHaveBeenCalled(); // descriptor not resolved yet
+
+    referent$.next(REFERENT);                  // descriptor lands
+    expect(onReferenceHover).toHaveBeenCalledTimes(1);
+    const hover = onReferenceHover.mock.calls[0]![0];
+    expect(hover.annotation.id).toBe('ref-resolved');
+    expect(hover.referent).toBe(REFERENT);
+    expect(typeof hover.anchorRect.top).toBe('number'); // DOMRect from the hovered span
+
+    referent$.next({ ...REFERENT });           // later cache emissions must NOT re-fire
+    expect(onReferenceHover).toHaveBeenCalledTimes(1);
+  });
+
+  it('a stub reference fires nothing — not even null on leave', () => {
+    const onReferenceHover = vi.fn();
+    const { content, beckonHover, hoverTarget } = setup(onReferenceHover);
+
+    const { target } = hoverTarget('ref-stub');
+    fireEvent.mouseOver(content, { target });
+    vi.advanceTimersByTime(DWELL + 10);
+    fireEvent.mouseOut(content, { target });
+
+    expect(onReferenceHover).not.toHaveBeenCalled();
+    expect(beckonHover).toHaveBeenCalledWith('ref-stub'); // panel-highlight path unaffected
+  });
+
+  it('leaving before the descriptor resolves cancels: no fire, and a late resolve stays silent', () => {
+    const onReferenceHover = vi.fn();
+    const { content, referent$, hoverTarget } = setup(onReferenceHover);
+
+    const { target } = hoverTarget('ref-resolved');
+    fireEvent.mouseOver(content, { target });
+    vi.advanceTimersByTime(DWELL + 10);        // dwell fired, load in flight
+    fireEvent.mouseOut(content, { target });   // leave first
+
+    referent$.next(REFERENT);                  // late resolve
+    expect(onReferenceHover).not.toHaveBeenCalled(); // cancelled — and no stray null either
+  });
+
+  it('leaving after a fire sends null', () => {
+    const onReferenceHover = vi.fn();
+    const { content, referent$, hoverTarget } = setup(onReferenceHover);
+
+    const { target } = hoverTarget('ref-resolved');
+    fireEvent.mouseOver(content, { target });
+    vi.advanceTimersByTime(DWELL + 10);
+    referent$.next(REFERENT);
+    expect(onReferenceHover).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseOut(content, { target });
+    expect(onReferenceHover).toHaveBeenCalledTimes(2);
+    expect(onReferenceHover).toHaveBeenLastCalledWith(null);
+  });
+
+  it('without onReferenceHover, hover still emits beckon:hover and loads nothing', () => {
+    const { content, beckonHover, browseResource, hoverTarget } = setup();
+
+    fireEvent.mouseOver(content, { target: hoverTarget('ref-resolved').target });
+    vi.advanceTimersByTime(DWELL + 10);
+
+    expect(beckonHover).toHaveBeenCalledWith('ref-resolved');
+    expect(browseResource).not.toHaveBeenCalled(); // no handler → no referent load
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/browse-renderers.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/browse-renderers.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 0 — regression: the browse `text` default
+ * renders markdown as **formatted prose**, not raw source.
+ *
+ * The other BrowseView suites mock `react-markdown` away for simplicity, so
+ * nothing currently pins that the default text renderer actually *formats*
+ * markdown. This spec uses the real renderer and guards against a regression to
+ * raw/source rendering.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TextBrowseRenderer, defaultBrowseRenderers } from '../browse-renderers';
+
+const base = { mimeType: 'text/markdown', resourceUri: 'res-1', annotations: [] };
+
+describe('browse-renderers — markdown-as-prose (Phase 0 regression)', () => {
+  it('TextBrowseRenderer is the default `text` renderer', () => {
+    expect(defaultBrowseRenderers.text).toBe(TextBrowseRenderer);
+  });
+
+  it('renders markdown as formatted HTML, not raw source', () => {
+    const { container } = render(
+      <TextBrowseRenderer content={'# Big Heading\n\nsome **bold** and a [link](https://x.test).'} {...base} />,
+    );
+    // Formatted: heading / strong / anchor elements exist (react-markdown output).
+    expect(container.querySelector('h1')?.textContent).toBe('Big Heading');
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://x.test');
+    // NOT raw: the literal markdown syntax must not survive to the text content.
+    expect(container.textContent).not.toContain('# Big Heading');
+    expect(container.textContent).not.toContain('**bold**');
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/inline-embedding.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/inline-embedding.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 1 — inline embedding.
+ *
+ * `inline` is a display variant (default: today's pane behavior, frontend
+ * untouched): the viewer renders at content height in a bare container — no
+ * inner scroll container, no pane chrome. jsdom can't compute stylesheet
+ * layout, so this spec pins the two testable seams: (1) the components emit
+ * the `--inline` modifier classes; (2) the stylesheet contains the inline
+ * overrides (height:auto / overflow:visible / padding drop). The visual
+ * auto-height check is the plan's live smoke-test.
+ *
+ * Started RED (no `inline` prop) and GREEN once Phase 1 lands.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SemiontSession } from '@semiont/sdk';
+import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { BrowseView } from '../BrowseView';
+import { ResourceViewer } from '../ResourceViewer';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+const resource: SemiontResource & { content: string } = {
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  '@id': 'res-1' as ResourceId,
+  name: 'Doc',
+  created: '2024-01-01T00:00:00Z',
+  entityTypes: [],
+  archived: false,
+  representations: [{ mediaType: 'text/plain', byteSize: 10 }],
+  content: 'Inline content.',
+};
+
+describe('inline embedding (Phase 1)', () => {
+  it('BrowseView: `inline` adds the modifier class; default does not', () => {
+    const props = {
+      content: 'x', mimeType: 'text/plain', resourceUri: 'res-1',
+      annotations: emptyAnnotations, annotateMode: false, session: fakeSession(),
+    };
+    const { container: pane } = render(<BrowseView {...props} />);
+    expect(pane.querySelector('.semiont-browse-view')).not.toHaveClass('semiont-browse-view--inline');
+
+    const { container } = render(<BrowseView {...props} inline />);
+    expect(container.querySelector('.semiont-browse-view')).toHaveClass('semiont-browse-view--inline');
+  });
+
+  it('ResourceViewer: `inline` marks its root and threads to BrowseView', () => {
+    const { container } = render(
+      <ResourceViewer
+        resource={resource} annotations={emptyAnnotations}
+        session={fakeSession()} inline
+      />,
+    );
+    expect(container.querySelector('.semiont-resource-viewer')).toHaveClass('semiont-resource-viewer--inline');
+    expect(container.querySelector('.semiont-browse-view')).toHaveClass('semiont-browse-view--inline');
+  });
+
+  it('stylesheet carries the inline overrides (static gate — layout itself is the live check)', () => {
+    // vitest runs with cwd = the package root (same in CI's per-workspace run).
+    const css = readFileSync(resolve(process.cwd(), 'src/styles/features/resource-viewer.css'), 'utf8');
+    // Auto-height roots, and the content area stops being a scroll container / drops the pane gutter.
+    expect(css).toMatch(/\.semiont-resource-viewer--inline\s*\{[^}]*height:\s*auto/);
+    expect(css).toMatch(/\.semiont-browse-view--inline\s*\{[^}]*height:\s*auto/);
+    expect(css).toMatch(/\.semiont-browse-view--inline\s+\.semiont-browse-view__content\s*\{[^}]*overflow:\s*visible/);
+    expect(css).toMatch(/\.semiont-browse-view--inline\s+\.semiont-browse-view__content\s*\{[^}]*padding:\s*0/);
+  });
+});

--- a/packages/react-ui/src/components/resource/__tests__/media-completeness.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/media-completeness.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * EMBEDDABLE-VIEWER-COMPLETION Phase 4 — media-completeness sweep.
+ *
+ * ONE mounted component (`ResourceViewer`, inline, bare session, no providers)
+ * renders every standard media type from the DEFAULTS — text, markdown, image,
+ * pdf — with the annotation-overlay container present and zero per-type wiring.
+ * (Formatted-markdown correctness is pinned by browse-renderers.test; visual
+ * overlay alignment is the plan's live smoke-test. This sweep pins the routing
+ * parity: every type reaches its renderer from one component.)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { ResourceViewer } from '../ResourceViewer';
+
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div data-testid="md">{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+// pdfjs can't load in jsdom — the sweep pins ROUTING to the pdf renderer, not pdf.js itself.
+vi.mock('../../pdf-annotation/PdfAnnotationCanvas.client', () => ({
+  PdfAnnotationCanvas: ({ pdfUrl }: { pdfUrl: string }) => <div data-testid="pdf-canvas">{pdfUrl}</div>,
+}));
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+function makeResource(mediaType: string, content: string): SemiontResource & { content: string } {
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    '@id': 'res-1' as ResourceId,
+    name: 'Doc',
+    created: '2024-01-01T00:00:00Z',
+    entityTypes: [],
+    archived: false,
+    representations: [{ mediaType, byteSize: 10 }],
+    content,
+  };
+}
+
+function mount(mediaType: string, content: string) {
+  return render(
+    <ResourceViewer
+      resource={makeResource(mediaType, content)}
+      annotations={emptyAnnotations}
+      session={fakeSession()}
+      inline
+    />,
+  );
+}
+
+describe('media-completeness sweep (Phase 4) — one component, all types, inline, defaults only', () => {
+  it.each([
+    ['text/plain', 'plain body'],
+    ['text/markdown', '# md body'],
+  ])('%s renders via the text default with the overlay container', (mt, content) => {
+    const { container } = mount(mt, content);
+    expect(container.querySelector('.semiont-browse-view[data-mime-type="text"]')).toBeInTheDocument();
+    expect(screen.getByTestId('md')).toHaveTextContent(content.replace('# ', '# ').trim());
+    expect(container.querySelector('.semiont-browse-view__content')).toBeInTheDocument(); // overlay anchor
+    expect(container.querySelector('.semiont-browse-view')).toHaveClass('semiont-browse-view--inline');
+  });
+
+  it('image/png renders via the image default', () => {
+    const { container } = mount('image/png', 'https://media.test/img.png?token=t');
+    expect(container.querySelector('.semiont-browse-view[data-mime-type="image"]')).toBeInTheDocument();
+    expect(container.querySelector('img')).toBeInTheDocument();
+    expect(container.querySelector('.semiont-browse-view__content')).toBeInTheDocument();
+  });
+
+  it('application/pdf routes to the pdf default', async () => {
+    const { container } = mount('application/pdf', 'https://media.test/doc.pdf?token=t');
+    expect(container.querySelector('.semiont-browse-view[data-mime-type="pdf"]')).toBeInTheDocument();
+    expect(await screen.findByTestId('pdf-canvas')).toHaveTextContent('https://media.test/doc.pdf?token=t');
+  });
+
+  it('an unknown type degrades to metadata + download (no crash, no per-type wiring)', () => {
+    const { container } = mount('application/octet-stream', '');
+    expect(container.querySelector('[data-mime-type="unsupported"]')).toBeInTheDocument();
+    expect(screen.getByText(/Preview not available/)).toBeInTheDocument();
+  });
+});

--- a/packages/react-ui/src/components/toolbar/Toolbar.css
+++ b/packages/react-ui/src/components/toolbar/Toolbar.css
@@ -219,3 +219,17 @@
 }
 
 /* Popup Components */
+
+/* ── Compact display form ────────────────────────────────────────────────────
+ * Display-only variant for inline embeds: icon-only, tight, chromeless. The
+ * bar's functionality is identical — only its form changes. */
+.semiont-annotate-toolbar--compact {
+  gap: 0.375rem;
+  padding: 0.25rem 0;
+  background: transparent; /* the host container owns the background */
+  border-bottom: none;
+}
+
+.semiont-annotate-toolbar--compact .semiont-dropdown-label {
+  display: none; /* icon-only collapsed triggers; expanded menus keep labels */
+}

--- a/packages/react-ui/src/styles/features/resource-viewer.css
+++ b/packages/react-ui/src/styles/features/resource-viewer.css
@@ -111,6 +111,25 @@
   padding: 0 1.5rem; /* Move padding from parent to scrollable content */
 }
 
+/* ── Inline embed variant ────────────────────────────────────────────────────
+ * Auto-height to content, no inner scroll container, no pane chrome — the
+ * viewer drops into a chat bubble / card / list item and the HOST page
+ * scrolls. Default (no modifier) keeps the fill-the-pane behavior above. */
+.semiont-resource-viewer--inline {
+  height: auto;
+}
+
+.semiont-browse-view--inline {
+  height: auto;
+  background-color: transparent; /* the host container owns the background */
+}
+
+.semiont-browse-view--inline .semiont-browse-view__content {
+  flex: none; /* size to content, not to a pane */
+  overflow: visible; /* no inner scrollbar — the host page is the scroll context */
+  padding: 0; /* no pane gutter — the host owns spacing */
+}
+
 /* ── Markdown prose typography ──────────────────────────────────────────────
  * The global CSS reset zeroes margins/padding on all block elements and
  * removes list styles. Re-apply semantic typographic defaults scoped to the

--- a/packages/sdk/docs/CACHE-SEMANTICS.md
+++ b/packages/sdk/docs/CACHE-SEMANTICS.md
@@ -80,7 +80,8 @@ Consequences:
    flight?" Observers get the first as `V | undefined`. The second is
    the private `fetching*` guard and is not exposed.
 3. **Empty is terminal only until an observer or invalidate acts.**
-   A permanent fetch failure does not auto-retry.
+   Each act gets one bounded retry (B14); after that the key goes idle
+   until the next act. There is no standing retry loop.
 
 ## Two consumption paths
 
@@ -210,6 +211,31 @@ A future cache primitive may add subscriber ref-counting and GC.
 For now, the full cache lifetime matches a `SemiontClient`
 instance, which matches a browser tab or a CLI process — so the
 leak is strictly bounded.
+
+### B14 — SWR fetch failure retries once (anti-starvation)
+
+A fetch triggered by the **swallowed** paths — first observation (B1),
+`invalidate` (B7/B8), `invalidateAll` — that fails MUST be re-issued
+exactly once. If the retry also fails, the key goes idle (B6 state:
+empty or stale-fresh) until the next observe/invalidate acts.
+
+Rationale: the swallowed paths hide failures from subscribers by design
+(B6), which means a lost one-shot reply — e.g. a `busRequest` whose SSE
+result raced a connection swap and timed out
+(`.plans/bugs/concurrent-browse-resource-starvation.md`) — previously
+starved every subscriber of a never-loaded key **silently and
+permanently**: no retry, no error, `undefined` forever. One bounded
+retry converts "reply lost" from permanent starvation into one slow
+load, without a standing retry loop hammering a genuinely-down backend.
+
+Boundaries:
+
+1. The `fetch(key)` await path NEVER auto-retries — its caller sees the
+   rejection and owns retry policy (unchanged).
+2. The retry joins any in-flight fetch another caller has started in the
+   meantime (B3 dedup); it never duplicates.
+3. An invalidate during a retry chain disowns it (B9) — the chain's
+   late success may still write (last-write-wins, same as B9).
 
 ## Bus-event-driven invalidation
 
@@ -403,3 +429,8 @@ changing a behavior must update both this doc and the test.
 - 2026-04-19 — initial spec, written as part of CACHE-LIBRARY.md
   Phase 1. Documents behavior as it exists after the
   `invalidateResourceDetail` SWR fix (test 04).
+- 2026-07-05 — B14 added (bounded SWR retry); lifecycle consequence 3
+  amended ("a permanent fetch failure does not auto-retry" → one retry
+  per act). Part of the concurrent-browse-resource-starvation fix
+  (ask 3): a lost one-shot reply must not permanently starve
+  subscribers.

--- a/packages/sdk/src/__tests__/browse-concurrent-loaders.test.ts
+++ b/packages/sdk/src/__tests__/browse-concurrent-loaders.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Integration repro for `.plans/bugs/concurrent-browse-resource-starvation.md`:
+ * mount N loaders for N DISTINCT resources at connect time (the embeddable
+ * viewer's "resource per chat message" pattern — `useResourceLoader` per
+ * message) and require that ALL N resolve. Pre-fix, exactly one resolved and
+ * the other N−1 starved forever:
+ *
+ *   - loaders 2..N: `subscribeToResource` threw (single-scope contention) and
+ *     errored their subscriptions silently → fixed by withScope degrading to
+ *     unscoped observation (browse.ts);
+ *   - replies lost on the wire (SSE swap abort) left the per-key cache
+ *     pending forever → fixed by the transport linger-drain
+ *     (http-transport actor-state-unit, tested there) and the cache's bounded
+ *     SWR retry (B14, cache.ts) as defense in depth.
+ *
+ * This file automates the repro at the `BrowseNamespace` level, mimicking
+ * `useResourceLoader`'s consumption: one `resource(rid)` + one
+ * `annotations(rid)` live-query subscription per loader.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Observable, Subject } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { IContentTransport, ITransport, ResourceId } from '@semiont/core';
+import { BrowseNamespace } from '../namespaces/browse';
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+/**
+ * Fake transport with HttpTransport's SINGLE-scope `subscribeToResource`
+ * contract (throws for a second distinct resource while one is held) and
+ * synchronous correlated replies. `failFirstResourceFetchFor` makes the
+ * first `browse:resource-requested` emit for that rid reject — simulating a
+ * request whose reply was lost (busRequest timeout), which drives the B14
+ * retry path.
+ */
+function makeSingleScopeTransport(opts: { failFirstResourceFetchFor?: string } = {}) {
+  const subjects = new Map<string, Subject<Record<string, unknown>>>();
+  const subjectFor = (channel: string) => {
+    let s = subjects.get(channel);
+    if (!s) {
+      s = new Subject<Record<string, unknown>>();
+      subjects.set(channel, s);
+    }
+    return s;
+  };
+
+  let active: { rId: ResourceId; refCount: number } | null = null;
+  const subscribeToResource = vi.fn((rId: ResourceId) => {
+    if (active && active.rId !== rId) {
+      throw new Error(`HttpTransport already subscribed to resource ${active.rId}`);
+    }
+    if (active) active.refCount++;
+    else active = { rId, refCount: 1 };
+    return () => {
+      if (active && --active.refCount <= 0) active = null;
+    };
+  });
+
+  let pendingFailure = opts.failFirstResourceFetchFor;
+
+  const transport = {
+    baseUrl: 'http://test',
+    emit: async (channel: string, payload: Record<string, unknown>) => {
+      if (channel === 'browse:resource-requested') {
+        const rid = payload.resourceId as string;
+        if (pendingFailure === rid) {
+          // One-shot loss: the request never gets a reply (the real failure
+          // is a busRequest timeout; a rejected emit produces the same
+          // fetch rejection without waiting 30s).
+          pendingFailure = undefined;
+          throw new Error(`simulated lost reply for ${rid}`);
+        }
+        subjectFor('browse:resource-result').next({
+          correlationId: payload.correlationId as string,
+          response: { resource: { '@id': rid, name: `Resource ${rid}` } },
+        });
+      }
+      if (channel === 'browse:annotations-requested') {
+        subjectFor('browse:annotations-result').next({
+          correlationId: payload.correlationId as string,
+          response: { annotations: [], total: 0 },
+        });
+      }
+    },
+    stream: (channel: string): Observable<Record<string, unknown>> => subjectFor(channel).asObservable(),
+    subscribeToResource,
+    bridgeInto: () => {},
+    state$: new Subject(),
+    errors$: new Subject(),
+    dispose: () => {},
+  };
+  return { transport: transport as unknown as ITransport, subscribeToResource };
+}
+
+const noopContent = {
+  getBinary: async () => ({ data: new ArrayBuffer(0), contentType: 'text/plain' }),
+  getBinaryStream: async () => ({ stream: new ReadableStream(), contentType: 'text/plain' }),
+  dispose: () => {},
+} as unknown as IContentTransport;
+
+/** Mimic one `useResourceLoader(client, rid)`: resource + annotations subscriptions. */
+function mountLoader(browse: BrowseNamespace, rid: ResourceId) {
+  const state = {
+    resource: undefined as unknown,
+    annotations: undefined as unknown,
+    errors: [] as unknown[],
+    get loaded() {
+      return this.resource !== undefined && this.annotations !== undefined;
+    },
+  };
+  const subs = [
+    browse.resource(rid).subscribe({
+      next: (v) => { if (v !== undefined) state.resource = v; },
+      error: (e) => state.errors.push(e),
+    }),
+    browse.annotations(rid).subscribe({
+      next: (v) => { if (v !== undefined) state.annotations = v; },
+      error: (e) => state.errors.push(e),
+    }),
+  ];
+  return { state, unmount: () => subs.forEach((s) => s.unsubscribe()) };
+}
+
+describe('N concurrent distinct-rid loaders at connect (starvation repro)', () => {
+  const RIDS = ['res-1', 'res-2', 'res-3', 'res-4'].map(makeResourceId);
+
+  it('all N loaders resolve — none starved, none errored', async () => {
+    const bus = new EventBus();
+    const { transport } = makeSingleScopeTransport();
+    const browse = new BrowseNamespace(transport, bus, noopContent);
+
+    const loaders = RIDS.map((rid) => mountLoader(browse, rid));
+    await flush();
+
+    for (const [i, loader] of loaders.entries()) {
+      expect(loader.state.errors, `loader ${i} errored`).toEqual([]);
+      expect(loader.state.loaded, `loader ${i} starved`).toBe(true);
+    }
+
+    loaders.forEach((l) => l.unmount());
+    bus.destroy();
+  });
+
+  it('a loader whose first fetch fails recovers via the bounded SWR retry (B14)', async () => {
+    const bus = new EventBus();
+    const { transport } = makeSingleScopeTransport({ failFirstResourceFetchFor: 'res-3' });
+    const browse = new BrowseNamespace(transport, bus, noopContent);
+
+    const loaders = RIDS.map((rid) => mountLoader(browse, rid));
+    await flush();
+
+    for (const [i, loader] of loaders.entries()) {
+      expect(loader.state.errors, `loader ${i} errored`).toEqual([]);
+      expect(loader.state.loaded, `loader ${i} starved`).toBe(true);
+    }
+
+    loaders.forEach((l) => l.unmount());
+    bus.destroy();
+  });
+
+  it('unmount/remount of a degraded loader keeps working (the "permanent per key" symptom)', async () => {
+    const bus = new EventBus();
+    const { transport } = makeSingleScopeTransport();
+    const browse = new BrowseNamespace(transport, bus, noopContent);
+
+    const loaders = RIDS.map((rid) => mountLoader(browse, rid));
+    await flush();
+    loaders.forEach((l) => l.unmount());
+
+    // Remount just the previously-degraded loaders (2..N).
+    const remounted = RIDS.slice(1).map((rid) => mountLoader(browse, rid));
+    await flush();
+    for (const [i, loader] of remounted.entries()) {
+      expect(loader.state.errors, `remounted loader ${i} errored`).toEqual([]);
+      expect(loader.state.loaded, `remounted loader ${i} starved`).toBe(true);
+    }
+
+    remounted.forEach((l) => l.unmount());
+    bus.destroy();
+  });
+});

--- a/packages/sdk/src/__tests__/browse-scope-by-observation.test.ts
+++ b/packages/sdk/src/__tests__/browse-scope-by-observation.test.ts
@@ -129,3 +129,107 @@ describe('browse live-query subscription acquires the resource scope (#847 Phase
     sub.unsubscribe();
   });
 });
+
+describe('scope contention degrades to unscoped observation (concurrent-browse-resource-starvation)', () => {
+  // HttpTransport is SINGLE-scope: `subscribeToResource` throws for a second
+  // distinct resourceId while the first is held. N distinct-rid loaders at
+  // mount (the embeddable-viewer "resource per chat message" pattern) hit
+  // that throw on loaders 2..N — and an errored subscription starves its
+  // component forever, silently. Scope acquisition failure must DEGRADE the
+  // live query to unscoped observation (correlated replies are globally
+  // bridged; only per-resource broadcast invalidations are scope-gated), not
+  // error the stream. See .plans/bugs/concurrent-browse-resource-starvation.md.
+
+  /** Fake transport with HttpTransport's single-scope contract. */
+  function makeSingleScopeTransport() {
+    const subjects = new Map<string, Subject<Record<string, unknown>>>();
+    const subjectFor = (channel: string) => {
+      let s = subjects.get(channel);
+      if (!s) {
+        s = new Subject<Record<string, unknown>>();
+        subjects.set(channel, s);
+      }
+      return s;
+    };
+
+    let active: { rId: ResourceId; refCount: number } | null = null;
+    const subscribeToResource = vi.fn((rId: ResourceId) => {
+      if (active && active.rId !== rId) {
+        throw new Error(
+          `HttpTransport already subscribed to resource ${active.rId}; ` +
+            `call the unsubscribe returned from the previous subscribeToResource before subscribing to ${rId}.`,
+        );
+      }
+      if (active) active.refCount++;
+      else active = { rId, refCount: 1 };
+      return () => {
+        if (active && --active.refCount <= 0) active = null;
+      };
+    });
+
+    const transport = {
+      baseUrl: 'http://test',
+      emit: async (channel: string, payload: Record<string, unknown>) => {
+        if (channel === 'browse:resource-requested') {
+          subjectFor('browse:resource-result').next({
+            correlationId: payload.correlationId as string,
+            response: { resource: { '@id': payload.resourceId, name: `Resource ${payload.resourceId as string}` } },
+          });
+        }
+      },
+      stream: (channel: string): Observable<Record<string, unknown>> => subjectFor(channel).asObservable(),
+      subscribeToResource,
+      bridgeInto: () => {},
+      state$: new Subject(),
+      errors$: new Subject(),
+      dispose: () => {},
+    };
+    return { transport: transport as unknown as ITransport, subscribeToResource };
+  }
+
+  const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+  const rid1: ResourceId = makeResourceId('res-1');
+  const rid2: ResourceId = makeResourceId('res-2');
+
+  it('a second distinct-rid live query still delivers values when scope acquisition throws', async () => {
+    const bus = new EventBus();
+    const { transport } = makeSingleScopeTransport();
+    const browse = new BrowseNamespace(transport, bus, noopContent);
+
+    const values1: unknown[] = [];
+    const values2: unknown[] = [];
+    const errors2: unknown[] = [];
+
+    // Loader 1 acquires the single scope; loader 2's acquisition throws.
+    browse.resource(rid1).subscribe({ next: (v) => values1.push(v) });
+    browse.resource(rid2).subscribe({ next: (v) => values2.push(v), error: (e) => errors2.push(e) });
+    await flush();
+
+    expect(errors2).toEqual([]); // NOT errored by the scope contention…
+    expect(values2.filter(Boolean)).toHaveLength(1); // …and the value arrives (degraded/unscoped)
+    expect(values1.filter(Boolean)).toHaveLength(1); // loader 1 unaffected
+
+    bus.destroy();
+  });
+
+  it('degradation is per-subscription: once the scope frees, a new subscription acquires it', async () => {
+    const bus = new EventBus();
+    const { transport, subscribeToResource } = makeSingleScopeTransport();
+    const browse = new BrowseNamespace(transport, bus, noopContent);
+
+    const sub1 = browse.resource(rid1).subscribe(() => {});
+    const sub2 = browse.resource(rid2).subscribe(() => {}); // degraded (contention)
+    await flush();
+
+    sub1.unsubscribe(); // scope freed
+    sub2.unsubscribe();
+
+    // A fresh subscription for rid2 now acquires the scope normally.
+    subscribeToResource.mockClear();
+    browse.resource(rid2).subscribe(() => {});
+    expect(subscribeToResource).toHaveBeenCalledWith(rid2);
+    expect(subscribeToResource).toHaveReturned(); // no throw this time
+
+    bus.destroy();
+  });
+});

--- a/packages/sdk/src/__tests__/cache.test.ts
+++ b/packages/sdk/src/__tests__/cache.test.ts
@@ -89,9 +89,11 @@ describe('Cache<K, V>', () => {
   });
 
   describe('B6 — fetch failure leaves the previous state intact', () => {
-    it('empty key stays empty after a rejected fetch; guard is released', async () => {
+    it('empty key stays empty after fetch failures; guard is released', async () => {
+      // Two rejections exhaust the observe attempt + its B14 retry.
       const fetchFn = vi
         .fn()
+        .mockRejectedValueOnce(new Error('boom'))
         .mockRejectedValueOnce(new Error('boom'))
         .mockResolvedValueOnce('v1');
       const cache = createCache<string, string>(fetchFn);
@@ -107,9 +109,11 @@ describe('Cache<K, V>', () => {
     });
 
     it('previously-fresh value survives a failed refetch', async () => {
+      // Two rejections exhaust the invalidate refetch + its B14 retry.
       const fetchFn = vi
         .fn()
         .mockResolvedValueOnce('v1')
+        .mockRejectedValueOnce(new Error('boom'))
         .mockRejectedValueOnce(new Error('boom'));
       const cache = createCache<string, string>(fetchFn);
       await firstDefined(cache.observe('k'));
@@ -306,16 +310,84 @@ describe('Cache<K, V>', () => {
       expect(fetchFn).toHaveBeenCalledTimes(1);
     });
 
-    it('rejects on failure and leaves subscribers untouched (B6)', async () => {
+    it('rejects on failure; subscribers are never errored and recover via the B14 retry', async () => {
       const fetchFn = vi
         .fn()
         .mockRejectedValueOnce(new Error('boom'))
         .mockResolvedValueOnce('v1');
       const cache = createCache<string, string>(fetchFn);
       const seen: Array<string | undefined> = [];
-      cache.observe('k').subscribe((v) => seen.push(v));
+      const errors: unknown[] = [];
+      cache.observe('k').subscribe({ next: (v) => seen.push(v), error: (e) => errors.push(e) });
+      // The awaiter joins the (failing) in-flight fetch and sees the rejection…
       await expect(cache.fetch('k')).rejects.toThrow('boom');
-      expect(seen).toEqual([undefined]); // subscriber stays at loading state
+      expect(errors).toEqual([]); // …but the subscriber is never errored (B6)
+      // …and the observe path's B14 retry recovers the subscriber.
+      await flush();
+      expect(seen[seen.length - 1]).toBe('v1');
+    });
+  });
+
+  describe('B14 — SWR fetch failure retries once (anti-starvation)', () => {
+    // Motivating failure: a one-shot busRequest reply lost on the wire (SSE
+    // connection swap) times out and rejects; without a bounded retry, every
+    // subscriber of a never-loaded key starves silently until some future
+    // observe()/invalidate() happens to act.
+    // See .plans/bugs/concurrent-browse-resource-starvation.md (ask 3).
+
+    it('observe path: a failed first fetch is re-issued once and subscribers recover', async () => {
+      const fetchFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('bus.timeout: reply lost'))
+        .mockResolvedValueOnce('v1');
+      const cache = createCache<string, string>(fetchFn);
+      const seen: Array<string | undefined> = [];
+      cache.observe('k').subscribe((v) => seen.push(v));
+      await flush();
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+      expect(seen[seen.length - 1]).toBe('v1');
+    });
+
+    it('caps at one retry: a persistently failing key goes idle, and a later observe() recovers it', async () => {
+      const fetchFn = vi.fn().mockRejectedValue(new Error('down'));
+      const cache = createCache<string, string>(fetchFn);
+      cache.observe('k').subscribe(() => {});
+      await flush();
+      expect(fetchFn).toHaveBeenCalledTimes(2); // attempt + one retry, then idle
+      await flush();
+      expect(fetchFn).toHaveBeenCalledTimes(2); // no tight loop
+
+      // Recoverable: the key is idle-empty ("empty is terminal only until an
+      // observer acts"), so a later observe() starts a fresh attempt chain.
+      fetchFn.mockResolvedValueOnce('v-late');
+      const v = await firstDefined(cache.observe('k'));
+      expect(v).toBe('v-late');
+    });
+
+    it('invalidate path: a failed SWR refetch retries once; stale value survives throughout (B6)', async () => {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce('v1')
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce('v2');
+      const cache = createCache<string, string>(fetchFn);
+      await firstDefined(cache.observe('k'));
+      cache.invalidate('k');
+      expect(cache.get('k')).toBe('v1'); // stale value visible during refetch + retry
+      await flush();
+      expect(cache.get('k')).toBe('v2');
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('await path is untouched: fetch() rejects without auto-retry (caller owns retry policy)', async () => {
+      const fetchFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce('v');
+      const cache = createCache<string, string>(fetchFn);
+      await expect(cache.fetch('k')).rejects.toThrow('boom');
+      await flush();
+      expect(fetchFn).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -33,9 +33,10 @@
  *   - No subscriber ref-counting / GC of unobserved keys (B11). Acceptable
  *     given cache lifetime == client lifetime.
  *   - No TTL / cacheTime. Entries are evicted only by explicit remove.
- *   - No retry / backoff. A failing fetch leaves the cache unchanged for
- *     *subscribers* (B6); the `fetch`/await path surfaces the rejection so
- *     the caller can retry.
+ *   - Bounded retry on the SWR paths only (B14): a failed observe/invalidate
+ *     fetch is re-issued exactly once, then the key goes idle. The
+ *     `fetch`/await path never auto-retries — it surfaces the rejection so
+ *     the caller owns retry policy.
  */
 
 import { BehaviorSubject, Observable, distinctUntilChanged, map } from 'rxjs';
@@ -117,12 +118,33 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     return p;
   };
 
+  /**
+   * Fetch driver for the swallowed SWR paths (observe / invalidate): retry
+   * once on failure (B14), then go idle.
+   *
+   * The motivating failure is a lost one-shot reply — the busRequest timed
+   * out because its SSE result raced a connection swap
+   * (.plans/bugs/concurrent-browse-resource-starvation.md). Without a retry,
+   * every subscriber of a never-loaded key starves silently until some future
+   * observe()/invalidate() happens to act. Failures stay invisible to
+   * subscribers (B6); the retry joins any fetch another caller started in the
+   * meantime (B3), and an exhausted key is left idle-empty so the next
+   * observe()/invalidate() starts a fresh chain. The `fetch`/await path never
+   * comes through here — its caller sees the rejection and owns retry policy.
+   */
+  const runFetchSWR = (key: K): void => {
+    void runFetch(key).catch(() => {
+      void runFetch(key).catch(() => {});
+    });
+  };
+
   return {
     observe(key: K): Observable<V | undefined> {
       if (!store$.value.has(key) && !inflight.has(key)) {
         // Subscribe path: fire-and-forget, swallow failures so a subscriber
-        // stays at its last value (B6). The awaiter's `fetch` surfaces them.
-        void runFetch(key).catch(() => {});
+        // stays at its last value (B6); one bounded retry (B14). The
+        // awaiter's `fetch` surfaces failures instead.
+        runFetchSWR(key);
       }
       // B4: return a stable Observable per key.
       let obs = obsCache.get(key);
@@ -150,10 +172,10 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
 
     invalidate(key: K): void {
       // B7: do NOT erase the value. Clear the guard (B9 orphan recovery)
-      // and trigger a fresh fetch. Observers keep seeing the stale value
-      // until the new value replaces it.
+      // and trigger a fresh fetch (with the B14 bounded retry). Observers
+      // keep seeing the stale value until the new value replaces it.
       inflight.delete(key);
-      void runFetch(key).catch(() => {});
+      runFetchSWR(key);
     },
 
     remove(key: K): void {
@@ -176,7 +198,7 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
       // keeps its stale value until its refetch resolves.
       for (const key of store$.value.keys()) {
         inflight.delete(key);
-        void runFetch(key).catch(() => {});
+        runFetchSWR(key);
       }
     },
 

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -133,8 +133,25 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
    * comes through here — its caller sees the rejection and owns retry policy.
    */
   const runFetchSWR = (key: K): void => {
-    void runFetch(key).catch(() => {
-      void runFetch(key).catch(() => {});
+    void runFetch(key).catch((firstErr: unknown) => {
+      // Always-on breadcrumb: the pre-B14 version of this path swallowed the
+      // failure with zero trace, which is how lost replies starved silently
+      // (.plans/bugs/concurrent-browse-resource-starvation.md). Not deduped —
+      // a spamming retry line means fetches are failing repeatedly, which is
+      // itself the signal.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[cache RETRY] SWR fetch failed for key ${String(key)}; re-issuing once (B14):`,
+        firstErr instanceof Error ? firstErr.message : firstErr,
+      );
+      void runFetch(key).catch((retryErr: unknown) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[cache IDLE] retry also failed for key ${String(key)}; going idle until the ` +
+            `next observe()/invalidate() (B14):`,
+          retryErr instanceof Error ? retryErr.message : retryErr,
+        );
+      });
     });
   };
 

--- a/packages/sdk/src/namespaces/__tests__/cache-semantics.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/cache-semantics.test.ts
@@ -325,13 +325,14 @@ describe('Cache semantics — behaviors B1–B13 against BrowseNamespace', () =>
   });
 
   describe('B6 — fetch failure leaves the previous state intact', () => {
-    it('observer stays undefined on a first-fetch failure; guard is released', async () => {
-      const { browse, emitSpy, state } = createHarness({ rejectNext: 1 });
+    it('observer stays undefined on first-fetch failures; guard is released', async () => {
+      // Two rejections exhaust the observe attempt + its B14 retry.
+      const { browse, emitSpy, state } = createHarness({ rejectNext: 2 });
       const seen: Array<ResourceDescriptor | undefined> = [];
       browse.resource(RID).subscribe((v) => seen.push(v));
       await flush();
       expect(seen).toEqual([undefined]);
-      expect(emitSpy).toHaveBeenCalledTimes(1);
+      expect(emitSpy).toHaveBeenCalledTimes(2); // attempt + B14 retry, then idle
 
       // Guard is released: a subsequent fetch succeeds and the observer sees it.
       state.rejectRemaining = 0;
@@ -345,14 +346,15 @@ describe('Cache semantics — behaviors B1–B13 against BrowseNamespace', () =>
       const first = await firstDefined(browse.resource(RID));
       expect(first).toMatchObject({ name: 'Resource res-1' });
 
-      state.rejectRemaining = 1;
+      // Two rejections exhaust the invalidate refetch + its B14 retry.
+      state.rejectRemaining = 2;
       browse.invalidateResourceDetail(RID);
       await flush();
 
       // Stale value is still served; no transient undefined.
       const latest = await firstDefined(browse.resource(RID));
       expect(latest).toMatchObject({ name: 'Resource res-1' });
-      expect(emitSpy).toHaveBeenCalledTimes(2);
+      expect(emitSpy).toHaveBeenCalledTimes(3); // initial + refetch + B14 retry
     });
   });
 
@@ -383,16 +385,17 @@ describe('Cache semantics — behaviors B1–B13 against BrowseNamespace', () =>
     it('clears the in-flight guard before refetching (commit 845c6b24 regression)', async () => {
       // Scenario: a fetch is stuck in-flight (guard never cleared). If
       // invalidate does not clear the guard, the refetch short-circuits.
-      const { browse, emitSpy, state } = createHarness({ rejectNext: 1 });
+      // Two rejections exhaust the observe attempt + its B14 retry first.
+      const { browse, emitSpy, state } = createHarness({ rejectNext: 2 });
       const seen: Array<ResourceDescriptor | undefined> = [];
       browse.resource(RID).subscribe((v) => seen.push(v));
-      await flush(); // First fetch rejects; guard should release in finally.
+      await flush(); // Attempt + B14 retry both reject; guard releases in finally.
 
       state.rejectRemaining = 0;
       browse.invalidateResourceDetail(RID);
       const val = await firstDefined(browse.resource(RID));
       expect(val).toBeDefined();
-      expect(emitSpy).toHaveBeenCalledTimes(2);
+      expect(emitSpy).toHaveBeenCalledTimes(3); // attempt + retry + invalidate refetch
     });
   });
 

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -199,16 +199,33 @@ export class BrowseNamespace implements IBrowseNamespace {
    * ref-counts concurrent subscriptions for the same resource onto a single
    * SSE scope. Single-scope model unchanged — multi-scope is deferred (see
    * `.plans/MULTI-RESOURCE-SCOPE.md`).
+   *
+   * Scope acquisition can FAIL under that single-scope model — another
+   * resource already holds the scope, which is the normal state of affairs
+   * for N distinct-rid loaders mounted together (the embeddable-viewer
+   * "resource per chat message" pattern). That must DEGRADE, not error the
+   * live query: correlated replies are globally bridged, so the initial load
+   * and all store updates still flow unscoped; only this resource's broadcast
+   * invalidations are missed while degraded. Erroring instead starved every
+   * such subscriber silently and permanently
+   * (.plans/bugs/concurrent-browse-resource-starvation.md). Each new
+   * subscription retries acquisition, so degradation is per-subscription —
+   * once the scope frees, the next subscribe scopes normally.
    */
   private withScope<T>(rId: ResourceId, source: Observable<T | undefined>): Observable<T | undefined> {
     let scoped = this.scopedSources.get(source) as Observable<T | undefined> | undefined;
     if (!scoped) {
       scoped = new Observable<T | undefined>((subscriber) => {
-        const release = this.transport.subscribeToResource(rId);
+        let release: (() => void) | null = null;
+        try {
+          release = this.transport.subscribeToResource(rId);
+        } catch {
+          // Scope held by another resource — observe unscoped (degraded).
+        }
         const inner = source.subscribe(subscriber);
         return () => {
           inner.unsubscribe();
-          release();
+          release?.();
         };
       });
       this.scopedSources.set(source, scoped);

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -221,6 +221,18 @@ export class BrowseNamespace implements IBrowseNamespace {
           release = this.transport.subscribeToResource(rId);
         } catch {
           // Scope held by another resource — observe unscoped (degraded).
+          // Always-on warn (once per resource): silent degradation is how the
+          // starvation incident stayed invisible to a full evidence chain —
+          // see .plans/bugs/concurrent-browse-resource-starvation.md.
+          if (!this.degradedScopeWarned.has(rId)) {
+            this.degradedScopeWarned.add(rId);
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[browse DEGRADED] scope contention: observing ${rId} unscoped — its live ` +
+                `per-resource invalidations are paused until the scope frees (re-subscribe ` +
+                `re-attempts; real fix: .plans/MULTI-RESOURCE-SCOPE.md).`,
+            );
+          }
         }
         const inner = source.subscribe(subscriber);
         return () => {
@@ -232,6 +244,9 @@ export class BrowseNamespace implements IBrowseNamespace {
     }
     return scoped;
   }
+
+  /** One degradation warn per resource per namespace lifetime — signal, not spam. */
+  private readonly degradedScopeWarned = new Set<ResourceId>();
 
   // ── Live queries ────────────────────────────────────────────────────────
   //


### PR DESCRIPTION
## Summary

Mounting N loaders for N **distinct** resources at connect — the embeddable viewer's resource-per-chat-message pattern — resolved one and **starved the other N−1 permanently, with no client-visible errors**. Three independent defects stacked to produce that silence; this PR fixes all three (each RED→GREEN) and then makes the formerly-silent paths observable so this class of bug can't hide again. Diagnosis: `.plans/bugs/concurrent-browse-resource-starvation.md`.

> **Note on the diff:** the first commit (the cross-media embeddable viewer) is **already in `main` via #944**, squash-merged from this same branch; it appears in the diff only because the branch wasn't rebased. Merging this PR effectively lands the **sdk / http-transport / docs** changes below — the branch's react-ui content is byte-identical to `main`.

## The three stacked defects

1. **http-transport — SSE handoff discarded written-but-unread replies.** The make-before-break handoff aborted the superseded connection the instant the new one opened, discarding replies already written to the old socket but not yet read (a hydrating page's busy main thread is exactly the repro window). Superseded connections now **linger and drain for `LINGER_MS` (1s)** before the abort; the existing event-id dedup absorbs the overlap (persisted ids are stable; correlated reply ids are deterministic per `routes/bus.ts`). A lingering connection's exit no longer restarts the reconnect machinery.
2. **sdk (browse) — loaders 2..N errored their subscriptions silently at mount.** `withScope` called `subscribeToResource` inside every live-query subscribe, and the transport's single-scope model **throws** for a second distinct resource. Scope-acquisition failure now **degrades to unscoped observation** (correlated replies are globally bridged; only that resource's broadcast invalidations are missed) instead of erroring the stream. Degradation is per-subscription; the transport's strict throw stays for explicit callers. The real fix remains `.plans/MULTI-RESOURCE-SCOPE.md`.
3. **sdk (cache) — a lost reply starved its key forever.** A fetch whose reply was lost rejected at the busRequest timeout, but nothing re-issued it — subscribers of a never-loaded key starved until some future `observe()`/`invalidate()` happened to act. New contract **B14** (`CACHE-SEMANTICS.md`): the swallowed SWR paths (first observation, invalidate, invalidateAll) get **exactly one bounded retry, then go idle**. The `fetch()`/await path never auto-retries — its caller owns retry policy.

## Observability follow-up (no behavior change; log lines + docs)

All three defects produced *silence* — which is why a careful wire-level evidence chain still misdiagnosed the bug. Breadcrumbs on each path (house idiom: rare/high-signal = always-on warn, like `[bus DROP]`; per-event diagnostic = busLog-gated):

- **`[browse DEGRADED]`** (sdk `browse.ts`) — withScope fell back to unscoped observation under scope contention; once per resource, names the consequence and points at `MULTI-RESOURCE-SCOPE.md`.
- **`[cache RETRY]` / `[cache IDLE]`** (sdk `cache.ts`) — B14 re-issued a failed SWR fetch / exhausted its one retry. Deliberately **not** deduped: a spamming retry line means fetches are failing repeatedly, which is itself the signal.
- **`[bus LINGER]`** (http-transport `actor-state-unit.ts`) — an event was delivered on a superseded (draining) connection, i.e. one an immediate handover abort would have discarded. busLog-gated (bursty during overlap); flip bus logging on to measure the window.

`docs/protocol/TRANSPORT-HTTP.md`: reconnect-discipline + connection-handoff sections updated to the linger-drain semantics, and a new **"Abort discipline (drain-over-abort)"** section — `abort()` is reserved for explicit consumer cancellation and terminal teardown; a lifecycle-handover abort is the buffered-loss bug class. Includes an audit of all six live `.abort()` sites (all sanctioned; the one historical violator was converted to linger-drain by this fix). Revision log entry for the contract change.

## Testing

- New integration repro: `sdk/src/__tests__/browse-concurrent-loaders.test.ts` — 4 distinct-rid loaders mimicking `useResourceLoader` (resource + annotations subs) all resolve; lost-first-reply recovery via B14; remount of degraded loaders.
- New/extended: `browse-scope-by-observation.test.ts`, `cache.test.ts`, `cache-semantics.test.ts`, `actor-state-unit.test.ts`.
- **sdk 375/375, http-transport 101/101, `tsc --noEmit` clean on both** (`node:24-alpine`).

## Notes

- Backend replay of correlated results (ask 2 in the diagnosis) deliberately **not** pursued: reply ids are `e-*` = non-replayable by design.
- Consumer validation: `adampingel/chat`'s held Phase-2 live run needs a release carrying this fix.
- No authentication / authorization changes — the security checklist is N/A.
