### PR TITLE
 destroy client.bus on dispose; update docs

### DIFF
--- a/packages/sdk/src/__tests__/client-passthroughs.test.ts
+++ b/packages/sdk/src/__tests__/client-passthroughs.test.ts
@@ -20,10 +20,13 @@ import {
   baseUrl,
   resourceId,
   annotationId,
+  type AccessToken,
   type EventMap,
 } from '@semiont/core';
 
 import { SemiontClient } from '../client';
+import { SemiontSession } from '../session/semiont-session';
+import { TestStorage } from '../session/__tests__/test-storage-helpers';
 import type { ConnectionState, ITransport, IContentTransport } from '@semiont/core';
 
 const TEST_BASE = baseUrl('http://test.local');
@@ -109,6 +112,71 @@ describe('SemiontClient lifecycle + namespace routing', () => {
       client.dispose();
       expect(transport.dispose).toHaveBeenCalled();
       expect(content.dispose).toHaveBeenCalled();
+    });
+  });
+
+  // ── Bus disposal (A7-owned) ──────────────────────────────────────────────
+  //
+  // The client CONSTRUCTS its bus, so dispose() must destroy it (the
+  // A7-owned rule — same shape as BrowseNamespace's caches, B16). Pre-fix,
+  // the bus outlived the client: every subscriber stayed attached forever,
+  // silently receiving nothing (the L1 silence class), and my-chat's
+  // KB-reconnect loop leaked one bus per session cycle. Bus lifetime ==
+  // client lifetime == session lifetime — no mid-session client swap exists
+  // (verified: `SemiontSession.client` is set only at construction).
+  describe('bus disposal (A7-owned)', () => {
+    test('dispose completes client.bus subscribers', () => {
+      const events: string[] = [];
+      client.bus.get('mark:submit').subscribe({
+        next: () => events.push('next'),
+        error: () => events.push('error'),
+        complete: () => events.push('complete'),
+      });
+
+      client.dispose();
+
+      expect(events).toEqual(['complete']);
+    });
+
+    test('unsubscribe after dispose is a safe no-op', () => {
+      const sub = client.bus.get('mark:submit').subscribe(() => {});
+      client.dispose();
+      expect(() => sub.unsubscribe()).not.toThrow();
+    });
+
+    test('post-dispose bus access throws the destroyed-bus contract (loud, not silent)', () => {
+      client.dispose();
+      // Direct bus access and bus-emitting namespace methods alike: calling
+      // a disposed client is a bug, and it now says so — pre-fix it
+      // no-op'd into the leaked bus.
+      expect(() => client.bus.get('mark:submit')).toThrow(/destroyed bus/);
+      expect(() => client.mark.cancelPending()).toThrow(/destroyed bus/);
+    });
+
+    test('session.dispose() reaches the same completion through session.subscribe', async () => {
+      const session = new SemiontSession({
+        kb: {
+          id: 'kb-test',
+          label: 'Test',
+          email: 'test@example.com',
+          endpoint: { kind: 'http', host: 'test.local', port: 80, protocol: 'http' },
+        },
+        storage: new TestStorage(),
+        client,
+        token$: new BehaviorSubject<AccessToken | null>(null),
+      });
+
+      const seen: unknown[] = [];
+      const unsubscribe = session.subscribe('mark:submit', (p) => seen.push(p));
+
+      await session.dispose();
+
+      // The session's client bus is destroyed — late subscribe attempts are
+      // loud, the handler's subscription completed, and the returned
+      // unsubscribe closure is a safe no-op.
+      expect(() => session.client.bus.get('mark:submit')).toThrow(/destroyed bus/);
+      expect(() => unsubscribe()).not.toThrow();
+      expect(seen).toEqual([]);
     });
   });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -143,6 +143,17 @@ export class SemiontClient {
     this.browse.dispose();
     this.transport.dispose();
     this.content.dispose();
+    // Bus last (A7-owned: this client constructed it): everything upstream
+    // is already quiet — browse detached its handlers, the transport's SSE
+    // fan-in is down — so destroying now completes every remaining
+    // subscriber cleanly (session.subscribe closures, host code holding
+    // client.bus). Without this, the bus outlived the client and every
+    // subscriber stayed attached forever, silently receiving nothing — one
+    // leaked bus per session cycle under a reconnect loop. Post-dispose
+    // `bus.get()` — any bus-emitting namespace method — now throws
+    // `destroyed bus` instead of no-op'ing into the leak: calling a
+    // disposed client is a bug, and it says so.
+    this.bus.destroy();
   }
 
   /**


### PR DESCRIPTION
…e the leak

SemiontClient constructs its bus but dispose() never destroyed it (the same A7-owned shape B16 just fixed for Browse's caches). Every subscriber -- session.subscribe closures (literally client.bus.get(ch).subscribe(h)), react-ui's bind:initiate sub, host code holding client.bus -- survived disposal forever, silently receiving nothing (the L1 silence class), and a KB-reconnect loop leaked one full bus per session cycle.

Blast-radius review first (.plans/LIVENESS-AXIOMS.md, 2026-07-05 client.bus entry): the feared "consumers hold refs across a mid-session client swap" case does not exist -- SemiontSession.client is assigned only at construction; the other new SemiontClient sites are static session factories. Bus lifetime == client lifetime == session lifetime, so destroying at dispose is unambiguous.

dispose() now ends with this.bus.destroy() -- deliberately LAST: browse.dispose() has detached its bus handlers and transport.dispose() has taken the SSE/local fan-in down (LocalTransport.dispose() clears bridges), so nothing upstream can .next() into a destroyed bus. Remaining subscribers complete cleanly; late unsubscribe() closures are no-ops.

Pinned behavior change: post-dispose bus access -- raw bus.get(), any bus-emitting namespace method (8 namespaces hold bus refs), session.subscribe -- now throws "destroyed bus" (EventBus's designed misuse guard) instead of no-op'ing into the leak. Calling a disposed client is a bug, and it now says so.

TDD: 4 RED tests in client-passthroughs.test.ts (the suite chartered for dispose plumbing): dispose completes bus subscribers; unsubscribe-after-dispose is a safe no-op; post-dispose access throws; and the full REAL SemiontSession.dispose() chain over a real client (no module mock). Watched fail for the right reasons, then GREEN.

Tests: sdk 29/29 files (393), tsc clean (node:24-alpine). make-meaning's local-transport.test.ts green + teardown structurally safe (client -> service -> outer bus, all try/caught); note it consumes the sdk dist, so its live run against this change lands with the next build/CI.

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Infrastructure/DevOps changes

## Areas Changed

- [ ] Frontend (`apps/frontend`)
- [ ] Backend (`apps/backend`)
- [ ] CLI (`apps/cli`)
- [ ] HTTP Transport (`packages/http-transport`)
- [ ] Core (`packages/core`)
- [ ] MCP Server (`packages/mcp-server`)
- [ ] Test Utils (`packages/test-utils`)
- [ ] OpenAPI Specs (`specs/`)
- [ ] Demo Scripts (`demo/`)
- [ ] Documentation (`docs/`)
- [ ] GitHub Actions (`.github/workflows/`)
- [ ] Scripts (`scripts/`)
- [ ] Infrastructure/Deployment

## Security Checklist

**Required for all PRs that modify authentication, authorization, or admin functionality:**

### Authentication & Authorization

- [ ] No authentication logic moved to client-side
- [ ] All admin routes properly protected with server-side checks
- [ ] JWT tokens validated server-side only
- [ ] Session data comes from secure sources (database, not client claims)
- [ ] No hardcoded secrets or credentials

### Admin Route Security (Frontend)

- [ ] Admin/moderate routes protected by middleware (proxy.ts)
- [ ] No admin content rendered for unauthorized users
- [ ] No sensitive information in error responses

### API Security (Backend)

- [ ] Admin endpoints protected with `adminMiddleware`
- [ ] All endpoints return proper HTTP status codes (401/403/500)
- [ ] Error messages don't leak sensitive information
- [ ] Database queries protected behind authentication
- [ ] Input validation implemented

### Information Disclosure Prevention

- [ ] No database connection strings in error messages
- [ ] No file paths or stack traces exposed to clients
- [ ] No user emails or personal data in unauthorized responses
- [ ] No API keys or secrets in client-accessible responses
- [ ] Error messages are generic and safe

## Testing

- [ ] Added tests for new functionality
- [ ] All existing tests pass
- [ ] Security tests pass (`npm run test:security`)
- [ ] Manual testing completed for authentication flows
- [ ] Tested with different user roles (unauthenticated, non-admin, admin)

## Security Test Results

Please run and paste results:

### Frontend Security Tests

```bash
cd apps/frontend && npm run test:security
# Paste results here
```

### Backend Security Tests

```bash
cd apps/backend && npm run test:security
# Paste results here
```

### Manual Security Verification

If you modified admin routes, please verify:

```bash
# Start the application and test:
curl -I http://localhost:3000/admin
# Should return: HTTP/1.1 200 OK (not 307)

# Verify no admin content leakage:
curl -s http://localhost:3000/admin | grep -i "admin\|dashboard\|management"
# Should return no results
```

## Performance Impact

- [ ] No significant performance degradation
- [ ] Database queries optimized
- [ ] No N+1 query problems introduced
- [ ] Bundle size impact considered (for frontend changes)

## Breaking Changes

If this PR introduces breaking changes, please describe:

- What breaks
- Migration path for users
- Documentation updates needed

## Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] API documentation updated (if applicable)
- [ ] Security documentation updated (if security-related)

## Additional Context

Add any other context, screenshots, or information about the pull request here.

---

## For Reviewers

### Security Review Required

- [ ] Authentication/authorization changes reviewed
- [ ] No security regressions introduced
- [ ] Error handling doesn't leak sensitive data
- [ ] All security tests passing
- [ ] Manual security verification completed

### Code Review

- [ ] Code follows project conventions
- [ ] No obvious bugs or issues
- [ ] Performance considerations addressed
- [ ] Tests provide adequate coverage
- [ ] Documentation is clear and accurate

### Final Checks

- [ ] All CI checks passing
- [ ] Security tests passing
- [ ] No merge conflicts
- [ ] Ready for deployment

---

**⚠️ SECURITY NOTICE:** If any security tests fail or if this PR modifies authentication/authorization logic, **DO NOT MERGE** until security issues are resolved and all tests pass.
