### PR TITLE
INLINE-CITATIONS P1–P3: cite option — model-emitted [[<id>]] tokens reconciled into W3C linking annotations

### DIFF
--- a/docs/protocol/flows/YIELD.md
+++ b/docs/protocol/flows/YIELD.md
@@ -198,6 +198,11 @@ Generation has no dedicated REST endpoint — it runs as a bus job. The SDK's `y
                               // to outputMediaType, never its peer. Unknown strings become a freeform
                               // "Organize the output as: …" directive (+ warn). UNSET ⇒ NO structure
                               // directive at all — the task framing and the model determine shape
+  cite?: boolean;             // Inline citations: the model is instructed to emit [[<id>]] transport
+                              // tokens next to each claim; the worker strips them pre-upload and mints
+                              // each as a W3C linking annotation on the derived resource (see
+                              // "Citation convention" below). Off by default — when unset, [[…]] in
+                              // generated content is left alone as legitimate content
 }
 ```
 
@@ -308,6 +313,9 @@ Requirements:
                                                                     //   'prose'    → flowing paragraphs, no section headings
                                                                     //   'chat'     → conversational transcript — alternating, speaker-labeled turns
                                                                     //   any other string → Organize the output as: {structure} (worker warns)
+- Ground every claim … cite its source by emitting [[<id>]] …      // ONLY when `cite` is set — the model may
+                                                                    // cite only ids shown in the context above
+                                                                    // (input label [abc] → output token [[abc]])
 - Use markdown formatting                                           // text/plain instead: no markup; title on its own first line
 - Write the response as markdown
 ```
@@ -342,6 +350,30 @@ resource (`RESOURCE_CONTENT_CAP`), semantic passages top-3 by score at 240
 chars each (`SEMANTIC_MATCH_LIMIT`/`SEMANTIC_MATCH_CHARS`), over a gather-side
 pre-filter of ≤10 matches above 0.5 cosine. They become caller options only
 if a consumer hits the wall.
+
+**Citation convention** (`cite: true`). The output-side counterpart of the
+identifier convention above: the model is instructed to ground every claim
+and cite its source by emitting a **double-bracket token** — `[[<resourceId>]]`,
+or `[[<resourceId>/<annotationId>]]` when citing an annotation-derived
+passage — immediately after the claim, using only ids shown (single-bracketed)
+in the embedded context. Double-bracket *out* vs single-bracket *in* means an
+echoed input label is never misread as a citation. The tokens are
+**transport, not content**: the worker parses them, validates each id against
+the embedded context (**hallucination guard** — an id absent from the context
+is stripped with a `warn`, never minted into a link to an invented source),
+**strips them before upload** (stored content stays clean prose), and mints
+each citation as a **W3C linking annotation on the derived resource** — the
+target anchors the claim span (the sentence preceding the token, as
+`TextPositionSelector` + `TextQuoteSelector` computed against the final
+stored bytes), the body is a `SpecificResource` pointing at the cited source.
+Citations are therefore **first-class references** — navigable, rendered by
+the Browser like any other resolved reference, and edges in the knowledge
+graph — not a parallel rendering path. This *complements* the post-hoc
+`mark.assist('linking')` pass rather than replacing it. The token is only the
+*text-modality transport*: the citation itself is the annotation, which
+generalizes to other modalities (an image region, a media-fragment time
+range) with their own transports. When `cite` is unset the resolver never
+runs — `[[…]]` in generated content is left untouched as legitimate content.
 
 The Q&A recipe (`my-chat`-style consumers): `task: 'answer'` with
 `structure: 'prose'` (or `'chat'` for speaker-labeled turns) — ask the

