### PR TITLE
Resource tag editing: controlled vocabulary end-to-end (picker + server gate + event-log integrity)

### DIFF
--- a/apps/backend/src/routes/exchange.ts
+++ b/apps/backend/src/routes/exchange.ts
@@ -146,7 +146,7 @@ exchangeRouter.post('/api/admin/exchange/restore', async (c) => {
 
         send({ phase: 'started', message: 'Restoring backup...' });
         const { knowledgeSystem: { kb: backupKb } } = c.get('makeMeaning');
-        const result = await importBackup(input, { eventBus, contentStore: backupKb.content });
+        const result = await importBackup(input, { eventBus, eventStore: backupKb.eventStore, contentStore: backupKb.content });
         send({
           phase: 'complete',
           result: {

--- a/apps/cli/src/core/commands/import.ts
+++ b/apps/cli/src/core/commands/import.ts
@@ -118,7 +118,7 @@ export async function runImport(options: ImportOptions): Promise<CommandResults>
   const eventBus = new EventBus();
   const eventStore = createEventStore(project, eventBus, logger);
   const kb = await createKnowledgeBase(eventStore, project, createNoopGraphDatabase(), eventBus, logger);
-  const stower = new Stower(kb, eventBus, logger.child({ component: 'stower' }));
+  const stower = new Stower(kb, eventBus, project, logger.child({ component: 'stower' }));
   await stower.initialize();
 
   try {

--- a/apps/cli/src/core/commands/mv.ts
+++ b/apps/cli/src/core/commands/mv.ts
@@ -115,7 +115,7 @@ export async function runMv(options: MvOptions): Promise<CommandResults> {
   const eventBus = new EventBus();
   const eventStore = createEventStore(project, eventBus, logger);
   const kb = await createKnowledgeBase(eventStore, project, createNoopGraphDatabase(), eventBus, logger);
-  const stower = new Stower(kb, eventBus, logger.child({ component: 'stower' }));
+  const stower = new Stower(kb, eventBus, project, logger.child({ component: 'stower' }));
   await stower.initialize();
 
   try {

--- a/apps/cli/src/core/commands/restore.ts
+++ b/apps/cli/src/core/commands/restore.ts
@@ -112,12 +112,12 @@ export async function runRestore(options: RestoreOptions): Promise<CommandResult
   const eventBus = new EventBus();
   const eventStore = createEventStore(project, eventBus, logger);
   const kb = await createKnowledgeBase(eventStore, project, createNoopGraphDatabase(), eventBus, logger);
-  const stower = new Stower(kb, eventBus, logger.child({ component: 'stower' }));
+  const stower = new Stower(kb, eventBus, project, logger.child({ component: 'stower' }));
   await stower.initialize();
 
   try {
     const input = fs.createReadStream(filePath);
-    const result = await importBackup(input, { eventBus, contentStore: kb.content, logger });
+    const result = await importBackup(input, { eventBus, eventStore, contentStore: kb.content, logger });
 
     if (!options.quiet) {
       printSuccess(

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -11,6 +11,8 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
+import { promises as fs } from 'fs';
+import { join } from 'path';
 import { AnnotationOperations } from '../annotation-operations';
 import { ResourceOperations } from '../resource-operations';
 import { resourceId, userId, EventBus, type Logger, type SupportedMediaType } from '@semiont/core';
@@ -67,6 +69,7 @@ describe('AnnotationOperations', () => {
   let stower: Stower;
   let kb: KnowledgeBase;
   let testResourceId: string;
+  let suiteProject: Awaited<ReturnType<typeof createTestProject>>['project'];
 
   async function create(
     opts: { name: string; content: Buffer; format: SupportedMediaType; language?: string; entityTypes?: string[] },
@@ -84,6 +87,7 @@ describe('AnnotationOperations', () => {
   beforeAll(async () => {
     const { project, teardown: td } = await createTestProject('annotation-ops');
     teardown = td;
+    suiteProject = project;
 
     // Initialize EventBus and stores
     eventBus = new EventBus();
@@ -93,7 +97,7 @@ describe('AnnotationOperations', () => {
     const repStore = new WorkingTreeStore(project, mockLogger);
     kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, graphConsumer: {} as any };
 
-    stower = new Stower(kb, eventBus, mockLogger);
+    stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
 
     // Create a test resource for annotations
@@ -827,6 +831,12 @@ describe('AnnotationOperations', () => {
       // request would hang to timeout (.plans/bugs/BRIDGE-GAPS.md shape).
       // Passing a non-empty `current` that differs from `updated` exercises both
       // diff branches: 'Person' is added, 'Legacy' is removed.
+      // The vocabulary gate requires ADDS to be registered (removals are never
+      // gated — 'Legacy' needs no registration), so register 'Person' first.
+      const systemDir = join(suiteProject.stateDir, 'projections', '__system__');
+      await fs.mkdir(systemDir, { recursive: true });
+      await fs.writeFile(join(systemDir, 'entitytypes.json'), JSON.stringify({ entityTypes: ['Person'] }));
+
       const correlationId = 'uet-cid-1';
       const ok$ = firstValueFrom(
         eventBus.get('mark:update-entity-types-ok').pipe(
@@ -864,7 +874,7 @@ describe('AnnotationOperations', () => {
       const failingKb = {
         eventStore: { appendEvent: vi.fn().mockRejectedValue(new Error('disk full')) },
       } as unknown as KnowledgeBase;
-      const failStower = new Stower(failingKb, failBus, mockLogger);
+      const failStower = new Stower(failingKb, failBus, suiteProject, mockLogger);
       await failStower.initialize();
 
       const correlationId = 'uet-cid-fail';
@@ -875,12 +885,15 @@ describe('AnnotationOperations', () => {
         ),
       );
 
+      // A REMOVAL, not an add: removals are never vocabulary-gated (the gate
+      // would otherwise reject the tag before appendEvent runs), so this still
+      // exercises the append-failure catch branch — the test's actual subject.
       failBus.get('mark:update-entity-types').next({
         correlationId,
         _userId: 'user-1',
         resourceId: testResourceId,
-        currentEntityTypes: [],
-        updatedEntityTypes: ['Person'],
+        currentEntityTypes: ['Person'],
+        updatedEntityTypes: [],
       });
 
       const failure = await failed$;

--- a/packages/make-meaning/src/__tests__/bootstrap/entity-types.test.ts
+++ b/packages/make-meaning/src/__tests__/bootstrap/entity-types.test.ts
@@ -42,7 +42,7 @@ describe('Entity Types Bootstrap', () => {
     eventStore = createEventStore(project, eventBus, mockLogger);
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
-    stower = new Stower(kb, eventBus, mockLogger);
+    stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
   });
 

--- a/packages/make-meaning/src/__tests__/exchange/backup-importer.test.ts
+++ b/packages/make-meaning/src/__tests__/exchange/backup-importer.test.ts
@@ -11,6 +11,7 @@ import { Readable, Writable } from 'node:stream';
 import type { Logger, ResourceId, UserId } from '@semiont/core';
 import { EventBus } from '@semiont/core';
 import type { WorkingTreeStore } from '@semiont/content';
+import type { EventStore } from '@semiont/event-sourcing';
 import { importBackup } from '../../exchange/backup-importer';
 import { writeTarGz, type TarEntry } from '../../exchange/tar';
 import { BACKUP_FORMAT } from '../../exchange/manifest';
@@ -32,6 +33,10 @@ const mockLogger: Logger = {
   error: vi.fn(),
   child: vi.fn(() => mockLogger),
 };
+
+// Replay appends historical entity-tag events as facts (never re-issues
+// commands) — the fake receives those appends.
+const mockEventStore = { appendEvent: vi.fn().mockResolvedValue(undefined) } as unknown as EventStore;
 
 function collectWritable(): { writable: Writable; promise: Promise<Buffer> } {
   const chunks: Buffer[] = [];
@@ -123,7 +128,7 @@ describe('backup-importer', () => {
       { name: '.semiont/events/__system__.jsonl', data: Buffer.from(systemEvents) },
     ]);
 
-    const result = await importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore, logger: mockLogger });
+    const result = await importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore, logger: mockLogger });
 
     expect(result.manifest.format).toBe(BACKUP_FORMAT);
     expect(result.stats.eventsReplayed).toBe(1);
@@ -163,7 +168,7 @@ describe('backup-importer', () => {
       { name: 'sha-content.md', data: contentBlob },
     ]);
 
-    const result = await importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore, logger: mockLogger });
+    const result = await importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore, logger: mockLogger });
 
     expect(result.stats.eventsReplayed).toBe(1);
     expect(result.stats.resourcesCreated).toBe(1);
@@ -197,7 +202,7 @@ describe('backup-importer', () => {
       { name: 'deadbeef1234.pdf', data: pdfContent },
     ]);
 
-    await importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore, logger: mockLogger });
+    await importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore, logger: mockLogger });
 
     expect(receivedChecksum).toBeDefined();
   });
@@ -208,7 +213,7 @@ describe('backup-importer', () => {
     ]);
 
     await expect(
-      importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore })
+      importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore })
     ).rejects.toThrow(/missing \.semiont\/manifest\.jsonl/);
   });
 
@@ -226,7 +231,7 @@ describe('backup-importer', () => {
     ]);
 
     await expect(
-      importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore })
+      importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore })
     ).rejects.toThrow(/expected format/);
   });
 
