### PR TITLE
YIELD-STRUCTURE P1–P4 + CONTEXT-IDENTIFIERS P1: task/structure output control + id-labelled context (Tiers 1+2)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -131,6 +131,7 @@ semiont listen resource <resourceId>
 ```bash
 semiont yield --upload ./paper.pdf
 semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://out.md
+semiont yield --delegate --resource <resourceId> --storage-uri file://answer.md --title "What is X?" --task answer --structure prose
 ```
 
 **beckon** — direct a participant's attention

--- a/apps/cli/docs/KNOWLEDGE-WORK.md
+++ b/apps/cli/docs/KNOWLEDGE-WORK.md
@@ -289,13 +289,20 @@ semiont yield --upload ./paper.pdf --name "My Paper"
 semiont yield --upload ./a.md --upload ./b.md   # multiple files
 ```
 
-**Delegate mode** — delegate resource generation from annotation context to a configured worker:
+**Delegate mode** — delegate resource generation to a configured worker. With
+`--annotation`, generation is grounded in that annotation's gathered context;
+without it, in the whole source resource's context (`yield.fromResource`):
 
 ```bash
 semiont yield --delegate \
   --resource <resourceId> \
   --annotation <annotationId> \
   --storage-uri file://generated/output.md
+
+# Whole-resource Q&A — no annotation; the title is the question
+semiont yield --delegate --resource <resourceId> \
+  --storage-uri file://generated/answer.md \
+  --title "What is X?" --task answer --structure prose
 ```
 
 | Flag | Description |
@@ -304,11 +311,14 @@ semiont yield --delegate \
 | `--name <name>` | Resource name (upload mode, single file only) |
 | `--delegate` | Delegate to a configured worker; mutually exclusive with `--upload` |
 | `--resource <id>` | Source resource for delegate mode |
-| `--annotation <id>` | Source annotation for delegate mode |
+| `--annotation <id>` | Source annotation (optional — omit for whole-resource generation) |
 | `--storage-uri <uri>` | Where to store the generated output |
-| `--prompt <text>` | Override the generation prompt |
+| `--prompt <text>` | Refining instruction for generation (composes with `--task`) |
+| `--task <t>` | Generation framing — `resource` \| `answer` \| `summary`, or any custom framing string (default: `resource`) |
+| `--structure <s>` | Output shape — `prose` \| `sections` \| `chat`, or any custom organization string (default: none imposed) |
+| `--output-media-type <mt>` | Media type of the generated resource (default: `text/markdown`) |
 | `--temperature <n>` | Model temperature (0–1) |
-| `--max-tokens <n>` | Maximum tokens to generate |
+| `--max-tokens <n>` | Maximum tokens to generate (length only — never implies structure) |
 | `--context-window <n>` | Token budget for context gathering |
 
 ---

--- a/apps/cli/src/core/commands/__tests__/yield-command.test.ts
+++ b/apps/cli/src/core/commands/__tests__/yield-command.test.ts
@@ -294,6 +294,13 @@ describe('runYield', () => {
       await expect(runYield(makeDelegateOptions({ outputMediaType: 'text/markdwn' })))
         .rejects.toThrow(/text\/markdwn/);
     });
+
+    it('passes task/structure through to yield.fromAnnotation (open-string task, canonical chat)', async () => {
+      await runYield(makeDelegateOptions({ task: 'translate to French', structure: 'chat' }));
+      const [, , opts] = mockYield.fromAnnotation.mock.calls[0];
+      expect(opts.task).toBe('translate to French');
+      expect(opts.structure).toBe('chat');
+    });
   });
 
   describe('delegate mode — resource-anchored', () => {
@@ -344,6 +351,20 @@ describe('runYield', () => {
       mockYield.fromResource.mockReset();
       mockYield.fromResource.mockReturnValueOnce(throwError(() => new Error('Derive failed')));
       await expect(runYield(makeResourceDelegateOptions())).rejects.toThrow('Derive failed');
+    });
+
+    it('passes task/structure through to yield.fromResource (the Q&A recipe)', async () => {
+      await runYield(makeResourceDelegateOptions({ task: 'answer', structure: 'prose' }));
+      const [, opts] = mockYield.fromResource.mock.calls[0];
+      expect(opts.task).toBe('answer');
+      expect(opts.structure).toBe('prose');
+    });
+
+    it('leaves task/structure undefined when the flags are unset (D2: no CLI defaults)', async () => {
+      await runYield(makeResourceDelegateOptions());
+      const [, opts] = mockYield.fromResource.mock.calls[0];
+      expect(opts.task).toBeUndefined();
+      expect(opts.structure).toBeUndefined();
     });
   });
 });

--- a/apps/cli/src/core/commands/yield.ts
+++ b/apps/cli/src/core/commands/yield.ts
@@ -64,6 +64,20 @@ export const YieldOptionsSchema = ApiOptionsSchema.extend({
    * authorable / role-appropriateness rejection (MEDIA-TYPES).
    */
   outputMediaType: z.string().optional(),
+  /**
+   * Framing of the generation (delegate mode) — what the model is asked to
+   * do. Canonical: resource | answer | summary; any other string is used
+   * verbatim as the framing line (loud degrade at the worker). No default
+   * here — unset passes through as undefined.
+   */
+  task: z.string().optional(),
+  /**
+   * Shape of the generated output (delegate mode). Canonical: prose |
+   * sections | chat; any other string becomes a freeform organization
+   * instruction (loud degrade at the worker). No default — unset means the
+   * worker emits no structure directive at all (D2).
+   */
+  structure: z.string().optional(),
 }).superRefine((val, ctx) => {
   const hasUpload = val.upload.length > 0;
   const hasDelegate = val.delegate;
@@ -138,6 +152,8 @@ async function runDelegate(
         temperature: options.temperature,
         maxTokens: options.maxTokens,
         outputMediaType,
+        task: options.task,
+        structure: options.structure,
       }),
     );
     return extractResult(final);
@@ -174,6 +190,8 @@ async function runDelegate(
       temperature: options.temperature,
       maxTokens: options.maxTokens,
       outputMediaType,
+      task: options.task,
+      structure: options.structure,
     }),
   );
   return extractResult(final);
@@ -278,7 +296,8 @@ export const yieldCmd = new CommandBuilder()
     'semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/paris.md',
     'semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/paris.md --title "Paris" --language en',
     'semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/paris.md --prompt "Write a brief encyclopedia entry" --temperature 0.3',
-    'semiont yield --delegate --resource <resourceId> --storage-uri file://generated/summary.md --prompt "Summarize this document"',
+    'semiont yield --delegate --resource <resourceId> --storage-uri file://generated/summary.md --task summary',
+    'semiont yield --delegate --resource <resourceId> --storage-uri file://generated/answer.md --title "What is X?" --task answer --structure prose',
     'semiont yield --delegate --resource <resourceId> --storage-uri file://generated/translated.html --prompt "Translate to French" --language fr --output-media-type text/html',
     'NEW_ID=$(semiont yield --delegate --resource <resourceId> --annotation <annotationId> --storage-uri file://generated/loc.md --quiet | jq -r \'.resourceId\') && semiont bind <resourceId> <annotationId> "$NEW_ID"',
   )
@@ -336,6 +355,14 @@ export const yieldCmd = new CommandBuilder()
       '--output-media-type': {
         type: 'string',
         description: 'Delegate mode: media type of the generated resource (e.g. text/markdown, text/html; default: text/markdown)',
+      },
+      '--task': {
+        type: 'string',
+        description: 'Delegate mode: generation framing — resource | answer | summary, or any custom framing string (default: resource)',
+      },
+      '--structure': {
+        type: 'string',
+        description: 'Delegate mode: output shape — prose | sections | chat, or any custom organization string (default: none imposed)',
       },
     }, {
       '-n': '--name',

--- a/docs/protocol/flows/YIELD.md
+++ b/docs/protocol/flows/YIELD.md
@@ -176,7 +176,9 @@ Generation has no dedicated REST endpoint — it runs as a bus job. The SDK's `y
   title: string;              // Title of the synthesized resource; also the LLM topic
   storageUri: string;         // Where the generated content is written (file://…)
   context: GatheredContext;   // Correlated context from the Gather flow (grounds the prompt)