--- a/packages/jobs/docs/JobTypes.md
+++ b/packages/jobs/docs/JobTypes.md
@@ -133,6 +133,10 @@ interface GenerationParams {
                                     // Shape, subordinate to outputMediaType. Unknown strings
                                     // become "Organize the output as: …" + warn. UNSET ⇒ no
                                     // structure directive at all
+  cite?: boolean;                   // Inline citations: model emits [[<id>]] tokens; the worker
+                                    // strips them pre-upload and mints W3C linking annotations
+                                    // on the derived resource (hallucination-guarded against the
+                                    // embedded context ids). Off ⇒ resolver never runs
 }
 ```
 

--- a/packages/jobs/src/__tests__/generation-params.types.test.ts
+++ b/packages/jobs/src/__tests__/generation-params.types.test.ts
@@ -29,4 +29,9 @@ describe('GenerationParams contract', () => {
     expect(canonical.task).toBe('answer');
     expect(custom.structure).toBe('a bulleted list of key facts');
   });
+
+  it('accepts cite (INLINE-CITATIONS P1)', () => {
+    const p: GenerationParams = { cite: true };
+    expect(p.cite).toBe(true);
+  });
 });

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { resourceId, annotationId, entityType } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
-import type { components, TagSchema } from '@semiont/core';
+import type { components, TagSchema, GatheredContext, Logger } from '@semiont/core';
 
 type Agent = components['schemas']['Agent'];
 
@@ -344,6 +344,97 @@ describe('processGenerationJob', () => {
 
     expect(result.title).toBe('Fallback Title');
     expect(result.result.resourceName).toBe('Fallback Title');
+  });
+});
+
+describe('processGenerationJob — inline citations (INLINE-CITATIONS P1)', () => {
+  // The resolver runs inside processGenerationJob: parse [[<id>]] transport
+  // tokens from the generated content, validate each against the ids actually
+  // present in the embedded context (hallucination guard), STRIP the tokens
+  // from the stored content, and return claim-span citations for the worker
+  // to mint as linking annotations.
+  const CITE_CONTEXT: GatheredContext = {
+    focus: {
+      kind: 'resource',
+      resource: {
+        '@context': 'https://www.w3.org/ns/anno.jsonld',
+        '@id': 'src-1',
+        name: 'Source Doc',
+        representations: [],
+      },
+    },
+    graph: {
+      nodes: [
+        { id: 'src-1', type: 'resource', label: 'Source Doc' },
+        { id: 'ctx-9', type: 'resource', label: 'Context Doc' },
+      ],
+      edges: [],
+    },
+    metadata: {},
+  };
+
+  function makeWarnLogger(): { logger: Logger; warn: ReturnType<typeof vi.fn> } {
+    const warn = vi.fn();
+    const logger: Logger = { debug: () => {}, info: () => {}, warn, error: () => {}, child: () => logger };
+    return { logger, warn };
+  }
+
+  it('strips tokens from the content and returns claim-span citations', async () => {
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({
+      content: 'Paris is the capital of France. [[ctx-9]] It is large.',
+      title: 'T',
+    });
+
+    const r = await processGenerationJob(
+      makeInferenceClient(),
+      { title: 'T', cite: true, context: CITE_CONTEXT },
+      vi.fn(),
+      LOGGER,
+    );
+
+    expect(r.content).toBe('Paris is the capital of France. It is large.');
+    expect(r.citations).toHaveLength(1);
+    const c = r.citations[0]!;
+    expect(c.resourceId).toBe('ctx-9');
+    expect(c.exact).toBe('Paris is the capital of France.');
+    // anchor invariant: the selector must reproduce exact from the FINAL content
+    expect(r.content.substring(c.start, c.end)).toBe(c.exact);
+  });
+
+  it('drops a hallucinated id loudly — stripped, warned, no citation', async () => {
+    const { logger, warn } = makeWarnLogger();
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({
+      content: 'A bold claim. [[not-in-context]]',
+      title: 'T',
+    });
+
+    const r = await processGenerationJob(
+      makeInferenceClient(),
+      { title: 'T', cite: true, context: CITE_CONTEXT },
+      vi.fn(),
+      logger,
+    );
+
+    expect(r.content).toBe('A bold claim.');
+    expect(r.citations).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('cite unset leaves bracketed content untouched (no accidental stripping)', async () => {
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({
+      content: 'Wiki-style [[links]] are legitimate content.',
+      title: 'T',
+    });
+
+    const r = await processGenerationJob(
+      makeInferenceClient(),
+      { title: 'T', context: CITE_CONTEXT },
+      vi.fn(),
+      LOGGER,
+    );
+
+    expect(r.content).toBe('Wiki-style [[links]] are legitimate content.');
+    expect(r.citations).toHaveLength(0);
   });
 });
 
@@ -695,10 +786,10 @@ describe('locale threading', () => {
       );
 
       // Positional signature: topic, entityTypes, client, logger, prompt, locale,
-      // context, temperature, maxTokens, sourceLanguage, outputMediaType, task, structure.
+      // context, temperature, maxTokens, sourceLanguage, outputMediaType, task, structure, cite.
       expect(generateResourceFromTopic).toHaveBeenCalledWith(
         'Topic', [], client, LOGGER, undefined, 'de', undefined,
-        undefined, undefined, 'fr', 'text/markdown', undefined, undefined,
+        undefined, undefined, 'fr', 'text/markdown', undefined, undefined, undefined,
       );
     });
   });

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -239,6 +239,7 @@ describe('handleJob orchestration', () => {
         content: '# Generated\n\nBody.',
         title: 'New Resource',
         format: 'text/markdown',
+        citations: [],
         result: { tokensUsed: 100 } as never,
       });
       const h = makeFakeSessionAndAdapter();
@@ -274,6 +275,7 @@ describe('handleJob orchestration', () => {
         content: 'body',
         title: 'T',
         format: 'text/markdown',
+        citations: [],
         result: {} as never,
       });
       const h = makeFakeSessionAndAdapter();
@@ -293,6 +295,7 @@ describe('handleJob orchestration', () => {
         content: 'body',
         title: 'T',
         format: 'text/markdown',
+        citations: [],
         result: {} as never,
       });
       const h = makeFakeSessionAndAdapter();
@@ -319,6 +322,7 @@ describe('handleJob orchestration', () => {
         content: 'body',
         title: 'T',
         format: 'text/markdown',
+        citations: [],
         result: {} as never,
       });
       const h = makeFakeSessionAndAdapter();
@@ -335,7 +339,7 @@ describe('handleJob orchestration', () => {
       // mints a navigable reference: target = the whole source resource (resource-level,
       // no selector), body = SpecificResource → the derived resource.
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: 'body', title: 'Derived Doc', format: 'text/markdown', result: {} as never,
+        content: 'body', title: 'Derived Doc', format: 'text/markdown', citations: [], result: {} as never,
       });
       const h = makeFakeSessionAndAdapter();
 
@@ -356,6 +360,41 @@ describe('handleJob orchestration', () => {
       const ann = (markCreate!.payload as { annotation: { target: { selector?: unknown } } }).annotation;
       expect(ann.target.selector).toBeUndefined();
 
+      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'job:complete']);
+    });
+
+    it('mints a linking annotation on the DERIVED resource for each resolved citation (INLINE-CITATIONS P1)', async () => {
+      // The processor resolved [[ctx-9]] into a claim-span citation; the worker
+      // mints it after upload (only then is the derived resourceId known):
+      // target = the derived resource + position/quote selectors for the claim,
+      // body = SpecificResource → the cited source.
+      vi.mocked(processGenerationJob).mockResolvedValue({
+        content: 'Paris is the capital of France. It is large.',
+        title: 'Answer',
+        format: 'text/markdown',
+        citations: [{ resourceId: 'ctx-9', start: 0, end: 31, exact: 'Paris is the capital of France.' }],
+        result: {} as never,
+      });
+      const h = makeFakeSessionAndAdapter();
+
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { referenceId: 'ref-1', cite: true }));
+
+      const markCreates = h.busEmits.filter(e => e.channel === 'mark:create');
+      expect(markCreates, 'one mark:create per resolved citation').toHaveLength(1);
+      expect(markCreates[0]!.payload).toMatchObject({
+        resourceId: 'new-res-42', // the annotation lives on the DERIVED resource
+        annotation: {
+          motivation: 'linking',
+          target: {
+            source: 'new-res-42',
+            selector: [
+              { type: 'TextPositionSelector', start: 0, end: 31 },
+              { type: 'TextQuoteSelector', exact: 'Paris is the capital of France.' },
+            ],
+          },
+          body: { type: 'SpecificResource', source: 'ctx-9', purpose: 'linking' },
+        },
+      });
       expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'job:complete']);
     });
   });
@@ -464,6 +503,7 @@ describe('handleJob orchestration', () => {
         content: 'body',
         title: 'T',
         format: 'text/markdown',
+        citations: [],
         result: {} as never,
       });
       const h = makeFakeSessionAndAdapter();

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -12,6 +12,7 @@
 import { AnnotationDetection } from './workers/annotation-detection';
 import { extractEntities } from './workers/detection/entity-extractor';
 import { generateResourceFromTopic } from './workers/generation/resource-generation';
+import { resolveCitationTokens, collectContextResourceIds, type GenerationCitation } from './workers/generation/citation-resolver';
 import { generateAnnotationId } from '@semiont/event-sourcing';
 import { didToAgent, type Logger, type ResourceId, type SupportedMediaType, type components } from '@semiont/core';
 import { reconcileSelector, type ReconciledSelector } from '@semiont/core';
@@ -457,7 +458,7 @@ export async function processGenerationJob(
   params: GenerationParams,
   onProgress: OnProgress,
   logger: Logger,
-): Promise<{ content: string; title: string; format: SupportedMediaType; result: GenerationResult }> {
+): Promise<{ content: string; title: string; format: SupportedMediaType; citations: GenerationCitation[]; result: GenerationResult }> {
   // Generation produces text only for now. Refuse any other requested media type
   // loudly (the throw propagates as job:fail) rather than silently emitting markdown
   // under a mislabeled format. Validate before the LLM call so it fails fast.
@@ -490,14 +491,28 @@ export async function processGenerationJob(
     outputMediaType,
     params.task,
     params.structure,
+    params.cite,
   );
+
+  // Under `cite`, the model emitted [[<id>]] transport tokens — resolve them:
+  // validate against the ids the context actually contained, strip from the
+  // stored content, and carry claim-span citations for the worker to mint.
+  // When cite is off, bracketed text is legitimate content — leave it alone.
+  let content = generated.content;
+  let citations: GenerationCitation[] = [];
+  if (params.cite === true) {
+    const resolved = resolveCitationTokens(content, collectContextResourceIds(params.context), logger);
+    content = resolved.content;
+    citations = resolved.citations;
+  }
 
   onProgress(85, 'Creating resource...', 'creating');
 
   return {
-    content: generated.content,
+    content,
     title: generated.title ?? title,
     format: outputMediaType,
+    citations,
     result: {
       resourceId: '' as ResourceId,
       resourceName: generated.title ?? title,

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -124,6 +124,14 @@ export interface GenerationParams {
    * the model determine shape. See .plans/YIELD-STRUCTURE.md D2/D5.
    */
   structure?: 'prose' | 'sections' | 'chat' | (string & {});
+  /**
+   * Ask the model to cite: emit `[[<id>]]` transport tokens after each claim, using
+   * the ids the context embedding provides (CONTEXT-IDENTIFIERS). The worker
+   * validates each id against the embedded context (unknown ids are dropped
+   * loudly), strips the tokens from the stored content, and mints W3C linking
+   * annotations on the derived resource. See .plans/INLINE-CITATIONS.md.
+   */
+  cite?: boolean;
 }
 
 /**

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -328,6 +328,29 @@ async function handleJobInner(
       await emitEvent(session, 'mark:create', { annotation: provenanceRef, userId, resourceId });
     }
 
+    // Inline citations (INLINE-CITATIONS P1): the processor resolved the model's
+    // [[<id>]] transport tokens into claim-span citations against the final
+    // (token-stripped) content. Mint each as a linking annotation ON THE DERIVED
+    // resource — the target anchors the claim span, the body points at the cited
+    // source — so citations are first-class references like any other.
+    for (const citation of genResult.citations) {
+      const { annotation: citationRef } = assembleAnnotation(
+        {
+          motivation: 'linking',
+          target: {
+            source: String(newResourceId),
+            selector: [
+              { type: 'TextPositionSelector', start: citation.start, end: citation.end },
+              { type: 'TextQuoteSelector', exact: citation.exact },
+            ],
+          },
+          body: { type: 'SpecificResource', source: citation.resourceId, purpose: 'linking' },
+        },
+        generator,
+      );
+      await emitEvent(session, 'mark:create', { annotation: citationRef, userId, resourceId: newResourceId });
+    }
+
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
       result: { resourceId: newResourceId, resourceName: genResult.title } as never,

--- a/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
+++ b/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
@@ -523,6 +523,35 @@ describe('generateResourceFromTopic', () => {
     });
   });
 
+  // ── Inline citations (INLINE-CITATIONS P1) — the cite instruction asks the
+  // model to emit [[<id>]] transport tokens next to each claim, citing only ids
+  // shown in the embedded context. Signature tail: (..., task, structure, cite).
+
+  describe('cite instruction', () => {
+    it('cite=true instructs the model to emit [[id]] citation markers', async () => {
+      client.setResponses(['Paris is big. [[r1]]']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined,
+        makeContext({ semanticContext: [{ text: 'NEEDLE', resourceId: 'r1', score: 0.8 }] }),
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        true,
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toContain('[[');
+      expect(prompt).toMatch(/cite/i);
+    });
+
+    it('cite unset adds no citation instruction', async () => {
+      client.setResponses(['# X\n\nbody']);
+
+      await generateResourceFromTopic('Topic', [], client, LOGGER, undefined, undefined, makeContext());
+
+      expect(promptArg()).not.toContain('[[');
+    });
+  });
+
   // ── Context identifiers (CONTEXT-IDENTIFIERS P1) — every excerpt carries a
   // stable, model-visible [<resourceId>] handle; annotation-derived semantic
   // matches add /<annotationId>. Same bracket convention as related-content blocks.

--- a/packages/jobs/src/workers/generation/citation-resolver.ts
+++ b/packages/jobs/src/workers/generation/citation-resolver.ts
@@ -1,0 +1,107 @@
+/**
+ * Citation-token resolver (INLINE-CITATIONS P1).
+ *
+ * Under `cite`, the generation prompt asks the model to emit `[[<resourceId>]]` /
+ * `[[<resourceId>/<annotationId>]]` transport tokens after each claim, citing ids
+ * the context embedding put in front of it (CONTEXT-IDENTIFIERS). Tokens are
+ * TRANSPORT, not content: this resolver parses them, validates each id against the
+ * ids actually present in the embedded context (the hallucination guard — an
+ * unknown id is dropped loudly, never silently linked), STRIPS them from the
+ * content before upload, and returns claim-span citations the worker mints as W3C
+ * linking annotations on the derived resource. See .plans/INLINE-CITATIONS.md.
+ */
+import type { GatheredContext, Logger } from '@semiont/core';
+
+export interface GenerationCitation {
+  /** The cited source resource (validated present in the embedded context). */
+  resourceId: string;
+  /** The contributing annotation, when the cited excerpt was annotation-derived. */
+  annotationId?: string;
+  /** Claim span in the FINAL (token-stripped) content; substring(start, end) === exact. */
+  start: number;
+  end: number;
+  exact: string;
+}
+
+/** `[[rid]]` or `[[rid/annId]]` — ids are bare (no whitespace, brackets, or slashes). */
+const CITATION_TOKEN = /\[\[([^\s[\]/]+)(?:\/([^\s[\]/]+))?\]\]/g;
+
+/**
+ * The ids the context embedding actually put in front of the model — the
+ * hallucination guard's ground truth. Mirrors what the prompt renderers label:
+ * the focal resource, graph resource nodes, semantic matches, related content.
+ */
+export function collectContextResourceIds(context: GatheredContext | undefined): Set<string> {
+  const ids = new Set<string>();
+  if (!context) return ids;
+
+  const { focus } = context;
+  ids.add(focus.kind === 'annotation' ? focus.sourceResource['@id'] : focus.resource['@id']);
+  for (const node of context.graph.nodes) {
+    if (node.type === 'resource') ids.add(node.id);
+  }
+  for (const m of context.semanticContext?.similar ?? []) ids.add(m.resourceId);
+  if (focus.kind === 'resource') {
+    for (const id of Object.keys(focus.content?.related ?? {})) ids.add(id);
+  }
+  return ids;
+}
+
+export function resolveCitationTokens(
+  content: string,
+  validResourceIds: ReadonlySet<string>,
+  logger: Logger,
+): { content: string; citations: GenerationCitation[] } {
+  const citations: GenerationCitation[] = [];
+  let clean = '';
+  let last = 0;
+
+  for (const match of content.matchAll(CITATION_TOKEN)) {
+    const token = match[0];
+    const citedResourceId = match[1]!;
+    const annotationId = match[2];
+
+    // Append the text before the token, dropping the whitespace run immediately
+    // preceding it so stripping never leaves a dangling space.
+    clean += content.slice(last, match.index).replace(/[ \t]+$/, '');
+    last = match.index! + token.length;
+
+    if (!validResourceIds.has(citedResourceId)) {
+      logger.warn('Citation token references an id absent from the provided context — dropped', {
+        resourceId: citedResourceId,
+      });
+      continue;
+    }
+
+    // Claim span: the sentence preceding the token, computed against the clean
+    // content. Offsets are final — later appends never shift earlier positions.
+    const end = clean.length;
+    let start = 0;
+    for (let i = end - 2; i >= 0; i--) {
+      const ch = clean[i];
+      if (ch === '.' || ch === '!' || ch === '?' || ch === '\n') {
+        start = i + 1;
+        break;
+      }
+    }
+    while (start < end && /\s/.test(clean[start]!)) start++;
+    const exact = clean.slice(start, end);
+    if (exact.length === 0) {
+      logger.warn('Citation token has no preceding claim text — dropped', {
+        resourceId: citedResourceId,
+      });
+      continue;
+    }
+
+    citations.push({
+      resourceId: citedResourceId,
+      ...(annotationId ? { annotationId } : {}),
+      start,
+      end,
+      exact,
+    });
+  }
+
+  clean += content.slice(last);
+  return { content: clean, citations };
+}

--- a/packages/jobs/src/workers/generation/resource-generation.ts
+++ b/packages/jobs/src/workers/generation/resource-generation.ts
@@ -53,7 +53,8 @@ export async function generateResourceFromTopic(
   sourceLanguage?: string,
   outputMediaType: SupportedMediaType = 'text/markdown',
   task: string = 'resource',
-  structure?: string
+  structure?: string,
+  cite: boolean = false
 ): Promise<{ title: string; content: string }> {
   logger.debug('Generating resource from topic', {
     topicPreview: topic.substring(0, 100),
@@ -242,6 +243,14 @@ ${after ? `${after}...` : ''}
     structureRequirement = `\n- Organize the output as: ${structure}`;
   }
 
+  // Citation instruction (INLINE-CITATIONS): ask the model to emit [[<id>]]
+  // transport tokens next to each claim, citing only ids the context embedding
+  // shows. The worker strips the tokens and reconciles them into linking
+  // annotations — they never reach the stored content.
+  const citeRequirement = cite
+    ? '\n- Ground every claim in the provided context. Immediately after each claim, cite its source by emitting [[<id>]], where <id> is an id shown in square brackets in the context above (for a passage labeled [abc], emit [[abc]]). Cite only ids that appear in the context.'
+    : '';
+
   const formatRequirements = isPlainText
     ? `- Write the response as plain text — no formatting markup (no #, *, backticks, headings, or links)
 - Begin with the title on its own first line`
@@ -256,7 +265,7 @@ ${entityTypes.length > 0 ? `Focus on these entity types: ${entityTypes.join(', '
 
 Requirements:
 - Aim for approximately ${finalMaxTokens} tokens of content
-- Be factual and informative${structureRequirement}${titleRequirement}
+- Be factual and informative${structureRequirement}${titleRequirement}${citeRequirement}
 ${formatRequirements}`;
 
   // Simple parser - just use the response directly as markdown

--- a/packages/sdk/docs/DEVELOPER-GUIDE.md
+++ b/packages/sdk/docs/DEVELOPER-GUIDE.md
@@ -192,8 +192,10 @@ the role in `prompt` anymore. On completion the worker mints a source→derived 
 annotation, so provenance is automatic. The generated resource id arrives on the terminal
 `complete` event. The context excerpts embedded in the generation prompt are id-labelled
 (`[<resourceId>]` / `[<resourceId>/<annotationId>]` — see the prompt walkthrough in
-[YIELD.md](../../../docs/protocol/flows/YIELD.md)), so a `prompt` asking the model to
-attribute its sources has stable handles to cite.
+[YIELD.md](../../../docs/protocol/flows/YIELD.md)), and `cite: true` turns that into
+inline citations: the model's `[[<id>]]` tokens are stripped before storage and minted as
+W3C linking annotations on the generated resource (claim span → cited source) — citations
+arrive as ordinary navigable references, not links in the text.
 
 ```typescript
 const done = await session.client.yield.fromResource(resourceId, {

--- a/packages/sdk/docs/Usage.md
+++ b/packages/sdk/docs/Usage.md
@@ -410,8 +410,14 @@ semiont.yield.fromAnnotation(resourceId, annotationId, {
 //   prompt    — refines HOW (an authoritative Instruction under the framing);
 //               task says WHAT. They compose.
 // Every context excerpt the worker embeds is id-labelled ([<resourceId>], or
-// [<resourceId>/<annotationId>] for annotation-derived passages), so prompts
-// that ask the model to attribute its sources have real handles to use.
+// [<resourceId>/<annotationId>] for annotation-derived passages), and
+// `cite: true` makes that actionable: the model emits [[<id>]] tokens next to
+// each claim, the worker strips them before storage and mints each as a W3C
+// linking annotation on the generated resource (claim-span target, body →
+// the cited source). Citations arrive as ordinary references — navigable in
+// the Browser — NOT inline links; ids absent from the context are dropped
+// with a warn (hallucination guard). Composes with task/structure; the
+// post-hoc mark.assist('linking') pass still works alongside it.
 // The Q&A recipe: ask the question via `title`, then
 semiont.yield.fromResource(resourceId, {
   title: 'What does the appendix say about retry budgets?',
@@ -419,7 +425,8 @@ semiont.yield.fromResource(resourceId, {
   context: resourceContext,
   task: 'answer',
   structure: 'prose',
-  prompt: 'Cite the sections you draw from; be terse.',
+  cite: true,
+  prompt: 'Be terse.',
   outputMediaType: 'text/markdown',
 }).subscribe({
   next: (event) => console.log(event.kind, event),

--- a/packages/sdk/src/namespaces/__tests__/commands.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/commands.test.ts
@@ -657,6 +657,39 @@ describe('YieldNamespace', () => {
     }, 20));
   });
 
+  it('fromResource({ cite: true }) carries cite into job:create params (INLINE-CITATIONS P2)', () => {
+    yld.fromResource(RID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext, cite: true }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
+        params: expect.objectContaining({ cite: true }),
+      }));
+      resolve();
+    }, 20));
+  });
+
+  it('fromAnnotation({ cite: true }) carries cite into job:create params', () => {
+    yld.fromAnnotation(RID, AID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext, cite: true }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
+        params: expect.objectContaining({ cite: true }),
+      }));
+      resolve();
+    }, 20));
+  });
+
+  it('unset cite reaches job:create as undefined — the resolver gates on presence', () => {
+    // The worker parses/strips [[..]] tokens ONLY when cite is set: double-
+    // bracketed text is legitimate content otherwise. An SDK-invented
+    // default would corrupt non-citing generations.
+    yld.fromResource(RID, { title: 'T', storageUri: 'file://x', context: {} as GatheredContext }).subscribe(() => {});
+    return new Promise<void>((resolve) => setTimeout(() => {
+      const call = emitSpy.mock.calls.find((c: unknown[]) => c[0] === 'job:create');
+      const params = (call![1] as { params: Record<string, unknown> }).params;
+      expect(params.cite).toBeUndefined();
+      resolve();
+    }, 20));
+  });
+
   it('fromAnnotation({ entityTypes }) carries entityTypes through into job:create params', () => {
     // Regression — see .plans/ENTITY-TYPES-GAP.md. Before the fix the
     // SDK silently dropped entityTypes between the GenerationOptions

--- a/packages/sdk/src/namespaces/types.ts
+++ b/packages/sdk/src/namespaces/types.ts
@@ -132,6 +132,20 @@ export interface GenerationOptions {
    * framing and the model determine shape; length (`maxTokens`) never does.
    */
   structure?: 'prose' | 'sections' | 'chat' | (string & {});
+  /**
+   * Ask the generator to ground claims in the supplied `context` as it
+   * writes. Citations do NOT appear as links in the content: the model emits
+   * inline `[[<id>]]` tokens, which the worker resolves into
+   * `SpecificResource` **linking annotations on the generated resource**
+   * (anchored to the claim span) and strips before storage — stored content
+   * stays clean prose. Only ids actually present in `context` resolve;
+   * unknown ids are dropped with a worker-side warn, never a minted link
+   * (hallucination guard). Composes with `task: 'answer'` for grounded Q&A;
+   * complements — never replaces — the post-hoc `mark.assist('linking')`
+   * pass. Leave unset for content where literal `[[…]]` text is legitimate:
+   * the worker parses tokens only when this is set.
+   */
+  cite?: boolean;
 }
 
 /** Options for mark.assist() */

--- a/packages/sdk/src/namespaces/yield.ts
+++ b/packages/sdk/src/namespaces/yield.ts
@@ -110,6 +110,7 @@ export class YieldNamespace implements IYieldNamespace {
       outputMediaType: options.outputMediaType,
       task: options.task,
       structure: options.structure,
+      cite: options.cite,
       context: options.context as unknown as Record<string, unknown>,
     });
   }
