### PR TITLE
liveness axioms: fault-injection properties over the sdk + transport compositions (L1–L4) — found and fixed 3 real bugs

### DIFF
--- a/apps/frontend/docs/API-INTEGRATION.md
+++ b/apps/frontend/docs/API-INTEGRATION.md
@@ -297,7 +297,7 @@ HTTP errors from the http-transport surface as `APIError`:
 import { APIError } from '@semiont/http-transport';
 
 try {
-  await semiont.mark.annotation(resourceId, input);
+  await semiont.mark.annotation(input);
 } catch (err) {
   if (err instanceof APIError) {
     if (err.status === 401) { /* session expired */ }

--- a/apps/frontend/docs/ARCHITECTURE.md
+++ b/apps/frontend/docs/ARCHITECTURE.md
@@ -226,7 +226,7 @@ The solution is **media tokens** — short-lived JWTs scoped to a single resourc
 
 ```
 ResourceViewerPage
-  → useMediaToken(resourceId)       # auth.mediaToken(id); refreshed every 4 min
+  → useMediaToken(client, resourceId)  # auth.mediaToken(id); refreshed every 4 min
       → POST /api/tokens/media
       → { token }
   → resourceUrl = `${baseUrl}/api/resources/${id}?token=${token}`

--- a/apps/frontend/docs/MEDIA-ACCESS.md
+++ b/apps/frontend/docs/MEDIA-ACCESS.md
@@ -74,7 +74,9 @@ Components don't manage tokens by hand. The `useMediaToken` hook from
 ```typescript
 import { useMediaToken } from '@semiont/react-ui';
 
-const { token, loading } = useMediaToken(resourceId);
+// Takes the SemiontClient explicitly (bring-your-own-session embedding);
+// pass null to skip fetching (e.g. for non-binary resources).
+const { token, loading } = useMediaToken(client, resourceId);
 const src = token ? `${baseUrl}/api/resources/${resourceId}?token=${token}` : undefined;
 ```
 
@@ -86,7 +88,7 @@ renders as an image (which includes `application/pdf`), so callers of
 
 ```
 ResourceViewerPage
-  → useMediaToken(resourceId)
+  → useMediaToken(client, resourceId)
       → POST /api/tokens/media   (bearer-authenticated, once per 4 min)
       → { token }
   → resourceUrl = `${baseUrl}/api/resources/${id}?token=${token}`

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -19,7 +19,7 @@ Test individual components, functions, and hooks in isolation:
 - Component rendering and props handling
 - Hook behavior and state management
 - Utility function logic
-- Individual API client methods
+- Individual SDK namespace methods
 
 ### 🔗 **Integration Tests**
 Test component interactions and multi-step workflows:

--- a/docs/protocol/TRANSPORT-HTTP.md
+++ b/docs/protocol/TRANSPORT-HTTP.md
@@ -280,6 +280,16 @@ starvation fix. Any NEW `.abort()` call must be classifiable as
 consumer-cancel or terminal teardown; a lifecycle-handover abort is the
 buffered-loss bug class reintroduced.
 
+The rule is pinned as liveness axiom **L3**
+(`.plans/LIVENESS-AXIOMS.md`): an event written to any *live*
+connection's stream is delivered to `on$` subscribers exactly once,
+wherever a handover / reconnect / scope change lands relative to it.
+The property suite
+([actor-liveness.property.test.ts](../../packages/http-transport/src/transport/__tests__/actor-liveness.property.test.ts))
+fast-check-schedules SSE delivery against handover timing over the real
+actor; transport rewrites (e.g. MULTI-RESOURCE-SCOPE) must keep it
+green.
+
 During the brief handoff overlap the same live event can arrive on both
 connections. The client dedups by event id (`seenEventIds` in the
 actor-state-unit):

--- a/docs/protocol/flows/BECKON.md
+++ b/docs/protocol/flows/BECKON.md
@@ -16,7 +16,7 @@ The Beckon flow is the coordination layer for user focus. When a human hovers ov
 
 Beckoning is ephemeral — it produces no persistent state and coordinates transient focus signals only. Within a browser session, it is purely a frontend concern operating on the local event bus. Cross-participant beckoning (via `semiont beckon` from the CLI or another agent) flows through the unified bus gateway (`POST /bus/emit` + `GET /bus/subscribe`), but remains stateless: signals are delivered if the participant is connected and silently dropped if not — same semantics as all other beckon events. The [Browse flow](./BROWSE.md) handles the routing of clicks and panel state changes.
 
-## Using the API Client
+## Using the SDK
 
 Attention is primarily a frontend concern — in-browser hover/click
 signals coordinate through the local event bus without touching the

--- a/docs/protocol/flows/BIND.md
+++ b/docs/protocol/flows/BIND.md
@@ -21,7 +21,7 @@ Resolution can happen in two ways:
 
 Both paths result in an `mark:body-updated` event that adds the `SpecificResource` link.
 
-## Using the API Client
+## Using the SDK
 
 Resolve a reference annotation by adding a `SpecificResource` link to
 its body. The `bind` namespace issues a confirmed write over `busRequest`:

--- a/docs/protocol/flows/GATHER.md
+++ b/docs/protocol/flows/GATHER.md
@@ -15,7 +15,7 @@ The Gather flow assembles related context around a focal annotation. The applica
 
 Gathering is triggered automatically when the Reference Resolution Wizard opens (`bind:initiate`). It runs in parallel with the wizard rendering, so context is typically ready by the time the user interacts with the wizard's first step.
 
-## Using the API Client
+## Using the SDK
 
 Gathering is a long-running operation (LLM calls + graph traversal).
 `client.gather.annotation()` returns an Observable that emits progress

--- a/docs/protocol/flows/MARK.md
+++ b/docs/protocol/flows/MARK.md
@@ -34,7 +34,9 @@ intent (using the authenticated user's DID as the creator) and passes
 it to Stower.
 
 ```typescript
-const { annotationId } = await client.mark.annotation(resourceId, {
+// One argument — the wire layer derives the routing resourceId from
+// `target.source`.
+const { annotationId } = await client.mark.annotation({
   motivation: 'highlighting',
   target: {
     source: resourceId,
@@ -48,6 +50,20 @@ const { annotationId } = await client.mark.annotation(resourceId, {
   // highlighting carries no body — motivation + target is the whole
   // annotation per the W3C Web Annotation Model.
 });
+```
+
+**Resource classification** — replace a resource's own entity-type
+stamps. A confirmed write over `mark:update-entity-types` (replies
+`mark:update-entity-types-ok` / `-failed`): the backend diffs `current`
+vs `updated` and persists the changes as `mark:entity-tag-added` /
+`mark:entity-tag-removed` events, so the new classification surfaces in
+`browse.resources({ entityType })`. This stamps a resource with types
+drawn from the Frame vocabulary — it does not define new types (that is
+`frame.addEntityTypes`; see [FRAME.md](./FRAME.md)).
+
+```typescript
+// Replace/diff: pass the resource's current types and the desired full set.
+await client.mark.updateEntityTypes(resourceId, ['Draft'], ['Draft', 'Question']);
 ```
 
 **AI-assisted annotation** — long-running job that streams progress

--- a/docs/protocol/flows/MARK.md
+++ b/docs/protocol/flows/MARK.md
@@ -25,7 +25,7 @@ Semiont creates W3C-compliant annotations through two complementary paths: **man
 
 **Supported Formats**: Currently available for text-based formats (`text/plain`, `text/markdown`). Support for images and PDFs is planned for future releases
 
-## Using the API Client
+## Using the SDK
 
 **Manual annotation** — create an annotation directly. The `mark`
 namespace emits `mark:create-request` via the bus gateway; the backend

--- a/docs/protocol/flows/MATCHER.md
+++ b/docs/protocol/flows/MATCHER.md
@@ -15,7 +15,7 @@ The Matcher resolves entity mentions to concrete resources. Given a `GatheredCon
 
 The Matcher handles only the read side of resolution. Writing the chosen link (adding a `SpecificResource` body item to the annotation) is done by the Bind flow via `client.bind.body()`.
 
-## Using the API Client
+## Using the SDK
 
 `client.match.search()` returns an Observable of `MatchSearchProgress`
 — for the Matcher, that's a single final event containing scored
@@ -153,6 +153,6 @@ When `useSemanticScoring: true`, scores in the 25–49 range may shift significa
 
 - **Matcher actor**: [packages/make-meaning/src/matcher.ts](../../../packages/make-meaning/src/matcher.ts) — retrieval, structural scoring, inference re-ranking, referenced-by
 - **Bus gateway**: [apps/backend/src/routes/bus.ts](../../../apps/backend/src/routes/bus.ts) — `/bus/emit` + `/bus/subscribe`; the Matcher subscribes to `match:search-requested` on the EventBus
-- **API client**: `client.match.search()` in [@semiont/sdk](../../../packages/sdk/README.md) — Observable of scored results
+- **SDK**: `client.match.search()` in [@semiont/sdk](../../../packages/sdk/README.md) — Observable of scored results
 - **StateUnit**: [packages/sdk/src/state/flows/match-state-unit.ts](../../../packages/sdk/src/state/flows/match-state-unit.ts)
 - **Event definitions**: [packages/core/src/bus-protocol.ts](../../../packages/core/src/bus-protocol.ts) — `MATCH FLOW` section

--- a/docs/protocol/flows/YIELD.md
+++ b/docs/protocol/flows/YIELD.md
@@ -24,7 +24,7 @@ The Yield flow creates new resources from reference annotations (motivation: `li
 
 **Supported Formats**: Currently available for text-based formats (`text/plain`, `text/markdown`). Generated resources take the requested `outputMediaType`, defaulting to `text/markdown`; the worker rejects any media type outside `text/markdown` | `text/plain`. Support for generating from annotations in images and PDFs is planned for future releases
 
-## Using the API Client
+## Using the SDK
 
 Generation is a long-running job. `client.yield.fromAnnotation()`
 returns an Observable that emits `progress` events during LLM

--- a/docs/system/HUMAN-UI.md
+++ b/docs/system/HUMAN-UI.md
@@ -13,7 +13,7 @@ graph TB
     subgraph ui ["Human UI"]
         subgraph spa ["SPA (static)"]
             FE["React UI"]
-            API["API Client<br/>(RxJS)"]
+            API["SDK Client<br/>(RxJS)"]
             FE -->|RxJS| API
         end
 

--- a/docs/system/README.md
+++ b/docs/system/README.md
@@ -21,7 +21,7 @@ The deeper story splits across the docs below — each focused on one diagram an
 | Doc | What it covers |
 |---|---|
 | **[ACTOR-MODEL.md](ACTOR-MODEL.md)** | The actor topology, six actor categories (Reader, Analyst, Author, Marker, Generator, Linker), Feeder + content streams, and why human ↔ AI peer collaboration falls out of the design. *Diagram: actor topology.* |
-| **[HUMAN-UI.md](HUMAN-UI.md)** | The Semiont Browser SPA — Vite + React, state-unit split, RxJS API client, multi-KB session model. How human actors connect to the bus. *Diagram: SPA architecture.* |
+| **[HUMAN-UI.md](HUMAN-UI.md)** | The Semiont Browser SPA — Vite + React, state-unit split, RxJS SDK client, multi-KB session model. How human actors connect to the bus. *Diagram: SPA architecture.* |
 | **[KNOWLEDGE-SYSTEM.md](KNOWLEDGE-SYSTEM.md)** | The five reactive KB actors (Stower, Gatherer, Matcher, Browser, Smelter) that mediate every read and write to the knowledge base, plus the storage layout (event log, materialized views, content store, graph, vectors). *Diagram: knowledge system.* |
 | **[CONTAINER-TOPOLOGY.md](CONTAINER-TOPOLOGY.md)** | Multi-container deployment: how the four Semiont-code containers (frontend, backend, worker, smelter) and four infrastructure containers (postgres, neo4j, qdrant, ollama) fit together; the unified bus contract and `SemiontSession`; deployment platforms (POSIX / Container / AWS). *Diagram: container topology.* |
 | **[PACKAGE-ARCHITECTURE.md](PACKAGE-ARCHITECTURE.md)** | The workspace packages organized by layer (foundation → wire → SDK → AI → application logic), the actual `package.json` dependency graph, and the five architectural principles that govern dependency direction. *Diagram: layered package dependencies.* |

--- a/packages/core/src/__tests__/liveness-axioms.test.ts
+++ b/packages/core/src/__tests__/liveness-axioms.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Teeth for the liveness axioms (.plans/LIVENESS-AXIOMS.md, P1) — the same
+ * discipline as state-unit-axioms.test.ts: before the harness is trusted
+ * GREEN against real compositions (P2/P3), it must FAIL against
+ * deliberately-broken doubles reconstructing the pre-fix behaviors from the
+ * starvation incident (.plans/bugs/concurrent-browse-resource-starvation.md):
+ *
+ *   (a)  a no-retry cache double that swallows the rejection   → L2 (swallow)
+ *   (a2) an unbounded-retry variant                            → L2 (budget)
+ *   (a3) a swallow-into-pending-forever await variant          → L2 (settlement)
+ *   (b)  a throw-on-contention scope double                    → L1
+ *   (c)  an abort-at-handover connection double                → L3 (lost)
+ *   (c2) a double-flush connection double                      → L3 (duplicate)
+ *
+ * Plus the does-not-cry-wolf positives: compliant doubles (retry once +
+ * surface, degrade on contention, drain at handover) stay green across
+ * generated fault schedules, scope models, and op interleavings.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { Observable, Subject } from 'rxjs';
+import { busRequest } from '../bus-request';
+import { resourceId } from '../identifiers';
+import { FaultyTransport } from '../faulty-transport';
+import {
+  assertLivenessAxioms,
+  assertExactlyOnceDelivery,
+  type DeliveryOp,
+  type DeliverySubject,
+} from '../liveness-axioms';
+
+/** Small enough that a full drop→timeout→retry→timeout chain stays in ms. */
+const TIMEOUT_MS = 10;
+const OP = 'browse:resource-requested' as const;
+
+// ── L1/L2 doubles ─────────────────────────────────────────────────────────
+
+/**
+ * The FIXED composition, reconstructed: a cold live-query that starts its
+ * request on subscribe, degrades on scope contention (keeps fetching
+ * unscoped), retries a faulted request once (B14), and surfaces the final
+ * rejection as an error notification.
+ */
+function compliantQuery(transport: FaultyTransport, rid: string): Observable<unknown> {
+  return new Observable((subscriber) => {
+    try {
+      transport.subscribeToResource(resourceId(rid));
+    } catch {
+      // Contention → degrade: no scoped freshness, but the fetch proceeds.
+    }
+    const attempt = (retriesLeft: number): void => {
+      busRequest(transport, OP, { resourceId: rid }, TIMEOUT_MS)
+        .then((v) => subscriber.next(v))
+        .catch((err: unknown) => {
+          if (retriesLeft > 0) attempt(retriesLeft - 1);
+          else subscriber.error(err);
+        });
+    };
+    attempt(1);
+  });
+}
+
+/** (a) Pre-B14: the rejection is swallowed — no retry, no surfaced signal. */
+function swallowingQuery(transport: FaultyTransport, rid: string): Observable<unknown> {
+  return new Observable((subscriber) => {
+    busRequest(transport, OP, { resourceId: rid }, TIMEOUT_MS)
+      .then((v) => subscriber.next(v))
+      .catch(() => { /* swallowed — the pre-fix catch(() => {}) */ });
+  });
+}
+
+/** (a2) Retry storm: re-issues far past the sanctioned budget, then surfaces. */
+function stormingQuery(transport: FaultyTransport, rid: string): Observable<unknown> {
+  return new Observable((subscriber) => {
+    const attempt = (issued: number): void => {
+      busRequest(transport, OP, { resourceId: rid }, TIMEOUT_MS)
+        .then((v) => subscriber.next(v))
+        .catch((err: unknown) => {
+          if (issued < 6) attempt(issued + 1);
+          else subscriber.error(err);
+        });
+    };
+    attempt(1);
+  });
+}
+
+/** (b) Pre-fix scope handling: the contention throw is swallowed into an
+ * unread error state and the fetch never happens — that output starves. */
+function contentionStarvedQuery(transport: FaultyTransport, rid: string): Observable<unknown> {
+  return new Observable((subscriber) => {
+    try {
+      transport.subscribeToResource(resourceId(rid));
+    } catch {
+      return; // swallowed; no request is ever issued
+    }
+    busRequest(transport, OP, { resourceId: rid }, TIMEOUT_MS)
+      .then((v) => subscriber.next(v))
+      .catch((err: unknown) => subscriber.error(err));
+  });
+}
+
+// ── L3 doubles ────────────────────────────────────────────────────────────
+
+/**
+ * A connection-stream double with buffered (asynchronous) delivery. The mode
+ * decides what a client-initiated transition does with the not-yet-delivered
+ * buffer: `drain` flushes it first (the fix), `abort` discards it (pre-linger
+ * defect 2), `duplicate` flushes every event twice (a dedup-failure stand-in).
+ */
+function connectionDouble(mode: 'drain' | 'abort' | 'duplicate'): DeliverySubject {
+  const out = new Subject<string>();
+  let buffer: string[] = [];
+  const flush = (): void => {
+    const pending = buffer;
+    buffer = [];
+    for (const id of pending) {
+      out.next(id);
+      if (mode === 'duplicate') out.next(id);
+    }
+  };
+  return {
+    write: (id) => { buffer.push(id); },
+    transition: () => {
+      if (mode === 'abort') buffer = []; // retire by abort: buffered events die
+      else flush(); // retire by drain
+    },
+    output$: out.asObservable(),
+    settle: async () => { flush(); }, // a live connection eventually delivers
+  };
+}
+
+// ── The teeth ─────────────────────────────────────────────────────────────
+
+describe('liveness axioms — the harness has teeth', () => {
+  it(
+    'passes a compliant retry-and-surface composition across generated schedules and both scope models (does not cry wolf)',
+    async () => {
+      await assertLivenessAxioms({
+        setup: (transport) => ({
+          outputs: ['res-a', 'res-b'].map((rid) => compliantQuery(transport, rid)),
+          // The await path: a caller that surfaces the rejection always settles.
+          settlements: [
+            busRequest(transport, OP, { resourceId: 'res-c' }, TIMEOUT_MS).catch(() => 'surfaced'),
+          ],
+        }),
+        timeoutMs: TIMEOUT_MS,
+        scopeModel: 'both',
+      });
+    },
+    30_000,
+  );
+
+  it('(a) L2: a no-retry double that swallows the rejection is caught', async () => {
+    await expect(
+      assertLivenessAxioms({
+        setup: (transport) => ({ outputs: [swallowingQuery(transport, 'res-a')] }),
+        timeoutMs: TIMEOUT_MS,
+        scheduleArb: fc.constant([{ kind: 'drop-reply' }] as const),
+        numRuns: 3,
+      }),
+    ).rejects.toThrow(/^L2: .*rejection swallowed/s);
+  });
+
+  it('(a2) L2: an unbounded-retry double exceeds the pinned budget', async () => {
+    await expect(
+      assertLivenessAxioms({
+        setup: (transport) => ({ outputs: [stormingQuery(transport, 'res-a')] }),
+        timeoutMs: TIMEOUT_MS,
+        scheduleArb: fc.constant([{ kind: 'drop-reply' }] as const),
+        numRuns: 3,
+      }),
+    ).rejects.toThrow(/^L2: .*exceeds the retry budget/s);
+  }, 15_000);
+
+  it('(a3) L2: an await path swallowed into pending-forever is caught', async () => {
+    await expect(
+      assertLivenessAxioms({
+        setup: (transport) => ({
+          outputs: [],
+          settlements: [
+            busRequest(transport, OP, { resourceId: 'res-a' }, TIMEOUT_MS)
+              // Pre-fix encoding of the forbidden fourth state: the rejection
+              // is converted into a promise that never settles.
+              .catch(() => new Promise(() => {})),
+          ],
+        }),
+        timeoutMs: TIMEOUT_MS,
+        scheduleArb: fc.constant([{ kind: 'drop-reply' }] as const),
+        numRuns: 3,
+      }),
+    ).rejects.toThrow(/^L2: [\s\S]*settlement #0 did not settle/);
+  });
+
+  it('(b) L1: a throw-on-contention double starves the second output', async () => {
+    await expect(
+      assertLivenessAxioms({
+        setup: (transport) => ({
+          outputs: ['res-a', 'res-b'].map((rid) => contentionStarvedQuery(transport, rid)),
+        }),
+        timeoutMs: TIMEOUT_MS,
+        scheduleArb: fc.constant([{ kind: 'deliver' }] as const),
+        scopeModel: 'single-slot-throw',
+        numRuns: 3,
+      }),
+    ).rejects.toThrow(/^L1: [\s\S]*output #1 [\s\S]*silently pending/);
+  });
+
+  it('(b-compliant) the same contention, degraded instead of swallowed, passes', async () => {
+    await assertLivenessAxioms({
+      setup: (transport) => ({
+        outputs: ['res-a', 'res-b'].map((rid) => compliantQuery(transport, rid)),
+      }),
+      timeoutMs: TIMEOUT_MS,
+      scheduleArb: fc.constant([{ kind: 'deliver' }] as const),
+      scopeModel: 'single-slot-throw',
+      numRuns: 3,
+    });
+  });
+
+  it('passes a drain-at-transition connection across generated interleavings (does not cry wolf)', async () => {
+    await assertExactlyOnceDelivery({
+      setup: () => connectionDouble('drain'),
+    });
+  });
+
+  it('(c) L3: an abort-at-transition double loses the buffered event', async () => {
+    await expect(
+      assertExactlyOnceDelivery({
+        setup: () => connectionDouble('abort'),
+        opsArb: fc.constant(['write', 'transition'] as const satisfies readonly DeliveryOp[]),
+        numRuns: 3,
+      }),
+    ).rejects.toThrow(/^L3: .*delivered 0 times.*lost across a transition/s);
+  });
+
+  it('(c2) L3: a double-flush double is caught as duplicate delivery', async () => {
+    await expect(
+      assertExactlyOnceDelivery({
+        setup: () => connectionDouble('duplicate'),
+        opsArb: fc.constant(['write'] as const satisfies readonly DeliveryOp[]),
+        numRuns: 3,
+      }),
+    ).rejects.toThrow(/^L3: .*delivered 2 times.*duplicate/s);
+  });
+});

--- a/packages/core/src/bus-request.ts
+++ b/packages/core/src/bus-request.ts
@@ -124,11 +124,20 @@ export async function busRequest<Op extends BusOperationKey>(
   // (which can happen with an in-process LocalTransport bus).
   const resultPromise = firstValueFrom(result$);
 
-  // No guard around emit: an emit rejection propagates to the caller
-  // naturally, and `result$`'s `defaultIfEmpty` guarantees `resultPromise`
-  // *resolves* (never rejects) when the bus is disposed before a reply — so it
-  // cannot leak an unhandled rejection regardless of whether anyone awaits it.
-  await bus.emit(operation as keyof EventMap, fullPayload as EventMap[keyof EventMap]);
+  // An emit rejection (e.g. /bus/emit 4xx) propagates to the caller — but the
+  // caller then never awaits `resultPromise`, which is already subscribed and
+  // will REJECT with `bus.timeout` at `timeoutMs` (the request never left, so
+  // no reply can save it). Detach it before rethrowing so the doomed promise
+  // can't surface later as an unhandled rejection. (`defaultIfEmpty` covers
+  // only the disposed-bus case, where the stream completes and the promise
+  // *resolves* `bus.closed`.) Found by the liveness harness's reject-emit
+  // schedules (.plans/LIVENESS-AXIOMS.md, P1).
+  try {
+    await bus.emit(operation as keyof EventMap, fullPayload as EventMap[keyof EventMap]);
+  } catch (emitError) {
+    resultPromise.catch(() => {});
+    throw emitError;
+  }
 
   const result = await resultPromise;
   if (!result.ok) {

--- a/packages/core/src/faulty-transport.ts
+++ b/packages/core/src/faulty-transport.ts
@@ -1,0 +1,231 @@
+/**
+ * FaultyTransport — a seeded, scriptable `ITransport` simulator for the
+ * liveness axioms (`.plans/LIVENESS-AXIOMS.md`). fast-check draws a fault
+ * schedule; the transport applies one `FaultAction` per request-channel emit
+ * and synthesizes replies from the `BUS_OPERATIONS` registry, so real
+ * compositions (`busRequest`, SWR caches, live queries) run unmodified against
+ * generated wire behavior no hand-written test names.
+ *
+ * Home is core (not sdk/test-utils) for the same reason as
+ * `assertStateUnitAxioms`: it needs only core types, and every layer —
+ * including `http-transport`, below sdk — can consume it via
+ * `@semiont/core/testing` without a dependency cycle.
+ *
+ * Deterministic-by-construction: no `Date.now`, no randomness of its own —
+ * all variation comes in through the schedule (fast-check owns the seed).
+ * Time is real `setTimeout` at millisecond scale; properties pass a small
+ * explicit `timeoutMs` to `busRequest`, so nothing waits 30 s.
+ */
+
+import { BehaviorSubject, Subject, type Observable } from 'rxjs';
+import type { SemiontError } from './errors';
+import type { BaseUrl } from './branded-types';
+import { baseUrl as makeBaseUrl } from './branded-types';
+import type { ResourceId } from './identifiers';
+import type { EventMap } from './bus-protocol';
+import type { ConnectionState, ITransport } from './transport';
+import { EventBus } from './event-bus';
+import { BRIDGED_CHANNELS } from './bridged-channels';
+import { BUS_OPERATIONS, type BusOperationKey } from './bus-operations';
+
+/** One wire behavior, applied to a single request-channel emit. */
+export type FaultAction =
+  | { kind: 'deliver' }
+  | { kind: 'drop-reply' }
+  | { kind: 'delay'; ms: number }
+  | { kind: 'duplicate-reply' }
+  | { kind: 'reject-emit' };
+
+/**
+ * Scope-contention behavior of `subscribeToResource`:
+ * `single-slot-throw` mirrors today's HttpTransport (one distinct scope at a
+ * time; a second distinct scope throws); `multi` mirrors the
+ * post-MULTI-RESOURCE-SCOPE world. The same properties run under both so the
+ * migration can't silently change liveness behavior.
+ */
+export type ScopeModel = 'single-slot-throw' | 'multi';
+
+/** requestLog entry — one per request-channel emit, in arrival order. */
+export interface RequestLogEntry {
+  channel: BusOperationKey;
+  /** The action the schedule assigned to this emit. */
+  action: FaultAction;
+  correlationId: string | undefined;
+  /**
+   * Request identity for retry accounting: channel + payload minus the
+   * per-issue fields (`correlationId`, `_trace`, `_userId`). Two emits with
+   * the same key are the same logical request re-issued.
+   */
+  retryKey: string;
+}
+
+export interface FaultyTransportConfig {
+  /**
+   * The i-th request-channel emit applies `schedule[i % schedule.length]`.
+   * Empty/omitted → every request delivers.
+   */
+  schedule?: readonly FaultAction[];
+  /** Default `'single-slot-throw'` (today's HttpTransport). */
+  scopeModel?: ScopeModel;
+  /**
+   * Synthesize the `response` value for a delivered reply. Return `undefined`
+   * for a void ack (`{ correlationId }` only). Default: `{}` for every op.
+   */
+  makeResponse?: (operation: BusOperationKey, payload: Record<string, unknown>) => unknown;
+}
+
+function isOperation(channel: string): channel is BusOperationKey {
+  return channel in BUS_OPERATIONS;
+}
+
+/** Stable request identity: channel + sorted payload minus per-issue fields. */
+export function retryKeyOf(channel: string, payload: Record<string, unknown>): string {
+  const entries = Object.entries(payload)
+    .filter(([k]) => k !== 'correlationId' && k !== '_trace' && k !== '_userId')
+    .sort(([a], [b]) => (a < b ? -1 : 1));
+  return `${channel} ${JSON.stringify(entries)}`;
+}
+
+export class FaultyTransport implements ITransport {
+  readonly baseUrl: BaseUrl = makeBaseUrl('faulty://simulator');
+  readonly state$ = new BehaviorSubject<ConnectionState>('open');
+  private readonly errorsSubject = new Subject<SemiontError>();
+  readonly errors$: Observable<SemiontError> = this.errorsSubject.asObservable();
+
+  /** Every request-channel emit, in order — the L2 accounting surface. */
+  readonly requestLog: RequestLogEntry[] = [];
+
+  private readonly bus = new EventBus();
+  private readonly schedule: readonly FaultAction[];
+  private readonly scopeModel: ScopeModel;
+  private readonly makeResponse: (op: BusOperationKey, payload: Record<string, unknown>) => unknown;
+  private requestCount = 0;
+  private activeScope: string | null = null;
+  private scopeRefs = 0;
+  private readonly timers = new Set<ReturnType<typeof setTimeout>>();
+  private disposed = false;
+
+  constructor(cfg: FaultyTransportConfig = {}) {
+    this.schedule = cfg.schedule ?? [];
+    this.scopeModel = cfg.scopeModel ?? 'single-slot-throw';
+    this.makeResponse = cfg.makeResponse ?? (() => ({}));
+  }
+
+  // ── Bus primitives ──────────────────────────────────────────────────────
+
+  async emit<K extends keyof EventMap>(
+    channel: K,
+    payload: EventMap[K],
+    resourceScope?: ResourceId,
+  ): Promise<void> {
+    if (this.disposed) return;
+    const name = channel as string;
+    if (!isOperation(name)) {
+      // Non-request channel: forward as-is (scoped or global).
+      const target = resourceScope === undefined
+        ? this.bus.get(channel)
+        : this.bus.scope(resourceScope as string).get(channel);
+      target.next(payload);
+      return;
+    }
+
+    const record = payload as Record<string, unknown>;
+    const action: FaultAction = this.schedule.length === 0
+      ? { kind: 'deliver' }
+      : this.schedule[this.requestCount % this.schedule.length]!;
+    this.requestCount += 1;
+    this.requestLog.push({
+      channel: name,
+      action,
+      correlationId: typeof record.correlationId === 'string' ? record.correlationId : undefined,
+      retryKey: retryKeyOf(name, record),
+    });
+
+    if (action.kind === 'reject-emit') {
+      // Models a /bus/emit 4xx: the request never reaches the bus.
+      throw new Error(`FaultyTransport: emit rejected by schedule (reject-emit) on ${name}`);
+    }
+
+    // The request itself is observable (handlers-eye view), then the
+    // simulator plays backend: synthesize the registry reply per the action.
+    this.bus.get(channel).next(payload);
+
+    const reply = (): void => {
+      if (this.disposed) return;
+      const response = this.makeResponse(name, record);
+      const replyPayload = response === undefined
+        ? { correlationId: record.correlationId }
+        : { correlationId: record.correlationId, response };
+      const resultChannel = BUS_OPERATIONS[name].result as keyof EventMap;
+      this.bus.get(resultChannel).next(replyPayload as EventMap[keyof EventMap]);
+    };
+
+    switch (action.kind) {
+      case 'deliver':
+        queueMicrotask(reply);
+        break;
+      case 'duplicate-reply':
+        queueMicrotask(reply);
+        queueMicrotask(reply);
+        break;
+      case 'delay': {
+        const t = setTimeout(() => { this.timers.delete(t); reply(); }, action.ms);
+        this.timers.add(t);
+        break;
+      }
+      case 'drop-reply':
+        break;
+    }
+  }
+
+  on<K extends keyof EventMap>(channel: K, handler: (payload: EventMap[K]) => void): () => void {
+    const sub = this.bus.get(channel).subscribe(handler);
+    return () => sub.unsubscribe();
+  }
+
+  stream<K extends keyof EventMap>(channel: K): Observable<EventMap[K]> {
+    return this.bus.get(channel);
+  }
+
+  subscribeToResource(rid: ResourceId): () => void {
+    const scope = rid as string;
+    if (this.scopeModel === 'single-slot-throw' && this.activeScope !== null && this.activeScope !== scope) {
+      // Mirrors HttpTransport's one-distinct-scope-at-a-time contention throw.
+      throw new Error(
+        `FaultyTransport: scope slot busy (${this.activeScope}); ` +
+        `unsubscribe before subscribing to ${scope} (scopeModel=single-slot-throw)`,
+      );
+    }
+    this.activeScope = this.activeScope ?? scope;
+    this.scopeRefs += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.scopeRefs -= 1;
+      if (this.scopeRefs === 0) this.activeScope = null;
+    };
+  }
+
+  bridgeInto(bus: EventBus): void {
+    for (const channel of BRIDGED_CHANNELS) {
+      this.bus.get(channel as keyof EventMap).subscribe((payload) => {
+        bus.get(channel as keyof EventMap).next(payload as EventMap[keyof EventMap]);
+      });
+    }
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────────────────
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const t of this.timers) clearTimeout(t);
+    this.timers.clear();
+    this.state$.next('closed');
+    this.state$.complete();
+    this.errorsSubject.complete();
+    // Completes every subject: in-flight busRequests resolve `bus.closed`.
+    this.bus.destroy();
+  }
+}

--- a/packages/core/src/liveness-axioms.ts
+++ b/packages/core/src/liveness-axioms.ts
@@ -1,0 +1,340 @@
+/**
+ * Executable enforcement of the liveness axioms — the runtime twin of
+ * `.plans/LIVENESS-AXIOMS.md`, and the composition-level sibling of
+ * `assertStateUnitAxioms` (state-unit-axioms.ts). Where the StateUnit axioms
+ * make *per-unit* wrongness mechanically detectable, these make *silence*
+ * detectable: every existing enforcement tier is safety (nothing wrong is
+ * delivered); these assert liveness (something is eventually delivered).
+ *
+ * Axioms (fault-schedule dimension; fast-check):
+ *   L1  Subscriber liveness — every output emits next|error within the bound,
+ *       under any fault schedule. Error is a permitted outcome; the forbidden
+ *       fourth state is pending-forever.
+ *   L2  Request settlement — every awaited path settles within the bound;
+ *       re-issues per logical request stay within the retry budget (B14: one);
+ *       a faulted request must be re-issued or surfaced, never swallowed.
+ *   L3  Delivery across lifecycle transitions — every event written to a live
+ *       connection reaches the output exactly once, wherever a client-initiated
+ *       transition (handover / reconnect / scope change) lands. Retirement is
+ *       by drain, never by abort (TRANSPORT-HTTP.md, Abort discipline).
+ *
+ * Framework-agnostic on purpose — only `rxjs` + `fast-check`, no `vitest` — so
+ * it ships through `@semiont/core/testing` and any package's test runner can
+ * invoke it. Deterministic virtual time: properties pass a small explicit
+ * `timeoutMs` to `busRequest`; no `Date.now`, no 30 s real waits.
+ */
+
+import * as fc from 'fast-check';
+import type { Observable, Subscription } from 'rxjs';
+import { FaultyTransport, type FaultAction, type ScopeModel } from './faulty-transport';
+
+// ── L1/L2: liveness over a composition on FaultyTransport ────────────────
+
+/** What one fresh run of the composition exposes to the axioms. */
+export interface LivenessScenario {
+  /**
+   * Live-query-shaped outputs. The harness subscribes each one; every
+   * subscription must see `next` or `error` within the bound (L1).
+   */
+  outputs: readonly Observable<unknown>[];
+  /**
+   * Awaited paths. Each promise must settle — resolve or reject — within the
+   * bound (L2). Rejections are fine; pending-forever is the violation.
+   */
+  settlements?: readonly Promise<unknown>[];
+  teardown?: () => void;
+}
+
+export interface LivenessAxiomSpec {
+  /** Build a FRESH composition wired to the given transport. Called per run. */
+  setup: (transport: FaultyTransport) => LivenessScenario | Promise<LivenessScenario>;
+  /**
+   * The timeoutMs the scenario passes to `busRequest` — the bound is derived
+   * from it: (timeoutMs × (1 + retryBudget) + Σdelays) × slackFactor.
+   */
+  timeoutMs: number;
+  /** Max sanctioned re-issues per logical request (B14 budget). Default 1. */
+  retryBudget?: number;
+  /** Override the generated fault schedules (teeth tests pin one). */
+  scheduleArb?: fc.Arbitrary<readonly FaultAction[]>;
+  /** Scope model(s) to run under. Default `'single-slot-throw'`. */
+  scopeModel?: ScopeModel | 'both';
+  /** Passed through to FaultyTransport (reply synthesis). */
+  makeResponse?: (operation: string, payload: Record<string, unknown>) => unknown;
+  /** fast-check run budget (default 25 — CI-fast; crank locally). */
+  numRuns?: number;
+  /** Real-scheduler jitter headroom on the bound (default 4×). */
+  slackFactor?: number;
+}
+
+/** The five wire behaviors, uniformly weighted; delays stay small (≤5 ms). */
+export function arbFaultAction(): fc.Arbitrary<FaultAction> {
+  return fc.oneof(
+    fc.constant<FaultAction>({ kind: 'deliver' }),
+    fc.constant<FaultAction>({ kind: 'drop-reply' }),
+    fc.integer({ min: 0, max: 5 }).map((ms): FaultAction => ({ kind: 'delay', ms })),
+    fc.constant<FaultAction>({ kind: 'duplicate-reply' }),
+    fc.constant<FaultAction>({ kind: 'reject-emit' }),
+  );
+}
+
+export function arbFaultSchedule(maxLength = 8): fc.Arbitrary<readonly FaultAction[]> {
+  return fc.array(arbFaultAction(), { minLength: 1, maxLength });
+}
+
+function describeSchedule(schedule: readonly FaultAction[]): string {
+  return schedule.map((a) => (a.kind === 'delay' ? `delay(${a.ms})` : a.kind)).join(',');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Sibling of state-unit-axioms' `run`, adapted for properties that check more
+ * than one axiom: fast-check's falsification message carries the seed and
+ * counterexample but not the thrown axiom id (fc v4 moves the inner error to
+ * `cause`), so the property captures its own labeled violation into `slot`
+ * and the wrapper re-throws with the axiom id leading and fc's detail after.
+ */
+async function runLabeled(
+  fallback: string,
+  slot: { violation: Error | null },
+  assertion: () => Promise<void>,
+): Promise<void> {
+  try {
+    await assertion();
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    if (slot.violation) throw new Error(`${slot.violation.message}\n${detail}`);
+    throw new Error(`${fallback}: ${detail}`);
+  }
+}
+
+/** Wrap a check block so its labeled throw lands in `slot` before falsifying. */
+function capturing(slot: { violation: Error | null }, block: () => void): void {
+  try {
+    block();
+  } catch (e) {
+    slot.violation = e instanceof Error ? e : new Error(String(e));
+    throw e;
+  }
+}
+
+/**
+ * Run L1 + L2 against `spec` across generated fault schedules. Throws a
+ * labeled Error (`L1: …` / `L2: …`) on the first violation.
+ */
+export async function assertLivenessAxioms(spec: LivenessAxiomSpec): Promise<void> {
+  const retryBudget = spec.retryBudget ?? 1;
+  const slack = spec.slackFactor ?? 4;
+  const scheduleArb = spec.scheduleArb ?? arbFaultSchedule();
+  const scopeArb: fc.Arbitrary<ScopeModel> =
+    spec.scopeModel === 'both'
+      ? fc.constantFrom<ScopeModel>('single-slot-throw', 'multi')
+      : fc.constant(spec.scopeModel ?? 'single-slot-throw');
+
+  const slot = { violation: null as Error | null };
+  await runLabeled('liveness', slot, () =>
+    fc.assert(
+      fc.asyncProperty(scheduleArb, scopeArb, async (schedule, scopeModel) => {
+        const delayTotal = schedule.reduce((n, a) => n + (a.kind === 'delay' ? a.ms : 0), 0);
+        const bound = (spec.timeoutMs * (1 + retryBudget) + delayTotal) * slack;
+        const transport = new FaultyTransport({
+          schedule,
+          scopeModel,
+          ...(spec.makeResponse ? { makeResponse: spec.makeResponse } : {}),
+        });
+        const scenario = await spec.setup(transport);
+        const outputs = scenario.outputs;
+        const settlements = scenario.settlements ?? [];
+
+        // Subscribe every output (that's what makes a live query live) and
+        // track notifications; track settlement of every awaited path.
+        const notified: boolean[] = outputs.map(() => false);
+        const settled: boolean[] = settlements.map(() => false);
+        let doneResolve: () => void = () => {};
+        const allDone = new Promise<void>((resolve) => { doneResolve = resolve; });
+        const check = (): void => {
+          if (notified.every(Boolean) && settled.every(Boolean)) doneResolve();
+        };
+        const subs: Subscription[] = outputs.map((o, i) =>
+          o.subscribe({
+            next: () => { notified[i] = true; check(); },
+            error: () => { notified[i] = true; check(); },
+          }),
+        );
+        settlements.forEach((p, i) => {
+          p.then(() => { settled[i] = true; check(); },
+                 () => { settled[i] = true; check(); });
+        });
+        check();
+
+        // Wait for full liveness or the bound, whichever first.
+        await Promise.race([allDone, sleep(bound)]);
+
+        try {
+          // L2 first: when it applies it names the mechanism (swallow, budget,
+          // unsettled await); L1 below is the broader every-output net. All-
+          // outputs-silent is a subset of any-output-silent, so checking L1
+          // first would shadow the sharper L2 diagnoses entirely.
+          capturing(slot, () => {
+            // L2 — settlement: every awaited path settled.
+            settled.forEach((seen, i) => {
+              if (!seen) {
+                throw new Error(
+                  `L2: settlement #${i} did not settle within ${bound}ms ` +
+                  `under schedule ⟨${describeSchedule(schedule)}⟩ — the forbidden fourth state`,
+                );
+              }
+            });
+
+            // L2 — retry accounting over the transport's request log.
+            const issues = new Map<string, { count: number; lastFaulted: boolean }>();
+            for (const entry of transport.requestLog) {
+              const prior = issues.get(entry.retryKey) ?? { count: 0, lastFaulted: false };
+              issues.set(entry.retryKey, {
+                count: prior.count + 1,
+                lastFaulted: entry.action.kind === 'drop-reply' || entry.action.kind === 'reject-emit',
+              });
+            }
+            for (const [key, { count, lastFaulted }] of issues) {
+              if (count > 1 + retryBudget) {
+                throw new Error(
+                  `L2: request ⟨${key}⟩ issued ${count} times — exceeds the retry budget ` +
+                  `(1 + ${retryBudget}) under schedule ⟨${describeSchedule(schedule)}⟩`,
+                );
+              }
+              // Swallow detection: the final issue of a logical request was
+              // faulted, the composition had retry budget left but didn't use
+              // it, and no output surfaced anything — the rejection went into
+              // a void (the pre-B14 `catch(() => {})`).
+              if (lastFaulted && count <= retryBudget && outputs.length > 0 && !notified.some(Boolean)) {
+                throw new Error(
+                  `L2: faulted request ⟨${key}⟩ was neither re-issued nor surfaced ` +
+                  `under schedule ⟨${describeSchedule(schedule)}⟩ — rejection swallowed`,
+                );
+              }
+            }
+
+            // L1 — every subscription saw next|error; pending-forever is the bug.
+            notified.forEach((seen, i) => {
+              if (!seen) {
+                throw new Error(
+                  `L1: output #${i} received no next/error within ${bound}ms ` +
+                  `under schedule ⟨${describeSchedule(schedule)}⟩ (scope=${scopeModel}) — silently pending`,
+                );
+              }
+            });
+          });
+        } finally {
+          subs.forEach((s) => s.unsubscribe());
+          scenario.teardown?.();
+          transport.dispose();
+        }
+      }),
+      { numRuns: spec.numRuns ?? 25 },
+    ),
+  );
+}
+
+// ── L3: exactly-once delivery across client-initiated transitions ────────
+
+/**
+ * A connection-stream-shaped subject: something that accepts writes to the
+ * live connection, can be told to transition (handover / reconnect / scope
+ * change), and exposes the subscriber-facing output. P3 adapts the real
+ * actor's mock-connection harness to this shape; the teeth tests drive
+ * reconstructed pre-fix doubles.
+ */
+export interface DeliverySubject {
+  /** Write the event with this id to the currently-live connection. */
+  write: (eventId: string) => void;
+  /** Client-initiated lifecycle transition. */
+  transition: () => void | Promise<void>;
+  /** Subscriber-facing output; each emission is a delivered event id. */
+  output$: Observable<string>;
+  /**
+   * Drain pending asynchronous delivery at end of sequence (a live connection
+   * eventually flushes). Default: one macrotask tick.
+   */
+  settle?: () => Promise<void>;
+  teardown?: () => void;
+}
+
+export type DeliveryOp = 'write' | 'transition';
+
+export interface DeliveryAxiomSpec {
+  /** Build a FRESH subject. Called per run. */
+  setup: () => DeliverySubject;
+  /** Override the generated op sequences (teeth tests pin one). */
+  opsArb?: fc.Arbitrary<readonly DeliveryOp[]>;
+  /** Max generated sequence length (default 12). */
+  maxOps?: number;
+  /** fast-check run budget (default 50 — these runs are cheap). */
+  numRuns?: number;
+}
+
+export function arbDeliveryOps(maxOps = 12): fc.Arbitrary<readonly DeliveryOp[]> {
+  return fc
+    .array(fc.constantFrom<DeliveryOp>('write', 'transition'), { minLength: 1, maxLength: maxOps })
+    // A sequence with no write asserts nothing — always exercise delivery.
+    .map((ops) => (ops.includes('write') ? ops : ([...ops, 'write'] as const)));
+}
+
+/**
+ * Run L3 against `spec` across generated write/transition interleavings.
+ * Throws a labeled Error (`L3: …`) on the first violation: an event written
+ * to a live connection delivered zero times (lost — retired by abort instead
+ * of drain) or more than once (duplicate).
+ */
+export async function assertExactlyOnceDelivery(spec: DeliveryAxiomSpec): Promise<void> {
+  const opsArb = spec.opsArb ?? arbDeliveryOps(spec.maxOps ?? 12);
+
+  const slot = { violation: null as Error | null };
+  await runLabeled('L3', slot, () =>
+    fc.assert(
+      fc.asyncProperty(opsArb, async (ops) => {
+        const subject = spec.setup();
+        const delivered: string[] = [];
+        const sub = subject.output$.subscribe((id) => delivered.push(id));
+        const written: string[] = [];
+        try {
+          for (let i = 0; i < ops.length; i++) {
+            if (ops[i] === 'write') {
+              const id = `e${i}`;
+              written.push(id);
+              subject.write(id);
+            } else {
+              await subject.transition();
+            }
+            // Deliberately no settling between ops: the interesting races are
+            // transitions landing before a write's asynchronous delivery.
+          }
+          await (subject.settle?.() ?? sleep(0));
+
+          capturing(slot, () => {
+            for (const id of written) {
+              const n = delivered.filter((d) => d === id).length;
+              if (n === 0) {
+                throw new Error(
+                  `L3: event ⟨${id}⟩ delivered 0 times under ⟨${ops.join(',')}⟩ — ` +
+                  `lost across a transition (retire by drain, never by abort)`,
+                );
+              }
+              if (n > 1) {
+                throw new Error(
+                  `L3: event ⟨${id}⟩ delivered ${n} times under ⟨${ops.join(',')}⟩ — duplicate delivery`,
+                );
+              }
+            }
+          });
+        } finally {
+          sub.unsubscribe();
+          subject.teardown?.();
+        }
+      }),
+      { numRuns: spec.numRuns ?? 50 },
+    ),
+  );
+}

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -1,11 +1,13 @@
 /**
- * `@semiont/core/testing` — test-only utilities for verifying the StateUnit
- * pattern across packages. Not part of the runtime surface; consumers import it
- * from their test suites and must have `fast-check` in their own devDependencies.
+ * `@semiont/core/testing` — test-only utilities for verifying cross-package
+ * invariants. Not part of the runtime surface; consumers import it from their
+ * test suites and must have `fast-check` in their own devDependencies.
  *
  * Lives in core (not sdk) so every layer — including `http-transport`, which is
- * below sdk — can share one harness without dependency cycles. See
- * `.plans/STATE-UNIT-AXIOMS.md` for the axiom ledger.
+ * below sdk — can share one harness without dependency cycles. Two axiom
+ * families: the StateUnit axioms (`.plans/STATE-UNIT-AXIOMS.md`, per-unit
+ * safety) and the liveness axioms (`.plans/LIVENESS-AXIOMS.md`,
+ * composition-level liveness over `FaultyTransport`).
  */
 export {
   assertStateUnitAxioms,
@@ -13,3 +15,25 @@ export {
   type StateUnitAxiomSpec,
   type DisposeProbe,
 } from './state-unit-axioms';
+
+export {
+  FaultyTransport,
+  retryKeyOf,
+  type FaultAction,
+  type ScopeModel,
+  type FaultyTransportConfig,
+  type RequestLogEntry,
+} from './faulty-transport';
+
+export {
+  assertLivenessAxioms,
+  assertExactlyOnceDelivery,
+  arbFaultAction,
+  arbFaultSchedule,
+  arbDeliveryOps,
+  type LivenessScenario,
+  type LivenessAxiomSpec,
+  type DeliverySubject,
+  type DeliveryOp,
+  type DeliveryAxiomSpec,
+} from './liveness-axioms';

--- a/packages/http-transport/docs/MEDIA-TOKENS.md
+++ b/packages/http-transport/docs/MEDIA-TOKENS.md
@@ -40,7 +40,8 @@ const url = `${client.baseUrl}/api/resources/${resourceId}?token=${token}`;
 ```typescript
 import { useMediaToken } from '@semiont/react-ui';
 
-const { token, loading } = useMediaToken(resourceId);
+// Takes the SemiontClient explicitly; pass null to skip fetching.
+const { token, loading } = useMediaToken(client, resourceId);
 ```
 
 - The hook fetches a token on mount and then refreshes it every 4 minutes via `setInterval` — ahead of the 5-minute expiry. The 1-minute margin absorbs clock skew and request latency so a fetch in flight when the token rolls over still completes against a valid token.
@@ -53,7 +54,7 @@ const { token, loading } = useMediaToken(resourceId);
 
 ```
 ResourceViewerPage
-  → useMediaToken(resourceId)
+  → useMediaToken(client, resourceId)
       → POST /api/tokens/media  (Bearer auth, once per 4 min)
       → { token }
   → resourceUrl = `${baseUrl}/api/resources/${id}?token=${token}`

--- a/packages/http-transport/src/transport/__tests__/actor-liveness.property.test.ts
+++ b/packages/http-transport/src/transport/__tests__/actor-liveness.property.test.ts
@@ -19,8 +19,11 @@
  * The hand-written linger/dedup tests in actor-state-unit.test.ts stay as
  * readable anchors; this property adds the interleavings nobody named.
  *
- * P4 note: `[bus LINGER]` breadcrumbs are silenced here with a console.debug
- * spy; P4 flips that spy into the L4 assertion (degradation ⇒ ≥1 breadcrumb).
+ * L4 (P4): the property describe silences `[bus LINGER]` (bursty, expected);
+ * the dedicated L4 describe below asserts it — the gated breadcrumb fires for
+ * a superseded-connection delivery once `busLogEnabled()` is on
+ * (`globalThis.__SEMIONT_BUS_LOG__`, the existing switch), on the
+ * deterministic linger-drain scenario borrowed from the hand-written anchor.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fc from 'fast-check';
@@ -193,5 +196,66 @@ describe('L3 — delivery across lifecycle transitions (liveness axioms P3)', ()
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ── L4 — observable degradation: the [bus LINGER] breadcrumb (liveness P4) ──
+
+describe('L4 — [bus LINGER] fires for a superseded-connection delivery', () => {
+  const busLogGlobal = globalThis as { __SEMIONT_BUS_LOG__?: boolean };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockFetch.mockReset();
+    // Recording spy — the assertion surface. The breadcrumb is gated behind
+    // busLogEnabled(); flip the existing runtime switch for this describe.
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    // The gate also turns on busLog's RECV/SSE lines — keep them off stdout.
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    busLogGlobal.__SEMIONT_BUS_LOG__ = true;
+  });
+
+  afterEach(() => {
+    delete busLogGlobal.__SEMIONT_BUS_LOG__;
+    vi.mocked(console.debug).mockRestore();
+    vi.mocked(console.log).mockRestore();
+  });
+
+  it('a drain-window delivery emits the breadcrumb — degradation is never silent', async () => {
+    // The linger-drain anchor scenario (actor-state-unit.test.ts): a reply
+    // written to the OLD socket around the handover, delivered while that
+    // connection is superseded and draining. L4 asserts the delivery leaves
+    // a forensic trace — the exact evidence the starvation incident's
+    // investigation lacked.
+    const c1 = mockConn();
+    const actor = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: [CHANNEL],
+    });
+    const received: unknown[] = [];
+    actor.on$(CHANNEL).subscribe((p) => received.push(p));
+    actor.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    const c2 = mockConn({ defer: true });
+    actor.addChannels(['mark:added'], 'res-l4');
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+
+    // Handover completes; c1 is now superseded, draining.
+    c2.open();
+    await new Promise((r) => setTimeout(r, 20));
+
+    c1.sse.push(sseChunkId(
+      'bus-event',
+      JSON.stringify({ channel: CHANNEL, payload: { correlationId: 'c-l4', response: {} } }),
+      `e-${CHANNEL}:c-l4`,
+    ));
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    const debugs = vi.mocked(console.debug).mock.calls.map((c) => String(c[0]));
+    expect(debugs.some((d) => d.includes(`[bus LINGER] ${CHANNEL} delivered on superseded connection`))).toBe(true);
+
+    actor.dispose();
   });
 });

--- a/packages/http-transport/src/transport/__tests__/actor-liveness.property.test.ts
+++ b/packages/http-transport/src/transport/__tests__/actor-liveness.property.test.ts
@@ -1,0 +1,197 @@
+/**
+ * L3 — delivery across lifecycle transitions — over the REAL actor
+ * (.plans/LIVENESS-AXIOMS.md, Phase 3).
+ *
+ * Property: every event written to a live connection's stream reaches `on$`
+ * subscribers exactly once, wherever a scope-change handover lands relative
+ * to the write. Retirement is by drain, never by handover abort
+ * (docs/protocol/TRANSPORT-HTTP.md, Abort discipline).
+ *
+ * Teeth before trust: the property is first proven to FAIL against a
+ * test-local double reconstructing the pre-fix behavior — defect 2 of the
+ * starvation bug (.plans/bugs/concurrent-browse-resource-starvation.md):
+ * a transition that errors the old stream immediately, so queued-but-unread
+ * frames are discarded by `ReadableStreamDefaultController.error()` — the
+ * exact byte-loss mechanism, reproduced at the stream level rather than
+ * P1's abstract buffer double. Only then is the property trusted green
+ * against the real `createActorStateUnit`.
+ *
+ * The hand-written linger/dedup tests in actor-state-unit.test.ts stay as
+ * readable anchors; this property adds the interleavings nobody named.
+ *
+ * P4 note: `[bus LINGER]` breadcrumbs are silenced here with a console.debug
+ * spy; P4 flips that spy into the L4 assertion (degradation ⇒ ≥1 breadcrumb).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fc from 'fast-check';
+import { Subject, map } from 'rxjs';
+import { assertExactlyOnceDelivery, type DeliverySubject, type DeliveryOp } from '@semiont/core/testing';
+import { createActorStateUnit } from '../actor-state-unit';
+import { mockFetch, mockConn, createSSEStream, sseChunkId } from './helpers/mock-conn';
+
+const CHANNEL = 'browse:resource-result';
+
+// ── The pre-fix double (teeth) ──────────────────────────────────────────────
+
+/**
+ * A minimal SSE read loop over the same ReadableStream mechanics the real
+ * actor uses. `transition()` errors the live stream immediately — the pre-fix
+ * abort, no drain. Because the glue issues consecutive ops synchronously, a
+ * `write` directly followed by a `transition` leaves its frame queued-but-
+ * unread, and `controller.error()` discards it: L3-lost, deterministically.
+ */
+function preFixAbortingConnection(): DeliverySubject {
+  const out = new Subject<string>();
+
+  function newConn() {
+    const sse = createSSEStream();
+    const reader = sse.stream.getReader();
+    const decoder = new TextDecoder();
+    void (async () => {
+      let buf = '';
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const frames = buf.split('\n\n');
+          buf = frames.pop() ?? '';
+          for (const frame of frames) {
+            const idLine = frame.split('\n').find((l) => l.startsWith('id: '));
+            if (idLine) out.next(idLine.slice(4));
+          }
+        }
+      } catch {
+        // Aborted — pre-fix semantics: whatever was queued is gone.
+      }
+    })();
+    return { sse };
+  }
+
+  let current = newConn();
+  return {
+    write: (id) => current.sse.push(sseChunkId('bus-event', '{}', id)),
+    transition: () => {
+      current.sse.error(new DOMException('Aborted', 'AbortError')); // abort, no drain
+      current = newConn();
+    },
+    output$: out.asObservable(),
+    settle: () => new Promise((r) => setTimeout(r, 10)),
+  };
+}
+
+// ── The real actor behind the DeliverySubject shape ─────────────────────────
+
+/**
+ * Adapts the real `createActorStateUnit` + the mockConn harness to
+ * `DeliverySubject`. Fake timers are mandatory: `RECONNECT_DEBOUNCE_MS` (100)
+ * and `LINGER_MS` (1000) are hardcoded, and fast-check runs many sequences.
+ *
+ * `write` pushes a deterministic-id frame to the newest OPENED connection —
+ * during an initiated-but-unopened handover that is the OLD connection,
+ * which is exactly the starvation race (results in flight on the old socket
+ * when the swap lands).
+ *
+ * `transition` alternates: initiate a handover (scope churn → debounced
+ * reconnect → deferred fetch, left unopened) / complete it (open the new
+ * connection). The alternation is what makes generated sequences place
+ * writes inside every phase of the handover window.
+ */
+function realActorSubject(): DeliverySubject {
+  mockFetch.mockReset();
+
+  const conns: ReturnType<typeof mockConn>[] = [];
+  let liveIdx = 0; // newest OPENED connection
+  let pendingIdx: number | null = null; // initiated handover, not yet open
+  let churn = 0;
+
+  conns.push(mockConn()); // conn 0 opens as soon as the actor connects
+  const actor = createActorStateUnit({
+    baseUrl: 'http://localhost:4000',
+    token: 'tok',
+    channels: [CHANNEL],
+  });
+  actor.start();
+
+  return {
+    write: (id) => {
+      conns[liveIdx].sse.push(
+        sseChunkId('bus-event', JSON.stringify({ channel: CHANNEL, payload: { id } }), `e-test:${id}`),
+      );
+    },
+    transition: async () => {
+      if (pendingIdx !== null) {
+        // Complete the in-flight handover: the new connection opens; the old
+        // one is superseded and lingers (drains) until LINGER_MS.
+        conns[pendingIdx].open();
+        liveIdx = pendingIdx;
+        pendingIdx = null;
+        await vi.advanceTimersByTimeAsync(5); // let the new read loop attach
+      } else {
+        // Initiate a handover: scope churn schedules a debounced reconnect.
+        conns.push(mockConn({ defer: true }));
+        pendingIdx = conns.length - 1;
+        actor.addChannels(['mark:added'], `res-${churn++}`);
+        const before = mockFetch.mock.calls.length;
+        await vi.advanceTimersByTimeAsync(150); // past RECONNECT_DEBOUNCE_MS
+        if (mockFetch.mock.calls.length <= before) {
+          throw new Error('adapter: debounced reconnect did not issue a new fetch');
+        }
+      }
+    },
+    settle: async () => {
+      if (pendingIdx !== null) {
+        conns[pendingIdx].open();
+        liveIdx = pendingIdx;
+        pendingIdx = null;
+      }
+      // Flush deliveries (reads are microtask-driven; advancing interleaves
+      // them). Stays well below LINGER_MS so no linger abort races the flush.
+      await vi.advanceTimersByTimeAsync(50);
+    },
+    teardown: () => actor.dispose(),
+    output$: actor.on$<{ id: string }>(CHANNEL).pipe(map((p) => p.id)),
+  };
+}
+
+// ── The tests ───────────────────────────────────────────────────────────────
+
+describe('L3 — delivery across lifecycle transitions (liveness axioms P3)', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockFetch.mockReset();
+    // [bus LINGER] breadcrumbs fire on superseded-connection deliveries —
+    // expected under this property. P4 flips this spy into the L4 assertion.
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.mocked(console.debug).mockRestore();
+  });
+
+  it('teeth: the pre-fix abort-at-handover stream double trips L3-lost', async () => {
+    await expect(
+      assertExactlyOnceDelivery({
+        setup: preFixAbortingConnection,
+        // Pin the minimal losing interleaving (P1 teeth convention): the
+        // write's frame is queued when the abort lands.
+        opsArb: fc.constant(['write', 'write', 'transition'] as readonly DeliveryOp[]),
+        numRuns: 3,
+      }),
+    ).rejects.toThrow(/^L3: .*delivered 0 times.*retire by drain, never by abort/s);
+  });
+
+  it('holds over the real actor across generated write/handover interleavings', async () => {
+    vi.useFakeTimers();
+    try {
+      await assertExactlyOnceDelivery({
+        setup: realActorSubject,
+        maxOps: 10,
+        numRuns: 25,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
+++ b/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
@@ -2,77 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { createActorStateUnit } from '../actor-state-unit';
 import { assertStateUnitAxioms } from '@semiont/core/testing';
-
-const mockFetch = vi.fn();
-vi.stubGlobal('fetch', mockFetch);
-
-function sseChunk(event: string, data: string): string {
-  return `event: ${event}\ndata: ${data}\n\n`;
-}
-
-function sseChunkId(event: string, data: string, id: string): string {
-  return `event: ${event}\nid: ${id}\ndata: ${data}\n\n`;
-}
-
-function createSSEStream() {
-  let controller!: ReadableStreamDefaultController<Uint8Array>;
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream<Uint8Array>({
-    start(c) { controller = c; },
-  });
-  return {
-    stream,
-    // Swallow enqueue/close after the stream has errored or closed. Aborting a
-    // connection errors its stream; a test may still try to push to the now-
-    // retired connection, and that should be a no-op rather than a throw.
-    push: (text: string) => { try { controller.enqueue(encoder.encode(text)); } catch { /* errored/closed */ } },
-    close: () => { try { controller.close(); } catch { /* already errored/closed */ } },
-    error: (e: unknown) => { try { controller.error(e); } catch { /* already errored/closed */ } },
-  };
-}
-
-function mockSSEResponse() {
-  const sse = createSSEStream();
-  const response = {
-    ok: true,
-    status: 200,
-    body: sse.stream,
-  };
-  mockFetch.mockResolvedValueOnce(response);
-  return sse;
-}
-
-/**
- * A signal-honoring, optionally-deferred SSE connection mock. Unlike
- * `mockSSEResponse` (which ignores the abort signal), this errors its stream
- * when the connection's `AbortController` fires — faithfully reproducing how a
- * real `fetch(url, { signal })` cancels the response body. `defer: true` holds
- * the fetch promise unresolved until `open()` is called, so a test can observe
- * the window where a new connection is connecting-but-not-yet-open (the
- * make-before-break handoff). `aborted` reflects the captured signal.
- */
-function mockConn({ defer = false }: { defer?: boolean } = {}) {
-  const sse = createSSEStream();
-  let capturedSignal: AbortSignal | undefined;
-  let resolveFetch!: (r: unknown) => void;
-  const fetchPromise = new Promise((res) => { resolveFetch = res; });
-  const response = { ok: true, status: 200, body: sse.stream };
-  mockFetch.mockImplementationOnce((_url: string, opts: { signal?: AbortSignal }) => {
-    capturedSignal = opts.signal;
-    if (capturedSignal) {
-      capturedSignal.addEventListener('abort', () =>
-        sse.error(new DOMException('Aborted', 'AbortError')),
-      );
-    }
-    if (!defer) resolveFetch(response);
-    return fetchPromise;
-  });
-  return {
-    sse,
-    open: () => resolveFetch(response),
-    get aborted() { return capturedSignal?.aborted ?? false; },
-  };
-}
+// The SSE/fetch harness lives in helpers/mock-conn.ts (shared with the
+// liveness property suite). Importing it stubs the global fetch.
+import {
+  mockFetch,
+  sseChunk,
+  sseChunkId,
+  mockSSEResponse,
+  mockConn,
+} from './helpers/mock-conn';
 
 describe('createActorStateUnit', () => {
   beforeEach(() => {

--- a/packages/http-transport/src/transport/__tests__/helpers/mock-conn.ts
+++ b/packages/http-transport/src/transport/__tests__/helpers/mock-conn.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared SSE/fetch mocking harness for the actor-state-unit suites.
+ *
+ * Extracted verbatim from `actor-state-unit.test.ts` so the liveness
+ * property suite (`actor-liveness.property.test.ts`, LIVENESS-AXIOMS.md P3)
+ * can drive the same connection mechanics without duplicating them.
+ *
+ * Importing this module stubs the global `fetch` with `mockFetch`. vitest
+ * isolates the module registry per test file, so each suite gets its own
+ * `mockFetch` instance; reset it in your `beforeEach` (`mockReset()` — the
+ * `*Once` queues survive `clearAllMocks`).
+ */
+import { vi } from 'vitest';
+
+export const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+export function sseChunk(event: string, data: string): string {
+  return `event: ${event}\ndata: ${data}\n\n`;
+}
+
+export function sseChunkId(event: string, data: string, id: string): string {
+  return `event: ${event}\nid: ${id}\ndata: ${data}\n\n`;
+}
+
+export function createSSEStream() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { controller = c; },
+  });
+  return {
+    stream,
+    // Swallow enqueue/close after the stream has errored or closed. Aborting a
+    // connection errors its stream; a test may still try to push to the now-
+    // retired connection, and that should be a no-op rather than a throw.
+    push: (text: string) => { try { controller.enqueue(encoder.encode(text)); } catch { /* errored/closed */ } },
+    close: () => { try { controller.close(); } catch { /* already errored/closed */ } },
+    error: (e: unknown) => { try { controller.error(e); } catch { /* already errored/closed */ } },
+  };
+}
+
+export function mockSSEResponse() {
+  const sse = createSSEStream();
+  const response = {
+    ok: true,
+    status: 200,
+    body: sse.stream,
+  };
+  mockFetch.mockResolvedValueOnce(response);
+  return sse;
+}
+
+/**
+ * A signal-honoring, optionally-deferred SSE connection mock. Unlike
+ * `mockSSEResponse` (which ignores the abort signal), this errors its stream
+ * when the connection's `AbortController` fires — faithfully reproducing how a
+ * real `fetch(url, { signal })` cancels the response body. `defer: true` holds
+ * the fetch promise unresolved until `open()` is called, so a test can observe
+ * the window where a new connection is connecting-but-not-yet-open (the
+ * make-before-break handoff). `aborted` reflects the captured signal.
+ */
+export function mockConn({ defer = false }: { defer?: boolean } = {}) {
+  const sse = createSSEStream();
+  let capturedSignal: AbortSignal | undefined;
+  let resolveFetch!: (r: unknown) => void;
+  const fetchPromise = new Promise((res) => { resolveFetch = res; });
+  const response = { ok: true, status: 200, body: sse.stream };
+  mockFetch.mockImplementationOnce((_url: string, opts: { signal?: AbortSignal }) => {
+    capturedSignal = opts.signal;
+    if (capturedSignal) {
+      capturedSignal.addEventListener('abort', () =>
+        sse.error(new DOMException('Aborted', 'AbortError')),
+      );
+    }
+    if (!defer) resolveFetch(response);
+    return fetchPromise;
+  });
+  return {
+    sse,
+    open: () => resolveFetch(response),
+    get aborted() { return capturedSignal?.aborted ?? false; },
+  };
+}

--- a/packages/make-meaning/src/__tests__/local-transport.test.ts
+++ b/packages/make-meaning/src/__tests__/local-transport.test.ts
@@ -216,7 +216,14 @@ describe('SemiontClient over LocalTransport', () => {
         ).pipe(take(1));
         const observed = firstValueFrom(failed$);
 
-        h.client.browse.resource(makeResourceId('does-not-exist')).subscribe();
+        // B15 pin (CACHE-SEMANTICS / LIVENESS-AXIOMS): cache-backed observables
+        // can ERROR — a value-less key whose B14 retry exhausts pushes the
+        // terminal failure to observers. Without this handler, the push (which
+        // can land post-dispose as `bus.closed` when the retry straddles
+        // teardown) reaches RxJS reportUnhandledError and fails CI with all
+        // tests green (PR #946, run 28754440662). Same pin class as the sdk
+        // suite's pre-B15 handler-less subscriptions (LIVENESS-AXIOMS B15 log).
+        h.client.browse.resource(makeResourceId('does-not-exist')).subscribe({ error: () => {} });
 
         const ev = await observed;
         expect(ev.message).toBeTruthy();

--- a/packages/sdk/docs/CACHE-SEMANTICS.md
+++ b/packages/sdk/docs/CACHE-SEMANTICS.md
@@ -137,11 +137,16 @@ value, then the new value; never a transient `undefined`.
 
 ### B6 — Fetch failure leaves the previous state intact
 
-On failed fetch, the entry MUST NOT be cleared or marked with an
-error state. If the entry was previously `empty`, it remains
-`empty`. If it was previously `fresh`, it remains `fresh` with the
-stale value. The `fetching*` guard MUST be released in all cases
-(success, failure, cancellation) via the `finally` block.
+On failed fetch, the entry MUST NOT be cleared. If the entry was
+previously `fresh`, it remains `fresh` with the stale value
+(stale-beats-error). The `fetching*` guard MUST be released in all
+cases (success, failure, cancellation) via the `finally` block.
+
+Boundary: stale-beats-error presumes a stale value to serve. A
+previously-`empty` key stays `empty` through the B14 retry chain — but
+if that chain EXHAUSTS with the key still value-less, B15 applies: the
+terminal failure is surfaced to that key's observers as an error
+notification, not absorbed into eternal `undefined`.
 
 ### B7 — Invalidate is stale-while-revalidate
 
@@ -236,6 +241,35 @@ Boundaries:
    meantime (B3 dedup); it never duplicates.
 3. An invalidate during a retry chain disowns it (B9) — the chain's
    late success may still write (last-write-wins, same as B9).
+
+### B15 — Terminal failure of a value-less key errors its observers
+
+When the B14 retry ALSO fails and the key holds **no cached value**, the
+key is marked failed and the failure MUST be delivered to that key's
+observers as an **error notification** — never `undefined` forever:
+
+1. Subscribers attached at exhaustion time are errored (push).
+2. Subscribers attaching later see the same error (replay at subscribe
+   time), until an act clears the marker.
+3. The marker is cleared — and the key thereby returns to plain `empty`
+   — by `observe()` (which also starts a fresh attempt chain, so a
+   remount recovers), `invalidate`, `set`, `remove`, or any fetch
+   success. The error state is always retriable; nothing is latched.
+4. Keys WITH a cached value never come here — B6 stale-beats-error is
+   unchanged.
+5. An errored subscription is terminal (RxJS semantics); recovery
+   applies to subsequent subscriptions. This matches hook consumption:
+   a remount calls the live-query method again → fresh subscription.
+
+Rationale: liveness (`.plans/LIVENESS-AXIOMS.md`, axiom L1 — found by
+the P2 property suite as
+`.plans/bugs/valueless-key-terminal-failure-starves-observers.md`).
+B14 converted "reply lost" into one slow load when the retry succeeds;
+B15 covers the remaining corner — retry ALSO fails — where "idle" was
+indistinguishable from the pre-B14 permanent silent starvation for
+value-less keys. The `[cache IDLE]` breadcrumb (L4) is unchanged; B15
+adds the in-band signal consumers can actually react to
+(`useResourceLoader`'s `error` callback now fires).
 
 ## Bus-event-driven invalidation
 
@@ -434,3 +468,8 @@ changing a behavior must update both this doc and the test.
   per act). Part of the concurrent-browse-resource-starvation fix
   (ask 3): a lost one-shot reply must not permanently starve
   subscribers.
+- 2026-07-05 — B15 added (terminal failure of a value-less key errors
+  its observers, retriable); B6 narrowed to its true scope
+  (stale-beats-error requires a stale value). Driven by the
+  LIVENESS-AXIOMS P2 property suite falsifying L1/L2 against the real
+  composition (valueless-key-terminal-failure-starves-observers.md).

--- a/packages/sdk/docs/CACHE-SEMANTICS.md
+++ b/packages/sdk/docs/CACHE-SEMANTICS.md
@@ -85,7 +85,7 @@ Consequences:
 
 ## Two consumption paths
 
-The cache has two read paths with different freshness semantics, and B1–B13
+The cache has two read paths with different freshness semantics, and B1–B16
 below describe the **`observe` / subscribe** path (the stale-while-revalidate
 live view). The second path:
 
@@ -279,6 +279,41 @@ value-less keys. The `[cache IDLE]` breadcrumb (L4) is unchanged; B15
 adds the in-band signal consumers can actually react to
 (`useResourceLoader`'s `error` callback now fires).
 
+### B16 — Disposal is terminal and inert
+
+`dispose()` completes every per-key observable (subscribers receive
+`complete` and detach cleanly — `store$` AND `failure$`, the
+merge-completion edge), and stuns all later acts:
+
+1. Post-dispose `observe()` returns a stream that completes immediately
+   and issues NO fetch. `invalidate`/`invalidateAll`/`set`/`remove` are
+   no-ops. `fetch()` rejects (`Cache disposed`) without invoking the
+   fetch function — surfaced, not silent, since the await path's caller
+   owns retry policy (B14 boundary 1).
+2. A fetch/retry chain that STRADDLES disposal dies quietly at its next
+   resumption point: no B14 re-issue, no breadcrumb, no B15 push. The
+   `disposed` flag is checked at every async resumption, not just at
+   entry — and a late `failure$.next` would land on a completed subject
+   regardless (structural no-op, belt and braces).
+3. `dispose()` is idempotent.
+4. At the namespace level, `BrowseNamespace.dispose()` (called by
+   `SemiontClient.dispose()`) disposes all owned caches (A7-owned: it
+   constructed them) and detaches its bus-event subscriptions, so late
+   invalidation events cannot refetch into disposed caches.
+
+Rationale: a B14 retry straddling client teardown resolves `bus.closed`
+(`busRequest`'s disposed-bus path) — a teardown artifact, not a data
+failure. Pre-B16 the B15 push then errored observers at shutdown
+(disposal noise; it escaped as a flaky unhandled rejection in a
+make-meaning test — see `.plans/LIVENESS-AXIOMS.md`, the 2026-07-05 CI-escape
+entry). B16 makes the push structurally impossible after disposal
+instead of special-casing the `bus.closed` error code, which would have
+carved a silent exception into liveness axiom L1 (per its D1 binding:
+policy changes must edit the axiom visibly, not drift). L1 holds
+unconditionally: live client → terminal failures error observers (B15);
+disposed client → observers were completed at disposal, so none exist
+to starve.
+
 ## Bus-event-driven invalidation
 
 Cache entries are also invalidated by incoming bus events. The
@@ -461,7 +496,7 @@ once per `SemiontClient`.
 ## Test-parity
 
 A `cache-semantics.test.ts` in `packages/sdk/src/namespaces/__tests__/`
-asserts each of B1–B13 against the current implementation. Adding a
+asserts each of B1–B16 against the current implementation. Adding a
 new behavior here must be accompanied by a new test case referencing
 its number (`// B7 — invalidate preserves stale value`). Removing or
 changing a behavior must update both this doc and the test.

--- a/packages/sdk/docs/CACHE-SEMANTICS.md
+++ b/packages/sdk/docs/CACHE-SEMANTICS.md
@@ -242,6 +242,14 @@ Boundaries:
 3. An invalidate during a retry chain disowns it (B9) — the chain's
    late success may still write (last-write-wins, same as B9).
 
+Liveness: B14's one-retry budget is pinned by axioms **L1/L2**
+(`.plans/LIVENESS-AXIOMS.md`) — L2's settlement bound on the swallowed
+paths is `timeoutMs × (1 + this retry)`, enforced against the real
+`BrowseNamespace` + cache + `busRequest` composition by the property
+suite ([browse-liveness.property.test.ts](../src/__tests__/browse-liveness.property.test.ts)).
+Changing the retry count is a policy change that must edit L2's budget
+visibly, not drift past it.
+
 ### B15 — Terminal failure of a value-less key errors its observers
 
 When the B14 retry ALSO fails and the key holds **no cached value**, the

--- a/packages/sdk/docs/STATE-UNITS.md
+++ b/packages/sdk/docs/STATE-UNITS.md
@@ -202,11 +202,12 @@ A few specific shapes are wrong and worth calling out:
 
 The structural contract — `dispose()` exists — is the only part the **type system** catches. Everything else is enforced by an executable axiom suite plus CI compliance scripts (the runtime twin of this doc), with a residue of review-only conventions. The axiom ledger and FOPL specs live in [`.plans/STATE-UNIT-AXIOMS.md`](../../../.plans/STATE-UNIT-AXIOMS.md); the harness is `assertStateUnitAxioms` in `@semiont/core/testing`, invoked once from each state unit's test file.
 
-Four enforcement tiers:
+Five enforcement tiers:
 
 | Tier | Mechanism | Rules |
 |---|---|---|
 | **Axioms** — property-based (fast-check) | `assertStateUnitAxioms`, per unit | **A5** idempotent & total dispose · **A5b** post-dispose inertness · **A6** subscribers see `complete` · **X3-runtime** instance isolation |
+| **Liveness axioms** — property-based (fast-check), composition-level | `assertLivenessAxioms` / `assertExactlyOnceDelivery` from `@semiont/core/testing`, driving `FaultyTransport` (sdk) and the mock-conn SSE harness (http-transport); ledger in [`.plans/LIVENESS-AXIOMS.md`](../../../.plans/LIVENESS-AXIOMS.md) | **L1** subscriptions never silently pend forever · **L2** every `busRequest` settles within timeout × retry budget · **L3** exactly-once delivery across handovers (drain-over-abort) · **L4** degraded modes emit breadcrumbs |
 | **Structural assertions** — single-shot | `assertStateUnitAxioms`, per unit | **A1** plain-object identity · **X1** no raw origin Subject on the surface · **A7-passed** don't dispose injected deps · **A7-owned** do dispose constructed children |
 | **Static compliance** — CI grep (`scripts/compliance/`, run by `architecture-compliance.yml`) | bash + grep | **A1-static** no `class` in state-unit files · **X3-static** no module-scoped mutable state · **X5** no fire-and-forget `Promise<void>` in SDK namespaces |
 | **Conventions** — code review only | — | **A3-interior** internal state in Subjects · **X2** no `Promise<T>` on long-running ops · **X6** no dual bus+field exposure of the same state |

--- a/packages/sdk/docs/Usage.md
+++ b/packages/sdk/docs/Usage.md
@@ -294,6 +294,14 @@ await semiont.mark.delete(resourceId, annotationId);
 await semiont.mark.archive(resourceId);
 await semiont.mark.unarchive(resourceId);
 
+// Replace a resource's own entity-type classification — replace/diff:
+// pass the current types and the desired full set; the backend diffs
+// them into mark:entity-tag-added / -removed events, so the change
+// surfaces in browse.resources({ entityType }). (Stamps the resource
+// with types from the Frame vocabulary — defining the vocabulary
+// itself is frame.addEntityTypes.)
+await semiont.mark.updateEntityTypes(resourceId, ['Draft'], ['Draft', 'Question']);
+
 // AI-assisted annotation — StreamObservable<MarkAssistEvent>: subscribe
 // for progress, await for the final event.
 semiont.mark.assist(resourceId, 'linking', {

--- a/packages/sdk/src/__tests__/browse-fetch-failure.test.ts
+++ b/packages/sdk/src/__tests__/browse-fetch-failure.test.ts
@@ -14,9 +14,14 @@
  *
  * The contract this pins:
  *   1. `await` of a Browse read REJECTS when the underlying fetch fails.
- *   2. `.subscribe(...)` of the same read PRESERVES B6 — it sees `undefined`
- *      (loading) and is NOT errored. The fix must surface the failure to the
- *      awaiter WITHOUT erroring live-query subscribers.
+ *   2. `.subscribe(...)` of the same read sees `undefined` (loading) through
+ *      the B14 retry chain — and when the chain EXHAUSTS on a key with no
+ *      cached value, the subscriber is ERRORED (B15) rather than left on
+ *      `undefined` forever. (Pre-B15 this file pinned "never errored"; the
+ *      liveness axioms showed that to be L1's forbidden fourth state for
+ *      value-less keys — see
+ *      .plans/bugs/valueless-key-terminal-failure-starves-observers.md.
+ *      Keys WITH a stale value keep B6 stale-beats-error: never errored.)
  *
  * No backend: a fake transport drives `busRequest` to a deterministic
  * failure-channel rejection.
@@ -120,20 +125,23 @@ describe('browse read — await semantics on fetch failure (Link 3)', () => {
     expect(outcome).toBe('rejected');
   });
 
-  it('subscribe preserves SWR on fetch failure — stays undefined, not errored (B6)', async () => {
+  it('subscribe on a value-less key: loading through the retry chain, then errored on exhaustion (B15)', async () => {
     const seen: Array<unknown> = [];
-    let errored = false;
+    const errors: unknown[] = [];
     const sub = browse.annotations(rId).subscribe({
       next: (v) => seen.push(v),
-      error: () => {
-        errored = true;
-      },
+      error: (e) => errors.push(e),
     });
 
     await delay(50);
     sub.unsubscribe();
 
+    // No value ever emitted (the store was never written — that half of B6
+    // stands)…
     expect(seen).toEqual([undefined]);
-    expect(errored).toBe(false);
+    // …but the exhausted chain's terminal failure reached the subscriber as
+    // an error notification (B15) — carrying the bus rejection, not silence.
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toContain('boom');
   });
 });

--- a/packages/sdk/src/__tests__/browse-liveness.property.test.ts
+++ b/packages/sdk/src/__tests__/browse-liveness.property.test.ts
@@ -21,6 +21,18 @@
  * a fresh issue otherwise — sharing rids with mounts would make the per-key
  * issue count ambiguous. The invalidate property widens the budget to 3: an
  * observe chain (≤2) plus a sanctioned invalidate chain (≤2) on one key.
+ *
+ * L4 (P4): the console-warn spy is the assertion surface, not just a
+ * silencer. Property 1 carries the per-run implication — a consumed fault on
+ * a MOUNTED rid's observe path ⇒ ≥1 breadcrumb before that run's outputs all
+ * settled ([cache RETRY] fires before the retry that gates notification).
+ * Scoped deliberately: fetch()/await-path faults have NO breadcrumb by design
+ * (the caller owns retry policy), and the invalidate property is excluded —
+ * an invalidate chain's warn can land after the bound when outputs were
+ * already notified via the stale value, so asserting there would be flaky.
+ * The three breadcrumbs are also pinned individually in the deterministic
+ * trio test at the bottom ([browse DEGRADED] can't join the implication:
+ * FaultyTransport doesn't expose the per-run scope model).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -28,10 +40,7 @@ import { filter } from 'rxjs/operators';
 import type { Observable } from 'rxjs';
 import { EventBus, resourceId as makeResourceId } from '@semiont/core';
 import type { IContentTransport, ITransport } from '@semiont/core';
-import {
-  assertLivenessAxioms,
-  type FaultyTransport,
-} from '@semiont/core/testing';
+import { assertLivenessAxioms, FaultyTransport } from '@semiont/core/testing';
 import { BrowseNamespace } from '../namespaces/browse';
 
 /** Small explicit busRequest timeout — deterministic virtual time (no 30 s). */
@@ -66,8 +75,9 @@ function loaderOutputs(browse: BrowseNamespace, rid: string): Observable<unknown
 
 describe('liveness axioms over the real BrowseNamespace composition (P2)', () => {
   // The breadcrumbs ([browse DEGRADED], [cache RETRY]/[cache IDLE]) are
-  // always-on by design (L4); silence them here so property runs don't spam.
-  // P4 turns this spy into the L4 assertion (degradation ⇒ ≥1 breadcrumb).
+  // always-on by design (L4). The spy keeps property runs quiet AND is the
+  // L4 assertion surface: property 1 checks degradation ⇒ ≥1 breadcrumb
+  // per run; the trio test below pins each breadcrumb individually.
   let warnSpy: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -89,6 +99,10 @@ describe('liveness axioms over the real BrowseNamespace composition (P2)', () =>
         ['res-a'],
       ];
       let run = 0;
+      // L4 accumulator: violating runs are collected (not thrown) so a
+      // breadcrumb failure can't shadow a sharper L1/L2 diagnosis from the
+      // harness's finally block; asserted empty after the property.
+      const l4Silent: string[] = [];
 
       await assertLivenessAxioms({
         timeoutMs: TIMEOUT_MS,
@@ -97,6 +111,7 @@ describe('liveness axioms over the real BrowseNamespace composition (P2)', () =>
         makeResponse,
         setup: (transport: FaultyTransport) => {
           const rids = RID_CONFIGS[run++ % RID_CONFIGS.length]!;
+          warnSpy.mockClear(); // per-run L4 window
           const bus = new EventBus();
           const browse = new BrowseNamespace(
             transport as unknown as ITransport,
@@ -128,9 +143,36 @@ describe('liveness axioms over the real BrowseNamespace composition (P2)', () =>
             ),
           ];
 
-          return { outputs, settlements, teardown: () => bus.destroy() };
+          return {
+            outputs,
+            settlements,
+            teardown: () => {
+              // L4 — degradation ⇒ ≥1 breadcrumb. Runs after the harness's
+              // L1/L2 checks (its finally), so every mounted-rid chain that
+              // consumed a fault has already warned: [cache RETRY] precedes
+              // the retry whose outcome gates the output's notification.
+              // Quote-bounded rid match — '"res-a"' must not match the
+              // await path's '"res-await"'.
+              const observePathFaults = transport.requestLog.filter(
+                (e) =>
+                  (e.action.kind === 'drop-reply' || e.action.kind === 'reject-emit') &&
+                  rids.some((r) => e.retryKey.includes(`"${r}"`)),
+              );
+              if (observePathFaults.length > 0 && warnSpy.mock.calls.length === 0) {
+                l4Silent.push(
+                  `L4: run with mounts [${rids.join(',')}] consumed ` +
+                  `${observePathFaults.length} observe-path fault(s) ` +
+                  `(${observePathFaults.map((e) => e.action.kind).join(',')}) ` +
+                  `but emitted zero breadcrumbs — silence under degradation`,
+                );
+              }
+              bus.destroy();
+            },
+          };
         },
       });
+
+      expect(l4Silent).toEqual([]);
     },
     60_000,
   );
@@ -171,4 +213,64 @@ describe('liveness axioms over the real BrowseNamespace composition (P2)', () =>
     },
     60_000,
   );
+
+  // ── L4 trio: each breadcrumb pinned individually (deterministic) ─────────
+
+  it('L4: [cache RETRY] then [cache IDLE] fire when an SWR chain fails and exhausts', async () => {
+    // Every request drops its reply → attempt times out (RETRY warn) → the
+    // B14 re-issue also drops → exhaustion (IDLE warn) + B15 error to the
+    // value-less key's observers. scopeModel 'multi' keeps [browse DEGRADED]
+    // out of this scenario's warns.
+    const transport = new FaultyTransport({ schedule: [{ kind: 'drop-reply' }], scopeModel: 'multi', makeResponse });
+    const bus = new EventBus();
+    const browse = new BrowseNamespace(
+      transport as unknown as ITransport, bus, noopContent, { busTimeoutMs: TIMEOUT_MS },
+    );
+
+    try {
+      const outputs = loaderOutputs(browse, 'res-trio');
+      await Promise.all(outputs.map(
+        (o) => new Promise<void>((resolve) => {
+          o.subscribe({ next: () => resolve(), error: () => resolve() });
+        }),
+      ));
+
+      const warns: string[] = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(warns.some((w) => w.includes('[cache RETRY]'))).toBe(true);
+      expect(warns.some((w) => w.includes('[cache IDLE]'))).toBe(true);
+      expect(warns.some((w) => w.includes('[browse DEGRADED]'))).toBe(false);
+    } finally {
+      bus.destroy();
+      transport.dispose();
+    }
+  });
+
+  it('L4: [browse DEGRADED] fires on scope contention — and the degraded loader still loads', async () => {
+    // Default single-slot-throw, healthy wire: the second distinct rid's
+    // withScope hits the contention throw, degrades to unscoped observation
+    // (warn), and BOTH loaders still deliver values — degradation is graceful
+    // AND observable, never silent (the incident's forensic gap).
+    const transport = new FaultyTransport({ makeResponse });
+    const bus = new EventBus();
+    const browse = new BrowseNamespace(
+      transport as unknown as ITransport, bus, noopContent, { busTimeoutMs: TIMEOUT_MS },
+    );
+
+    try {
+      const outputs = [...loaderOutputs(browse, 'res-one'), ...loaderOutputs(browse, 'res-two')];
+      const values = await Promise.all(outputs.map(
+        (o) => new Promise<unknown>((resolve, reject) => {
+          o.subscribe({ next: (v) => resolve(v), error: reject });
+        }),
+      ));
+
+      expect(values).toHaveLength(4);
+      values.forEach((v) => expect(v).toBeDefined());
+      const warns: string[] = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(warns.some((w) => w.includes('[browse DEGRADED]'))).toBe(true);
+    } finally {
+      bus.destroy();
+      transport.dispose();
+    }
+  });
 });

--- a/packages/sdk/src/__tests__/browse-liveness.property.test.ts
+++ b/packages/sdk/src/__tests__/browse-liveness.property.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Liveness axioms P2 — L1/L2 over the REAL sdk composition
+ * (`.plans/LIVENESS-AXIOMS.md`, sdk lane).
+ *
+ * `BrowseNamespace` + `createCache` + `busRequest` run unmodified on
+ * `FaultyTransport` while fast-check draws fault schedules (drop / delay /
+ * duplicate / reject-emit) and the scope model (today's single-slot-throw AND
+ * the post-MULTI-RESOURCE-SCOPE multi). This generalizes
+ * `browse-concurrent-loaders.test.ts` — one hand-picked interleaving — to the
+ * interleavings nobody names.
+ *
+ * L1's "notification" here is a MEANINGFUL one: live-query observables emit an
+ * initial `undefined` (the SWR loading state) immediately, which would satisfy
+ * a naive next-counter and defang the axiom — so outputs are piped through
+ * `filter(v => v !== undefined)`. What must arrive is a value or an error;
+ * `undefined` forever is exactly the starvation the axiom forbids.
+ *
+ * Budget accounting (L2, via the transport's requestLog): a mounted loader's
+ * key may legitimately issue 1 + B14's one retry; the await-path settlements
+ * use DISJOINT rids because `fetch()` joins an in-flight chain (B3) but forces
+ * a fresh issue otherwise — sharing rids with mounts would make the per-key
+ * issue count ambiguous. The invalidate property widens the budget to 3: an
+ * observe chain (≤2) plus a sanctioned invalidate chain (≤2) on one key.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { filter } from 'rxjs/operators';
+import type { Observable } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { IContentTransport, ITransport } from '@semiont/core';
+import {
+  assertLivenessAxioms,
+  type FaultyTransport,
+} from '@semiont/core/testing';
+import { BrowseNamespace } from '../namespaces/browse';
+
+/** Small explicit busRequest timeout — deterministic virtual time (no 30 s). */
+const TIMEOUT_MS = 50;
+
+/** Registry-shaped replies for the ops this composition issues. */
+function makeResponse(operation: string, payload: Record<string, unknown>): unknown {
+  switch (operation) {
+    case 'browse:resource-requested':
+      return { resource: { '@id': payload.resourceId, name: `Resource ${String(payload.resourceId)}` } };
+    case 'browse:annotations-requested':
+      return { annotations: [], total: 0 };
+    default:
+      return {};
+  }
+}
+
+const noopContent = {
+  getBinary: async () => ({ data: new ArrayBuffer(0), contentType: 'text/plain' }),
+  getBinaryStream: async () => ({ stream: new ReadableStream(), contentType: 'text/plain' }),
+  dispose: () => {},
+} as unknown as IContentTransport;
+
+/** One `useResourceLoader`-shaped mount: resource + annotations live queries. */
+function loaderOutputs(browse: BrowseNamespace, rid: string): Observable<unknown>[] {
+  const id = makeResourceId(rid);
+  return [
+    browse.resource(id).pipe(filter((v) => v !== undefined)),
+    browse.annotations(id).pipe(filter((v) => v !== undefined)),
+  ];
+}
+
+describe('liveness axioms over the real BrowseNamespace composition (P2)', () => {
+  // The breadcrumbs ([browse DEGRADED], [cache RETRY]/[cache IDLE]) are
+  // always-on by design (L4); silence them here so property runs don't spam.
+  // P4 turns this spy into the L4 assertion (degradation ⇒ ≥1 breadcrumb).
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it(
+    'L1/L2: concurrent distinct-rid loaders on a faulty wire — every subscription sees a value or an error, requests stay within the B14 budget',
+    async () => {
+      // Rotate mount shapes across property runs (fresh composition per run):
+      // the flagship 4-distinct repro, a duplicate-rid variant (exercises B3
+      // in-flight joining), a pair, and a single.
+      const RID_CONFIGS: string[][] = [
+        ['res-a', 'res-b', 'res-c', 'res-d'],
+        ['res-a', 'res-a', 'res-b'],
+        ['res-a', 'res-b'],
+        ['res-a'],
+      ];
+      let run = 0;
+
+      await assertLivenessAxioms({
+        timeoutMs: TIMEOUT_MS,
+        retryBudget: 1,
+        scopeModel: 'both',
+        makeResponse,
+        setup: (transport: FaultyTransport) => {
+          const rids = RID_CONFIGS[run++ % RID_CONFIGS.length]!;
+          const bus = new EventBus();
+          const browse = new BrowseNamespace(
+            transport as unknown as ITransport,
+            bus,
+            noopContent,
+            { busTimeoutMs: TIMEOUT_MS },
+          );
+
+          const outputs = rids.flatMap((rid) => loaderOutputs(browse, rid));
+
+          // Await-path settlements on rids DISJOINT from the mounts (see the
+          // module note on budget accounting). Both must settle — resolve or
+          // reject — within the bound; rejection is a permitted outcome.
+          const awaitRid = makeResourceId('res-await');
+          const settlements = [
+            Promise.resolve(browse.resource(awaitRid)).then(
+              (v) => v,
+              (e) => {
+                expect(e).toBeInstanceOf(Error);
+                return undefined;
+              },
+            ),
+            Promise.resolve(browse.annotations(awaitRid)).then(
+              (v) => v,
+              (e) => {
+                expect(e).toBeInstanceOf(Error);
+                return undefined;
+              },
+            ),
+          ];
+
+          return { outputs, settlements, teardown: () => bus.destroy() };
+        },
+      });
+    },
+    60_000,
+  );
+
+  it(
+    'L1/L2 hold across the invalidate path (budget widened for the sanctioned refetch chain)',
+    async () => {
+      await assertLivenessAxioms({
+        timeoutMs: TIMEOUT_MS,
+        // One key may legitimately see the observe chain (1 + retry) PLUS the
+        // invalidate chain (1 + retry) = 4 issues = 1 + 3.
+        retryBudget: 3,
+        scopeModel: 'both',
+        makeResponse,
+        setup: async (transport: FaultyTransport) => {
+          const bus = new EventBus();
+          const browse = new BrowseNamespace(
+            transport as unknown as ITransport,
+            bus,
+            noopContent,
+            { busTimeoutMs: TIMEOUT_MS },
+          );
+
+          const outputs = [
+            ...loaderOutputs(browse, 'res-x'),
+            ...loaderOutputs(browse, 'res-y'),
+          ];
+
+          // Let the initial chains make some progress, then invalidate one
+          // resource mid-flight — the interleaving the incident's evidence
+          // chain never covered (a refetch racing the original chain, B9).
+          await new Promise<void>((r) => setTimeout(r, 0));
+          browse.invalidateResourceDetail(makeResourceId('res-x'));
+
+          return { outputs, teardown: () => bus.destroy() };
+        },
+      });
+    },
+    60_000,
+  );
+});

--- a/packages/sdk/src/__tests__/cache.test.ts
+++ b/packages/sdk/src/__tests__/cache.test.ts
@@ -1,7 +1,7 @@
 /**
  * Contract tests for the `Cache<K, V>` primitive.
  *
- * These mirror the B1–B13 behaviors spec'd in
+ * These mirror the B1–B16 behaviors spec'd in
  * `packages/sdk/docs/CACHE-SEMANTICS.md`, but assert them against
  * the primitive directly (no BrowseNamespace, no busRequest). The
  * `cache-semantics.test.ts` suite covers the same behaviors at the
@@ -487,6 +487,82 @@ describe('Cache<K, V>', () => {
       await firstDefined(cache.observe('k'));
       cache.dispose();
       expect(seen[seen.length - 1]).toBe('COMPLETE');
+    });
+  });
+
+  // B16 — disposal is terminal and inert. Motivated by the make-meaning CI
+  // escape (.plans/LIVENESS-AXIOMS.md, 2026-07-05 entry): a B14 retry chain
+  // straddling client teardown pushed a B15 `bus.closed` error into a test's
+  // handler-less subscriber. The fix is structural (finding b): disposal
+  // completes every per-key observable and stuns all later acts — so a
+  // teardown-straddling failure has no observers to error and no retry to
+  // issue. No error-code special-casing anywhere (finding a / L1 D1 binding).
+  describe('B16 — dispose() is terminal and inert', () => {
+    it('a retry chain straddling dispose() goes quiet: no retry, no error, no breadcrumb; observers complete at dispose', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        let rejectFirst!: (e: Error) => void;
+        const fetchFn = vi
+          .fn()
+          .mockImplementationOnce(() => new Promise<string>((_, rej) => { rejectFirst = rej; }))
+          .mockRejectedValue(new Error('retry would also fail'));
+        const cache = createCache<string, string>(fetchFn);
+
+        const events: string[] = [];
+        cache.observe('k').subscribe({
+          next: (v) => { if (v !== undefined) events.push('next'); },
+          error: () => events.push('error'),
+          complete: () => events.push('complete'),
+        });
+
+        cache.dispose();                       // teardown with attempt 1 in flight
+        rejectFirst(new Error('late loss'));   // the straddling failure lands
+        await flush();
+        await flush();
+
+        expect(events).toEqual(['complete']);      // completed at dispose — never errored
+        expect(fetchFn).toHaveBeenCalledTimes(1);  // no B14 re-issue after dispose
+        expect(warnSpy).not.toHaveBeenCalled();    // no [cache RETRY]/[cache IDLE] teardown noise
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('post-dispose observe() completes immediately and issues no fetch', async () => {
+      const fetchFn = vi.fn().mockResolvedValue('v');
+      const cache = createCache<string, string>(fetchFn);
+      cache.dispose();
+
+      const events: string[] = [];
+      cache.observe('k').subscribe({
+        next: () => events.push('next'),
+        error: () => events.push('error'),
+        complete: () => events.push('complete'),
+      });
+      await flush();
+
+      expect(events).toEqual(['complete']);
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it('post-dispose invalidate()/invalidateAll()/fetch() issue no fetches; fetch() rejects', async () => {
+      const fetchFn = vi.fn().mockResolvedValue('v');
+      const cache = createCache<string, string>(fetchFn);
+      await firstDefined(cache.observe('k'));   // one real fetch, so invalidateAll has a key
+      cache.dispose();
+
+      cache.invalidate('k');
+      cache.invalidateAll();
+      await expect(cache.fetch('k')).rejects.toThrow(/disposed/);
+      await flush();
+
+      expect(fetchFn).toHaveBeenCalledTimes(1); // only the pre-dispose fetch
+    });
+
+    it('dispose() is idempotent', () => {
+      const cache = createCache<string, string>(vi.fn().mockResolvedValue('v'));
+      cache.dispose();
+      expect(() => cache.dispose()).not.toThrow();
     });
   });
 });

--- a/packages/sdk/src/__tests__/cache.test.ts
+++ b/packages/sdk/src/__tests__/cache.test.ts
@@ -89,8 +89,12 @@ describe('Cache<K, V>', () => {
   });
 
   describe('B6 — fetch failure leaves the previous state intact', () => {
-    it('empty key stays empty after fetch failures; guard is released', async () => {
-      // Two rejections exhaust the observe attempt + its B14 retry.
+    it('empty key: store stays empty after chain exhaustion, observers are errored (B15), and invalidate + a fresh subscription recover', async () => {
+      // Two rejections exhaust the observe attempt + its B14 retry. Pre-B15
+      // this test pinned "subscriber sees only [undefined]" — the silent
+      // pending-forever state the liveness axioms forbid (L1). B15: the
+      // value-less terminal failure errors the subscriber; the STORE is
+      // still not written (that part of B6 stands — `get` stays undefined).
       const fetchFn = vi
         .fn()
         .mockRejectedValueOnce(new Error('boom'))
@@ -98,14 +102,21 @@ describe('Cache<K, V>', () => {
         .mockResolvedValueOnce('v1');
       const cache = createCache<string, string>(fetchFn);
       const seen: Array<string | undefined> = [];
-      cache.observe('k').subscribe((v) => seen.push(v));
+      const errors: unknown[] = [];
+      cache.observe('k').subscribe({ next: (v) => seen.push(v), error: (e) => errors.push(e) });
       await flush();
       expect(seen).toEqual([undefined]);
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toBe('boom');
+      expect(cache.get('k')).toBeUndefined(); // store untouched
 
-      // Guard released: invalidate triggers a new fetch that succeeds.
+      // Guard + marker released: invalidate triggers a new fetch that
+      // succeeds. The errored subscription is terminal (RxJS), so recovery
+      // is observed via a fresh subscription — the hook-remount shape.
       cache.invalidate('k');
       await flush();
-      expect(seen[seen.length - 1]).toBe('v1');
+      const late = await firstDefined(cache.observe('k'));
+      expect(late).toBe('v1');
     });
 
     it('previously-fresh value survives a failed refetch', async () => {
@@ -348,17 +359,19 @@ describe('Cache<K, V>', () => {
       expect(seen[seen.length - 1]).toBe('v1');
     });
 
-    it('caps at one retry: a persistently failing key goes idle, and a later observe() recovers it', async () => {
+    it('caps at one retry: a persistently failing key errors observers (B15) without a tight loop, and a later observe() recovers it', async () => {
       const fetchFn = vi.fn().mockRejectedValue(new Error('down'));
       const cache = createCache<string, string>(fetchFn);
-      cache.observe('k').subscribe(() => {});
+      const errors: unknown[] = [];
+      cache.observe('k').subscribe({ next: () => {}, error: (e) => errors.push(e) });
       await flush();
       expect(fetchFn).toHaveBeenCalledTimes(2); // attempt + one retry, then idle
+      expect(errors).toHaveLength(1); // …surfaced, not silent (B15)
       await flush();
       expect(fetchFn).toHaveBeenCalledTimes(2); // no tight loop
 
-      // Recoverable: the key is idle-empty ("empty is terminal only until an
-      // observer acts"), so a later observe() starts a fresh attempt chain.
+      // Recoverable: observe() on the failed key clears the marker and
+      // starts a fresh attempt chain — the error state is never latched.
       fetchFn.mockResolvedValueOnce('v-late');
       const v = await firstDefined(cache.observe('k'));
       expect(v).toBe('v-late');
@@ -388,6 +401,78 @@ describe('Cache<K, V>', () => {
       await expect(cache.fetch('k')).rejects.toThrow('boom');
       await flush();
       expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('B15 — terminal failure of a value-less key errors its observers', () => {
+    // Found by the LIVENESS-AXIOMS P2 property suite (L1/L2 falsified under
+    // schedule ⟨reject-emit⟩): after B14 exhaustion a value-less key's
+    // subscribers previously saw `undefined` forever — the forbidden fourth
+    // state. See .plans/bugs/valueless-key-terminal-failure-starves-observers.md.
+
+    const exhaust = () =>
+      vi.fn().mockRejectedValueOnce(new Error('lost')).mockRejectedValueOnce(new Error('lost'));
+
+    it('replays the failure to a subscriber attaching AFTER exhaustion (held observable, no observe() call)', async () => {
+      const cache = createCache<string, string>(exhaust());
+      const obs = cache.observe('k'); // starts the chain; hold the observable
+      await flush(); // chain exhausts with no subscriber attached
+      const errors: unknown[] = [];
+      obs.subscribe({ next: () => {}, error: (e) => errors.push(e) });
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toBe('lost');
+    });
+
+    it('observe() after exhaustion clears the marker first: the new subscription waits on the fresh chain, no stale error', async () => {
+      const fetchFn = exhaust().mockResolvedValueOnce('v2');
+      const cache = createCache<string, string>(fetchFn);
+      cache.observe('k').subscribe({ next: () => {}, error: () => {} });
+      await flush(); // exhausted, marker set
+
+      const errors: unknown[] = [];
+      const seen: Array<string | undefined> = [];
+      cache.observe('k').subscribe({ next: (v) => seen.push(v), error: (e) => errors.push(e) });
+      await flush();
+      expect(errors).toEqual([]); // marker cleared before the obs was handed out
+      expect(seen[seen.length - 1]).toBe('v2');
+    });
+
+    it('a key WITH a stale value never errors — B6 stale-beats-error is unchanged', async () => {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce('v1')
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockRejectedValueOnce(new Error('boom'));
+      const cache = createCache<string, string>(fetchFn);
+      const errors: unknown[] = [];
+      cache.observe('k').subscribe({ next: () => {}, error: (e) => errors.push(e) });
+      await firstDefined(cache.observe('k'));
+      cache.invalidate('k'); // refetch + retry both fail — but a value exists
+      await flush();
+      expect(errors).toEqual([]);
+      expect(cache.get('k')).toBe('v1');
+    });
+
+    it('set() supersedes the failure marker', async () => {
+      const cache = createCache<string, string>(exhaust());
+      cache.observe('k').subscribe({ next: () => {}, error: () => {} });
+      await flush(); // exhausted, marker set
+      cache.set('k', 'written');
+      const v = await firstDefined(cache.observe('k'));
+      expect(v).toBe('written'); // no error replay — the write cleared it
+    });
+
+    it('a fetch() success while the marker is set clears it for future subscribers', async () => {
+      const fetchFn = exhaust().mockResolvedValueOnce('v3');
+      const cache = createCache<string, string>(fetchFn);
+      const obs = cache.observe('k'); // chain started; hold the observable
+      await flush(); // exhausted, marker set
+      await expect(cache.fetch('k')).resolves.toBe('v3'); // await path succeeds
+      const errors: unknown[] = [];
+      const seen: Array<string | undefined> = [];
+      obs.subscribe({ next: (v) => seen.push(v), error: (e) => errors.push(e) });
+      expect(errors).toEqual([]); // success cleared the marker — no replay
+      expect(seen[seen.length - 1]).toBe('v3');
     });
   });
 

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -1,7 +1,7 @@
 /**
  * RxJS-native read-through cache primitive.
  *
- * Behavioral contract: packages/sdk/docs/CACHE-SEMANTICS.md (B1–B13).
+ * Behavioral contract: packages/sdk/docs/CACHE-SEMANTICS.md (B1–B16).
  *
  * Framework-agnostic: no React, no dependency on any namespace. Used by
  * `BrowseNamespace` to back its per-key stores, but equally usable from
@@ -27,7 +27,11 @@
  *   - `remove(key)`: drops the cache entry entirely (B13a). No refetch.
  *   - `set(key, value)`: write-through without a fetch (B13b).
  *   - `invalidateAll()`: per-key SWR refetch of every currently-cached entry.
- *   - `dispose()`: completes the store so observers unsubscribe.
+ *   - `dispose()`: terminal and inert (B16) — completes every per-key
+ *     observable (subscribers detach cleanly) and stuns all later acts:
+ *     no fetch, retry, breadcrumb, or B15 push may fire after disposal, so
+ *     a retry chain straddling client teardown dies quietly instead of
+ *     erroring observers (`bus.closed` disposal noise needs no special-case).
  *
  * What's deliberately out:
  *   - No subscriber ref-counting / GC of unobserved keys (B11). Acceptable
@@ -105,6 +109,15 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
   const obsCache = new Map<K, Observable<V | undefined>>();
 
   /**
+   * B16 — disposal is terminal and inert. Once set, no path may issue a
+   * fetch, retry, or failure push: a B14 chain that straddles teardown
+   * (busRequest resolving `bus.closed` mid-retry) must die quietly instead
+   * of erroring observers that dispose() just completed. Checked at every
+   * async resumption point in the SWR driver, not just at entry.
+   */
+  let disposed = false;
+
+  /**
    * B15 — terminal-failure markers for VALUE-LESS keys. Set when the B14
    * retry also fails and the store holds nothing to serve; delivered to that
    * key's observers as an error notification — pushed via `failure$` to
@@ -165,7 +178,10 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
    * comes through here — its caller sees the rejection and owns retry policy.
    */
   const runFetchSWR = (key: K): void => {
+    if (disposed) return;
     void runFetch(key).catch((firstErr: unknown) => {
+      // B16: teardown straddled the attempt — no retry, no breadcrumb noise.
+      if (disposed) return;
       // Always-on breadcrumb: the pre-B14 version of this path swallowed the
       // failure with zero trace, which is how lost replies starved silently
       // (.plans/bugs/concurrent-browse-resource-starvation.md). Not deduped —
@@ -177,6 +193,9 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
         firstErr instanceof Error ? firstErr.message : firstErr,
       );
       void runFetch(key).catch((retryErr: unknown) => {
+        // B16: teardown straddled the retry — its failure has nowhere it
+        // needs to go (observers completed at dispose).
+        if (disposed) return;
         // eslint-disable-next-line no-console
         console.warn(
           `[cache IDLE] retry also failed for key ${String(key)}; going idle until the ` +
@@ -198,7 +217,11 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
 
   return {
     observe(key: K): Observable<V | undefined> {
-      if (failures.has(key)) {
+      if (disposed) {
+        // B16: the store is completed, so any per-key observable (memoized
+        // or fresh) completes its subscribers immediately — just don't
+        // issue a fetch for a client that no longer exists.
+      } else if (failures.has(key)) {
         // B15 recovery: an observer acting on a failed key clears the marker
         // and starts a fresh attempt chain — a hook remount recovers instead
         // of replaying the stale error.
@@ -238,6 +261,9 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     },
 
     fetch(key: K): Promise<V> {
+      // B16: surfaced, not silent — the await path's caller owns retry
+      // policy (B14 boundary 1), so it gets a rejection it can see.
+      if (disposed) return Promise.reject(new Error('Cache disposed'));
       return runFetch(key);
     },
 
@@ -250,6 +276,7 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     },
 
     invalidate(key: K): void {
+      if (disposed) return; // B16
       // B7: do NOT erase the value. Clear the guard (B9 orphan recovery)
       // and the B15 failure marker, then trigger a fresh fetch (with the
       // B14 bounded retry). Observers keep seeing the stale value until the
@@ -260,6 +287,7 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     },
 
     remove(key: K): void {
+      if (disposed) return; // B16
       // B13a: drop the entry. The value is gone; observers see `undefined`.
       const next = new Map(store$.value);
       next.delete(key);
@@ -269,6 +297,7 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     },
 
     set(key: K, value: V): void {
+      if (disposed) return; // B16
       // B13b: write-through. No fetch. Atomic update. A written value
       // supersedes any B15 failure marker.
       failures.delete(key);
@@ -278,6 +307,7 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     },
 
     invalidateAll(): void {
+      if (disposed) return; // B16
       // Per-key SWR refetch of every currently-cached entry. Each entry
       // keeps its stale value until its refetch resolves.
       for (const key of store$.value.keys()) {
@@ -287,6 +317,8 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     },
 
     dispose(): void {
+      if (disposed) return; // idempotent (B16)
+      disposed = true;
       store$.complete();
       // Must complete alongside store$: the per-key observable is a merge,
       // and merge completes only when ALL its sources complete — leaving

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -37,9 +37,27 @@
  *     fetch is re-issued exactly once, then the key goes idle. The
  *     `fetch`/await path never auto-retries — it surfaces the rejection so
  *     the caller owns retry policy.
+ *   - Terminal failure of a VALUE-LESS key errors its observers (B15): when
+ *     the B14 retry also fails and there is no cached value to serve, the
+ *     key's observers get an error notification (replayed to late
+ *     subscribers) instead of `undefined` forever — L1's forbidden fourth
+ *     state (.plans/LIVENESS-AXIOMS.md; found by the P2 property suite).
+ *     Retriable: the next observe()/invalidate()/set() clears the marker.
+ *     Keys WITH a value keep B6 stale-beats-error, unchanged.
  */
 
-import { BehaviorSubject, Observable, distinctUntilChanged, map } from 'rxjs';
+import {
+  BehaviorSubject,
+  EMPTY,
+  Observable,
+  Subject,
+  defer,
+  distinctUntilChanged,
+  filter,
+  map,
+  merge,
+  throwError,
+} from 'rxjs';
 
 export interface Cache<K, V> {
   /** Observable stream of the value at `key` (SWR). Triggers a fetch if not cached. */
@@ -87,6 +105,18 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
   const obsCache = new Map<K, Observable<V | undefined>>();
 
   /**
+   * B15 — terminal-failure markers for VALUE-LESS keys. Set when the B14
+   * retry also fails and the store holds nothing to serve; delivered to that
+   * key's observers as an error notification — pushed via `failure$` to
+   * subscribers attached at exhaustion time, replayed via a subscribe-time
+   * `defer` to later ones. Cleared by observe()/invalidate()/set()/remove()
+   * and by any fetch success, so the error state is always retriable.
+   */
+  const failures = new Map<K, Error>();
+  const failure$ = new Subject<{ key: K; error: Error }>();
+  const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)));
+
+  /**
    * Run (or join) a fetch for `key`. Resolves with the value and updates the
    * store on success; rejects on failure WITHOUT touching the store (B6 —
    * subscribers keep their prior value / loading state). Concurrent callers
@@ -102,6 +132,8 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     p = (async () => {
       try {
         const value = await fetchFn(key);
+        // A value arrived from ANY path — the key is live again (B15).
+        failures.delete(key);
         // Atomic update: one `.next` with a fresh Map reference so
         // downstream `distinctUntilChanged` sees the transition (B5).
         const next = new Map(store$.value);
@@ -151,13 +183,28 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
             `next observe()/invalidate() (B14):`,
           retryErr instanceof Error ? retryErr.message : retryErr,
         );
+        // B15: with no cached value to serve, "idle" would leave observers
+        // on `undefined` forever — the forbidden fourth state (L1). Surface
+        // the terminal failure as an error notification instead. A key WITH
+        // a stale value stays silent (B6 stale-beats-error).
+        if (!store$.value.has(key)) {
+          const error = toError(retryErr);
+          failures.set(key, error);
+          failure$.next({ key, error });
+        }
       });
     });
   };
 
   return {
     observe(key: K): Observable<V | undefined> {
-      if (!store$.value.has(key) && !inflight.has(key)) {
+      if (failures.has(key)) {
+        // B15 recovery: an observer acting on a failed key clears the marker
+        // and starts a fresh attempt chain — a hook remount recovers instead
+        // of replaying the stale error.
+        failures.delete(key);
+        runFetchSWR(key);
+      } else if (!store$.value.has(key) && !inflight.has(key)) {
         // Subscribe path: fire-and-forget, swallow failures so a subscriber
         // stays at its last value (B6); one bounded retry (B14). The
         // awaiter's `fetch` surfaces failures instead.
@@ -166,9 +213,24 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
       // B4: return a stable Observable per key.
       let obs = obsCache.get(key);
       if (!obs) {
-        obs = store$.pipe(
-          map((m) => m.get(key)),
-          distinctUntilChanged(),
+        obs = merge(
+          store$.pipe(
+            map((m) => m.get(key)),
+            distinctUntilChanged(),
+          ),
+          // B15 push: terminal failure of this (value-less) key errors its
+          // subscribers. A throwing `map` turns the event into an RxJS error
+          // notification on this key's observable only.
+          failure$.pipe(
+            filter((f) => f.key === key),
+            map((f): V | undefined => { throw f.error; }),
+          ),
+          // B15 replay: a subscriber attaching AFTER the exhaustion moment
+          // must see the failure too (the push above is hot and gone).
+          defer(() => {
+            const error = failures.get(key);
+            return error ? throwError(() => error) : EMPTY;
+          }),
         );
         obsCache.set(key, obs);
       }
@@ -189,9 +251,11 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
 
     invalidate(key: K): void {
       // B7: do NOT erase the value. Clear the guard (B9 orphan recovery)
-      // and trigger a fresh fetch (with the B14 bounded retry). Observers
-      // keep seeing the stale value until the new value replaces it.
+      // and the B15 failure marker, then trigger a fresh fetch (with the
+      // B14 bounded retry). Observers keep seeing the stale value until the
+      // new value replaces it.
       inflight.delete(key);
+      failures.delete(key);
       runFetchSWR(key);
     },
 
@@ -201,10 +265,13 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
       next.delete(key);
       store$.next(next);
       inflight.delete(key);
+      failures.delete(key);
     },
 
     set(key: K, value: V): void {
-      // B13b: write-through. No fetch. Atomic update.
+      // B13b: write-through. No fetch. Atomic update. A written value
+      // supersedes any B15 failure marker.
+      failures.delete(key);
       const next = new Map(store$.value);
       next.set(key, value);
       store$.next(next);
@@ -221,6 +288,11 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
 
     dispose(): void {
       store$.complete();
+      // Must complete alongside store$: the per-key observable is a merge,
+      // and merge completes only when ALL its sources complete — leaving
+      // failure$ open would keep every observer's subscription alive.
+      failure$.complete();
+      failures.clear();
       obsCache.clear();
       inflight.clear();
     },

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -136,6 +136,11 @@ export class SemiontClient {
   }
 
   dispose(): void {
+    // Browse first: completing its caches stops any SWR fetch/retry chain
+    // from issuing new requests into a transport that's about to go away
+    // (B16 — a chain straddling teardown must die quietly, not error
+    // observers or fire post-dispose traffic).
+    this.browse.dispose();
     this.transport.dispose();
     this.content.dispose();
   }

--- a/packages/sdk/src/namespaces/__tests__/cache-semantics.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/cache-semantics.test.ts
@@ -1,7 +1,7 @@
 /**
  * Cache-semantics contract tests.
  *
- * Enumerates behaviors B1–B13 from
+ * Enumerates behaviors B1–B16 from
  * `packages/sdk/docs/CACHE-SEMANTICS.md` against `BrowseNamespace`.
  *
  * Each `describe` block is tagged with the behavior number it verifies.
@@ -217,7 +217,7 @@ function flush(): Promise<void> {
   return new Promise((r) => setTimeout(r, 0));
 }
 
-describe('Cache semantics — behaviors B1–B13 against BrowseNamespace', () => {
+describe('Cache semantics — behaviors B1–B16 against BrowseNamespace', () => {
   const RID = resourceId('res-1');
   const AID = annotationId('ann-1');
 
@@ -656,6 +656,64 @@ describe('Cache semantics — behaviors B1–B13 against BrowseNamespace', () =>
       const channels = emitSpy.mock.calls.map(([ch]) => ch);
       const detailFetches = channels.filter((c) => c === 'browse:annotation-requested').length;
       expect(detailFetches).toBe(1); // just the initial observe
+    });
+  });
+
+  // B16 — disposal is terminal and inert at the namespace level. The
+  // make-meaning CI escape (.plans/LIVENESS-AXIOMS.md, 2026-07-05): a B14
+  // retry straddled client teardown, busRequest resolved `bus.closed`, and
+  // the B15 push errored a handler-less subscriber — an unhandled rejection
+  // racing worker teardown. Structural fix (finding b): BrowseNamespace owns
+  // its caches (A7-owned), so disposing it completes every per-key
+  // observable and detaches its bus handlers; the straddling failure then
+  // has no observers to error. No `bus.closed` special-casing (finding a).
+  describe('B16 — browse.dispose() completes observers; teardown failures are structural no-ops', () => {
+    it('mid-chain dispose: value-less-key subscriber completes, never errors; no post-dispose retry traffic', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        // Every fetch would fail — but dispose lands before the first
+        // failure reply, so the chain must die quietly instead of retrying.
+        const { browse, emitSpy } = createHarness({ rejectNext: 2 });
+
+        const events: string[] = [];
+        browse.resource(RID).subscribe({
+          next: (v) => { if (v !== undefined) events.push('next'); },
+          error: () => events.push('error'),
+          complete: () => events.push('complete'),
+        });
+        expect(emitSpy).toHaveBeenCalledTimes(1); // attempt 1 in flight
+
+        browse.dispose();          // teardown straddles the pending reply
+        await flush();
+        await flush();             // the -failed reply lands post-dispose
+
+        expect(events).toEqual(['complete']);     // completed at dispose — the escape's subscriber shape is safe
+        expect(emitSpy).toHaveBeenCalledTimes(1); // no B14 re-issue after dispose
+        expect(warnSpy).not.toHaveBeenCalled();   // no teardown breadcrumb noise
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('bus invalidation events arriving after dispose() trigger no fetches', async () => {
+      const { browse, eventBus, emitSpy } = createHarness();
+      await firstDefined(browse.resource(RID));
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+
+      browse.dispose();
+      // mark:added would invalidate the annotation-list + events caches —
+      // with the namespace disposed, its bus subscriptions are detached.
+      eventBus.get('mark:added').next(fakeMarkAdded(RID, 'ann-9'));
+      await flush();
+
+      expect(emitSpy).toHaveBeenCalledTimes(1); // nothing refetched
+    });
+
+    it('dispose() is idempotent', async () => {
+      const { browse } = createHarness();
+      await firstDefined(browse.resource(RID));
+      browse.dispose();
+      expect(() => browse.dispose()).not.toThrow();
     });
   });
 });

--- a/packages/sdk/src/namespaces/__tests__/cache-semantics.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/cache-semantics.test.ts
@@ -325,16 +325,22 @@ describe('Cache semantics — behaviors B1–B13 against BrowseNamespace', () =>
   });
 
   describe('B6 — fetch failure leaves the previous state intact', () => {
-    it('observer stays undefined on first-fetch failures; guard is released', async () => {
-      // Two rejections exhaust the observe attempt + its B14 retry.
+    it('value-less key: first-fetch exhaustion errors the observer (B15); guard + marker released', async () => {
+      // Two rejections exhaust the observe attempt + its B14 retry. Post-B15
+      // the value-less terminal failure is an error notification to this
+      // key's observers — not `undefined` forever (LIVENESS-AXIOMS L1; see
+      // .plans/bugs/valueless-key-terminal-failure-starves-observers.md).
       const { browse, emitSpy, state } = createHarness({ rejectNext: 2 });
       const seen: Array<ResourceDescriptor | undefined> = [];
-      browse.resource(RID).subscribe((v) => seen.push(v));
+      const errors: unknown[] = [];
+      browse.resource(RID).subscribe({ next: (v) => seen.push(v), error: (e) => errors.push(e) });
       await flush();
       expect(seen).toEqual([undefined]);
+      expect(errors).toHaveLength(1); // surfaced through withScope + CacheObservable
       expect(emitSpy).toHaveBeenCalledTimes(2); // attempt + B14 retry, then idle
 
-      // Guard is released: a subsequent fetch succeeds and the observer sees it.
+      // Guard + marker released: a subsequent fetch succeeds and a fresh
+      // subscription (the errored one is terminal) sees it.
       state.rejectRemaining = 0;
       browse.invalidateResourceDetail(RID);
       const val = await firstDefined(browse.resource(RID));
@@ -388,7 +394,9 @@ describe('Cache semantics — behaviors B1–B13 against BrowseNamespace', () =>
       // Two rejections exhaust the observe attempt + its B14 retry first.
       const { browse, emitSpy, state } = createHarness({ rejectNext: 2 });
       const seen: Array<ResourceDescriptor | undefined> = [];
-      browse.resource(RID).subscribe((v) => seen.push(v));
+      // Value-less exhaustion also errors this subscriber (B15) — absorbed;
+      // this test is about the in-flight guard, not the notification.
+      browse.resource(RID).subscribe({ next: (v) => seen.push(v), error: () => {} });
       await flush(); // Attempt + B14 retry both reject; guard releases in finally.
 
       state.rejectRemaining = 0;

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -89,16 +89,29 @@ export class BrowseNamespace implements IBrowseNamespace {
    */
   private readonly scopedSources = new WeakMap<Observable<unknown>, Observable<unknown>>();
 
+  /**
+   * Timeout passed to every `busRequest` this namespace issues. `undefined`
+   * means `busRequest`'s default (30 s). Injectable so the liveness
+   * properties (`.plans/LIVENESS-AXIOMS.md`) can run the real composition on
+   * deterministic virtual time — the same knob `HttpTransportConfig.timeout`
+   * provides at the HTTP layer.
+   */
+  private readonly busTimeoutMs: number | undefined;
+
   constructor(
     private readonly transport: ITransport,
     private readonly bus: EventBus,
     private readonly content: IContentTransport,
+    options?: { busTimeoutMs?: number },
   ) {
+    this.busTimeoutMs = options?.busTimeoutMs;
+
     this.resourceCache = createCache<ResourceId, ResourceDescriptor>(async (id) => {
       const result = await busRequest(
         this.transport,
         'browse:resource-requested',
         { resourceId: id },
+        this.busTimeoutMs,
       );
       return result.resource as ResourceDescriptor;
     });
@@ -116,6 +129,7 @@ export class BrowseNamespace implements IBrowseNamespace {
           limit: filters.limit ?? 100,
           offset: 0,
         },
+        this.busTimeoutMs,
       );
       // Brand the wire type (unbranded @id: string) to the SDK's ResourceDescriptor
       // (@id: ResourceId) at the boundary — same as resourceCache above.
@@ -127,6 +141,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.transport,
         'browse:annotations-requested',
         { resourceId },
+        this.busTimeoutMs,
       );
     });
 
@@ -139,6 +154,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.transport,
         'browse:annotation-requested',
         { resourceId, annotationId },
+        this.busTimeoutMs,
       );
       return result.annotation as Annotation;
     });
@@ -148,6 +164,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.transport,
         'browse:entity-types-requested',
         {},
+        this.busTimeoutMs,
       );
       return result.entityTypes;
     });
@@ -157,6 +174,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.transport,
         'browse:tag-schemas-requested',
         {},
+        this.busTimeoutMs,
       );
       return result.tagSchemas;
     });
@@ -166,6 +184,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.transport,
         'browse:referenced-by-requested',
         { resourceId },
+        this.busTimeoutMs,
       );
       return result.referencedBy;
     });
