### PR TITLE
feat(react-ui): showToolbar={false}

### DIFF
--- a/packages/react-ui/src/components/resource/AnnotateView.tsx
+++ b/packages/react-ui/src/components/resource/AnnotateView.tsx
@@ -46,6 +46,8 @@ interface Props {
   newAnnotationIds?: Set<string>;
   /** The bar's Mode control reports the chosen mode here (the owner applies it). */
   onModeChange?: (mode: boolean) => void;
+  /** Render the built-in bar (default). false → no bar; selection capture and drawing stay live. */
+  showToolbar?: boolean;
 }
 
 /**
@@ -70,6 +72,7 @@ export function AnnotateView({
   session,
   newAnnotationIds,
   onModeChange,
+  showToolbar = true,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -198,6 +201,7 @@ export function AnnotateView({
     case 'text':
       return (
         <div className="semiont-annotate-view" data-mime-type="text" ref={containerRef}>
+          {showToolbar && (
           <AnnotateToolbar
             selectedMotivation={selectedMotivation}
             selectedClick={selectedClick}
@@ -210,6 +214,7 @@ export function AnnotateView({
             onSelectionChange={handleToolbarSelectionChange}
             onShapeChange={handleToolbarShapeChange}
           />
+          )}
           <div className="semiont-annotate-view__content">
             <CodeMirrorRenderer
             content={content}
@@ -235,6 +240,7 @@ export function AnnotateView({
       // PDF annotation support (spatial, FragmentSelector)
       return (
         <div className="semiont-annotate-view" data-mime-type="pdf" ref={containerRef}>
+          {showToolbar && (
           <AnnotateToolbar
             selectedMotivation={selectedMotivation}
             selectedClick={selectedClick}
@@ -247,6 +253,7 @@ export function AnnotateView({
             onSelectionChange={handleToolbarSelectionChange}
             onShapeChange={handleToolbarShapeChange}
           />
+          )}
           <div className="semiont-annotate-view__content">
             {content && (
               <Suspense fallback={<div className="semiont-annotate-view__loading">Loading PDF viewer...</div>}>
@@ -270,6 +277,7 @@ export function AnnotateView({
       // PNG, JPEG, etc. - full annotation support
       return (
         <div className="semiont-annotate-view" data-mime-type="image" ref={containerRef}>
+          {showToolbar && (
           <AnnotateToolbar
             selectedMotivation={selectedMotivation}
             selectedClick={selectedClick}
@@ -282,6 +290,7 @@ export function AnnotateView({
             onSelectionChange={handleToolbarSelectionChange}
             onShapeChange={handleToolbarShapeChange}
           />
+          )}
           <div className="semiont-annotate-view__content">
             {content && (
               <SvgDrawingCanvas

--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -50,6 +50,8 @@ interface Props {
   onModeChange?: (mode: boolean) => void;
   /** The bar's Click control reports the chosen action here (the owner applies it). */
   onClickActionChange?: (action: ClickAction) => void;
+  /** Render the built-in bar (default). false → no bar; all other seams stay live. */
+  showToolbar?: boolean;
 }
 
 /** Payload for `onReferenceHover` — the hovered linking annotation, its resolved referent, and where the span is. */
