### PR TITLE
headless react-ui

### DIFF
--- a/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
+++ b/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
@@ -171,7 +171,12 @@ export function ResourceViewerPage({
   const isBinary = renderMode === 'image' || renderMode === 'pdf';
 
   // Text path: fetch and decode representation (disabled for binary — mediaToken path handles those)
-  const { content: textContent, loading: textLoading } = useResourceContent(rUri, resource, !isBinary);
+  // Headless hook returns the error; the page (chrome tier) owns the toast.
+  const { content: textContent, loading: textLoading, error: contentError } = useResourceContent(semiont ?? null, rUri, resource, !isBinary);
+
+  useEffect(() => {
+    if (contentError) showError('Failed to load resource representation');
+  }, [contentError, showError]);
 
   // Binary path: fetch short-lived media token, construct URL
   const { token: mediaToken, loading: mediaTokenLoading } = useMediaToken(semiont ?? null, rUri);

--- a/packages/react-ui/src/hooks/__tests__/usePendingCreation.test.tsx
+++ b/packages/react-ui/src/hooks/__tests__/usePendingCreation.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * HEADLESS-CREATION-SEAM — usePendingCreation, the consuming half of the
+ * capture/policy split.
+ *
+ * The viewer captures and emits source-scoped mark:requested; this hook is the
+ * exported primitive that CLAIMS them: one event, one owner
+ * (enabled && source === resourceId), replace-on-reselect, no creation/UI/toast
+ * inside. Resolution chrome stays host-side.
+ *
+ * Session-first (not the ask's literal `client:` param): the sanctioned
+ * generic-channel subscription is `session.subscribe` (client.bus is
+ * audit-forbidden outside the SDK), and chat's reference hook is session-first.
+ *
+ * Started RED (the hook doesn't exist) and GREEN once the seam lands.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, render, fireEvent, within, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { resourceId } from '@semiont/core';
+import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
+import { usePendingCreation } from '../usePendingCreation';
+import { ResourceViewer } from '../../components/resource/ResourceViewer';
+
+vi.mock('../../components/CodeMirrorRenderer', () => ({
+  CodeMirrorRenderer: ({ content }: { content: string }) => <div className="codemirror-renderer">{content}</div>,
+}));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+/**
+ * Session double with a live subscribe registry. `client.mark.request` is wired
+ * to FEED the registry — a faithful mini-bus, so the integration case can run
+ * viewer capture → hook claim end to end.
+ */
+function liveSession() {
+  const handlers = new Map<string, Set<(p: unknown) => void>>();
+  const fire = (channel: string, payload?: unknown) =>
+    handlers.get(channel)?.forEach((h) => h(payload));
+  const client = {
+    browse: { click: vi.fn(), invalidateAnnotationList: vi.fn() },
+    beckon: { hover: vi.fn() },
+    mark: {
+      delete: vi.fn(),
+      request: vi.fn((source: unknown, selector: unknown, motivation: unknown) =>
+        fire('mark:requested', { source: String(source), selector, motivation })),
+    },
+  };
+  const session = {
+    client,
+    subscribe: (channel: string, handler: (p: unknown) => void) => {
+      if (!handlers.has(channel)) handlers.set(channel, new Set());
+      handlers.get(channel)!.add(handler);
+      return () => { handlers.get(channel)!.delete(handler); };
+    },
+  } as unknown as SemiontSession;
+  return { session, client, fire };
+}
+
+const REQ_A = { source: 'res-a', selector: { type: 'TextPositionSelector', start: 0, end: 5 }, motivation: 'highlighting' };
+const REQ_A2 = { source: 'res-a', selector: { type: 'TextPositionSelector', start: 9, end: 12 }, motivation: 'commenting' };
+
+describe('usePendingCreation — the exported creation seam', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keystone: two hooks on one session claim only their own source', () => {
+    const { session, fire } = liveSession();
+    const a = renderHook(() => usePendingCreation(session, resourceId('res-a'), true));
+    const b = renderHook(() => usePendingCreation(session, resourceId('res-b'), true));
+
+    act(() => { fire('mark:requested', REQ_A); });
+
+    expect(a.result.current.pending).toEqual(REQ_A);   // A claims its own…
+    expect(b.result.current.pending).toBeNull();       // …B stays null
+  });
+
+  it('enabled=false never claims, even for its own source (browse-mode viewers are inert)', () => {
+    const { session, fire } = liveSession();
+    const { result } = renderHook(() => usePendingCreation(session, resourceId('res-a'), false));
+
+    act(() => { fire('mark:requested', REQ_A); });
+
+    expect(result.current.pending).toBeNull();
+  });
+
+  it('a new request for the same resource REPLACES an unresolved pending', () => {
+    const { session, fire } = liveSession();
+    const { result } = renderHook(() => usePendingCreation(session, resourceId('res-a'), true));
+
+    act(() => { fire('mark:requested', REQ_A); });
+    expect(result.current.pending).toEqual(REQ_A);
+
+    act(() => { fire('mark:requested', REQ_A2); });    // user reselected
+    expect(result.current.pending).toEqual(REQ_A2);    // replaced, not queued
+  });
+
+  it('clearPending resolves to null; session=null is inert', () => {
+    const { session, fire } = liveSession();
+    const { result } = renderHook(() => usePendingCreation(session, resourceId('res-a'), true));
+
+    act(() => { fire('mark:requested', REQ_A); });
+    act(() => { result.current.clearPending(); });
+    expect(result.current.pending).toBeNull();
+
+    const inert = renderHook(() => usePendingCreation(null, resourceId('res-a'), true));
+    expect(inert.result.current.pending).toBeNull();
+  });
+
+  it('integration: viewer selection capture → hook claim, end to end', () => {
+    const { session } = liveSession();
+    const CONTENT = 'hello world selectme end';
+    const resource: SemiontResource & { content: string } = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      '@id': 'res-1' as ResourceId,
+      name: 'Doc',
+      created: '2024-01-01T00:00:00Z',
+      entityTypes: [],
+      archived: false,
+      representations: [{ mediaType: 'text/plain', byteSize: 10 }],
+      content: CONTENT,
+    };
+    const annotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+    const hook = renderHook(() => usePendingCreation(session, resourceId('res-1'), true));
+    const { container } = render(
+      <ResourceViewer session={session} resource={resource} annotations={annotations}
+        annotateMode={true} onAnnotateModeChange={vi.fn()}
+        selectionMotivation="highlighting" onSelectionMotivationChange={vi.fn()}
+        showToolbar={false} />,
+    );
+
+    // Select "world" (offsets 6..11) and mouseup — the viewer emits mark.request.
+    const contentEl = within(container).getByText(CONTENT);
+    const range = document.createRange();
+    range.setStart(contentEl.firstChild!, 6);
+    range.setEnd(contentEl.firstChild!, 11);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    fireEvent.mouseUp(contentEl);
+
+    expect(hook.result.current.pending).not.toBeNull();
+    expect(String(hook.result.current.pending!.source)).toBe('res-1');
+    expect(hook.result.current.pending!.motivation).toBe('highlighting');
+  });
+});