@@ -175,6 +194,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.transport,
         'browse:events-requested',
         { resourceId },
+        this.busTimeoutMs,
       );
       return result.events;
     });
@@ -334,6 +354,7 @@ export class BrowseNamespace implements IBrowseNamespace {
       this.transport,
       'browse:events-requested',
       { resourceId },
+      this.busTimeoutMs,
     );
     return result.events;
   }
@@ -343,6 +364,7 @@ export class BrowseNamespace implements IBrowseNamespace {
       this.transport,
       'browse:annotation-history-requested',
       { resourceId, annotationId },
+      this.busTimeoutMs,
     );
   }
 
@@ -366,6 +388,7 @@ export class BrowseNamespace implements IBrowseNamespace {
       this.transport,
       'browse:directory-requested',
       { path: dirPath ?? '.', sort: sort ?? 'name' },
+      this.busTimeoutMs,
     );
   }
 

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -98,6 +98,13 @@ export class BrowseNamespace implements IBrowseNamespace {
    */
   private readonly busTimeoutMs: number | undefined;
 
+  /**
+   * The `subscribeToEvents()` bus subscriptions, held so `dispose()` can
+   * detach them — a disposed namespace must not react to late bus events
+   * by refetching into disposed caches (B16).
+   */
+  private readonly busSubs: Array<{ unsubscribe(): void }> = [];
+
   constructor(
     private readonly transport: ITransport,
     private readonly bus: EventBus,
@@ -473,7 +480,35 @@ export class BrowseNamespace implements IBrowseNamespace {
     channel: K,
     handler: (payload: EventMap[K]) => void,
   ): void {
-    (this.bus.get(channel) as { subscribe(fn: (p: EventMap[K]) => void): unknown }).subscribe(handler);
+    this.busSubs.push(
+      (this.bus.get(channel) as {
+        subscribe(fn: (p: EventMap[K]) => void): { unsubscribe(): void };
+      }).subscribe(handler),
+    );
+  }
+
+  /**
+   * Dispose the namespace: detach every bus subscription and dispose all
+   * owned caches (B16 — this namespace constructed them, so it disposes
+   * them: the A7-owned rule). Every per-key observable completes, so
+   * subscribers detach cleanly; a fetch/retry chain straddling disposal
+   * dies quietly in the cache's own disposed guard. Idempotent. Called by
+   * `SemiontClient.dispose()`.
+   */
+  dispose(): void {
+    for (const sub of this.busSubs) sub.unsubscribe();
+    this.busSubs.length = 0;
+    this.resourceCache.dispose();
+    this.resourceListCache.dispose();
+    this.annotationListCache.dispose();
+    this.annotationDetailCache.dispose();
+    this.entityTypesCache.dispose();
+    this.tagSchemasCache.dispose();
+    this.referencedByCache.dispose();
+    this.resourceEventsCache.dispose();
+    this.annotationResources.clear();
+    this.resourceListFilters.clear();
+    this.annotationListObs.clear();
   }
 
   /**

--- a/scripts/compliance/audit-raw-bus.sh
+++ b/scripts/compliance/audit-raw-bus.sh
@@ -33,6 +33,12 @@ set -euo pipefail
 #                                       — LocalTransport implements ITransport
 #                                          on top of EventBus (bus.get is the
 #                                          natural backing primitive there)
+#   - packages/core/src/faulty-transport.ts
+#                                       — FaultyTransport (liveness-axioms
+#                                          simulator, @semiont/core/testing)
+#                                          implements ITransport on top of
+#                                          EventBus, same as LocalTransport;
+#                                          consumed by test suites only
 #   - packages/react-ui/src/state/**    — cross-feature page state units (shell, session)
 #                                          that subscribe to bus events for
 #                                          UI workflow coordination
@@ -60,6 +66,7 @@ filter_allowlist() {
     | grep -v "^packages/http-transport/src/" \
     | grep -v "^packages/jobs/src/" \
     | grep -v "^packages/make-meaning/src/local-transport\.ts:" \
+    | grep -v "^packages/core/src/faulty-transport\.ts:" \
     | grep -v "^packages/react-ui/src/state/" \
     | grep -v "^packages/react-ui/src/features/[^/]*/state/" \
     | grep -v "^packages/react-ui/src/contexts/useEventSubscription\.ts:"


### PR DESCRIPTION
## Summary

Gives **liveness** the same axiomatic treatment safety got from the StateUnit axioms — and the axioms earned their keep before the PR was done: the property suites **found and fixed three real bugs** the existing (all-safety) test surface had passed over.

The starvation incident (N−1 concurrent `useResourceLoader`s silently pending forever, PR #945's diagnosis) showed the next bug tier lives *between* verified layers: every unit contract held while the composition starved. This PR adds four liveness axioms, a fault-injecting harness that generates the interleavings nobody hand-writes, teeth-tests proving the harness can catch known-bad implementations, and property suites running the **real** sdk and transport compositions under fault schedules.

Design ledger: `.plans/LIVENESS-AXIOMS.md` (execution log is ground truth).

## The axioms

| Id | Axiom | Bug it makes unrepresentable |
| --- | --- | --- |
| **L1** | Every live-query subscription eventually emits a value or an error — never silently pending forever | the starved loader |
| **L2** | Every `busRequest` settles within timeout × retry budget; no swallowed rejection without a bounded re-issue or surfaced signal | the pre-B14 `catch(() => {})` |
| **L3** | An event written to a live connection is delivered to `on$` exactly once across handovers/reconnects; retirement is by drain, never abort | the buffered-reply loss at handover |
| **L4** | Degradation is observable: a fault-injected run in which degradation occurred must emit ≥1 breadcrumb | the forensic invisibility that misdirected the original diagnosis |

## Phases (one commit each, TDD-first — teeth before trust)

| Commit | Phase | What |
| --- | --- | --- |
| `33c8ff1` | **P1 — harness + teeth** (core) | `FaultyTransport` (seeded fault schedules: drop/delay/duplicate/reject-emit; both scope models) + `assertLivenessAxioms`/`assertExactlyOnceDelivery` in `@semiont/core/testing`; 9-test teeth suite proving three reconstructed pre-fix doubles each trip their axiom |
| `89c6e49` | **P2 — L1/L2 properties** (sdk) | Properties over the real `BrowseNamespace`+`createCache`+`busRequest`; `busTimeoutMs` option threaded so properties run on virtual time |
| `07a433f` | **P3 — L3 property** (http-transport) | fast-check-scheduled delivery vs. handover timing over the real `createActorStateUnit`; `mock-conn.ts` harness extracted for reuse |
| `29259c5` | **P4a+4b — L4 assertions** | sdk: per-run fault⇒breadcrumb implication + deterministic trio (`[cache RETRY]`/`[cache IDLE]`/`[browse DEGRADED]`); http-transport: `[bus LINGER]` via the `__SEMIONT_BUS_LOG__` gate |
| `12cc8f4` | **P4c — doc cross-links** | CACHE-SEMANTICS B14 ↔ L1/L2; TRANSPORT-HTTP abort-discipline ↔ L3; STATE-UNITS enforcement table gains the composition tier (five tiers now) |
| `df796f6`, `57fa111` | docs | MARK flow/media-token doc updates; stale `api-client` → `sdk` reference sweep |
| `052b252` | compliance | `audit-raw-bus.sh` allowlists core's `FaultyTransport` (an ITransport implementation, exempt like `LocalTransport`) |
| `b525db7` | **B16** (sdk) | Disposal is terminal and inert — see below |

## The three real bugs the axioms found

1. **`busRequest` emit-rejection left a doomed promise** (P1 teeth, `reject-emit` schedules): an emit failure rethrew to the caller but left the already-subscribed reply promise to reject `bus.timeout` later with no awaiter — an unhandled rejection in any real caller. Fixed in `bus-request.ts` (detach before rethrow).
2. **Value-less-key terminal failure starved observers** (P2 properties, RED on first run; fast-check shrank to `[[reject-emit], single-slot-throw]`): B14 exhaustion on a key with no cached value left subscribers on `undefined` forever — L1's forbidden fourth state, observable in a breadcrumb but not in-band. Fixed as **CACHE-SEMANTICS B15**: the terminal failure errors that key's observers (pushed + replayed, always retriable); keys with a stale value keep B6 stale-beats-error. `useResourceLoader`'s `error` callback now actually fires.
3. **B15 at teardown was disposal noise** (escaped as a flaky unhandled `bus.closed` rejection in make-meaning's CI — 30/30 files green + one Unhandled Error racing worker teardown): a retry chain straddling client teardown errored subscribers at shutdown. Fixed as **CACHE-SEMANTICS B16** rather than special-casing the error code (which would have carved silent drift into L1): disposal is terminal and inert — `dispose()` completes every per-key observable and stuns all later acts (no fetch, no retry, no breadcrumb, no push); `BrowseNamespace.dispose()` disposes its 8 owned caches and detaches its bus handlers; `SemiontClient.dispose()` calls it first.

## Testing

Every phase RED-first (teeth doubles or real counterexamples), then GREEN; verified per-lane in `node:24-alpine`. Final state: core 17 files, sdk 29 files (389 tests incl. both property suites at CI-fast `numRuns`), http-transport 29/29 across both actor suites. Properties are plain vitest tests — no new CI job.

## Follow-up (not in this PR)

`client.bus` had the same never-disposed shape B16 fixed for the caches; the blast-radius review and fix (`dispose()` destroys the bus; post-dispose access throws) landed after this PR merged.