@@ -244,7 +249,7 @@ describe('backup-importer', () => {
     ]);
 
     await expect(
-      importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore })
+      importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore })
     ).rejects.toThrow(/Unsupported format version/);
   });
 
@@ -259,7 +264,7 @@ describe('backup-importer', () => {
       // Note: no .semiont/events/missing-resource.jsonl
     ]);
 
-    const result = await importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore, logger: mockLogger });
+    const result = await importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore, logger: mockLogger });
 
     // Should complete without error, but skip the missing stream
     expect(result.stats.eventsReplayed).toBe(0);
@@ -302,7 +307,7 @@ describe('backup-importer', () => {
       { name: 'chk1.md', data: Buffer.from('content') },
     ]);
 
-    await importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore, logger: mockLogger });
+    await importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore, logger: mockLogger });
 
     expect(order).toEqual(['entity-type', 'resource-created']);
   });
@@ -351,7 +356,7 @@ describe('backup-importer', () => {
       { name: 'c2.md', data: Buffer.from('doc 2 content') },
     ]);
 
-    const result = await importBackup(bufferToReadable(archive), { eventBus, contentStore: mockContentStore, logger: mockLogger });
+    const result = await importBackup(bufferToReadable(archive), { eventBus, eventStore: mockEventStore, contentStore: mockContentStore, logger: mockLogger });
 
     expect(result.stats.eventsReplayed).toBe(4);
     expect(result.stats.entityTypesAdded).toBe(2);

--- a/packages/make-meaning/src/__tests__/exchange/replay.test.ts
+++ b/packages/make-meaning/src/__tests__/exchange/replay.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventBus, type ResourceId, type UserId, type AnnotationId, type PersistedEvent } from '@semiont/core';
 import type { WorkingTreeStore } from '@semiont/content';
+import type { EventStore } from '@semiont/event-sourcing';
 import { replayEventStream, type ContentBlobResolver } from '../../exchange/replay';
 
 const TEST_USER = 'did:web:localhost:users:test' as UserId;
@@ -98,11 +99,17 @@ const mockContentStore = {
   register: vi.fn().mockResolvedValue({ storageUri: 'file://test.md', checksum: 'abc123', byteSize: 100, created: new Date().toISOString() }),
 } as unknown as WorkingTreeStore;
 
+// Replay appends historical events as facts (never re-issues commands) —
+// the fake captures those appends for assertion.
+const mockAppendEvent = vi.fn().mockResolvedValue(undefined);
+const mockEventStore = { appendEvent: mockAppendEvent } as unknown as EventStore;
+
 describe('replay', () => {
   let eventBus: EventBus;
 
   beforeEach(() => {
     eventBus = new EventBus();
+    mockAppendEvent.mockClear();
   });
 
   afterEach(() => {
@@ -119,7 +126,7 @@ describe('replay', () => {
       const jsonl = entityTypeEvent('Person');
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
 
       expect(result.stats.eventsReplayed).toBe(1);
       expect(result.stats.entityTypesAdded).toBe(1);
@@ -142,7 +149,7 @@ describe('replay', () => {
       });
 
       const jsonl = resourceCreatedEvent('Test Resource', 'sha256-abc');
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
 
       expect(result.stats.eventsReplayed).toBe(1);
       expect(result.stats.resourcesCreated).toBe(1);
@@ -154,7 +161,7 @@ describe('replay', () => {
       const jsonl = resourceCreatedEvent('Test Resource', 'missing-checksum');
 
       await expect(
-        replayEventStream(jsonl, eventBus, resolver, mockContentStore)
+        replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore)
       ).rejects.toThrow(/Missing content blob/);
     });
 
@@ -166,7 +173,7 @@ describe('replay', () => {
       const jsonl = annotationAddedEvent('ann-1');
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
 
       expect(result.stats.eventsReplayed).toBe(1);
       expect(result.stats.annotationsCreated).toBe(1);
@@ -189,7 +196,7 @@ describe('replay', () => {
       });
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(1);
     });
 
@@ -206,7 +213,7 @@ describe('replay', () => {
       });
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(1);
     });
 
@@ -222,7 +229,7 @@ describe('replay', () => {
       });
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(1);
       expect(archiveSpy).toHaveBeenCalledOnce();
     });
@@ -239,12 +246,18 @@ describe('replay', () => {
       });
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(1);
       expect(unarchiveSpy).toHaveBeenCalledOnce();
     });
 