@@ -142,6 +143,7 @@ export class YieldNamespace implements IYieldNamespace {
       outputMediaType: options.outputMediaType,
       task: options.task,
       structure: options.structure,
+      cite: options.cite,
       context: options.context as unknown as Record<string, unknown>,
     });
   }


### PR DESCRIPTION
## INLINE-CITATIONS — `cite`: the model cites as it writes; tokens reconcile into W3C linking annotations

Tier 3 (the last tier) of the `my-chat` inference-template report (`.plans/bugs/INFERENCE-TEMPLATE.md`): for grounded Q&A, a post-hoc linking pass can only guess at sources — the model itself knows which context passage grounded each claim, but had no way to say so. With Tier 2's ids now in the embedded context (#978), this PR closes the loop: under a new `cite` option, the model emits an inline token per claim, and the worker reconciles each token into a **first-class W3C linking annotation** on the derived resource.

**The design (P0, settled with the maintainer — `.plans/INLINE-CITATIONS.md`):**
- **Token = `[[<resourceId>]]`** (`[[<rid>/<annId>]]` when annotation-derived) — the double-bracket *output* extension of Tier 2's single-bracket *input* labels, so an echoed input label is never misread as a citation. Chosen over markdown-links (bakes a URL scheme into stored content) and footnotes (the reference list sits exactly where `maxTokens` truncation bites).
- **Tokens are transport, not content.** The worker **strips them pre-upload** and anchors each citation to its claim span (the sentence preceding the token, position+quote selectors computed against the final bytes — so `substring(start,end) === exact` by construction). Stored content stays clean prose.
- **Hallucination guard:** only ids actually present in the embedded context resolve; an unknown id is stripped with a `warn` — never a silently minted link to an invented source.
- **Citations are annotations, not a render path.** Each resolves to a `SpecificResource` linking annotation (same shape `mark.assist` produces, minted via the same `assembleAnnotation` + `mark:create` path as the provenance mint) — navigable, Browser-native, graph edges, and modality-general (a future A/V generator reconciles a timecoded manifest into the *same* annotation shape).