-  prompt?: string;            // Freeform user instructions, injected as "Additional context: …"
+  prompt?: string;            // Freeform user instructions — rendered as an authoritative
+                              // "Instruction: …" line directly under the task framing
+                              // (task = what to produce, prompt = how; they compose)
   entityTypes?: string[];     // Stamped on the synthesized resource AND injected into the
                               // prompt as a topical bias ("Focus on these entity types: …"),
                               // so `browse.resources({ entityType: … })` can later find it
@@ -187,8 +189,25 @@ Generation has no dedicated REST endpoint — it runs as a bus job. The SDK's `y
   maxTokens?: number;         // Target LLM response length in tokens (worker default 500)
   outputMediaType?: SupportedMediaType; // Output format; the worker defaults to text/markdown
                               // and fails the job for anything outside text/markdown | text/plain
+  task?: 'resource' | 'answer' | 'summary' | (string & {});
+                              // Framing — what the model is asked to DO. Canonical values map to
+                              // tested lead lines; any other string is used VERBATIM as the framing
+                              // (loud degrade: worker warns, never silently falls back). Default 'resource'
+  structure?: 'prose' | 'sections' | 'chat' | (string & {});
+                              // Shape — how text-bearing output is internally segmented; subordinate
+                              // to outputMediaType, never its peer. Unknown strings become a freeform
+                              // "Organize the output as: …" directive (+ warn). UNSET ⇒ NO structure
+                              // directive at all — the task framing and the model determine shape
 }
 ```
+
+`outputMediaType` is the one **universal** axis (it selects the modality);
+`task` and `structure` are subordinate detail under it, not co-equal axes.
+`structure` values are per-modality — `prose | sections | chat` is what shape
+means for text-bearing output; other modalities (image, audio, video) get
+their own canonical sets if/when their generators exist. Length knobs
+(`maxTokens`, and one day duration/dimensions) are a separate axis and never
+imply structure.
 
 **Dispatch responsibilities** (SDK `yield` namespace + [job-commands.ts](../../../packages/make-meaning/src/handlers/job-commands.ts)):
 1. Validate params and authentication
@@ -242,9 +261,13 @@ The generation prompt is enriched with graph context from the [Gather flow](./GA
 **Prompt Structure** (assembled by `generateResourceFromTopic`; every section
 below is omitted when its underlying data is absent):
 ```
-Generate a concise, informative resource about "{title}".
+{task framing}                                                      // task: 'resource' → Generate a concise, informative resource about "{title}".
+                                                                    //       'answer'   → Answer the following question directly and concisely,
+                                                                    //                    grounded in the provided context: "{title}"
+                                                                    //       'summary'  → Write a concise summary of "{title}".
+                                                                    //       any other string → used verbatim as the framing (+ Topic: "{title}", worker warns)
+Instruction: {prompt}                                               // when a freeform prompt was supplied — authoritative, directly under the framing
 Focus on these entity types: {comma-separated entity types}.        // when entityTypes is non-empty
-Additional context: {prompt}                                        // when a freeform prompt was supplied
 
 Annotation context:                                                 // annotation-focus (fromAnnotation)
 - Annotation motivation: {motivation}
@@ -275,21 +298,32 @@ The source resource and embedded context are in {source language}.  // when sour
 IMPORTANT: Write the entire resource in {language}.                 // when language is not English
 
 Requirements:
-- Aim for approximately {maxTokens} tokens of content, organized into well-structured paragraphs
+- Aim for approximately {maxTokens} tokens of content
 - Be factual and informative
