### PR TITLE
fix(jobs): yield progress reports only real transitions, with wall-clock-shaped percentages

### DIFF
--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -321,9 +321,14 @@ describe('processGenerationJob', () => {
     expect(result.title).toBe('Generated Title');
     expect(result.format).toBe('text/markdown');
     expect(result.result.resourceName).toBe('Generated Title');
-    expect(progress).toHaveBeenCalledWith(20, expect.any(String), 'fetching');
-    expect(progress).toHaveBeenCalledWith(40, expect.any(String), 'generating');
-    expect(progress).toHaveBeenCalledWith(85, expect.any(String), 'creating');
+    // Honest lifecycle: generation has exactly two real transitions — the LLM
+    // call starting, and content finalized / creation beginning. No 'fetching'
+    // stage (it labeled zero work; context arrives pre-gathered in params).
+    // Percentages approximate the share of expected wall-clock complete at each
+    // transition: inference dominates, so its start is ~5 and its end ~95.
+    expect(progress).toHaveBeenCalledTimes(2);
+    expect(progress).toHaveBeenNthCalledWith(1, 5, expect.any(String), 'generating');
+    expect(progress).toHaveBeenNthCalledWith(2, 95, expect.any(String), 'creating');
   });
 
   it('falls back to request title when generator omits it', async () => {

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -470,12 +470,16 @@ export async function processGenerationJob(
     );
   }
 
-  onProgress(20, 'Fetching context...', 'fetching');
-
   const title = params.title ?? 'Untitled';
   const entityTypes = (params.entityTypes ?? []).map(String);
 
-  onProgress(40, 'Generating resource...', 'generating');
+  // Generation has exactly two observable transitions: the LLM call starting
+  // ('generating') and content finalized / creation beginning ('creating').
+  // There is no fetch — context arrives pre-gathered in params. Percentages
+  // approximate the share of expected wall-clock complete at each transition
+  // (a single atomic LLM call has no measurable progress, and inference
+  // dominates the job): its start is ~5, its end ~95.
+  onProgress(5, 'Generating resource...', 'generating');
 
   const generated = await generateResourceFromTopic(
     title,
@@ -506,7 +510,7 @@ export async function processGenerationJob(
     citations = resolved.citations;
   }
 
-  onProgress(85, 'Creating resource...', 'creating');
+  onProgress(95, 'Creating resource...', 'creating');
 
   return {
     content,

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -219,7 +219,8 @@ export interface DetectionResult {
  * Generation job progress
  */
 export interface YieldProgress {
-  stage: 'fetching' | 'generating' | 'creating' | 'linking';
+  /** The two real generation transitions — LLM call running, then persisting. */
+  stage: 'generating' | 'creating';
   percentage: number;
   message?: string;
 }


### PR DESCRIPTION
## What

Generation (`yield`) progress events now correspond to the job's **real transitions** — and nothing else:

| Event | When it fires | Percentage |
|---|---|---|
| `'generating'` | the LLM call starts | **5** |
| `'creating'` | content finalized, persistence begins | **95** |

- **Deleted the `'fetching'` stage.** It labeled zero work — between its emission and `'generating'` the only "work" was two default-fallback assignments. There is no fetch: the context arrives pre-gathered in `params.context`, and generation jobs read no source bytes (pinned by the existing media-gate test). The string traces to #651 and was vestigial.
- **Deleted `'linking'` from `YieldProgress.stage`.** Declared in the union, emitted by no code path — dead vocabulary.
- **Re-shaped the percentages to match wall-clock reality.** The old `20/40/85` claimed 40% completion *before inference did anything*, then sat there for the entire 10–90s LLM wait. Inference dominates the job, so the numbers now approximate the share of expected wall-clock complete at each transition: ~5 at inference start, ~95 at inference end. They remain placeholders (an atomic LLM call has no measurable progress) — documented as such in the code.

`YieldProgress.stage` is now `'generating' | 'creating'`.

## What deliberately did NOT change

- **No spec change.** `JobProgress.stage` is a free string and `percentage` stays required + populated. The fuller cleanup (making `percentage` optional spec-wide and dropping it from yield entirely) is assessed but deferred — nothing in-repo renders the yield percentage today (the generation progress widget reads `stage` only; the one percentage bar is TaggingPanel, a detection job, already guarded for absence).
- **Detection jobs untouched.** Their per-entity-type percents are loop-derived (semi-real) and rendered.
- The backend SSE integration test's `'fetching'` string is its own synthetic fixture (free-string stage), unaffected.

## Verification (node:24-alpine, musl)

- RED observed first at each step: the rewritten assertion failed against the old three-stage emission, then against `40/85`.
- Full `@semiont/jobs` suite: **290 passed | 1 skipped**; `tsc --noEmit`: **0 errors**.
- The test now pins the honest contract: exactly two progress calls, in order, `(5, 'generating')` then `(95, 'creating')`, with the rationale in a comment.