### PR TITLE
BrowseView: paint the annotation overlay when content arrives after annotations

### DIFF
--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -109,26 +109,23 @@ export const BrowseView = memo(function BrowseView({
     [allAnnotations]
   );
 
-  // Cache offset map (recomputed only when content changes)
-  const offsetMapRef = useRef<Map<number, number> | null>(null);
-
-  // Build offset map after markdown DOM paints (once per content change)
+  // The two-layer overlay in ONE effect, keyed on everything it reads: the
+  // rendered content DOM (`content` re-renders it) AND the annotations.
+  // Splitting these across two effects with a ref-passed offset map silently
+  // dropped the `content` dependency — content arriving after annotations
+  // (any async-content host) painted ZERO spans until a remount. The
+  // length===0 early-return is safe: the prior run's cleanup already cleared.
   useEffect(() => {
-    if (!containerRef.current) return;
-    offsetMapRef.current = buildSourceToRenderedMap(content, containerRef.current);
-  }, [content]);
-
-  // Layer 2: overlay annotations after DOM paint
-  useEffect(() => {
-    if (!containerRef.current || !offsetMapRef.current || overlayAnnotations.length === 0) return;
+    if (!containerRef.current || overlayAnnotations.length === 0) return;
 
     const container = containerRef.current;
+    const offsetMap = buildSourceToRenderedMap(content, container);
     const textNodeIndex = buildTextNodeIndex(container);
-    const ranges = resolveAnnotationRanges(overlayAnnotations, offsetMapRef.current, textNodeIndex);
+    const ranges = resolveAnnotationRanges(overlayAnnotations, offsetMap, textNodeIndex);
     applyHighlights(ranges);
 
     return () => clearHighlights(container);
-  }, [overlayAnnotations]);
+  }, [content, overlayAnnotations]);
 
   // Attach click handler, hover handler, and animations after render
   useEffect(() => {

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.overlay-async.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.overlay-async.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * BUG: browse-view-overlay-misses-async-content — the overlay effect must be
+ * keyed on everything it reads: the rendered content DOM AND the annotations.
+ *
+ * When annotations arrive BEFORE content (any host loading content async —
+ * useResourceContent), the overlay resolved ranges against the empty document
+ * and never re-ran when content landed: rendered text, ZERO spans, healed only
+ * by a remount. When content arrives first (sync-content hosts), it worked by
+ * accident of ordering. Both orders are pinned here, plus shrink-to-zero.
+ *
+ * REAL overlay pipeline (no annotation-overlay mocks) — react-markdown is
+ * mocked to identity, so the source→rendered offset map is 1:1 and spans
+ * paint in jsdom via the actual Range/surroundContents path.
+ *
+ * Started RED (async order → 0 spans) → GREEN with the single keyed effect.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { Annotation, AnnotationId } from '@semiont/core';
+import { BrowseView } from '../BrowseView';
+
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+const CONTENT = 'hello world selectme end';
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+/** A resolved reference over "world" (offsets 6..11) — real W3C shape. */
+function referenceOnWorld(): Annotation {
+  return {
+    '@context': 'http://www.w3.org/ns/anno.jsonld',
+    id: 'ref-world' as AnnotationId,
+    type: 'Annotation',
+    motivation: 'linking',
+    creator: { '@type': 'Person', name: 'user@example.com' },
+    created: '2026-07-10T00:00:00Z',
+    target: {
+      source: 'res-1',
+      selector: { type: 'TextPositionSelector', start: 6, end: 11 },
+    },
+  } as unknown as Annotation;
+}
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+const withReference = { ...emptyAnnotations, references: [referenceOnWorld()] };
+
+const baseProps = {
+  mimeType: 'text/plain',
+  resourceUri: 'res-1',
+  annotateMode: false,
+};
+
+const spans = (c: HTMLElement) => c.querySelectorAll('[data-annotation-id]');
+
+describe('BrowseView — overlay vs async content arrival', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('paints spans when content arrives AFTER annotations (the async-content bug)', () => {
+    const session = fakeSession();
+    const { container, rerender } = render(
+      <BrowseView {...baseProps} content="" annotations={withReference} session={session} />,
+    );
+    expect(spans(container)).toHaveLength(0); // nothing to anchor on yet
+
+    // Content lands (useResourceContent resolved) — annotations unchanged.
+    rerender(
+      <BrowseView {...baseProps} content={CONTENT} annotations={withReference} session={session} />,
+    );
+
+    expect(spans(container)).toHaveLength(1);
+    expect(spans(container)[0]!.textContent).toBe('world');
+    expect(spans(container)[0]!.getAttribute('data-annotation-type')).toBe('reference');
+  });
+
+  it('paints spans when annotations arrive AFTER content (the always-working order — pinned)', () => {
+    const session = fakeSession();
+    const { container, rerender } = render(
+      <BrowseView {...baseProps} content={CONTENT} annotations={emptyAnnotations} session={session} />,
+    );
+    expect(spans(container)).toHaveLength(0);
+
+    rerender(
+      <BrowseView {...baseProps} content={CONTENT} annotations={withReference} session={session} />,
+    );
+
+    expect(spans(container)).toHaveLength(1);
+    expect(spans(container)[0]!.textContent).toBe('world');
+  });
+
+  it('clears spans when annotations shrink to zero', () => {
+    const session = fakeSession();
+    const { container, rerender } = render(
+      <BrowseView {...baseProps} content={CONTENT} annotations={withReference} session={session} />,
+    );
+    expect(spans(container)).toHaveLength(1);
+
+    rerender(
+      <BrowseView {...baseProps} content={CONTENT} annotations={emptyAnnotations} session={session} />,
+    );
+
+    expect(spans(container)).toHaveLength(0);
+    expect(container.textContent).toContain(CONTENT); // text restored intact
+  });
+});


### PR DESCRIPTION
## Summary

Browse mode — the **default reading mode** — silently painted **zero** annotations whenever content arrived after the annotations did. That's the normal arrival order for any host loading content asynchronously (`useResourceContent`), e.g. a document pane fed by `useResourceLoader` + `useResourceContent`: text renders, no spans, and a mode toggle (remount) "heals" it — which is exactly why mode-toggling test choreography never caught it. Hosts passing content synchronously as a prop worked by accident of ordering.

Live discriminator that exposed it (doc with 4 known annotations): first browse render **0** spans → annotate mode **4** → back to browse (remount) **4**.

## Root cause

`BrowseView`'s two-layer overlay split its data flow across two effects with a **ref-smuggled offset map**:

- Layer 1 (`[content]`): build the source→rendered offset map into a ref.
- Layer 2 (`[overlayAnnotations]` — **`content` missing**): resolve ranges against the ref'd map and paint.

When annotations precede content: layer 2 fires once against the empty document's map (paints nothing); content lands, layer 1 rebuilds the map and React re-renders the markdown DOM — but layer 2 never re-runs, because its only dependency didn't change. Steady state: rendered text, zero spans. The ref is the smell that produced the missing dependency — the linter can't see through it.

## The fix

Collapse the two layers into **one effect keyed on everything it reads**: `[content, overlayAnnotations]` — build map → resolve → apply → cleanup — and delete the ref entirely. The ordering dependency is gone *by construction*, and the data flow is linter-visible again. The `length === 0` early-return stays (safe: the prior run's cleanup already cleared — now pinned by a spec instead of implicit).

## Testing (TDD-first, RED observed)

New `BrowseView.overlay-async.test.tsx` drives the **real** overlay pipeline in jsdom (react-markdown mocked to identity → a 1:1 offset map; actual `Range`/`surroundContents` painting — no annotation-overlay mocks):

1. **annotations → content** (the bug): observed RED, 0 spans — matching the live discriminator — now paints the span over the right text with the right `data-annotation-type`.
2. **content → annotations** (the accidentally-working order): pinned, so the fix can't trade one race for the other.
3. **shrink-to-zero**: cleanup path pinned; text restored intact.

RED **1 failed / 2 passed** → GREEN **3/3**, plus the full viewer sweep (BrowseView ×3, toolbar opt-out/prefs, mode-switch, embeddable, page): **49/49 across 9 files**; react-ui `tsc --noEmit` clean (`node:24-alpine`).

## Notes

- No API/spec/SDK change — one component's effect wiring; the data provably arrived all along (annotate mode painted it).
- One optional live follow-up noted in the diagnosis doc: the Browser's warm-annotations-cache first paint (back-navigation) was the unverified surface — both arrival orders are now spec-pinned, so it's covered by construction; a one-look check on the release build wouldn't hurt.
- Diagnosis + execution log: `.plans/bugs/browse-view-overlay-misses-async-content.md`.