-- Start with a clear heading (# Title)                              // markdown (default output)
-- Use markdown formatting
+- {structure directive}                                             // ONLY when `structure` is set:
+                                                                    //   'sections' → titled sections (## Section) + Start with a clear heading (# Title)
+                                                                    //   'prose'    → flowing paragraphs, no section headings
+                                                                    //   'chat'     → conversational transcript — alternating, speaker-labeled turns
+                                                                    //   any other string → Organize the output as: {structure} (worker warns)
+- Use markdown formatting                                           // text/plain instead: no markup; title on its own first line
 - Write the response as markdown
 ```
 
-There is no tone or length parameter. Generation is steered by the freeform
-`prompt`, the `entityTypes` bias, and the gathered context; the requested
-`maxTokens` sets the target length (and, for markdown output ≥1000 tokens, the
-prompt also asks for titled `## Section`s). When `outputMediaType` is
-`text/plain` the format requirements instead tell the model to emit plain text
-with the title on its own first line. Each context section is omitted when its
-data is absent — e.g. the graph section disappears for an isolated annotation
-with no connections.
+There is no tone parameter. Generation is steered by the `task` framing, the
+authoritative `Instruction:` line (`prompt`), the `entityTypes` bias, and the
+gathered context. `maxTokens` sets the target **length only** — it never
+implies structure. When `structure` is unset the prompt carries **no**
+structure or heading requirement at all: the task framing and the model
+determine shape (an `answer` naturally comes out prose; a `resource`
+naturally article-ish). The forced `# Title` heading exists only under
+canonical `sections` (markdown output). Each context section is omitted when
+its data is absent — e.g. the graph section disappears for an isolated
+annotation with no connections.
+
+The Q&A recipe (`my-chat`-style consumers): `task: 'answer'` with
+`structure: 'prose'` (or `'chat'` for speaker-labeled turns) — ask the
+question via `title`, refine with `prompt` ("cite every claim; be terse")
+instead of fighting the article framing through it.
 
 **Model Parameters**:
 - Model: Claude Sonnet 4.5

--- a/packages/jobs/docs/JobTypes.md
+++ b/packages/jobs/docs/JobTypes.md
@@ -109,19 +109,30 @@ AI content generation — creates new resources from source material and prompts
 
 ```typescript
 interface GenerationParams {
-  referenceId: AnnotationId;
-  sourceResourceId: ResourceId;
-  sourceResourceName: string;
-  annotation: Annotation;           // Full W3C Annotation
-  prompt?: string;
+  referenceId?: AnnotationId;       // Annotation-focus only (yield.fromAnnotation) — the
+                                    // unresolved reference; the worker auto-binds the new
+                                    // resource to it. Absent for resource-focus generation
+                                    // (yield.fromResource): provenance is a minted
+                                    // source→derived reference instead
+  prompt?: string;                  // Freeform refinement — rendered as an authoritative
+                                    // "Instruction:" line under the task framing
   title?: string;
   entityTypes?: EntityType[];
-  language?: string;                // Annotation body locale, e.g., 'en-US'
+  language?: string;                // Generated-content locale, e.g., 'en-US'
   sourceLanguage?: string;          // Source resource locale (BCP-47)
   context?: GatheredContext;
   temperature?: number;
-  maxTokens?: number;
+  maxTokens?: number;               // Length only — never implies structure
   storageUri?: string;
+  outputMediaType?: SupportedMediaType; // Default text/markdown; only text/markdown |
+                                    // text/plain are produced — anything else fails the job
+  task?: 'resource' | 'answer' | 'summary' | (string & {});
+                                    // Framing (what to produce). Unknown strings are used
+                                    // verbatim as the framing + a worker warn (loud degrade)
+  structure?: 'prose' | 'sections' | 'chat' | (string & {});
+                                    // Shape, subordinate to outputMediaType. Unknown strings
+                                    // become "Organize the output as: …" + warn. UNSET ⇒ no
+                                    // structure directive at all
 }
 ```
 

--- a/packages/jobs/src/__tests__/generation-params.types.test.ts
+++ b/packages/jobs/src/__tests__/generation-params.types.test.ts
@@ -17,4 +17,16 @@ describe('GenerationParams contract', () => {
     const p: GenerationParams = {};
     expect(p).toEqual({});
   });
+
+  it('task and structure accept canonical values AND arbitrary strings (open LiteralUnion)', () => {
+    // YIELD-STRUCTURE D1: '…canonical…' | (string & {}) — autocomplete for the
+    // tested set, any string as the power-user escape hatch.
+    const canonical: GenerationParams = { task: 'answer', structure: 'prose' };
+    const custom: GenerationParams = {
+      task: 'Translate the source into idiomatic French',
+      structure: 'a bulleted list of key facts',
+    };
+    expect(canonical.task).toBe('answer');
+    expect(custom.structure).toBe('a bulleted list of key facts');
+  });
 });

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -694,11 +694,11 @@ describe('locale threading', () => {
         LOGGER,
       );
 
-      // Positional signature: topic, entityTypes, client, logger, prompt,
-      // locale, context, temperature, maxTokens, sourceLanguage, outputMediaType.
+      // Positional signature: topic, entityTypes, client, logger, prompt, locale,
+      // context, temperature, maxTokens, sourceLanguage, outputMediaType, task, structure.
       expect(generateResourceFromTopic).toHaveBeenCalledWith(
         'Topic', [], client, LOGGER, undefined, 'de', undefined,
-        undefined, undefined, 'fr', 'text/markdown',
+        undefined, undefined, 'fr', 'text/markdown', undefined, undefined,
       );
     });
   });

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -488,6 +488,8 @@ export async function processGenerationJob(
     params.maxTokens,
     params.sourceLanguage,
     outputMediaType,
+    params.task,
+    params.structure,
   );
 
   onProgress(85, 'Creating resource...', 'creating');

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -109,6 +109,21 @@ export interface GenerationParams {
    * generation coverage is text-only for now and the gap is surfaced, not hidden.
    */
   outputMediaType?: SupportedMediaType;
+  /**
+   * What the model is asked to DO — the prompt's framing verb. Canonical values map
+   * to tested framings; any other string is used verbatim as the framing instruction
+   * (loud degrade: the worker warns, never silently falls back to 'resource').
+   * Default 'resource'. See .plans/YIELD-STRUCTURE.md.
+   */
+  task?: 'resource' | 'answer' | 'summary' | (string & {});
+  /**
+   * How the output is internally segmented — text-bearing shape, subordinate to
+   * `outputMediaType` (never its peer). Canonical values map to tested guidance; any
+   * other string becomes a freeform "Organize the output as: …" instruction (loud
+   * degrade). UNSET means NO structure directive is emitted — the task framing and
+   * the model determine shape. See .plans/YIELD-STRUCTURE.md D2/D5.
+   */
+  structure?: 'prose' | 'sections' | 'chat' | (string & {});
 }
 
 /**

--- a/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
+++ b/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
@@ -14,7 +14,7 @@
  * P4 matcher.test.ts pattern.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MockInferenceClient } from '@semiont/inference';
 import type { GatheredContext, Logger } from '@semiont/core';
 import { generateResourceFromTopic } from '../resource-generation';
@@ -523,6 +523,87 @@ describe('generateResourceFromTopic', () => {
     });
   });
 
+  // ── Context identifiers (CONTEXT-IDENTIFIERS P1) — every excerpt carries a
+  // stable, model-visible [<resourceId>] handle; annotation-derived semantic
+  // matches add /<annotationId>. Same bracket convention as related-content blocks.
+
+  describe('context identifiers', () => {
+    it('semantic passages carry their source resourceId', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined,
+        makeContext({ semanticContext: [{ text: 'NEEDLE', resourceId: 'sem-src-1', score: 0.8 }] }),
+      );
+
+      expect(promptArg()).toContain('[sem-src-1]');
+    });
+
+    it('annotation-derived semantic passages add the annotationId as a suffix', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined,
+        makeContext({
+          semanticContext: [{ text: 'NEEDLE', resourceId: 'sem-src-1', annotationId: 'ann-7', score: 0.8 }],
+        }),
+      );
+
+      expect(promptArg()).toContain('[sem-src-1/ann-7]');
+    });
+
+    it('graph connections carry name + [resourceId]', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined,
+        makeContext({
+          selected: { text: 'Topic' },
+          graph: buildGraph({
+            connections: [
+              { resourceId: 'conn-1', resourceName: 'Olympus' },
+              { resourceId: 'conn-2', resourceName: 'Hera', entityTypes: ['Person'] },
+            ],
+          }),
+        }),
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toContain('Olympus [conn-1]');
+      expect(prompt).toContain('Hera (Person) [conn-2]');
+    });
+
+    it('citedBy entries carry name + [resourceId]', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined,
+        makeContext({
+          selected: { text: 'Topic' },
+          graph: buildGraph({ citedByPresent: [{ resourceId: 'cit-1', resourceName: 'Theogony' }] }),
+        }),
+      );
+
+      expect(promptArg()).toContain('Theogony [cit-1]');
+    });
+
+    it('the focal resource line carries its [@id] (resource focus)', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic('Topic', [], client, LOGGER, undefined, undefined, makeResourceContext());
+
+      expect(promptArg()).toContain('Resource: Test Resource [test-resource]');
+    });
+
+    it('the source-resource line carries its [@id] (annotation focus)', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic('Topic', [], client, LOGGER, undefined, undefined, makeContext());
+
+      expect(promptArg()).toContain('Source resource: Test Resource [test-resource]');
+    });
+  });
+
   // ── Resource focus (P5: focus.kind switch; full grounding is YIELD-FROM-RESOURCE) ─
 
   describe('resource focus', () => {
@@ -575,6 +656,135 @@ describe('generateResourceFromTopic', () => {
       const prompt = promptArg();
       expect(prompt).not.toContain('Summary:');
       expect(prompt).not.toContain('Resource content:');
+    });
+  });
+
+  // ── task / structure — explicit output-shape control (YIELD-STRUCTURE P1) ────
+  // Positional signature tail: (..., sourceLanguage, outputMediaType, task, structure).
+
+  describe('task framing and structure control', () => {
+    function makeWarnLogger(): { logger: Logger; warn: ReturnType<typeof vi.fn> } {
+      const warn = vi.fn();
+      const logger: Logger = { debug: () => {}, info: () => {}, warn, error: () => {}, child: () => logger };
+      return { logger, warn };
+    }
+
+    it('task "answer" leads with answer framing and, with structure unset, forces no scaffolding', async () => {
+      client.setResponses(['The answer.']);
+
+      await generateResourceFromTopic(
+        'What is the capital of France?', [], client, LOGGER,
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        'answer',
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toMatch(/^Answer/);
+      expect(prompt).not.toContain('informative resource about');
+      // D2: structure unset ⇒ no structure directive, no forced heading
+      expect(prompt).not.toContain('# Title');
+      expect(prompt).not.toContain('## Section');
+    });
+
+    it('elevates the caller prompt to an Instruction, not "Additional context:"', async () => {
+      client.setResponses(['The answer.']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER,
+        'Ground every claim in the provided context',
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        'answer',
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toContain('Instruction: Ground every claim in the provided context');
+      expect(prompt).not.toContain('Additional context:');
+    });
+
+    it('structure "prose" beats a generous token budget (explicit beats budget)', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER,
+        undefined, undefined, undefined, undefined, 2000, undefined, undefined,
+        undefined, 'prose',
+      );
+
+      expect(promptArg()).not.toContain('## Section');
+    });
+
+    it('structure "sections" beats a small token budget', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER,
+        undefined, undefined, undefined, undefined, 400, undefined, undefined,
+        undefined, 'sections',
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toContain('titled sections');
+      expect(prompt).toContain('# Title');
+    });
+
+    it('defaults (task and structure unset) keep the resource framing but impose NO structure directive', async () => {
+      // Declared behavior change (D2): today's template always forces # Title +
+      // a structure-guidance clause; unset now means neither is emitted.
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic('Topic', [], client, LOGGER);
+
+      const prompt = promptArg();
+      expect(prompt).toContain('informative resource about');
+      expect(prompt).not.toContain('# Title');
+      expect(prompt).not.toContain('organized into');
+    });
+
+    it('structure "chat" is canonical — conversational-turns guidance, no warn, no forced heading', async () => {
+      const { logger, warn } = makeWarnLogger();
+      client.setResponses(['**Q:** …\n**A:** …']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, logger,
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, 'chat',
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toMatch(/conversational|chat transcript/i);
+      expect(prompt).not.toContain('Organize the output as:'); // canonical, not the unknown-string passthrough
+      expect(prompt).not.toContain('# Title');
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('an unknown task string is used verbatim as the framing instruction, with a warn', async () => {
+      const { logger, warn } = makeWarnLogger();
+      client.setResponses(['La réponse.']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, logger,
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        'Translate the source into idiomatic French',
+      );
+
+      expect(promptArg().startsWith('Translate the source into idiomatic French')).toBe(true);
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('an unknown structure string becomes a freeform organization instruction, with a warn and no forced heading', async () => {
+      const { logger, warn } = makeWarnLogger();
+      client.setResponses(['- a\n- b']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, logger,
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, 'a bulleted list of key facts',
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toContain('Organize the output as: a bulleted list of key facts');
+      expect(prompt).not.toContain('# Title');
+      expect(warn).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/jobs/src/workers/generation/resource-generation.ts
+++ b/packages/jobs/src/workers/generation/resource-generation.ts
@@ -13,6 +13,22 @@ function getLanguageName(locale: string): string {
   return getLocaleEnglishName(locale) || locale;
 }
 
+// Prompt-embedding caps — bound the context fed to the model (CONTEXT-IDENTIFIERS
+// D4: named constants; promote to caller-tunable options only if a consumer
+// actually hits the wall). A fact past these bounds never reaches the model.
+const RESOURCE_CONTENT_CAP = 4000;
+const SEMANTIC_MATCH_LIMIT = 3;
+const SEMANTIC_MATCH_CHARS = 240;
+
+/**
+ * Model-visible identifier handle for an embedded excerpt — the ONE bracket
+ * convention across all context sections (CONTEXT-IDENTIFIERS D1/D2): resource id
+ * always, annotation id as a suffix when the excerpt is annotation-derived.
+ */
+function idLabel(resourceId: string, annotationId?: string): string {
+  return `[${resourceId}${annotationId ? `/${annotationId}` : ''}]`;
+}
+
 /**
  * Generate resource content using inference.
  *
@@ -35,7 +51,9 @@ export async function generateResourceFromTopic(
   temperature?: number,
   maxTokens?: number,
   sourceLanguage?: string,
-  outputMediaType: SupportedMediaType = 'text/markdown'
+  outputMediaType: SupportedMediaType = 'text/markdown',
+  task: string = 'resource',
+  structure?: string
 ): Promise<{ title: string; content: string }> {
   logger.debug('Generating resource from topic', {
     topicPreview: topic.substring(0, 100),
@@ -45,7 +63,10 @@ export async function generateResourceFromTopic(
     sourceLanguage,
     hasContext: !!context,
     temperature,
-    maxTokens
+    maxTokens,
+    outputMediaType,
+    task,
+    structure
   });
 
   // Use provided values or defaults.
@@ -90,7 +111,7 @@ export async function generateResourceFromTopic(
     if (focus.kind === 'annotation') {
       const parts: string[] = [];
       parts.push(`- Annotation motivation: ${focus.annotation.motivation}`);
-      parts.push(`- Source resource: ${focus.sourceResource.name}`);
+      parts.push(`- Source resource: ${focus.sourceResource.name} ${idLabel(mainResourceId)}`);
       // Include body text for commenting/assessing annotations
       const { motivation, body } = focus.annotation;
       if (motivation === 'commenting' || motivation === 'assessing') {
@@ -116,8 +137,7 @@ ${after ? `${after}...` : ''}
       // Resource focus — ground in the focal resource's summary, suggested
       // references, and content (omit-empty). Content is capped per resource to
       // bound prompt size; the caller already chose breadth via gather.resource.
-      const RESOURCE_CONTENT_CAP = 4000;
-      const parts = [`- Resource: ${focus.resource.name}`];
+      const parts = [`- Resource: ${focus.resource.name} ${idLabel(mainResourceId)}`];
       if (focus.summary) parts.push(`- Summary: ${focus.summary}`);
       if (focus.suggestedReferences && focus.suggestedReferences.length > 0) {
         parts.push(`- Suggested references: ${focus.suggestedReferences.join(', ')}`);
@@ -144,13 +164,13 @@ ${after ? `${after}...` : ''}
 
       if (views.connections.length > 0) {
         const connList = views.connections
-          .map(c => `${c.resourceName}${c.entityTypes.length ? ` (${c.entityTypes.join(', ')})` : ''}`)
+          .map(c => `${c.resourceName}${c.entityTypes.length ? ` (${c.entityTypes.join(', ')})` : ''} ${idLabel(c.resourceId)}`)
           .join(', ');
         parts.push(`- Connected resources: ${connList}`);
       }
 
       if (views.citedByCount > 0) {
-        const citedNames = views.citedBy.map(c => c.resourceName).join(', ');
+        const citedNames = views.citedBy.map(c => `${c.resourceName} ${idLabel(c.resourceId)}`).join(', ');
         parts.push(`- This resource is cited by ${views.citedByCount} other resource${views.citedByCount > 1 ? 's' : ''}${citedNames ? `: ${citedNames}` : ''}`);
       }
 
@@ -170,39 +190,73 @@ ${after ? `${after}...` : ''}
 
   // Build semantic context section if available — the vector matches the gather
   // flow already retrieved for the focal passage, used to ground generation (RAG).
-  // Capped at top-3 by score and truncated per passage to bound prompt cost; the
-  // gather step pre-filters to ≤10 matches above a 0.5 cosine threshold.
-  // See .plans/SEMANTIC-CONTEXT-RAG.md.
+  // Capped and truncated to bound prompt cost (see the named caps above); the
+  // gather step pre-filters to ≤10 matches above a 0.5 cosine threshold. Each
+  // passage carries its source id so the model can attribute what it uses.
+  // See .plans/SEMANTIC-CONTEXT-RAG.md + .plans/CONTEXT-IDENTIFIERS.md.
   let semanticContextSection = '';
   const similar = context?.semanticContext?.similar ?? [];
   if (similar.length > 0) {
     const lines = [...similar]
       .sort((a, b) => b.score - a.score)
-      .slice(0, 3)
-      .map(m => `- (${m.score.toFixed(2)}) ${m.text.slice(0, 240)}`);
+      .slice(0, SEMANTIC_MATCH_LIMIT)
+      .map(m => `- ${idLabel(m.resourceId, m.annotationId)} (${m.score.toFixed(2)}) ${m.text.slice(0, SEMANTIC_MATCH_CHARS)}`);
     semanticContextSection = `\n\nRelated passages from the knowledge base:\n${lines.join('\n')}`;
   }
 
-  // Format instructions branch on the requested output media type. Markdown is the
-  // default; text/plain drops the markup scaffolding so the result is clean prose.
+  // ── Task framing (YIELD-STRUCTURE D1): canonical tasks map to tested framings;
+  // an unknown task string is used VERBATIM as the framing instruction (loud
+  // degrade — warn, never a silent fallback to 'resource').
+  let leadLine: string;
+  if (task === 'resource') {
+    leadLine = `Generate a concise, informative resource about "${topic}".`;
+  } else if (task === 'answer') {
+    leadLine = `Answer the following question directly and concisely, grounded in the provided context: "${topic}"`;
+  } else if (task === 'summary') {
+    leadLine = `Write a concise summary of "${topic}".`;
+  } else {
+    logger.warn('Unknown task — using it verbatim as the framing instruction', { task });
+    leadLine = `${task}\nTopic: "${topic}"`;
+  }
+
+  // ── Structure directive (YIELD-STRUCTURE D2/D4): emitted ONLY when the caller
+  // sets one — unset means no directive at all (the task framing and the model
+  // determine shape). Never derived from the token budget: maxTokens is length
+  // only. The forced `# Title` heading exists only under canonical 'sections'.
   const isPlainText = outputMediaType === 'text/plain';
-  const structureGuidance = !isPlainText && finalMaxTokens >= 1000
-    ? 'organized into titled sections (## Section) with well-structured paragraphs'
-    : 'organized into well-structured paragraphs';
+  let structureRequirement = '';
+  let titleRequirement = '';
+  if (structure === 'sections') {
+    structureRequirement = isPlainText
+      ? '\n- Organize the content into titled sections with well-structured paragraphs'
+      : '\n- Organize the content into titled sections (## Section) with well-structured paragraphs';
+    if (!isPlainText) {
+      titleRequirement = '\n- Start with a clear heading (# Title)';
+    }
+  } else if (structure === 'prose') {
+    structureRequirement = '\n- Write flowing, well-structured paragraphs with no section headings';
+  } else if (structure === 'chat') {
+    structureRequirement = '\n- Structure the content as a conversational chat transcript — a sequence of alternating, speaker-labeled turns (no section headings)';
+  } else if (structure) {
+    logger.warn('Unknown structure — passing it through as freeform organization guidance', { structure });
+    structureRequirement = `\n- Organize the output as: ${structure}`;
+  }
+
   const formatRequirements = isPlainText
     ? `- Write the response as plain text — no formatting markup (no #, *, backticks, headings, or links)
 - Begin with the title on its own first line`
-    : `- Start with a clear heading (# Title)
-- Use markdown formatting
+    : `- Use markdown formatting
 - Write the response as markdown`;
 
-  const prompt = `Generate a concise, informative resource about "${topic}".
-${entityTypes.length > 0 ? `Focus on these entity types: ${entityTypes.join(', ')}.` : ''}
-${userPrompt ? `Additional context: ${userPrompt}` : ''}${annotationSection}${contextSection}${resourceSection}${graphSection}${semanticContextSection}${sourceLanguageInstruction}${languageInstruction}
+  // The caller's prompt is an authoritative leading Instruction (YIELD-STRUCTURE D3),
+  // not background "additional context" — task = what to produce, prompt = how.
+  const prompt = `${leadLine}
+${userPrompt ? `Instruction: ${userPrompt}` : ''}
+${entityTypes.length > 0 ? `Focus on these entity types: ${entityTypes.join(', ')}.` : ''}${annotationSection}${contextSection}${resourceSection}${graphSection}${semanticContextSection}${sourceLanguageInstruction}${languageInstruction}
 
 Requirements:
-- Aim for approximately ${finalMaxTokens} tokens of content, ${structureGuidance}
-- Be factual and informative
+- Aim for approximately ${finalMaxTokens} tokens of content
+- Be factual and informative${structureRequirement}${titleRequirement}
 ${formatRequirements}`;
 
   // Simple parser - just use the response directly as markdown

--- a/packages/react-ui/src/test-utils.tsx
+++ b/packages/react-ui/src/test-utils.tsx
@@ -7,7 +7,7 @@
 
 import React, { ReactElement } from 'react';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';
-import { vi } from 'vitest';
+import { vi, afterEach } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { SemiontClient, type SemiontBrowser } from '@semiont/sdk';
 import { HttpContentTransport, HttpTransport } from '@semiont/http-transport';
@@ -16,6 +16,21 @@ import { TranslationProvider } from './contexts/TranslationContext';
 import { ToastProvider } from './components/Toast';
 import type { TranslationManager } from './types/TranslationManager';
 import { SemiontProvider } from './session/SemiontProvider';
+
+/**
+ * Every fake browser below constructs a REAL SemiontClient over HttpTransport,
+ * and its live-query caches issue REAL fetches (localhost:4000 — no server in
+ * unit runs, so they fail). Dispose each client at test end so a fetch/retry
+ * chain straddling teardown dies in the cache's B16 disposed-guard — no retry,
+ * no `[cache RETRY]`/`[cache IDLE]` breadcrumb landing while the vitest
+ * worker's RPC is closing (the `EnvironmentTeardownError` class CI hit).
+ * Registered at module scope: every file that imports test-utils — exactly the
+ * files that create clients — gets the hook.
+ */
+const liveTestClients: SemiontClient[] = [];
+afterEach(() => {
+  for (const client of liveTestClients.splice(0)) client.dispose();
+});
 
 /**
  * Minimal fake SemiontBrowser for tests. Emits a fake session whose `client`
@@ -32,6 +47,7 @@ function createFakeBrowserForTests(
   // it as backend so `client.auth` / `client.admin` are wired for tests
   // that exercise hooks like useMediaToken.
   const client = new SemiontClient(transport, new HttpContentTransport(transport), transport);
+  liveTestClients.push(client);
   const fakeSession = {
     client,
     kb: null,

--- a/packages/react-ui/vitest.setup.ts
+++ b/packages/react-ui/vitest.setup.ts
@@ -67,3 +67,27 @@ if (typeof globalThis !== 'undefined' && (globalThis as any).HTMLElement) {
 afterEach(() => {
   cleanup();
 });
+
+// Unit tests must never touch the network. The test-utils fake browsers
+// construct REAL SemiontClients over HttpTransport (localhost:4000); without
+// this stub their live-query caches issue real fetches that fail, and the
+// B14 fail→log→retry→log chain rides an async tail that can straddle the
+// vitest worker's RPC teardown (the `EnvironmentTeardownError` CI failures).
+// A never-settling fetch produces no rejection, no retry chain, no
+// post-teardown logs. A test that needs fetch behavior stubs it locally
+// (test-local stubs override this default). Belt to the braces in
+// test-utils' afterEach client disposal, which closes the same class for
+// chains already in flight.
+//
+// ⚠️ ACKNOWLEDGED INTERIM, not architecture. A never-settling promise models
+// nothing — it's a black hole, and its shape was chosen to dodge the B14 log
+// chain (a rejecting stub would re-trigger it), not because it's a good test
+// double. If a test ever legitimately awaits fetch, it will HANG here with no
+// error — that's this stub, not your code. The real defect is one layer down:
+// test-utils composes a real HttpTransport into unit tests. The right fix is
+// an in-memory ITransport double in test-utils (pending-by-default requests,
+// controllable responses, a baseUrl) — when that lands, DELETE this stub;
+// its continued existence past that point is a bug.
+// Diagnosis: .plans/bugs/panels-tests-b14-tail-races-vitest-teardown.md
+const neverSettlingFetch: typeof fetch = () => new Promise<Response>(() => {});
+globalThis.fetch = neverSettlingFetch;

--- a/packages/sdk/docs/DEVELOPER-GUIDE.md
+++ b/packages/sdk/docs/DEVELOPER-GUIDE.md
@@ -182,17 +182,23 @@ annotations* `mark.assist('tagging')` writes, which `excludeEntityTypes` does no
 ## 8. Generate a derived resource
 
 `yield.fromResource` / `yield.fromAnnotation` synthesize a **new resource** from a source,
-grounded in a `GatheredContext`. The role is carried by `prompt` (translate, summarize,
-answer, …); `outputMediaType` sets the result's format (default `text/markdown`). On
-completion the worker mints a source→derived reference annotation, so provenance is automatic.
-The generated resource id arrives on the terminal `complete` event.
+grounded in a `GatheredContext`. `outputMediaType` sets the result's format (default
+`text/markdown`); under it, `task` carries the framing (`'resource' | 'answer' | 'summary'`,
+or any custom string — used verbatim, with a worker-side warn) and `structure` the shape
+(`'prose' | 'sections' | 'chat'`, or any custom string; **unset ⇒ no structure directive** —
+the task framing and the model decide, and `maxTokens` is length only). `prompt` is a
+refining instruction that composes with `task` (task = what, prompt = how) — don't carry
+the role in `prompt` anymore. On completion the worker mints a source→derived reference
+annotation, so provenance is automatic. The generated resource id arrives on the terminal
+`complete` event.
 
 ```typescript
 const done = await session.client.yield.fromResource(resourceId, {
   title: 'Summary',
   storageUri: 'file://generated/summary.md',
   context,                                   // from gather.resource — required, grounds the output
-  prompt: 'Summarize, grounding every claim in the provided context.',
+  task: 'summary',                           // the framing; 'answer' + structure: 'prose' is the Q&A recipe
+  prompt: 'Ground every claim in the provided context.',
   entityTypes: ['Concept'],
   outputMediaType: 'text/markdown',
 }).run((ev) => { if (ev.kind === 'progress') showProgress(ev.data); });

--- a/packages/sdk/docs/Usage.md
+++ b/packages/sdk/docs/Usage.md
@@ -399,11 +399,24 @@ semiont.yield.fromAnnotation(resourceId, annotationId, {
 // (no annotationId). Ground it with a resource-focus GatheredContext from
 // gather.resource. `outputMediaType` (on both methods) sets the generated resource's
 // media type — default `text/markdown`; the worker validates it.
+//
+// Output shape is caller-controlled (both methods):
+//   task      — framing: 'resource' | 'answer' | 'summary', or ANY string (used
+//               verbatim as the framing; the worker warns — loud, never silent).
+//   structure — shape: 'prose' | 'sections' | 'chat', or any string (becomes a
+//               freeform "organize as: …" directive + warn). UNSET ⇒ no structure
+//               directive at all — task framing + model decide. maxTokens is
+//               length only; it never implies structure.
+//   prompt    — refines HOW (an authoritative Instruction under the framing);
+//               task says WHAT. They compose.
+// The Q&A recipe: ask the question via `title`, then
 semiont.yield.fromResource(resourceId, {
-  title: 'Summary',
-  storageUri: 'file://generated/summary.md',
+  title: 'What does the appendix say about retry budgets?',
+  storageUri: 'file://generated/answer.md',
   context: resourceContext,
-  prompt: 'Summarize, grounding every claim in the context.',
+  task: 'answer',
+  structure: 'prose',
+  prompt: 'Cite the sections you draw from; be terse.',
   outputMediaType: 'text/markdown',
 }).subscribe({
   next: (event) => console.log(event.kind, event),

--- a/packages/sdk/src/namespaces/__tests__/commands.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/commands.test.ts
@@ -619,6 +619,44 @@ describe('YieldNamespace', () => {
     }, 20));
   });
 
+  it('fromResource({ task, structure }) carries both into job:create params (YIELD-STRUCTURE P2)', () => {
+    // The Q&A recipe the plan exists for: task frames the ask, structure
+    // forces the shape. The worker's template branches on both (P1).
+    yld.fromResource(RID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext, task: 'answer', structure: 'prose' }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
+        params: expect.objectContaining({ task: 'answer', structure: 'prose' }),
+      }));
+      resolve();
+    }, 20));
+  });
+
+  it('fromAnnotation({ task, structure }) carries both — including an open-union custom string (D1)', () => {
+    // structure 'chat' is the third canonical; task exercises the
+    // (string & {}) escape hatch — the SDK must pass it through verbatim.
+    yld.fromAnnotation(RID, AID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext, task: 'translate to French', structure: 'chat' }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
+        params: expect.objectContaining({ task: 'translate to French', structure: 'chat' }),
+      }));
+      resolve();
+    }, 20));
+  });
+
+  it('unset task/structure reach job:create as undefined — the SDK invents no defaults (D2 pin)', () => {
+    // D2: unset structure ⇒ the worker emits NO structure directive. That
+    // only holds if the SDK leaves the fields untouched (undefined keys
+    // vanish at JSON serialization on the wire).
+    yld.fromResource(RID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      const call = emitSpy.mock.calls.find((c: unknown[]) => c[0] === 'job:create');
+      const params = (call![1] as { params: Record<string, unknown> }).params;
+      expect(params.task).toBeUndefined();
+      expect(params.structure).toBeUndefined();
+      resolve();
+    }, 20));
+  });
+
   it('fromAnnotation({ entityTypes }) carries entityTypes through into job:create params', () => {
     // Regression — see .plans/ENTITY-TYPES-GAP.md. Before the fix the
     // SDK silently dropped entityTypes between the GenerationOptions

--- a/packages/sdk/src/namespaces/types.ts
+++ b/packages/sdk/src/namespaces/types.ts
@@ -115,6 +115,23 @@ export interface GenerationOptions {
    * set and **fails the job** for anything it can't write — not a silent fallback.
    */
   outputMediaType?: SupportedMediaType;