--- a/packages/react-ui/src/hooks/__tests__/useResourceContent.test.tsx
+++ b/packages/react-ui/src/hooks/__tests__/useResourceContent.test.tsx
@@ -1,114 +1,95 @@
+/**
+ * HEADLESS-RESOURCE-CONTENT — useResourceContent is bring-your-own-client.
+ *
+ * The last provider-bound hook on the embeddable path joins the
+ * useResourceLoader/useMediaToken convention: client-first (`null` → idle),
+ * NO providers required, and errors are RETURNED, never toasted — the host
+ * decides chrome. Real decodeWithCharset over encoded bytes (no core mocks).
+ *
+ * Started RED (the old hook threw from useSemiont with no providers and took
+ * no client param) and GREEN once the de-provider lands.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { BehaviorSubject } from 'rxjs';
 import '@testing-library/jest-dom';
+import { resourceId } from '@semiont/core';
+import type { ResourceDescriptor } from '@semiont/core';
+import type { SemiontClient } from '@semiont/sdk';
 import { useResourceContent } from '../useResourceContent';
 
-const mockShowError = vi.fn();
 const mockResourceRepresentation = vi.fn();
-const stableMockClient = {
+const client = {
   browse: {
     get resourceRepresentation() { return mockResourceRepresentation; },
   },
-};
-const stableMockSession = { client: stableMockClient };
-const stableActiveSession$ = new BehaviorSubject<any>(stableMockSession);
-const stableMockBrowser = { activeSession$: stableActiveSession$ };
+} as unknown as SemiontClient;
 
-vi.mock('../../components/Toast', () => ({
-  useToast: () => ({ showError: mockShowError }),
-}));
+const resource = {
+  representations: [{ mediaType: 'text/plain', byteSize: 11 }],
+} as unknown as ResourceDescriptor;
 
-vi.mock('@semiont/core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@semiont/core')>();
-  return {
-    ...actual,
-  getPrimaryMediaType: vi.fn(() => 'text/plain'),
-  decodeWithCharset: vi.fn((data: string) => data),
-  };
-});
+const RID = resourceId('res-1');
+const utf8 = (s: string) => new TextEncoder().encode(s).buffer;
 
-vi.mock('../../session/SemiontProvider', async () => {
-  const actual = await vi.importActual<typeof import('../../session/SemiontProvider')>('../../session/SemiontProvider');
-  return {
-    ...actual,
-    useSemiont: () => stableMockBrowser,
-  };
-});
-
-// Minimal wrapper -- hooks under test don't need full providers
-function Wrapper({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
-}
-
-describe('useResourceContent', () => {
+describe('useResourceContent — bring-your-own-client, no providers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockResourceRepresentation.mockResolvedValue({ data: '', contentType: 'text/plain' });
+    mockResourceRepresentation.mockResolvedValue({ data: utf8(''), contentType: 'text/plain' });
   });
 
-  it('returns empty content and not loading when fetch resolves with empty data', async () => {
-    mockResourceRepresentation.mockResolvedValue({ data: '', contentType: 'text/plain' });
-
-    const { result } = renderHook(
-      () => useResourceContent('res-1' as any, { representations: [{ mediaType: 'text/plain' }] } as any),
-      { wrapper: Wrapper }
-    );
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+  it('resolves decoded content for text media (real charset decode)', async () => {
+    mockResourceRepresentation.mockResolvedValue({
+      data: utf8('Hello World'),
+      contentType: 'text/plain; charset=utf-8',
     });
 
-    expect(result.current.content).toBe('');
-  });
+    const { result } = renderHook(() => useResourceContent(client, RID, resource));
 
-  it('returns content when data is available', async () => {
-    mockResourceRepresentation.mockResolvedValue({ data: 'Hello World', contentType: 'text/plain' });
-
-    const { result } = renderHook(
-      () => useResourceContent('res-2' as any, { representations: [{ mediaType: 'text/plain' }] } as any),
-      { wrapper: Wrapper }
-    );
-
-    await waitFor(() => {
-      expect(result.current.content).toBe('Hello World');
-    });
-
+    await waitFor(() => expect(result.current.content).toBe('Hello World'));
     expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(mockResourceRepresentation).toHaveBeenCalledWith(RID);
   });
 
-  it('transitions through loading states', async () => {
+  it('transitions through a loading state', async () => {
     const loadingStates: boolean[] = [];
-    mockResourceRepresentation.mockResolvedValue({ data: 'done', contentType: 'text/plain' });
+    mockResourceRepresentation.mockResolvedValue({ data: utf8('done'), contentType: 'text/plain' });
 
-    const { result } = renderHook(
-      () => {
-        const r = useResourceContent('res-3' as any, { representations: [{ mediaType: 'text/plain' }] } as any);
-        loadingStates.push(r.loading);
-        return r;
-      },
-      { wrapper: Wrapper }
-    );
-
-    await waitFor(() => {
-      expect(result.current.content).toBe('done');
+    const { result } = renderHook(() => {
+      const r = useResourceContent(client, RID, resource);
+      loadingStates.push(r.loading);
+      return r;
     });
 
+    await waitFor(() => expect(result.current.content).toBe('done'));
     expect(loadingStates).toContain(true);
     expect(result.current.loading).toBe(false);
   });
 
-  it('calls showError when error occurs', async () => {
+  it('client=null stays idle — no fetch, not loading', () => {
+    const { result } = renderHook(() => useResourceContent(null, RID, resource));
+
+    expect(mockResourceRepresentation).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.content).toBe('');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('enabled=false fetches nothing (the binary/media-token path)', () => {
+    const { result } = renderHook(() => useResourceContent(client, RID, resource, false));
+
+    expect(mockResourceRepresentation).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('a failing fetch RETURNS the error — nothing is toasted (no provider to toast with)', async () => {
     mockResourceRepresentation.mockRejectedValue(new Error('Network error'));
 
-    renderHook(
-      () => useResourceContent('res-4' as any, { representations: [{ mediaType: 'text/plain' }] } as any),
-      { wrapper: Wrapper }
-    );
+    const { result } = renderHook(() => useResourceContent(client, RID, resource));
 
-    await waitFor(() => {
-      expect(mockShowError).toHaveBeenCalledWith('Failed to load resource representation');
-    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.content).toBe('');
   });
 });

--- a/packages/react-ui/src/hooks/usePendingCreation.ts
+++ b/packages/react-ui/src/hooks/usePendingCreation.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import type { EventMap, ResourceId } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from './useSessionEventSubscriptions';
+
+/**
+ * A claimed `mark:requested` — the typed event payload (selector + motivation +
+ * source), re-exported rather than a parallel shape.
+ */
+export type PendingCreation = EventMap['mark:requested'];
+
+/**
+ * The consuming half of the viewer's capture/policy split (HEADLESS-CREATION-SEAM).
+ *
+ * The viewer captures gestures and emits source-scoped `mark:requested`; this
+ * hook claims them for ONE viewer: an event is claimed iff
+ * `enabled && event.source === resourceId` — N mounted hooks on one session each
+ * claim only their own (the multi-mount contract MARK-REQUESTED-RESOURCE-SCOPE
+ * created). A new request for the same resource REPLACES an unresolved pending
+ * (the user reselected; the stale pending is abandoned).
+ *
+ * Headless by contract: no creation call, no UI, no toast in here — resolution
+ * (chooser flows, body forms, `mark.annotation`) is host policy. Session-first
+ * like every subscribing primitive (`session.subscribe` is the sanctioned
+ * generic-channel path); `null` → inert.
+ *
+ * @param session  Session whose bus carries this viewer's events; null → inert.
+ * @param resourceId  Claim only events whose `source` is this resource.
+ * @param enabled  The host's annotate-mode gate — browse-mode viewers never claim.
+ */
+export function usePendingCreation(
+  session: SemiontSession | null,
+  resourceId: ResourceId,
+  enabled: boolean,
+): { pending: PendingCreation | null; clearPending: () => void } {
+  const [pending, setPending] = useState<PendingCreation | null>(null);
+
+  useSessionEventSubscriptions(session, {
+    'mark:requested': (event) => {
+      if (!enabled) return;
+      // Scope equality on the branded id's string form.
+      if (String(event.source) !== String(resourceId)) return;
+      setPending(event);
+    },
+  });
+
+  const clearPending = useCallback(() => setPending(null), []);
+
+  return { pending, clearPending };
+}