@@ -80,6 +82,7 @@ export const BrowseView = memo(function BrowseView({
   selectedClick = 'detail',
   onModeChange,
   onClickActionChange,
+  showToolbar = true,
   annotateMode,
   hoverDelayMs = 150,
   session,
@@ -300,6 +303,7 @@ export const BrowseView = memo(function BrowseView({
 
   return (
     <div className={`semiont-browse-view${inlineMod}`} data-mime-type={render}>
+      {showToolbar && (
       <AnnotateToolbar
         selectedMotivation={null}
         selectedClick={selectedClick}
@@ -311,6 +315,7 @@ export const BrowseView = memo(function BrowseView({
         onClickActionChange={onClickActionChange}
         compact={inline}
       />
+      )}
       <div ref={containerRef} className="semiont-browse-view__content" onClick={handleContentClick}>
         <Renderer content={content} mimeType={mimeType} resourceUri={resourceUri} annotations={allAnnotations} />
       </div>

--- a/packages/react-ui/src/components/resource/ResourceViewer.tsx
+++ b/packages/react-ui/src/components/resource/ResourceViewer.tsx
@@ -69,6 +69,15 @@ interface Props {
   onSelectionMotivationChange?: (motivation: SelectionMotivation | null) => void;
   shape?: ShapeType;
   onShapeChange?: (shape: ShapeType) => void;
+  /**
+   * Render the built-in AnnotateToolbar (default true — today's behavior,
+   * byte-identical). `false` → no bar at any internal site (browse + every
+   * annotate render mode), while every seam stays live: annotate-mode selection
+   * capture, image/pdf drawing, `mark.request` emission, and the controlled
+   * props. Tier-2 hosts compose their own controls from the controlled props;
+   * this makes that opt-out a contract instead of a CSS override.
+   */
+  showToolbar?: boolean;
 }
 
 /**
@@ -102,6 +111,7 @@ export function ResourceViewer({
   onSelectionMotivationChange,
   shape: shapeProp,
   onShapeChange,
+  showToolbar = true,
 }: Props) {
   const t = useTranslations('ResourceViewer');
   const documentViewerRef = useRef<HTMLDivElement>(null);
@@ -360,6 +370,7 @@ export function ResourceViewer({
           hoverDelayMs={hoverDelayMs}
           annotateMode={annotateMode}
           onModeChange={changeAnnotateMode}
+          showToolbar={showToolbar}
           session={session}
           newAnnotationIds={newAnnotationIds}
         />
@@ -374,6 +385,7 @@ export function ResourceViewer({
           annotateMode={annotateMode}
           onModeChange={changeAnnotateMode}
           onClickActionChange={changeClickAction}
+          showToolbar={showToolbar}
           session={session}
           newAnnotationIds={newAnnotationIds}
           onLinkClick={onLinkClick}

--- a/packages/react-ui/src/components/resource/__tests__/ResourceViewer.toolbar-opt-out.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/ResourceViewer.toolbar-opt-out.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * VIEWER-TOOLBAR-OPT-OUT — `showToolbar={false}` is a supported opt-out.
+ *
+ * Tier-2 hosts (controlled props, host-composed controls) hide the built-in
+ * bar by CONTRACT, not by CSS-ing react-ui's internals. Hiding the bar must
+ * not disable any seam: the keystone here proves annotate-mode selection
+ * capture still emits mark.request with the bar gone.
+ *
+ * Started RED (the prop doesn't exist; bars render everywhere) → GREEN.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { ResourceViewer } from '../ResourceViewer';
+
+// Render the real content so jsdom text selection can target it.
+vi.mock('../../CodeMirrorRenderer', () => ({
+  CodeMirrorRenderer: ({ content }: { content: string }) => <div className="codemirror-renderer">{content}</div>,
+}));
+vi.mock('../../image-annotation/SvgDrawingCanvas', () => ({ SvgDrawingCanvas: () => <div>svg-mock</div> }));
+vi.mock('../../pdf-annotation/PdfAnnotationCanvas.client', () => ({ PdfAnnotationCanvas: () => <div>pdf-mock</div> }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+const CONTENT = 'hello world selectme end';
+
+function makeResource(mediaType = 'text/plain'): SemiontResource & { content: string } {
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    '@id': 'res-1' as ResourceId,
+    name: 'Doc',
+    created: '2024-01-01T00:00:00Z',
+    entityTypes: [],
+    archived: false,
+    representations: [{ mediaType, byteSize: 10 }],
+    content: CONTENT,
+  };
+}
+
+const annotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+function fakeSession() {
+  const client = {
+    browse: { click: vi.fn(), invalidateAnnotationList: vi.fn() },
+    beckon: { hover: vi.fn() },
+    mark: { request: vi.fn(), delete: vi.fn() },
+  };
+  return { session: { client, subscribe: () => () => {} } as unknown as SemiontSession, client };
+}
+
+const bars = (c: HTMLElement) => c.querySelectorAll('.semiont-annotate-toolbar').length;
+
+describe('ResourceViewer — showToolbar opt-out', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.getSelection()?.removeAllRanges();
+  });
+
+  it('default pins today’s behavior: the bar renders in browse and annotate modes', () => {
+    const { session } = fakeSession();
+    const browse = render(
+      <ResourceViewer session={session} resource={makeResource()} annotations={annotations} />,
+    );
+    expect(bars(browse.container)).toBe(1);
+
+    const annotate = render(
+      <ResourceViewer session={session} resource={makeResource()} annotations={annotations}
+        annotateMode={true} onAnnotateModeChange={vi.fn()} />,
+    );
+    expect(bars(annotate.container)).toBe(1);
+  });
+
+  it('showToolbar={false}: no bar in browse mode', () => {
+    const { session } = fakeSession();
+    const { container } = render(
+      <ResourceViewer session={session} resource={makeResource()} annotations={annotations}
+        showToolbar={false} />,
+    );
+    expect(bars(container)).toBe(0);
+    expect(screen.getByText(CONTENT)).toBeInTheDocument(); // content still renders
+  });
+
+  it('showToolbar={false}: no bar in any annotate render mode (text / image / pdf)', async () => {
+    const { session } = fakeSession();
+    const text = render(
+      <ResourceViewer session={session} resource={makeResource('text/plain')} annotations={annotations}
+        annotateMode={true} onAnnotateModeChange={vi.fn()} showToolbar={false} />,
+    );
+    expect(bars(text.container)).toBe(0);
+
+    const image = render(
+      <ResourceViewer session={session} resource={makeResource('image/png')} annotations={annotations}
+        annotateMode={true} onAnnotateModeChange={vi.fn()} showToolbar={false} />,
+    );
+    expect(within(image.container).getByText('svg-mock')).toBeInTheDocument();
+    expect(bars(image.container)).toBe(0);
+
+    const pdf = render(
+      <ResourceViewer session={session} resource={makeResource('application/pdf')} annotations={annotations}
+        annotateMode={true} onAnnotateModeChange={vi.fn()} showToolbar={false} />,
+    );
+    await within(pdf.container).findByText('pdf-mock'); // flush the lazy canvas
+    expect(bars(pdf.container)).toBe(0);
+  });
+
+  it('keystone: with the bar hidden, annotate-mode selection still emits mark.request', () => {
+    const { session, client } = fakeSession();
+    const { container } = render(
+      <ResourceViewer session={session} resource={makeResource('text/plain')} annotations={annotations}
+        annotateMode={true} onAnnotateModeChange={vi.fn()}
+        selectionMotivation="highlighting" onSelectionMotivationChange={vi.fn()}
+        showToolbar={false} />,
+    );
+    expect(bars(container)).toBe(0);
+
+    // Select "world" (offsets 6..11) inside the rendered content, then mouseup.
+    const contentEl = within(container).getByText(CONTENT);
+    const range = document.createRange();
+    range.setStart(contentEl.firstChild!, 6);
+    range.setEnd(contentEl.firstChild!, 11);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.mouseUp(contentEl);
+
+    expect(client.mark.request).toHaveBeenCalledTimes(1);
+    const [source, selectors, motivation] = client.mark.request.mock.calls[0]!;
+    expect(String(source)).toBe('res-1');
+    expect(selectors).toBeTruthy();
+    expect(motivation).toBe('highlighting');
+  });
+});


### PR DESCRIPTION
a supported opt-out for the viewer's built-in bar

Hosts get two supported tiers (ratified 2026-07-10): stock (mount ResourceViewer, get the built-in AnnotateToolbar) or host-composed (hide the bar, build controls from the controlled props). Tier 2's only opt-out was a CSS override of react-ui's internals
(.semiont-annotate-toolbar { display: none }) -- it works, but it isn't a contract and breaks silently on any restyle. A configurable middle tier (threading toolbarParts through ResourceViewer) was considered and DECLINED: every subset is achievable via the controlled props, and the one consumer that wanted a slimmed stock bar stopped wanting the stock bar at all once those props existed.
ResourceViewer gains showToolbar?: boolean (default true -- today's behavior byte-identical, naming per the showLineNumbers precedent). false renders no AnnotateToolbar at any internal site -- browse and all three annotate render modes -- while every seam stays live: annotate-mode selection capture, image/pdf drawing, mark.request emission, and the controlled props. Forwarded internally to BrowseView/AnnotateView; the public surface is the one boolean.
TDD-first: RED observed (3 failed / 1 passed -- the default-pin passed) against the prop-less component, then GREEN. The keystone spec proves the load-bearing claim with a real jsdom selection: bar hidden, annotate-mode selection still emits mark.request -- incidentally the first spec to cover the selection->mark.request seam at all. 36/36 across the viewer suites, tsc clean.

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Infrastructure/DevOps changes

## Areas Changed

- [ ] Frontend (`apps/frontend`)
- [ ] Backend (`apps/backend`)
- [ ] CLI (`apps/cli`)
- [ ] HTTP Transport (`packages/http-transport`)
- [ ] Core (`packages/core`)
- [ ] MCP Server (`packages/mcp-server`)
- [ ] Test Utils (`packages/test-utils`)
- [ ] OpenAPI Specs (`specs/`)
- [ ] Demo Scripts (`demo/`)
- [ ] Documentation (`docs/`)
- [ ] GitHub Actions (`.github/workflows/`)
- [ ] Scripts (`scripts/`)
- [ ] Infrastructure/Deployment

## Security Checklist

**Required for all PRs that modify authentication, authorization, or admin functionality:**

### Authentication & Authorization

- [ ] No authentication logic moved to client-side
- [ ] All admin routes properly protected with server-side checks
- [ ] JWT tokens validated server-side only
- [ ] Session data comes from secure sources (database, not client claims)
- [ ] No hardcoded secrets or credentials

### Admin Route Security (Frontend)

- [ ] Admin/moderate routes protected by middleware (proxy.ts)
- [ ] No admin content rendered for unauthorized users
- [ ] No sensitive information in error responses

### API Security (Backend)

- [ ] Admin endpoints protected with `adminMiddleware`
- [ ] All endpoints return proper HTTP status codes (401/403/500)
- [ ] Error messages don't leak sensitive information
- [ ] Database queries protected behind authentication
- [ ] Input validation implemented

### Information Disclosure Prevention

- [ ] No database connection strings in error messages
- [ ] No file paths or stack traces exposed to clients
- [ ] No user emails or personal data in unauthorized responses
- [ ] No API keys or secrets in client-accessible responses
- [ ] Error messages are generic and safe

## Testing

- [ ] Added tests for new functionality
- [ ] All existing tests pass
- [ ] Security tests pass (`npm run test:security`)
- [ ] Manual testing completed for authentication flows
- [ ] Tested with different user roles (unauthenticated, non-admin, admin)

## Security Test Results

Please run and paste results:

### Frontend Security Tests

```bash
cd apps/frontend && npm run test:security
# Paste results here
```

### Backend Security Tests

```bash
cd apps/backend && npm run test:security
# Paste results here
```

### Manual Security Verification

If you modified admin routes, please verify:

```bash
# Start the application and test:
curl -I http://localhost:3000/admin
# Should return: HTTP/1.1 200 OK (not 307)

# Verify no admin content leakage:
curl -s http://localhost:3000/admin | grep -i "admin\|dashboard\|management"
# Should return no results
```

## Performance Impact

- [ ] No significant performance degradation
- [ ] Database queries optimized
- [ ] No N+1 query problems introduced
- [ ] Bundle size impact considered (for frontend changes)

## Breaking Changes

If this PR introduces breaking changes, please describe:

- What breaks
- Migration path for users
- Documentation updates needed

## Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] API documentation updated (if applicable)
- [ ] Security documentation updated (if security-related)

## Additional Context

Add any other context, screenshots, or information about the pull request here.

---

## For Reviewers

### Security Review Required

- [ ] Authentication/authorization changes reviewed
- [ ] No security regressions introduced
- [ ] Error handling doesn't leak sensitive data
- [ ] All security tests passing
- [ ] Manual security verification completed

### Code Review

- [ ] Code follows project conventions
- [ ] No obvious bugs or issues
- [ ] Performance considerations addressed
- [ ] Tests provide adequate coverage
- [ ] Documentation is clear and accurate

### Final Checks

- [ ] All CI checks passing
- [ ] Security tests passing
- [ ] No merge conflicts
- [ ] Ready for deployment

---

**⚠️ SECURITY NOTICE:** If any security tests fail or if this PR modifies authentication/authorization logic, **DO NOT MERGE** until security issues are resolved and all tests pass.