+  /**
+   * What the model is asked to produce — the prompt's framing verb. Canonical
+   * values are the worker's tested framings; any other string is used VERBATIM
+   * as the lead instruction (+ a worker-side warn) — an open escape hatch, not
+   * a silent fallback. Unset ⇒ `'resource'` (article framing). `prompt` composes
+   * with it as the refining instruction (task = what, prompt = how).
+   */
+  task?: 'resource' | 'answer' | 'summary' | (string & {});
+  /**
+   * How the output is internally segmented — shape for text-bearing media,
+   * subordinate to `outputMediaType`. Canonical: `prose` (flowing paragraphs),
+   * `sections` (titled `## Section`s + `# Title`), `chat` (speaker-labeled
+   * turns). Any other string becomes a freeform "organize as: …" directive
+   * (+ worker-side warn). **Unset ⇒ NO structure directive at all** — the task
+   * framing and the model determine shape; length (`maxTokens`) never does.
+   */
+  structure?: 'prose' | 'sections' | 'chat' | (string & {});
 }
 
 /** Options for mark.assist() */

--- a/packages/sdk/src/namespaces/yield.ts
+++ b/packages/sdk/src/namespaces/yield.ts
@@ -108,6 +108,8 @@ export class YieldNamespace implements IYieldNamespace {
       maxTokens: options.maxTokens,
       storageUri: options.storageUri,
       outputMediaType: options.outputMediaType,
+      task: options.task,
+      structure: options.structure,
       context: options.context as unknown as Record<string, unknown>,
     });
   }