--- a/packages/react-ui/src/hooks/useResourceContent.ts
+++ b/packages/react-ui/src/hooks/useResourceContent.ts
@@ -1,45 +1,50 @@
 import { useEffect, useState } from 'react';
 import type { ResourceDescriptor, ResourceId } from '@semiont/core';
-import { getPrimaryMediaType } from '@semiont/core';
-import { decodeWithCharset } from '@semiont/core';
-import { useToast } from '../components/Toast';
-import { useSemiont } from '../session/SemiontProvider';
-import { useObservable } from './useObservable';
+import { getPrimaryMediaType, decodeWithCharset } from '@semiont/core';
+import type { SemiontClient } from '@semiont/sdk';
 
 export interface UseResourceContentResult {
   content: string;
   loading: boolean;
+  error: Error | null;
 }
 
+/**
+ * Fetch + decode a resource's primary representation from a bare client — the
+ * content sibling of `useResourceLoader`/`useMediaToken` (bring-your-own-client;
+ * `null` → idle). Headless: errors are RETURNED, never toasted — the host
+ * decides chrome (the Browser page toasts; an embedded host may render inline
+ * or ignore). `enabled=false` fetches nothing (the binary/media-token path).
+ */
 export function useResourceContent(
+  client: SemiontClient | null,
   rUri: ResourceId,
   resource: ResourceDescriptor,
   enabled = true
 ): UseResourceContentResult {
-  const { showError } = useToast();
-  const semiont = useObservable(useSemiont().activeSession$)?.client;
   const mediaType = enabled ? (getPrimaryMediaType(resource) || 'text/plain') : '';
 
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (!semiont || !enabled || !mediaType) return;
+    if (!client || !enabled || !mediaType) return;
     let cancelled = false;
     setLoading(true);
-    semiont.browse.resourceRepresentation(rUri).then(({ data, contentType }) => {
+    setError(null);
+    client.browse.resourceRepresentation(rUri).then(({ data, contentType }) => {
       if (cancelled) return;
       setContent(decodeWithCharset(data, contentType));
       setLoading(false);
-    }).catch((error) => {
+    }).catch((err) => {
       if (cancelled) return;
-      console.error('Failed to fetch representation:', error);
-      showError('Failed to load resource representation');
+      setError(err instanceof Error ? err : new Error(String(err)));
       setLoading(false);
     });
 
     return () => { cancelled = true; };
-  }, [semiont, rUri, mediaType, enabled, showError]);
+  }, [client, rUri, mediaType, enabled]);
 