-    it('replays entitytag.added through mark:update-entity-types', async () => {
+    // Replay semantics (ratified 2026-07-09): events are facts, commands are
+    // requests — replay appends the historical event verbatim and NEVER
+    // re-issues mark:update-entity-types. This excludes imports from the
+    // vocabulary gate by construction (pre-gate warts restore as the facts
+    // they are) and stops replay minting duplicate -added events from a
+    // fabricated empty diff base.
+    it('replays entitytag.added by appending the historical event verbatim', async () => {
       const updateSpy = vi.fn();
       eventBus.get('mark:update-entity-types').subscribe(updateSpy);
 
@@ -256,17 +269,22 @@ describe('replay', () => {
       });
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(1);
-      expect(updateSpy).toHaveBeenCalledWith(
+      // the fact is copied — original user preserved, payload verbatim
+      expect(mockAppendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          updatedEntityTypes: ['Person'],
-          currentEntityTypes: [],
+          type: 'mark:entity-tag-added',
+          resourceId: TEST_RESOURCE,
+          userId: TEST_USER,
+          payload: { entityType: 'Person' },
         })
       );
+      // no command re-issued: replay must not re-adjudicate history
+      expect(updateSpy).not.toHaveBeenCalled();
     });
 
-    it('replays entitytag.removed through mark:update-entity-types', async () => {
+    it('replays entitytag.removed by appending the historical event verbatim', async () => {
       const updateSpy = vi.fn();
       eventBus.get('mark:update-entity-types').subscribe(updateSpy);
 
@@ -278,14 +296,17 @@ describe('replay', () => {
       });
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(1);
-      expect(updateSpy).toHaveBeenCalledWith(
+      expect(mockAppendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          currentEntityTypes: ['Location'],
-          updatedEntityTypes: [],
+          type: 'mark:entity-tag-removed',
+          resourceId: TEST_RESOURCE,
+          userId: TEST_USER,
+          payload: { entityType: 'Location' },
         })
       );
+      expect(updateSpy).not.toHaveBeenCalled();
     });
 
     it('skips job events without error', async () => {
@@ -302,7 +323,7 @@ describe('replay', () => {
       const jsonl = lines.join('\n');
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(4);
       expect(result.stats.resourcesCreated).toBe(0);
       expect(result.stats.annotationsCreated).toBe(0);
@@ -322,7 +343,7 @@ describe('replay', () => {
       const jsonl = lines.join('\n');
       const resolver: ContentBlobResolver = () => undefined;
 
-      const result = await replayEventStream(jsonl, eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(jsonl, eventBus, mockEventStore, resolver, mockContentStore);
       expect(result.stats.eventsReplayed).toBe(2);
     });
 
@@ -352,7 +373,7 @@ describe('replay', () => {
         annotationAddedEvent('ann-1'),
       ];
 
-      const result = await replayEventStream(lines.join('\n'), eventBus, resolver, mockContentStore);
+      const result = await replayEventStream(lines.join('\n'), eventBus, mockEventStore, resolver, mockContentStore);
 
       expect(result.stats.eventsReplayed).toBe(3);
       expect(result.stats.entityTypesAdded).toBe(1);

--- a/packages/make-meaning/src/__tests__/graph-consumer.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-consumer.test.ts
@@ -466,6 +466,93 @@ describe('GraphDBConsumer', () => {
       expect(updateArg.entityTypes).toEqual(['article']);
     });
 
+    // The -added fold must be idempotent per event, mirroring the view
+    // materializer's includes-guard — duplicate adds must not diverge the
+    // graph from the view (bugs/graph-consumer-entity-tag-add-not-idempotent.md).
+    it('entitytag.added for a tag the graph doc already has leaves a single copy', async () => {
+      const docId = resourceId(`apply-entitytag-dup-${Date.now()}`);
+
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: docId,
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Test', format: 'text/plain', contentChecksum: 'h1' },
+      });
+      await tick();
+
+      vi.clearAllMocks();
+      // The graph doc ALREADY carries the tag (e.g. a stale caller diff base
+      // minted a duplicate -added, or the event is a historical duplicate).
+      (graphDb.getResource as ReturnType<typeof vi.fn>).mockResolvedValue({
+        '@id': `http://localhost:4000/resources/${docId}`,
+        entityTypes: ['article', 'note'],
+      });
+
+      await eventStore.appendEvent({
+        type: 'mark:entity-tag-added',
+        resourceId: docId,
+        userId: userId('user1'),
+        version: 1,
+        payload: { entityType: 'note' },
+      });
+      await tick();
+
+      // Idempotent fold: the tag is already present — no duplicating update.
+      expect(graphDb.updateResource).not.toHaveBeenCalled();
+    });
+
+    it('the same entitytag.added delivered twice leaves a single copy', async () => {
+      const docId = resourceId(`apply-entitytag-redeliver-${Date.now()}`);
+
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: docId,
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Test', format: 'text/plain', contentChecksum: 'h1' },
+      });
+      await tick();
+
+      vi.clearAllMocks();
+      (graphDb.getResource as ReturnType<typeof vi.fn>).mockResolvedValue({
+        '@id': `http://localhost:4000/resources/${docId}`,
+        entityTypes: ['article'],
+      });
+
+      await eventStore.appendEvent({
+        type: 'mark:entity-tag-added',
+        resourceId: docId,
+        userId: userId('user1'),
+        version: 1,
+        payload: { entityType: 'note' },
+      });
+      await tick();
+
+      // First delivery applies…
+      expect(graphDb.updateResource).toHaveBeenCalledTimes(1);
+      expect(
+        (graphDb.updateResource as ReturnType<typeof vi.fn>).mock.calls[0][1].entityTypes,
+      ).toEqual(['article', 'note']);
+
+      // …and once the graph reflects it, redelivery of the same fact is a no-op.
+      (graphDb.getResource as ReturnType<typeof vi.fn>).mockResolvedValue({
+        '@id': `http://localhost:4000/resources/${docId}`,
+        entityTypes: ['article', 'note'],
+      });
+
+      await eventStore.appendEvent({
+        type: 'mark:entity-tag-added',
+        resourceId: docId,
+        userId: userId('user1'),
+        version: 1,
+        payload: { entityType: 'note' },
+      });
+      await tick();
+
+      expect(graphDb.updateResource).toHaveBeenCalledTimes(1);
+    });
+
     it('should handle entitytype.added (system event, no resourceId)', async () => {
       await eventStore.appendEvent({
         type: 'frame:entity-type-added',

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -98,7 +98,7 @@ describe('LLM Context', () => {
     kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, graphConsumer: {} as any };
 
     // Start Stower
-    stower = new Stower(kb, eventBus, mockLogger);
+    stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
 
     // Create a test resource

--- a/packages/make-meaning/src/__tests__/resource-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-operations.test.ts
@@ -61,7 +61,7 @@ describe('ResourceOperations', () => {
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     kb = await createKnowledgeBase(testEventStore, project, graphDb, eventBus, mockLogger);
 
-    stower = new Stower(kb, eventBus, mockLogger);
+    stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
   });
 

--- a/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Stower `mark:update-entity-types` vocabulary gate
+ * (bugs/update-entity-types-skips-vocabulary-validation.md)
+ *
+ * Entity tags are a CONTROLLED VOCABULARY (ratified 2026-07-09). The direct
+ * update path must enforce the same gate the job path already does — same
+ * machinery (readEntityTypesProjection + validateEntityTypes), same
+ * "Entity type not registered: …" message — with two boundary rules:
+ *   - all-or-nothing per request: a mixed request must not half-land;
+ *   - removals are NEVER vocabulary-gated: deleting a stale/unregistered
+ *     legacy tag is the cleanup path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { firstValueFrom, race, timer } from 'rxjs';
+import { filter, map, take } from 'rxjs/operators';
+import { EventBus, resourceId, userId, type Logger, type ResourceId } from '@semiont/core';
+import type { SemiontProject } from '@semiont/core/node';
+import { createEventStore, type EventStore } from '@semiont/event-sourcing';
+import { getGraphDatabase } from '@semiont/graph';
+import type { GraphServiceConfig } from '@semiont/core';
+import { Stower } from '../stower';
+import { createKnowledgeBase } from '../knowledge-base';
+import { createTestProject } from './helpers/test-project';
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+describe('Stower mark:update-entity-types vocabulary gate', () => {
+  let teardown: () => Promise<void>;
+  let project: SemiontProject;
+  let eventStore: EventStore;
+  let eventBus: EventBus;
+  let stower: Stower;
+  let rid: ResourceId;
+  let cidCounter = 0;
+
+  beforeEach(async () => {
+    ({ project, teardown } = await createTestProject('stower-entity-types'));
+
+    eventBus = new EventBus();
+    eventStore = createEventStore(project, eventBus, mockLogger);
+    const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
+    const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
+    stower = new Stower(kb, eventBus, project, mockLogger);
+    await stower.initialize();
+
+    // Registered vocabulary — seeded the same way the reader tests do.
+    const systemDir = join(project.stateDir, 'projections', '__system__');
+    await fs.mkdir(systemDir, { recursive: true });
+    await fs.writeFile(join(systemDir, 'entitytypes.json'), JSON.stringify({ entityTypes: ['Person', 'Organization'] }));
+
+    // A resource for the tags to live on (log-level, mirrors graph-consumer tests).
+    rid = resourceId(`tags-res-${Date.now()}`);
+    await eventStore.appendEvent({
+      type: 'yield:created',
+      resourceId: rid,
+      userId: userId('user-1'),
+      version: 1,
+      payload: { name: 'Tagged', format: 'text/plain', contentChecksum: 'h1' },
+    });
+  });
+
+  afterEach(async () => {
+    await stower.stop();
+    eventBus.destroy();
+    await teardown();
+  });
+
+  function updateTags(current: string[], updated: string[]) {
+    const correlationId = `uet-cid-${++cidCounter}`;
+    const reply = firstValueFrom(
+      race(
+        eventBus.get('mark:update-entity-types-ok').pipe(
+          filter((e) => e.correlationId === correlationId),
+          map((e) => ({ kind: 'ok' as const, e })),
+        ),
+        eventBus.get('mark:update-entity-types-failed').pipe(
+          filter((e) => e.correlationId === correlationId),
+          map((e) => ({ kind: 'failed' as const, e })),
+        ),
+        timer(2000).pipe(
+          map((): never => {
+            throw new Error('no reply to mark:update-entity-types');
+          }),
+        ),
+      ).pipe(take(1)),
+    );
+    eventBus.get('mark:update-entity-types').next({
+      correlationId,
+      _userId: 'user-1',
+      resourceId: rid,
+      currentEntityTypes: current,
+      updatedEntityTypes: updated,
+    });
+    return reply.then((r) => ({ ...r, correlationId }));
+  }
+
+  async function tagEvents() {
+    const events = await eventStore.log.getEvents(rid);
+    return events.filter((e) => e.type === 'mark:entity-tag-added' || e.type === 'mark:entity-tag-removed');
+  }
+
+  it('rejects an unregistered add with the standard message and appends no events', async () => {
+    const r = await updateTags([], ['Dragon']);
+    if (r.kind !== 'failed') throw new Error('expected mark:update-entity-types-failed');
+    expect(r.e.correlationId).toBe(r.correlationId);
+    expect(r.e.message).toBe('Entity type not registered: Dragon');
+    expect(await tagEvents()).toEqual([]);
+  });
+
+  it('is all-or-nothing: a mixed request appends nothing, not even the valid add', async () => {
+    const r = await updateTags([], ['Person', 'Dragon']);
+    if (r.kind !== 'failed') throw new Error('expected mark:update-entity-types-failed');
+    expect(r.e.message).toBe('Entity type not registered: Dragon');
+    expect(await tagEvents()).toEqual([]); // Person must NOT have half-landed
+  });
+
+  it('accepts adds within the registered vocabulary unchanged', async () => {
+    const r = await updateTags([], ['Person', 'Organization']);
+    expect(r.kind).toBe('ok');
+    const events = await tagEvents();
+    expect(events.map((e) => [e.type, e.payload.entityType])).toEqual([
+      ['mark:entity-tag-added', 'Person'],
+      ['mark:entity-tag-added', 'Organization'],
+    ]);
+  });
+
+  it('never gates removals: an unregistered legacy tag can be removed', async () => {
+    // 'LegacyGunk' is not in the vocabulary — removing it is the cleanup path
+    // and must succeed; gating it would trap exactly the damage the gate prevents.
+    const r = await updateTags(['LegacyGunk'], []);
+    expect(r.kind).toBe('ok');
+    const events = await tagEvents();
+    expect(events.map((e) => [e.type, e.payload.entityType])).toEqual([
+      ['mark:entity-tag-removed', 'LegacyGunk'],
+    ]);
+  });
+});

--- a/packages/make-meaning/src/__tests__/views/entity-types-reader.test.ts
+++ b/packages/make-meaning/src/__tests__/views/entity-types-reader.test.ts
@@ -70,7 +70,7 @@ describe('Entity Types Projection Reader', () => {
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
       const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
-      const stower = new Stower(kb, eventBus, mockLogger);
+      const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
       await bootstrapEntityTypes(eventBus, eventStore);
       await stower.stop();
@@ -167,7 +167,7 @@ describe('Entity Types Projection Reader', () => {
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
       const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
-      const stower = new Stower(kb, eventBus, mockLogger);
+      const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
 
       const beforeBootstrap = await readEntityTypesProjection(project);

--- a/packages/make-meaning/src/__tests__/views/tag-schemas-reader.test.ts
+++ b/packages/make-meaning/src/__tests__/views/tag-schemas-reader.test.ts
@@ -143,7 +143,7 @@ describe('Tag Schemas Projection Reader', () => {
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
       const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
-      const stower = new Stower(kb, eventBus, mockLogger);
+      const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
 
       const before = await readTagSchemasProjection(project);

--- a/packages/make-meaning/src/exchange/backup-importer.ts
+++ b/packages/make-meaning/src/exchange/backup-importer.ts
@@ -15,6 +15,7 @@ import type { Readable } from 'node:stream';
 import type { Logger } from '@semiont/core';
 import { EventBus } from '@semiont/core';
 import type { WorkingTreeStore } from '@semiont/content';
+import type { EventStore } from '@semiont/event-sourcing';
 import { readTarGz } from './tar';
 import {
   BACKUP_FORMAT,
@@ -27,6 +28,8 @@ import { replayEventStream, type ReplayStats, type ContentBlobResolver } from '.
 
 export interface BackupImporterOptions {
   eventBus: EventBus;
+  /** Replay appends historical events directly (facts, not commands). */
+  eventStore: EventStore;
   contentStore: WorkingTreeStore;
   logger?: Logger;
 }
@@ -75,7 +78,7 @@ export async function importBackup(
   archive: Readable,
   options: BackupImporterOptions,
 ): Promise<BackupImportResult> {
-  const { eventBus, contentStore, logger } = options;
+  const { eventBus, eventStore, contentStore, logger } = options;
 
   // Stream and decompress archive entries
   const entries = new Map<string, Buffer>();
@@ -118,6 +121,7 @@ export async function importBackup(
     const result = await replayEventStream(
       systemData.toString('utf8'),
       eventBus,
+      eventStore,
       resolveBlob,
       contentStore,
       logger,
@@ -138,6 +142,7 @@ export async function importBackup(
     const result = await replayEventStream(
       eventData.toString('utf8'),
       eventBus,
+      eventStore,
       resolveBlob,
       contentStore,
       logger,

--- a/packages/make-meaning/src/exchange/replay.ts
+++ b/packages/make-meaning/src/exchange/replay.ts
@@ -17,6 +17,7 @@ import { asBusRequestPrimitive } from '../bus-request-local';
 import type { components } from '@semiont/core';
 import type { WorkingTreeStore } from '@semiont/content';
 import { deriveStorageUri } from '@semiont/content';
+import type { EventStore } from '@semiont/event-sourcing';
 
 type ContentFormat = components['schemas']['ContentFormat'];
 import type { Annotation } from '@semiont/core';
@@ -50,6 +51,7 @@ const REPLAY_TIMEOUT_MS = 30_000;
 export async function replayEventStream(
   jsonl: string,
   eventBus: EventBus,
+  eventStore: EventStore,
   resolveBlob: ContentBlobResolver,
   contentStore: WorkingTreeStore,
   logger?: Logger,
@@ -66,7 +68,7 @@ export async function replayEventStream(
 
   // Replay each event
   for (const stored of storedEvents) {
-    await replayEvent(stored, eventBus, resolveBlob, contentStore, stats, logger);
+    await replayEvent(stored, eventBus, eventStore, resolveBlob, contentStore, stats, logger);
     stats.eventsReplayed++;
   }
 
@@ -76,6 +78,7 @@ export async function replayEventStream(
 async function replayEvent(
   event: PersistedEvent,
   eventBus: EventBus,
+  eventStore: EventStore,
   resolveBlob: ContentBlobResolver,
   contentStore: WorkingTreeStore,
   stats: ReplayStats,
@@ -115,7 +118,7 @@ async function replayEvent(
 
     case 'mark:entity-tag-added':
     case 'mark:entity-tag-removed':
-      await replayEntityTagChange(event, eventBus, logger);
+      await replayEntityTagChange(event, eventStore, logger);
       break;
 
     // Job events are transient — skip during replay
@@ -286,27 +289,25 @@ async function replayResourceUnarchived(
 
 async function replayEntityTagChange(
   event: PersistedEvent & { type: 'mark:entity-tag-added' | 'mark:entity-tag-removed' },
-  eventBus: EventBus,
+  eventStore: EventStore,
   logger?: Logger,
 ): Promise<void> {
-  const resourceId = event.resourceId as ResourceId;
-  const entityType = event.payload.entityType;
-
+  // Events are facts, commands are requests (ratified 2026-07-09): copy the
+  // historical fact into the target log verbatim — never re-issue
+  // mark:update-entity-types. This keeps imports outside the vocabulary gate
+  // by construction (pre-gate warts restore as the facts they are, removable
+  // via the never-gated removal path) and cannot mint duplicate -added events
+  // from a fabricated empty diff base.
+  const base = {
+    resourceId: event.resourceId as ResourceId,
+    userId: event.userId,
+    version: event.version,
+  };
   if (event.type === 'mark:entity-tag-added') {
-    eventBus.get('mark:update-entity-types').next({
-      resourceId,
-      _userId: event.userId,
-      currentEntityTypes: [],
-      updatedEntityTypes: [entityType],
-    });
+    await eventStore.appendEvent({ ...base, type: 'mark:entity-tag-added', payload: event.payload });
   } else {
-    eventBus.get('mark:update-entity-types').next({
-      resourceId,
-      _userId: event.userId,
-      currentEntityTypes: [entityType],
-      updatedEntityTypes: [],
-    });
+    await eventStore.appendEvent({ ...base, type: 'mark:entity-tag-removed', payload: event.payload });
   }
 
-  logger?.debug('Replayed entity tag change', { type: event.type, entityType });
+  logger?.debug('Replayed entity tag change', { type: event.type, entityType: event.payload.entityType });
 }

--- a/packages/make-meaning/src/graph/consumer.ts
+++ b/packages/make-meaning/src/graph/consumer.ts
@@ -380,7 +380,11 @@ export class GraphDBConsumer {
         {
           const rid = makeResourceId(event.resourceId);
           const doc = await graphDb.getResource(rid);
-          if (doc) {
+          // Idempotent fold, mirroring the view materializer's includes-guard:
+          // duplicate -added events (stale caller diff base; historical
+          // duplicates on rebuild) must not duplicate the tag — the graph and
+          // the view are projections of one history and must agree.
+          if (doc && !(doc.entityTypes || []).includes(event.payload.entityType)) {
             await graphDb.updateResource(rid, {
               entityTypes: [...(doc.entityTypes || []), event.payload.entityType],
             });

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -137,7 +137,7 @@ async function createKnowledgeSystemFromConfig(
     return { ...event, annotation } as unknown as typeof event;
   });
 
-  const stower = new Stower(kb, eventBus, logger.child({ component: 'stower' }));
+  const stower = new Stower(kb, eventBus, project, logger.child({ component: 'stower' }));
   await stower.initialize();
 
   await bootstrapEntityTypes(eventBus, eventStore, logger.child({ component: 'entity-types-bootstrap' }));

--- a/packages/make-meaning/src/stower.ts
+++ b/packages/make-meaning/src/stower.ts
@@ -45,7 +45,10 @@ import { EventBus, annotationId, errField, resourceId, userId as makeUserId, gen
 import type { ResourceId } from '@semiont/core';
 import { withActorSpan } from '@semiont/observability';
 import { resolveStorageUri } from '@semiont/event-sourcing';
+import type { SemiontProject } from '@semiont/core/node';
 import type { KnowledgeBase } from './knowledge-base';
+import { readEntityTypesProjection } from './views/entity-types-reader';
+import { validateEntityTypes, entityTypesNotRegisteredMessage } from './views/projection-validators';
 
 export interface CreateResourceResult {
   resourceId: ResourceId;
@@ -59,6 +62,7 @@ export class Stower {
   constructor(
     private kb: KnowledgeBase,
     private eventBus: EventBus,
+    private project: SemiontProject,
     logger: Logger,
   ) {
     this.logger = logger;
@@ -448,6 +452,20 @@ export class Stower {
     const removed = event.currentEntityTypes.filter(et => !event.updatedEntityTypes.includes(et));
 
     try {
+      // Entity tags are a controlled vocabulary (ratified 2026-07-09): gate
+      // ADDS against the registered set with the same machinery the job path
+      // uses (job-commands.ts) — same projection read, same error message.
+      // Removals are never gated: deleting a stale/unregistered legacy tag is
+      // the cleanup path. Runs before the first append so a mixed request is
+      // all-or-nothing.
+      if (added.length > 0) {
+        const registered = await readEntityTypesProjection(this.project);
+        const result = validateEntityTypes(registered, added);
+        if (!result.ok) {
+          throw new Error(entityTypesNotRegisteredMessage(result.unknown));
+        }
+      }
+
       for (const entityType of added) {
         await this.kb.eventStore.appendEvent({
           type: 'mark:entity-tag-added',

--- a/packages/react-ui/src/components/ResourceTagsInline.tsx
+++ b/packages/react-ui/src/components/ResourceTagsInline.tsx
@@ -1,34 +1,117 @@
 'use client';
 
+import { useState } from 'react';
+
 interface ResourceTagsInlineProps {
   resourceId: string;
   tags: string[];
   isEditing: boolean;
+  /**
+   * Commit: called ONCE per edit with the FULL new tag set (the host diffs —
+   * its SDK call takes `(current, updated)`). Awaited; the editor renders
+   * inert while the returned promise is pending.
+   */
   onUpdate: (tags: string[]) => Promise<void>;
   disabled?: boolean;
+  /**
+   * The KB's registered entity types — the CONTROLLED VOCABULARY, host-supplied
+   * (the component is session-less; hosts fetch via `browse.entityTypes()`).
+   * Adds are a picker constrained to it: no free-text minting. Without it the
+   * editor is REMOVAL-ONLY (it cannot offer valid candidates). Removal is never
+   * vocabulary-gated — stale/unregistered tags must stay removable.
+   */
+  vocabulary?: string[];
 }
 
 export function ResourceTagsInline({
-  tags
+  tags,
+  isEditing,
+  onUpdate,
+  disabled = false,
+  vocabulary,
 }: ResourceTagsInlineProps) {
-  // If no tags, don't show anything
-  if (tags.length === 0) {
-    return null;
+  const [busy, setBusy] = useState(false);
+  const [picking, setPicking] = useState(false);
+
+  // Browse mode: exactly the historical read-only rendering (null when empty).
+  if (!isEditing) {
+    if (tags.length === 0) {
+      return null;
+    }
+    return (
+      <div className="semiont-resource-tags-inline">
+        <div className="semiont-resource-tags-list">
+          {tags.map((tag) => (
+            <span key={tag} className="semiont-resource-tag">
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
   }
 
+  // Edit mode: the empty strip still renders — tagging an UNTAGGED resource is
+  // the primary case; the null short-circuit is browse-only.
+  const inert = disabled || busy;
+  const candidates = (vocabulary ?? []).filter((v) => !tags.includes(v));
+
+  const commit = async (next: string[]) => {
+    if (inert) return; // in-flight or host-disabled: block further commits
+    setBusy(true);
+    try {
+      await onUpdate(next);
+    } finally {
+      setBusy(false);
+      setPicking(false);
+    }
+  };
+
   return (
-    <div className="semiont-resource-tags-inline">
+    <div className="semiont-resource-tags-inline semiont-resource-tags-inline--editing">
       <div className="semiont-resource-tags-list">
-        {/* Display existing tags */}
         {tags.map((tag) => (
-          <span
-            key={tag}
-            className="semiont-resource-tag"
-          >
+          <span key={tag} className="semiont-resource-tag semiont-resource-tag--editable">
             {tag}
+            <button
+              type="button"
+              className="semiont-resource-tag__remove"
+              aria-label={`Remove ${tag}`}
+              disabled={inert}
+              onClick={() => void commit(tags.filter((t) => t !== tag))}
+            >
+              ✕
+            </button>
           </span>
         ))}
+        {vocabulary && (
+          <button
+            type="button"
+            className="semiont-resource-tag semiont-resource-tag--add"
+            aria-label="Add tag"
+            aria-expanded={picking}
+            disabled={inert || candidates.length === 0}
+            onClick={() => setPicking((v) => !v)}
+          >
+            +
+          </button>
+        )}
       </div>
+      {picking && candidates.length > 0 && (
+        <div className="semiont-form__entity-type-buttons">
+          {candidates.map((entityType) => (
+            <button
+              key={entityType}
+              type="button"
+              className="semiont-form__entity-type-button"
+              disabled={inert}
+              onClick={() => void commit([...tags, entityType])}
+            >
+              {entityType}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/react-ui/src/components/StatusDisplay.css
+++ b/packages/react-ui/src/components/StatusDisplay.css
@@ -209,6 +209,42 @@
   font-size: var(--semiont-font-size-xs);
 }
 
+/* Editing affordances (RESOURCE-TAGS-INLINE-EDITING) */
+.semiont-resource-tag__remove {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: var(--semiont-font-size-xs);
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.semiont-resource-tag__remove:hover:not(:disabled) {
+  opacity: 1;
+}
+
+.semiont-resource-tag__remove:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.semiont-resource-tag--add {
+  cursor: pointer;
+  background: none;
+}
+
+.semiont-resource-tag--add:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.semiont-resource-tags-inline--editing .semiont-form__entity-type-buttons {
+  margin-top: var(--semiont-spacing-xs);
+}
+
 /* Dark mode for ResourceTagsInline - Fixed to respect data-theme attribute */
 [data-theme="dark"] .semiont-resource-tags-inline {
   border-top-color: var(--semiont-color-neutral-700);

--- a/packages/react-ui/src/components/__tests__/ResourceTagsInline.test.tsx
+++ b/packages/react-ui/src/components/__tests__/ResourceTagsInline.test.tsx
@@ -1,15 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ResourceTagsInline } from '../ResourceTagsInline';
 
 describe('ResourceTagsInline', () => {
-  const mockOnUpdate = vi.fn();
+  const mockOnUpdate = vi.fn(async () => {});
   const defaultProps = {
     resourceId: 'doc-123',
     tags: ['tag1', 'tag2', 'tag3'],
     isEditing: false,
     onUpdate: mockOnUpdate,
   };
+
+  beforeEach(() => {
+    mockOnUpdate.mockClear();
+    mockOnUpdate.mockImplementation(async () => {});
+  });
 
   describe('Rendering', () => {
     it('should render tags', () => {
@@ -175,6 +180,99 @@ describe('ResourceTagsInline', () => {
       rerender(<ResourceTagsInline {...defaultProps} tags={[]} />);
 
       expect(container.firstChild).toBeNull();
+    });
+  });
+
+  // ── RESOURCE-TAGS-INLINE-EDITING: the declared contract, implemented ──
+
+  describe('Editing mode', () => {
+    it('browse mode renders no editing affordances (pins today’s rendering)', () => {
+      const { container } = render(
+        <ResourceTagsInline {...defaultProps} isEditing={false} vocabulary={['Person']} />,
+      );
+      expect(container.querySelector('button')).toBeNull();
+    });
+
+    it('renders the editor for EMPTY tags while editing (the primary tagging case)', () => {
+      const { container } = render(
+        <ResourceTagsInline {...defaultProps} tags={[]} isEditing={true} vocabulary={['Person']} />,
+      );
+      // No null short-circuit in edit mode: the strip renders with an add affordance.
+      expect(container.firstChild).not.toBeNull();
+      expect(screen.getByLabelText('Add tag')).toBeInTheDocument();
+    });
+
+    it('removing a tag commits ONCE with the full new set', async () => {
+      render(<ResourceTagsInline {...defaultProps} isEditing={true} />);
+      fireEvent.click(screen.getByLabelText('Remove tag2'));
+      await waitFor(() => expect(mockOnUpdate).toHaveBeenCalledTimes(1));
+      expect(mockOnUpdate).toHaveBeenCalledWith(['tag1', 'tag3']);
+    });
+
+    it('disabled renders the editor inert', () => {
+      render(
+        <ResourceTagsInline {...defaultProps} isEditing={true} disabled={true} vocabulary={['Person']} />,
+      );
+      fireEvent.click(screen.getByLabelText('Remove tag1'));
+      expect(mockOnUpdate).not.toHaveBeenCalled();
+      expect(screen.getByLabelText('Remove tag1')).toBeDisabled();
+      expect(screen.getByLabelText('Add tag')).toBeDisabled();
+    });
+
+    it('an in-flight onUpdate blocks a second commit', async () => {
+      let resolveUpdate!: () => void;
+      mockOnUpdate.mockImplementation(() => new Promise<void>((r) => { resolveUpdate = r; }));
+      render(<ResourceTagsInline {...defaultProps} isEditing={true} />);
+
+      fireEvent.click(screen.getByLabelText('Remove tag1'));
+      fireEvent.click(screen.getByLabelText('Remove tag2')); // while pending — must not fire
+      expect(mockOnUpdate).toHaveBeenCalledTimes(1);
+
+      resolveUpdate();
+      await waitFor(() => expect(screen.getByLabelText('Remove tag2')).not.toBeDisabled());
+      fireEvent.click(screen.getByLabelText('Remove tag2')); // settled — fires again
+      expect(mockOnUpdate).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Vocabulary (controlled — adds are a picker, never free text)', () => {
+    it('the add affordance offers ONLY vocabulary entries minus already-applied tags', () => {
+      render(
+        <ResourceTagsInline {...defaultProps} tags={['Person']} isEditing={true}
+          vocabulary={['Person', 'Place', 'Topic']} />,
+      );
+      fireEvent.click(screen.getByLabelText('Add tag'));
+      expect(screen.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Topic' })).toBeInTheDocument();
+      // Already applied → not a candidate (the chip renders as text, not a candidate button)
+      expect(screen.queryByRole('button', { name: 'Person' })).not.toBeInTheDocument();
+    });
+
+    it('picking a candidate commits the full set including the added tag', async () => {
+      render(
+        <ResourceTagsInline {...defaultProps} tags={['Person']} isEditing={true}
+          vocabulary={['Person', 'Place']} />,
+      );
+      fireEvent.click(screen.getByLabelText('Add tag'));
+      fireEvent.click(screen.getByRole('button', { name: 'Place' }));
+      await waitFor(() => expect(mockOnUpdate).toHaveBeenCalledTimes(1));
+      expect(mockOnUpdate).toHaveBeenCalledWith(['Person', 'Place']);
+    });
+
+    it('without a vocabulary the editor is REMOVAL-ONLY (no add affordance)', () => {
+      render(<ResourceTagsInline {...defaultProps} isEditing={true} />);
+      expect(screen.queryByLabelText('Add tag')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Remove tag1')).toBeInTheDocument();
+    });
+
+    it('removal is never vocabulary-gated — a stale tag not in the vocabulary is removable', async () => {
+      render(
+        <ResourceTagsInline {...defaultProps} tags={['LegacyType', 'Person']} isEditing={true}
+          vocabulary={['Person']} />,
+      );
+      fireEvent.click(screen.getByLabelText('Remove LegacyType'));
+      await waitFor(() => expect(mockOnUpdate).toHaveBeenCalledTimes(1));
+      expect(mockOnUpdate).toHaveBeenCalledWith(['Person']);
     });
   });
 });


### PR DESCRIPTION
## Summary

Resource tagging goes live, end-to-end, under one ratified design decision (2026-07-09): **entity tags are a CONTROLLED VOCABULARY.** Two commits, two halves of that decision:

1. **`feat(react-ui)`: `ResourceTagsInline` implements its declared editing contract** — the etiquette: adds are a picker over the KB's registered entity types, never free text.
2. **`feat(make-meaning)`: the vocabulary gate + two event-log integrity fixes** — the enforcement: the server rejects unregistered adds, and the storage path is hardened against the duplicate/divergence bugs the review of this path surfaced.

`mark.updateEntityTypes` (SDK, shipped 2026-07-03) had been consumerless since it landed; this PR is the last gap between "the capability exists" and "a user can tag a resource" — including tagging an *untagged* upload so it appears in entity-type facets, the original motivation.

## Commit 1 — react-ui: the tag editor

`ResourceTagsInline` declared `isEditing` / `onUpdate` / `disabled` but destructured only `tags` and rendered read-only spans — declared-but-dead props, with the type system telling hosts the feature existed (`adampingel/chat`'s doc pane is already wired to the declared contract).

- **Browse mode is byte-identical** (read-only strip, `null` when empty — the short-circuit is now browse-only; an empty strip *renders* while editing).
- **Edit mode:** chips gain a remove button; new optional **`vocabulary?: string[]`** prop (host-supplied — the component stays session-less). Adds are a picker constrained to *vocabulary minus already-applied*; without `vocabulary` the editor is **removal-only**; removal is never vocabulary-gated, so stale/unregistered tags stay removable.
- **Every action is a commit:** one `onUpdate(fullNewSet)` per remove/pick, awaited; the editor renders inert in-flight and under `disabled`.

## Commit 2 — make-meaning: enforcement + storage integrity

- **The vocabulary gate** (`stower.ts` `handleUpdateEntityTypes`): validates the **added** set only, using the job path's exact machinery (`readEntityTypesProjection` + `validateEntityTypes` + `entityTypesNotRegisteredMessage` — no third implementation, no new error shape), **before the first append** so a mixed request is all-or-nothing; failures answer a correlated `mark:update-entity-types-failed`. Removals bypass by construction (cleanup must not be blocked by the gate that would have prevented the mess). Plumbing: the projection reader needs `SemiontProject`, so `Stower` gained a constructor param, threaded through all 12 sites.
- **Replay copies facts, never re-issues commands** (ratified 2026-07-09): `exchange/replay.ts` `replayEntityTagChange` now `eventStore.appendEvent`s the historical event verbatim instead of re-emitting `mark:update-entity-types` with a fabricated empty diff base. Two consequences by construction: legacy imports stay **outside the gate** (pre-gate warts restore as the facts they are, removable via the never-gated path), and replay can no longer **mint duplicate `-added` events**.
- **Idempotent graph fold**: the graph consumer's `mark:entity-tag-added` case now carries the same `includes` guard as the view materializer — a duplicate add (stale caller diff base, historical duplicates on rebuild) no longer diverges the graph (what facets read) from the resource-descriptor view. The event log is the system of record; two projections of one history must agree.

## Testing

TDD-first throughout, RED observed before GREEN in both halves:
- react-ui: 9 specs from the plan's sketch (8 failed against the display-only impl; the browse-mode pin passed) → **27/27**, `tsc` clean, `lint:css` clean.
- make-meaning: new `stower-entity-types.test.ts` (gate: unregistered add → `-failed` + **zero events appended**; in-vocabulary adds unchanged; removals ungated), `graph-consumer.test.ts` (add-when-present / same-event-twice → single copy), reworked `replay.test.ts` (direct append). `tsc` + targeted suites green (`node:24-alpine`); full suites CI.

## Notes

- **No spec/core regen, no SDK change** — the `-ok`/`-failed` channels and the error message already existed; chat's `onUpdate` already surfaces the rejection as a rejected promise.
- Chat's existing wiring compiles unchanged; its tag editing **activates on the release carrying this** once it passes `vocabulary` (additive — it already holds the list via `browse.entityTypes()`).
- No authentication / authorization changes — the security checklist is N/A.
- Design, decisions (controlled vocabulary; replay semantics), and execution logs: `.plans/RESOURCE-TAGS-INLINE-EDITING.md`, `.plans/bugs/update-entity-types-skips-vocabulary-validation.md`, `.plans/bugs/graph-consumer-entity-tag-add-not-idempotent.md`.