@@ -138,6 +140,8 @@ export class YieldNamespace implements IYieldNamespace {
       maxTokens: options.maxTokens,
       storageUri: options.storageUri,
       outputMediaType: options.outputMediaType,
+      task: options.task,
+      structure: options.structure,
       context: options.context as unknown as Record<string, unknown>,
     });
   }


### PR DESCRIPTION
## Tiers 1+2 of the inference-template report: `task`/`structure` output control + id-labelled context

Two sibling plans landed as one changeset (they share `resource-generation.ts`, each with its own RED→GREEN cycle): **YIELD-STRUCTURE P1–P4** (Tier 1 — the caller controls output *shape*) and **CONTEXT-IDENTIFIERS P1** (Tier 2 — every embedded context excerpt carries a stable, model-visible *id*). Both from `.plans/bugs/INFERENCE-TEMPLATE.md`, filed by the `my-chat` SDK consumer whose resource-focal Q&A got multi-section markdown *articles* instead of answers.

### Tier 1 — YIELD-STRUCTURE (`.plans/YIELD-STRUCTURE.md`, P1–P4)

The generation template imposed article framing unconditionally; the consumer's `prompt` was demoted to an "Additional context:" aside. Now:

- **`task`** — the generation framing: `resource | answer | summary`, **or any string** (a custom framing passes through verbatim; degradation is loud, not silent). Default `resource` preserves today's behavior.
- **`structure`** — the output organization: `prose | sections | chat`, or any string; **unset ⇒ no directive at all** (the worker imposes nothing).
- **`prompt` elevated** to an authoritative **`Instruction:`** line (composes with `task`), no longer buried as an aside.
- **Deleted (no-compat):** the `maxTokens >= 1000 ⇒ sections` heuristic (length never again implies structure) and the unconditional `# Title` requirement.
- Threaded end-to-end: `GenerationParams` (jobs) → `GenerationOptions` on both `yield.fromAnnotation`/`fromResource` (sdk, P2 — with unset-stays-`undefined` pins: no SDK-invented defaults) → CLI `--task`/`--structure` (P3) → docs (P4: `docs/protocol/flows/YIELD.md`, `JobTypes.md`, sdk guides, CLI docs). The chat consumer's Q&A recipe becomes `--task answer --structure prose`.