-  return { content, loading };
+  return { content, loading, error };
 }

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -44,6 +44,7 @@ export * from './hooks/useResourceLoader';
 export * from './hooks/useMediaToken';
 export * from './hooks/useSessionEventSubscriptions';
 export * from './hooks/useToolbarPrefs';
+export * from './hooks/usePendingCreation';
 
 // Session (the React layer — provider + hook + browser storage adapter).
 // All session classes (`SemiontSession`, `SemiontBrowser`, `SessionSignals`,


### PR DESCRIPTION
feat(react-ui): close the headless gaps — de-provider useResourceContent, export the creation seam

Two consumer-backed gaps from the headless lens (.plans/HEADLESS-REACT-UI.md): the embeddable path had one provider-bound hook left, and the consuming half of the capture/policy split lived host-side, re-derived by every embedding host. Both closed; the panels gap stays deliberately gated on a real consumer.
- useResourceContent joins the bring-your-own-client convention: useResourceContent(client | null, rUri, resource, enabled?) -- the useToast/useSemiont dependencies are deleted and errors are RETURNED, not toasted (chrome doesn't belong in a logic hook; the Browser page now toasts the returned error at its call site with the same message, UX byte-identical). Fetch/decode/cancel-guard unchanged -- a dependency inversion, not a rewrite. No compat overload; the one call site updated in the same change. The embeddable path is now fully provider-free: loader + content + media-token on one convention.
- usePendingCreation(session | null, resourceId, enabled) -> { pending, clearPending }: the exported primitive that claims source-scoped mark:requested for ONE viewer (enabled && source === resourceId -- N mounted hooks on one session each claim only their own), replace-on-reselect, no creation/UI/toast inside; resolution chrome is host policy. PendingCreation re-exports the typed event payload. Deliberately session-first where the ask wrote client-first: a bare client has no sanctioned subscription path (client.bus is audit-raw-bus-forbidden outside the SDK), and the reference host implementation is already session-first. A creation-calls helper stays host-side for now (yes-later, per the ask's lean). TDD-first, RED observed in both: the content spec (5/5 failed -- the old hook threw from useSemiont with no providers; rewrite also replaced the core mocks and `as any` casts with real decodeWithCharset over encoded bytes) and the seam spec (module not found), then GREEN -- content 5/5 + page 14/14; seam 5/5 incl. the end-to-end case (real jsdom selection in a showToolbar={false} viewer -> mark.request -> hook claims it); tsc clean. Embedding hosts can now delete their mirrored content-loading effects and hand-rolled pending-creation hooks on the release carrying this.

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Infrastructure/DevOps changes

## Areas Changed

- [ ] Frontend (`apps/frontend`)
- [ ] Backend (`apps/backend`)
- [ ] CLI (`apps/cli`)
- [ ] HTTP Transport (`packages/http-transport`)
- [ ] Core (`packages/core`)
- [ ] MCP Server (`packages/mcp-server`)
- [ ] Test Utils (`packages/test-utils`)
- [ ] OpenAPI Specs (`specs/`)
- [ ] Demo Scripts (`demo/`)
- [ ] Documentation (`docs/`)
- [ ] GitHub Actions (`.github/workflows/`)
- [ ] Scripts (`scripts/`)
- [ ] Infrastructure/Deployment

## Security Checklist

**Required for all PRs that modify authentication, authorization, or admin functionality:**

### Authentication & Authorization

- [ ] No authentication logic moved to client-side
- [ ] All admin routes properly protected with server-side checks
- [ ] JWT tokens validated server-side only
- [ ] Session data comes from secure sources (database, not client claims)
- [ ] No hardcoded secrets or credentials

### Admin Route Security (Frontend)

- [ ] Admin/moderate routes protected by middleware (proxy.ts)
- [ ] No admin content rendered for unauthorized users
- [ ] No sensitive information in error responses

### API Security (Backend)

- [ ] Admin endpoints protected with `adminMiddleware`
- [ ] All endpoints return proper HTTP status codes (401/403/500)
- [ ] Error messages don't leak sensitive information
- [ ] Database queries protected behind authentication
- [ ] Input validation implemented

### Information Disclosure Prevention

- [ ] No database connection strings in error messages
- [ ] No file paths or stack traces exposed to clients
- [ ] No user emails or personal data in unauthorized responses
- [ ] No API keys or secrets in client-accessible responses
- [ ] Error messages are generic and safe

## Testing

- [ ] Added tests for new functionality
- [ ] All existing tests pass
- [ ] Security tests pass (`npm run test:security`)
- [ ] Manual testing completed for authentication flows
- [ ] Tested with different user roles (unauthenticated, non-admin, admin)

## Security Test Results

Please run and paste results:

### Frontend Security Tests

```bash
cd apps/frontend && npm run test:security
# Paste results here
```

### Backend Security Tests

```bash
cd apps/backend && npm run test:security
# Paste results here
```

### Manual Security Verification

If you modified admin routes, please verify:

```bash
# Start the application and test:
curl -I http://localhost:3000/admin
# Should return: HTTP/1.1 200 OK (not 307)

# Verify no admin content leakage:
curl -s http://localhost:3000/admin | grep -i "admin\|dashboard\|management"
# Should return no results
```

## Performance Impact

- [ ] No significant performance degradation
- [ ] Database queries optimized
- [ ] No N+1 query problems introduced
- [ ] Bundle size impact considered (for frontend changes)

## Breaking Changes

If this PR introduces breaking changes, please describe:

- What breaks
- Migration path for users
- Documentation updates needed

## Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] API documentation updated (if applicable)
- [ ] Security documentation updated (if security-related)

## Additional Context

Add any other context, screenshots, or information about the pull request here.

---

## For Reviewers

### Security Review Required

- [ ] Authentication/authorization changes reviewed
- [ ] No security regressions introduced
- [ ] Error handling doesn't leak sensitive data
- [ ] All security tests passing
- [ ] Manual security verification completed

### Code Review

- [ ] Code follows project conventions
- [ ] No obvious bugs or issues
- [ ] Performance considerations addressed
- [ ] Tests provide adequate coverage
- [ ] Documentation is clear and accurate

### Final Checks

- [ ] All CI checks passing
- [ ] Security tests passing
- [ ] No merge conflicts
- [ ] Ready for deployment

---

**⚠️ SECURITY NOTICE:** If any security tests fail or if this PR modifies authentication/authorization logic, **DO NOT MERGE** until security issues are resolved and all tests pass.