### What changed, by phase

**P1 — `@semiont/jobs`: the resolver.** New `workers/generation/citation-resolver.ts`: `CITATION_TOKEN`, `resolveCitationTokens` (parse → guard → strip → claim-span anchor) and `collectContextResourceIds` (focal `@id` + graph nodes + semantic matches + related-content keys — mirroring exactly what the embedding labels). `GenerationParams.cite?: boolean`; the template gains the cite instruction (only ids shown in the context; `[abc]` in → `[[abc]]` out); `processGenerationJob` runs the resolver **only when `cite` is set** — bracketed text is legitimate content otherwise; the worker mints each citation post-upload on the derived resource.

**P2 — `@semiont/sdk`.** `GenerationOptions.cite?: boolean` threaded through both `yield.fromAnnotation` and `yield.fromResource`, with a consumer-contract docstring (annotations-not-links, strip-before-storage, guard, composes with `task: 'answer'`, complements `mark.assist`). Includes a deliberately load-bearing **unset-stays-`undefined`** pin: the resolver gates on the param's presence, so an SDK-invented default would corrupt non-citing generations.

**P3 — docs.** The `[[<id>]]` output convention documented in `docs/protocol/flows/YIELD.md` **beside Tier 2's input-label convention** (one page tells the whole id story: single-bracket in, double-bracket out), plus `JobTypes.md` and the SDK developer guide/usage.

### Verification
RED-first per phase in `node:24-alpine`: P1's 5 behavior tests observed failing against the unmodified pipeline (cite-instruction; strip+claim-span; hallucinated-id drop+warn; cite-off leaves `[[..]]` untouched; mint on the derived resource), then full jobs suite **290 passed | 1 skipped**, sdk **402/402**, `tsc` clean throughout.

### Scope notes
- **Complements `mark.assist`, does not replace it** — the post-hoc linking pass keeps enriching beyond what the model cited inline (the report's invariant).
- **No new render path** — reconciled citations are ordinary linking annotations the Browser already renders; the live Browser render check is the deferred follow-up.
- **Named implementation detail:** the claim-span heuristic (preceding sentence) — revisit against real model output if anchors prove too coarse.
- Closes the three-tier ladder: Tier 1 (`task`/`structure`, #978) + Tier 2 (context ids, #978) + **Tier 3 (this PR)** — `.plans/bugs/INFERENCE-TEMPLATE.md` is fully resolved when this merges.