### Tier 2 — CONTEXT-IDENTIFIERS P1 (`.plans/CONTEXT-IDENTIFIERS.md`)

Context attribution was uneven: related-content blocks carried an id, graph/focal facts only a name, and **semantic (RAG) passages — frequently the answer-bearing ones — were anonymous** (score + snippet). Even a perfect model couldn't attribute a fact drawn from a semantic match. Now one `idLabel` helper applies a single convention everywhere:

- **`[<resourceId>]`**, or **`[<resourceId>/<annotationId>]`** when annotation-derived — the load-bearing change is the semantic section; graph connections/citedBy keep the human name and gain the id; focal/source lines gain it too.
- The per-section caps are lifted from magic numbers to named constants (`RESOURCE_CONTENT_CAP = 4000`, `SEMANTIC_MATCH_LIMIT = 3`, `SEMANTIC_MATCH_CHARS = 240`) — deliberately **not** caller-tunable yet (provisional D4: promote only when a consumer hits the wall).
- The convention is documented in `docs/protocol/flows/YIELD.md` as a contract — it is the **input alphabet** for the citation feature (Tier 3, INLINE-CITATIONS: #979 builds `[[<id>]]` output tokens on top of these input labels).

### CI stabilization (rider commit)
react-ui's `vitest.setup.ts` gains a never-settling `fetch` stub: the test-utils fake browsers construct real `SemiontClient`s over HttpTransport, whose live-query caches issued real fetches — the B14 fail→retry→log chain could straddle the vitest worker's RPC teardown (`EnvironmentTeardownError` CI flakes). Unit tests now never touch the network; tests needing fetch behavior stub it locally.

### Verification
RED-first per phase in `node:24-alpine` — YIELD-STRUCTURE P1: 7 behavior tests observed failing against the unmodified template; CONTEXT-IDENTIFIERS P1: 6 id tests likewise; then full jobs suite green (282 passed | 1 skipped at the time), sdk/cli suites green, `tsc` clean throughout.

### Plans
`.plans/YIELD-STRUCTURE.md` (complete: P1–P4) · `.plans/CONTEXT-IDENTIFIERS.md` (P1 here; P3 docs landed separately; P2 dormant unless caps go caller-tunable) · Tier 3 follows in #979.
