### PR TITLE
rename GraphDBConsumer to Weaver

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -284,7 +284,7 @@ const content = new WorkingTreeStore(...);  // NEVER DO THIS
     - `kb.eventStore: EventStore` - Immutable event log and materialized views
     - `kb.content: WorkingTreeStore` - Working-tree file content (`file://` URIs, SHA-256 integrity checksums)
     - `kb.graph: GraphDatabase` - Graph database for relationships and traversal
-    - `kb.graphConsumer: GraphDBConsumer` - Event-to-graph synchronization
+    - `kb.weaver: Weaver` - Event-to-graph synchronization
   - `jobQueue: JobQueue` - Background job processing
   - Inference clients are created per-actor inside make-meaning (Gatherer, Matcher) - never in backend code
   - Background workers run in a separate worker-pool process (see [Architecture](./docs/ARCHITECTURE.md))

--- a/apps/backend/docs/ARCHITECTURE.md
+++ b/apps/backend/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ See [@semiont/make-meaning](../../../packages/make-meaning/) for the implementat
 2. **GraphDatabase** - Graph database connection
    - Provides relationship traversal and backlinks
    - Single connection pool shared across requests
-   - Automatically synchronized via GraphDBConsumer
+   - Automatically synchronized via Weaver
 
 3. **WorkingTreeStore** - Working-tree file content (`kb.content`)
    - The project working tree is the source of truth for file content
@@ -64,7 +64,7 @@ See [@semiont/make-meaning](../../../packages/make-meaning/) for the implementat
    - TagDetectionWorker
    - Workers connect to the KS over HTTP/SSE via WorkerStateUnit (from @semiont/http-transport), not via the in-process EventBus
 
-7. **GraphDBConsumer** - Event-to-graph synchronization
+7. **Weaver** - Event-to-graph synchronization
    - Subscribes to event store
    - Updates graph database on resource/annotation changes
    - Maintains graph consistency

--- a/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
+++ b/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
@@ -25,7 +25,7 @@ export function stubKnowledgeBase(overrides: Partial<KnowledgeBase> = {}): Knowl
     views:          {} as KnowledgeBase['views'],
     content:        { store: vi.fn(), retrieve: vi.fn() } as unknown as KnowledgeBase['content'],
     graph:          {} as KnowledgeBase['graph'],
-    graphConsumer:  { stop: vi.fn().mockResolvedValue(undefined) } as unknown as KnowledgeBase['graphConsumer'],
+    weaver:  { stop: vi.fn().mockResolvedValue(undefined) } as unknown as KnowledgeBase['weaver'],
     projectionsDir: '',
     ...overrides,
   };

--- a/apps/backend/src/__tests__/integration/annotation-crud.test.ts
+++ b/apps/backend/src/__tests__/integration/annotation-crud.test.ts
@@ -35,7 +35,7 @@ describe('Annotation CRUD Integration Tests - W3C multi-body annotation', () => 
 
     // Create KnowledgeBase for AnnotationContext calls
     const viewStorage = new FilesystemViewStorage(project);
-    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', graphConsumer: {} as any };
+    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaver: {} as any };
 
     // Create test resources in event store
     const eventStore = createEventStore(project, new EventBus(), mockLogger);

--- a/apps/backend/src/cli/rebuild-graph.ts
+++ b/apps/backend/src/cli/rebuild-graph.ts
@@ -35,16 +35,16 @@ async function rebuildGraph(rId?: string, environment?: string) {
   // Create EventBus
   const eventBus = new EventBus();
 
-  // Start make-meaning to get eventStore and graphConsumer
+  // Start make-meaning to get eventStore and weaver
   const makeMeaning = await startMakeMeaning(new SemiontProject(projectRoot), makeMeaningConfigFrom(config), eventBus, logger);
-  const { knowledgeSystem: { kb: { graphConsumer: consumer } } } = makeMeaning;
+  const { knowledgeSystem: { kb: { weaver } } } = makeMeaning;
 
   if (rId) {
     // Rebuild single resource
     logger.info('Rebuilding graph for resource', { resourceId: rId });
 
     try {
-      await consumer.rebuildResource(makeResourceId(rId));
+      await weaver.rebuildResource(makeResourceId(rId));
       logger.info('Resource rebuilt successfully', { resourceId: rId });
     } catch (error) {
       logger.error('Failed to rebuild resource', {
@@ -61,11 +61,11 @@ async function rebuildGraph(rId?: string, environment?: string) {
     logger.info('Note: This clears the database and replays all events');
 
     try {
-      await consumer.rebuildAll();
+      await weaver.rebuildAll();
       logger.info('Graph rebuilt successfully');
 
       // Show health metrics
-      const health = consumer.getHealthMetrics();
+      const health = weaver.getHealthMetrics();
       logger.info('Consumer health metrics', {
         activeSubscriptions: health.subscriptions,
         resourcesProcessed: Object.keys(health.lastProcessed).length

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -92,7 +92,7 @@ if (databaseUrlConstructed) {
 // Create global EventBus for real-time events
 const eventBus = new EventBus();
 
-// Initialize make-meaning service (job queue, workers, graph consumer).
+// Initialize make-meaning service (job queue, workers, Weaver).
 // startMakeMeaning registers all bus command handlers (annotation-assembly,
 // annotation-lookups, bind-update-body, job-commands) on the EventBus —
 // previously those were registered here in the backend. Moved into

--- a/apps/cli/src/core/commands/import.ts
+++ b/apps/cli/src/core/commands/import.ts
@@ -36,7 +36,7 @@ function createCliLogger(verbose: boolean): Logger {
 
 /**
  * Noop graph database for import — the graph rebuilds from events
- * after import via the GraphDBConsumer, not during import.
+ * after import via the Weaver, not during import.
  */
 function createNoopGraphDatabase(): GraphDatabase {
   const noop = async (): Promise<never> => { throw new Error('Graph not available during import'); };

--- a/apps/cli/src/core/commands/restore.ts
+++ b/apps/cli/src/core/commands/restore.ts
@@ -35,7 +35,7 @@ function createCliLogger(verbose: boolean): Logger {
 
 /**
  * Noop graph database for restore — the graph rebuilds from events
- * after restore via the GraphDBConsumer, not during restore.
+ * after restore via the Weaver, not during restore.
  */
 function createNoopGraphDatabase(): GraphDatabase {
   const noop = async (): Promise<never> => { throw new Error('Graph not available during restore'); };

--- a/docs/protocol/flows/MARK.md
+++ b/docs/protocol/flows/MARK.md
@@ -554,7 +554,7 @@ Stower emits mark:created on EventBus
     ↓
 View Materializer updates Materialized Views (fast single-doc queries)
     ↓
-Graph Consumer updates Graph Database (relationship traversal - backlinks, connections)
+Weaver updates Graph Database (relationship traversal - backlinks, connections)
 ```
 
 **Storage Locations**:

--- a/docs/system/ACTOR-MODEL.md
+++ b/docs/system/ACTOR-MODEL.md
@@ -23,7 +23,7 @@ graph TD
         MATCHER["Matcher"]
         BROWSER["Browser"]
         CTM["CloneTokenManager"]
-        GC["Graph Consumer<br/>(pipeline)"]
+        WEAVER["Weaver<br/>(pipeline)"]
         SMELTER["Smelter<br/>(pipeline)"]
         KB["Knowledge Base"]
         STOWER -->|"write"| KB
@@ -31,7 +31,7 @@ graph TD
         MATCHER -->|"query"| KB
         BROWSER -->|"query"| KB
         CTM -->|"query"| KB
-        GC -->|"project"| KB
+        WEAVER -->|"project"| KB
         SMELTER -->|"project"| KB
     end
 
@@ -40,7 +40,7 @@ graph TD
     BUS -->|"match"| MATCHER
     BUS -->|"browse"| BROWSER
     BUS -->|"clone"| CTM
-    BUS -->|"domain events"| GC
+    BUS -->|"domain events"| WEAVER
     BUS -->|"domain events"| SMELTER
 
     SOURCES["Content Sources"] --> FEEDER["Feeder"]
@@ -58,13 +58,13 @@ graph TD
     class BUS bus
     class KB kb
     class SOURCES stream
-    class FEEDER,STOWER,GATHERER,MATCHER,BROWSER,CTM,GC,SMELTER worker
+    class FEEDER,STOWER,GATHERER,MATCHER,BROWSER,CTM,WEAVER,SMELTER worker
 ```
 
 Three categories of actor:
 
 1. **Intelligent actors** — humans or AI agents that read, interpret, and annotate content. They produce events that carry semantic intent (mark, browse, yield, match, bind, gather, beckon).
-2. **The knowledge base** — a passive actor that listens to events and materializes durable state. It has no intelligence; it simply records what the intelligent actors decide. Seven reactive sub-actors serve it: five access actors that mediate every read and write (Stower, Browser, Gatherer, Matcher, CloneTokenManager) and two projection pipelines that follow the event log (Graph Consumer → graph, Smelter → vectors). See [KNOWLEDGE-SYSTEM.md](KNOWLEDGE-SYSTEM.md).
+2. **The knowledge base** — a passive actor that listens to events and materializes durable state. It has no intelligence; it simply records what the intelligent actors decide. Seven reactive sub-actors serve it: five access actors that mediate every read and write (Stower, Browser, Gatherer, Matcher, CloneTokenManager) and two projection pipelines that follow the event log (Weaver → graph, Smelter → vectors). See [KNOWLEDGE-SYSTEM.md](KNOWLEDGE-SYSTEM.md).
 3. **Content streams** — external sources that yield new resources into the system (uploads, web fetches, API ingestion). Mediated by the **Feeder** actor.
 
 The event bus is the only coupling between actors. An actor does not know who else is listening.

--- a/docs/system/CONTAINER-TOPOLOGY.md
+++ b/docs/system/CONTAINER-TOPOLOGY.md
@@ -24,7 +24,7 @@ graph TB
         BROWSER["Browser"]
         GATHERER["Gatherer"]
         MATCHER["Matcher"]
-        GC["Graph Consumer"]
+        WEAVER["Weaver"]
         VIEWS[("Materialized Views")]
     end
 
@@ -61,8 +61,8 @@ graph TB
     STOWER --- GIT
     STOWER --- VIEWS
     VIEWS --- GIT
-    GC --- GIT
-    GC --- NEO
+    WEAVER --- GIT
+    WEAVER --- NEO
     SMELTER --- QD
     BUS --- PG
     WORKERS --- OL
@@ -81,7 +81,7 @@ graph TB
     classDef service fill:#c97d5d,stroke:#8b4513,stroke-width:2px,color:#fff
 
     class BUS bus
-    class STOWER,BROWSER,GATHERER,MATCHER,GC,WORKERS,SMELTER actor
+    class STOWER,BROWSER,GATHERER,MATCHER,WEAVER,WORKERS,SMELTER actor
     class GIT,VIEWS,PG,NEO,QD store
     class SPA spa
     class OL service

--- a/docs/system/FILESYSTEM.md
+++ b/docs/system/FILESYSTEM.md
@@ -119,7 +119,7 @@ semiont rebuild --service backend --environment local
 await eventStore.rebuildAllViews();
 
 // Rebuild graph from events
-await graphConsumer.rebuildAll();
+await weaver.rebuildAll();
 ```
 
 ## Monitoring

--- a/docs/system/KNOWLEDGE-SYSTEM.md
+++ b/docs/system/KNOWLEDGE-SYSTEM.md
@@ -5,9 +5,9 @@ The **Knowledge System** binds the Knowledge Base to its seven reactive actors. 
 The knowledge base itself is not an intelligent actor. It has no goals, preferences, or decisions. It never initiates an event. It is inert storage — the durable record of what intelligent actors decide. Seven reactive sub-actors serve it, in two categories:
 
 - **Five access actors** mediate every read and write: **Stower** (write), **Browser** (read), **Gatherer** (context assembly), **Matcher** (search), and **CloneTokenManager** (clone tokens). They are the bus-facing interface of the knowledge base — commands and requests in, replies out, correlated by `correlationId`.
-- **Two projection pipelines** keep the eventually-consistent read models in sync with the event log: the **Graph Consumer** (events → graph) and the **Smelter** (events → vectors). Pipelines are addressed by no one and reply to nothing; they consume already-persisted domain events.
+- **Two projection pipelines** keep the eventually-consistent read models in sync with the event log: the **Weaver** (events → graph) and the **Smelter** (events → vectors). Pipelines are addressed by no one and reply to nothing; they consume already-persisted domain events.
 
-All seven subscribe to the bus via RxJS pipelines and expose no public business methods — `initialize()` and `stop()` for lifecycle, plus a startup recovery entry point on the pipelines (`GraphDBConsumer.rebuildAll()`, `Smelter.reconcile()`). Callers never call into an actor directly; they put a message on the bus and trust the actor is listening.
+All seven subscribe to the bus via RxJS pipelines and expose no public business methods — `initialize()` and `stop()` for lifecycle, plus a startup recovery entry point on the pipelines (`Weaver.rebuildAll()`, `Smelter.reconcile()`). Callers never call into an actor directly; they put a message on the bus and trust the actor is listening.
 
 The third derived read model — the materialized views — is deliberately **not** pipeline-maintained: the EventStore's `ViewManager` materializes views synchronously inside `appendEvent()`, before the event is published, so subscribers get a read-your-writes guarantee that a fire-and-forget pipeline cannot provide.
 
@@ -35,13 +35,13 @@ graph TB
     BE -->|"match"| MATCHER["Matcher"]
     BE -->|"browse"| BROWSER["Browser"]
     BE -->|"clone"| CTM["CloneTokenManager"]
-    BE -->|"domain events"| GC["Graph Consumer<br/>(pipeline)"]
+    BE -->|"domain events"| WEAVER["Weaver<br/>(pipeline)"]
     BE -->|"domain events"| SMELTER["Smelter<br/>(pipeline)"]
 
     STOWER -->|append| EVENTLOG
     STOWER -->|store| CONTENT
 
-    GC -->|project| GRAPH
+    WEAVER -->|project| GRAPH
     SMELTER -->|embed| VECTORS
     CONTENT -->|read| SMELTER
 
@@ -78,7 +78,7 @@ graph TB
 
     class API,BE backend
     class DB,EVENTLOG,VIEWS,CONTENT,GRAPH,VECTORS store
-    class STOWER,GATHERER,MATCHER,BROWSER,CTM,GC,SMELTER worker
+    class STOWER,GATHERER,MATCHER,BROWSER,CTM,WEAVER,SMELTER worker
 
     style top fill:none,stroke:none
 ```
@@ -90,7 +90,7 @@ graph TB
 | **Event Log** | Immutable append-only log of all domain events; system of record, committed to version control | Stower appends; startup rebuilds and pipelines replay it |
 | **Materialized Views** | Denormalized projections for fast reads; materialized **synchronously on append** by the EventStore's ViewManager (read-your-writes) | Gatherer/Matcher/Browser/CloneTokenManager query by resource id |
 | **Content Store** | Working-tree files addressed by `storageUri` (documents, images, PDFs) | Stower registers; Gatherer/Browser/Smelter read |
-| **Graph** | Eventually consistent relationship projection for traversal queries (backlinks, entity networks) | Graph Consumer projects; Gatherer/Matcher traverse and search |
+| **Graph** | Eventually consistent relationship projection for traversal queries (backlinks, entity networks) | Weaver projects; Gatherer/Matcher traverse and search |
 | **Vectors** | Embedding vectors in Qdrant for semantic similarity search; eventually consistent | Smelter projects; Gatherer/Matcher search |
 
 ## The seven KB actors
@@ -117,13 +117,13 @@ The Browser is the read actor for all deterministic KB queries — resources, an
 
 The CloneTokenManager handles the clone-token lifecycle in the yield flow. On `yield:clone-token-requested` it validates the source resource and its content, then issues a short-lived token (15-minute expiry, held in an in-memory map). `yield:clone-resource-requested` validates a token and returns the source resource; `yield:clone-create` validates the token and creates the cloned resource through the normal write path. Tokens never touch durable storage — losing them on restart is harmless.
 
-### Graph Consumer (projection pipeline)
+### Weaver (projection pipeline)
 
-The Graph Consumer follows the event log and keeps the graph projection in sync. It subscribes to the graph-relevant domain events on the bus, batches bursts per resource (`groupBy(resourceId)` + adaptive burst buffering + `concatMap`), and applies them to the graph database. Because the graph is eventually consistent and rebuildable, `rebuildAll()` replays the entire event log at startup — a wiped graph volume recovers by restarting the backend. It lives on the `KnowledgeBase` record (`kb.graphConsumer`), constructed inside `createKnowledgeBase()`.
+The Weaver follows the event log and keeps the graph projection in sync. It subscribes to the graph-relevant domain events on the bus, batches bursts per resource (`groupBy(resourceId)` + adaptive burst buffering + `concatMap`), and applies them to the graph database. Because the graph is eventually consistent and rebuildable, `rebuildAll()` replays the entire event log at startup — a wiped graph volume recovers by restarting the backend. It lives on the `KnowledgeBase` record (`kb.weaver`), constructed inside `createKnowledgeBase()`.
 
 ### Smelter (projection pipeline)
 
-The Smelter is the vector projection actor. It runs in its own container (`semiont-smelter`) — not in the backend process — and reaches the backend through the unified bus, the same way workers do. Beyond the bus it has two privileged attachments: the vector store (Qdrant, direct) and the content store (the KB working tree, bind-mounted; `SEMIONT_ROOT`). When a resource is created or an annotation is added, the Smelter receives the event, reads the content from the working tree, chunks the text into overlapping passages, computes embedding vectors via the configured embedding provider (Voyage AI or Ollama), and indexes them into the vector store. Vectors are a pure projection — nothing is written back to the event log. Because Qdrant is ephemeral, the Smelter reconciles it against the KS catalog on every startup: it lists what is indexed, lists what should be (via the `browse:*` channels), re-embeds what's missing or stale (each upsert is stamped with the embedded bytes' checksum, so content changed while the worker was down is detected), and deletes orphans — so a wiped Qdrant volume, or events missed while the worker was down, recover by restarting the smelter. The Smelter follows the same RxJS burst-buffer pattern as the Graph Consumer for per-resource ordering and batch efficiency.
+The Smelter is the vector projection actor. It runs in its own container (`semiont-smelter`) — not in the backend process — and reaches the backend through the unified bus, the same way workers do. Beyond the bus it has two privileged attachments: the vector store (Qdrant, direct) and the content store (the KB working tree, bind-mounted; `SEMIONT_ROOT`). When a resource is created or an annotation is added, the Smelter receives the event, reads the content from the working tree, chunks the text into overlapping passages, computes embedding vectors via the configured embedding provider (Voyage AI or Ollama), and indexes them into the vector store. Vectors are a pure projection — nothing is written back to the event log. Because Qdrant is ephemeral, the Smelter reconciles it against the KS catalog on every startup: it lists what is indexed, lists what should be (via the `browse:*` channels), re-embeds what's missing or stale (each upsert is stamped with the embedded bytes' checksum, so content changed while the worker was down is detected), and deletes orphans — so a wiped Qdrant volume, or events missed while the worker was down, recover by restarting the smelter. The Smelter follows the same RxJS burst-buffer pattern as the Weaver for per-resource ordering and batch efficiency.
 
 ## See also
 

--- a/docs/system/administration/BACKUP.md
+++ b/docs/system/administration/BACKUP.md
@@ -122,7 +122,7 @@ Integrity of the live event log is provided by git at the commit level: when `gi
 ## What Is Excluded
 
 - **Materialized views** — Rebuilt automatically from events during restore
-- **Graph database** — Rebuilt from events by the GraphDBConsumer after restore
+- **Graph database** — Rebuilt from events by the Weaver after restore
 - **Job queue state** — Transient; jobs re-run as needed
 - **User database** — Managed separately in PostgreSQL
 - **Application configuration** — Stored in environment config files, not in the knowledge base

--- a/docs/system/services/OVERVIEW.md
+++ b/docs/system/services/OVERVIEW.md
@@ -144,7 +144,7 @@ graph LR
 - Job progress streaming
 
 ### Event Bus
-- Event Store to Graph Consumer
+- Event Store to Weaver
 - Event Store to SSE subscribers
 
 ## Health Checks

--- a/packages/core/src/__tests__/annotation-utils.test.ts
+++ b/packages/core/src/__tests__/annotation-utils.test.ts
@@ -141,7 +141,7 @@ describe('@semiont/core - annotation-utils', () => {
     // ── Caller-convenience: passing a full BodyItem works too ─────────────
 
     it('accepts a full BodyItem structurally (ignores extra fields)', () => {
-      // View-materializer and graph-consumer pass `op.item` directly —
+      // View-materializer and weaver pass `op.item` directly —
       // which carries purpose and possibly other fields. This should Just
       // Work because BodyItem is structurally assignable to BodyItemIdentity.
       const body: BodyItem[] = [

--- a/packages/core/src/annotation-types.ts
+++ b/packages/core/src/annotation-types.ts
@@ -27,8 +27,8 @@ export interface CreateAnnotationInternal {
   motivation: Annotation['motivation'];
   target: Annotation['target'];
   // Body is optional — motivation:'highlighting' annotations carry no
-  // body per W3C. Other motivations always populate it; graph consumers
-  // that need to read `body` on non-highlights should assert its
+  // body per W3C. Other motivations always populate it; consumers
+  // (e.g. the Weaver) that need to read `body` on non-highlights should assert its
   // presence based on motivation rather than treat it as guaranteed.
   body?: Annotation['body'];
   creator: components['schemas']['Agent'];

--- a/packages/core/src/annotation-utils.ts
+++ b/packages/core/src/annotation-utils.ts
@@ -2,7 +2,7 @@
  * Annotation body utilities
  *
  * These are the matcher primitives used by the `mark:body-updated` event
- * replay path (ViewMaterializer and GraphDBConsumer) to apply add/remove/
+ * replay path (ViewMaterializer and Weaver) to apply add/remove/
  * replace operations against an annotation body.
  */
 

--- a/packages/core/src/operators/burst-buffer.ts
+++ b/packages/core/src/operators/burst-buffer.ts
@@ -17,8 +17,7 @@
  *   idleTimeoutMs  — How long after the last flush before returning to passthrough.
  *                    200ms is a good default. Must be >= burstWindowMs.
  *
- * See: BATCH-GRAPH-CONSUMER-RX.md for design rationale.
- * See: packages/graph/docs/ARCHITECTURE.md for graph consumer context.
+ * See: packages/graph/docs/ARCHITECTURE.md for Weaver context.
  */
 
 import { Observable, OperatorFunction } from 'rxjs';

--- a/packages/core/src/serialize-per-key.ts
+++ b/packages/core/src/serialize-per-key.ts
@@ -41,7 +41,7 @@
  *
  * Use RxJS `groupBy(keyFn) + concatMap(...)` when the work arrives as an
  * **event stream** that a component subscribes to once at startup. This
- * is how `Smelter`, `GraphDBConsumer`, and `Gatherer` serialize their own
+ * is how `Smelter`, `Weaver`, and `Gatherer` serialize their own
  * per-resource work — see their implementations in `packages/make-meaning`.
  *
  * Both patterns solve the same logical problem ("serialize work per key").

--- a/packages/event-sourcing/README.md
+++ b/packages/event-sourcing/README.md
@@ -27,7 +27,7 @@ The **EventStore** is the single write path. It coordinates three concerns:
 - **ViewManager** — Materializes resource views and system projections from events. Supports both incremental updates on every append and a full `rebuildAll(eventLog)` for startup recovery.
 - **Core EventBus** (`@semiont/core`) — Publishes `StoredEvent` to typed channels after persistence
 
-Event publishing uses the Core EventBus from `@semiont/core`. There is no internal pub/sub system — all subscribers (GraphDBConsumer, Smelter, SSE routes) subscribe directly to typed channels on the Core EventBus.
+Event publishing uses the Core EventBus from `@semiont/core`. There is no internal pub/sub system — all subscribers (Weaver, Smelter, SSE routes) subscribe directly to typed channels on the Core EventBus.
 
 The materialized views directory is **ephemeral by design** — see the [ViewManager / ViewMaterializer](#viewmanager--viewmaterializer) section for the rebuild model and how it relates to the graph and vector consumers.
 
@@ -155,7 +155,7 @@ This makes the views layer the third leg of a symmetric pattern: the three deriv
 
 | Derived store | Rebuild method | Owned by |
 |---|---|---|
-| Graph (Neo4j) | `GraphDBConsumer.rebuildAll()` | `@semiont/make-meaning` |
+| Graph (Neo4j) | `Weaver.rebuildAll()` | `@semiont/make-meaning` |
 | Vectors (Qdrant) | `Smelter.rebuildAll()` | `@semiont/make-meaning` |
 | Materialized views | `ViewManager.rebuildAll(eventLog)` | `@semiont/event-sourcing` |
 

--- a/packages/event-sourcing/docs/STORAGE-LAYOUT.md
+++ b/packages/event-sourcing/docs/STORAGE-LAYOUT.md
@@ -105,7 +105,7 @@ The rebuild step that makes "ephemeral" safe is `ViewManager.rebuildAll(eventLog
 2. Each resource view file under `resources/<ab>/<cd>/`.
 3. The storage-uri index entries.
 
-It is idempotent: existing files are overwritten, not appended. Running it on every startup is safe and is in fact the design — startup rebuild + live incremental update is the same pattern used by the graph (`GraphDBConsumer.rebuildAll()` + per-event consumer) and the vectors (`Smelter.rebuildAll()` + per-event smelter), giving all three derived read models the same lifecycle treatment.
+It is idempotent: existing files are overwritten, not appended. Running it on every startup is safe and is in fact the design — startup rebuild + live incremental update is the same pattern used by the graph (`Weaver.rebuildAll()` + per-event consumer) and the vectors (`Smelter.rebuildAll()` + per-event smelter), giving all three derived read models the same lifecycle treatment.
 
 If you wipe `<stateDir>` manually for debugging, the next process restart will repopulate it. The `<projectRoot>/.semiont/events/` directory is the only thing you must not delete.
 

--- a/packages/event-sourcing/src/view-manager.ts
+++ b/packages/event-sourcing/src/view-manager.ts
@@ -44,7 +44,7 @@ export interface ViewManagerConfig {
  * must block the caller until the view is written, so SSE subscribers
  * that see the subsequently-published event get the up-to-date view (a
  * read-your-writes guarantee). The RxJS stream-consumer pattern used by
- * `Smelter`, `GraphDBConsumer`, and `Gatherer` can't provide that
+ * `Smelter`, `Weaver`, and `Gatherer` can't provide that
  * guarantee because it's fire-and-forget from the publisher's perspective.
  * Both patterns solve "serialize work per resource" — see also
  * `packages/core/src/serialize-per-key.ts` for the shared primitive.
@@ -110,7 +110,7 @@ export class ViewManager {
 
   /**
    * Rebuild all materialized views from the event log on startup.
-   * Mirrors GraphDBConsumer.rebuildAll() — call this once during
+   * Mirrors Weaver.rebuildAll() — call this once during
    * createKnowledgeBase before the HTTP server begins accepting requests.
    * Idempotent: existing view files are overwritten.
    */

--- a/packages/event-sourcing/src/views/view-materializer.ts
+++ b/packages/event-sourcing/src/views/view-materializer.ts
@@ -393,7 +393,7 @@ export class ViewMaterializer {
    * Walk every event stream in the event log and materialize the corresponding
    * view from scratch. Idempotent: existing view files are overwritten.
    *
-   * Mirrors GraphDBConsumer.rebuildAll() and Smelter.rebuildAll() — this is the
+   * Mirrors Weaver.rebuildAll() and Smelter.rebuildAll() — this is the
    * recovery path that makes the ephemeral stateDir safe to wipe. The live
    * append path (EventStore.appendEvent → materializeIncremental /
    * materializeEntityTypes / materializeTagSchemas) is unchanged and runs in

--- a/packages/graph/docs/ARCHITECTURE.md
+++ b/packages/graph/docs/ARCHITECTURE.md
@@ -79,16 +79,16 @@ The graph is populated from Event Store events:
 ```mermaid
 graph LR
     API[API Request] --> ES[Event Store]
-    ES --> GC[GraphDBConsumer<br/>Event Processor]
-    GC --> GDB[Graph Database]
+    ES --> WEAVER[Weaver<br/>Event Processor]
+    WEAVER --> GDB[Graph Database]
 
-    ES -->|yield:created| GC
-    ES -->|mark:added| GC
-    ES -->|mark:entity-tag-added| GC
+    ES -->|yield:created| WEAVER
+    ES -->|mark:added| WEAVER
+    ES -->|mark:entity-tag-added| WEAVER
 
-    GC -->|createResource| GDB
-    GC -->|createAnnotation| GDB
-    GC -->|updateResource| GDB
+    WEAVER -->|createResource| GDB
+    WEAVER -->|createAnnotation| GDB
+    WEAVER -->|updateResource| GDB
 ```
 
 ### Event Processing Guarantees

--- a/packages/graph/docs/EVENTUAL-CONSISTENCY.md
+++ b/packages/graph/docs/EVENTUAL-CONSISTENCY.md
@@ -29,7 +29,7 @@ The bus is an RxJS subject per event type — publication is fire-and-forget fro
 
 ### Per-Resource Sequential Processing
 
-The GraphDBConsumer (`packages/make-meaning/src/graph/consumer.ts`) subscribes globally and pre-filters events to only the 9 graph-relevant types (`yield:created`, `mark:added`, etc.) before any processing. Irrelevant events (`job.*`, `detection.*`, `generation.*`) are discarded immediately.
+The Weaver (`packages/make-meaning/src/weaver.ts`) subscribes globally and pre-filters events to only the 9 graph-relevant types (`yield:created`, `mark:added`, etc.) before any processing. Irrelevant events (`job.*`, `detection.*`, `generation.*`) are discarded immediately.
 
 Relevant events are piped through an RxJS pipeline with adaptive burst buffering:
 
@@ -261,11 +261,11 @@ The graph can be rebuilt from events to fix any inconsistencies:
 
 ### Single Resource Rebuild
 
-The `GraphDBConsumer` lives in `@semiont/make-meaning` (`packages/make-meaning/src/graph/consumer.ts`) and is created by `createKnowledgeBase`:
+The `Weaver` lives in `@semiont/make-meaning` (`packages/make-meaning/src/weaver.ts`) and is created by `createKnowledgeBase`:
 
 ```typescript
-const { graphConsumer } = await createKnowledgeBase(/* ... */);
-await graphConsumer.rebuildResource(resourceId('resource-id-123'));
+const { weaver } = await createKnowledgeBase(/* ... */);
+await weaver.rebuildResource(resourceId('resource-id-123'));
 ```
 
 ### Full Graph Rebuild
@@ -288,7 +288,7 @@ The graph is one of three derived read models in the Semiont knowledge base. Eac
 
 | Derived store | Rebuild method | Owned by |
 |---|---|---|
-| Graph (Neo4j) | `GraphDBConsumer.rebuildAll()` | `@semiont/make-meaning` |
+| Graph (Neo4j) | `Weaver.rebuildAll()` | `@semiont/make-meaning` |
 | Vectors (Qdrant) | `Smelter.rebuildAll()` | `@semiont/make-meaning` |
 | Materialized views | `ViewManager.rebuildAll(eventLog)` | `@semiont/event-sourcing` |
 

--- a/packages/make-meaning/README.md
+++ b/packages/make-meaning/README.md
@@ -20,7 +20,7 @@ Five **access actors** mediate every read and write — the bus-facing interface
 
 Two **projection pipelines** follow the event log to keep the eventually-consistent read models in sync — addressed by no one, replying to nothing:
 
-- **Graph Consumer** (project) — subscribes to graph-relevant domain events and projects them into the graph database; carried on the KB record (`kb.graphConsumer`) and rebuilt from the event log at startup (`rebuildAll()`)
+- **Weaver** (project) — subscribes to graph-relevant domain events and projects them into the graph database; carried on the KB record (`kb.weaver`) and rebuilt from the event log at startup (`rebuildAll()`)
 - **Smelter** (embed) — standalone embedding pipeline run via `@semiont/make-meaning/smelter-main` (not started by `startMakeMeaning`); subscribes to domain events, reads content from the KB working tree via `WorkerContentTransport`, chunks text, embeds via `@semiont/vectors`, and indexes into the vector store (Qdrant). On startup it reconciles Qdrant against the KS catalog — re-embedding what's missing or stale (every upsert is stamped with the embedded bytes' checksum, so changed content is detected) and deleting orphans — so a wiped Qdrant volume, or events missed while the worker was down, recover by restarting the smelter
 
 (The third derived read model — the materialized views — is not pipeline-maintained: the EventStore's `ViewManager` materializes views synchronously inside `appendEvent()` for a read-your-writes guarantee.)
@@ -60,7 +60,7 @@ await makeMeaning.stop();
 
 This single call initializes:
 - **KnowledgeSystem** — groups the Knowledge Base and its actors
-  - **KnowledgeBase** — groups EventStore, ViewStorage, WorkingTreeStore, GraphDatabase, GraphDBConsumer, and optionally VectorStore
+  - **KnowledgeBase** — groups EventStore, ViewStorage, WorkingTreeStore, GraphDatabase, Weaver, and optionally VectorStore
   - **Stower** — subscribes to write commands on EventBus
   - **Browser** — subscribes to all KB read queries and directory browse requests on EventBus
   - **Gatherer** — subscribes to annotation and resource gather requests on EventBus; searches vectors for semantically similar passages
@@ -113,7 +113,7 @@ graph TB
         GATHERER["Gatherer<br/>(context assembly)"]
         MATCHER["Matcher<br/>(search/link)"]
         SMELTER["Smelter<br/>(embed pipeline, standalone process)"]
-        GC["Graph Consumer<br/>(graph pipeline)"]
+        WEAVER["Weaver<br/>(graph pipeline)"]
         CTM["CloneTokenManager<br/>(clone)"]
         KB["Knowledge Base"]
         VECTORS["Vector Store<br/>(Qdrant)"]
@@ -125,7 +125,7 @@ graph TB
         MATCHER -->|search| VECTORS
         SMELTER -->|embed & index| VECTORS
         SMELTER -->|read| KB
-        GC -->|project| KB
+        WEAVER -->|project| KB
         CTM -->|query| KB
     end
 
@@ -134,7 +134,7 @@ graph TB
     BUS -->|"gather:requested<br/>gather:resource-requested"| GATHERER
     BUS -->|"match:search-requested"| MATCHER
     BUS -->|"domain events:<br/>yield:created, yield:updated<br/>yield:representation-added<br/>mark:added, mark:removed, mark:archived"| SMELTER
-    BUS -->|"graph-relevant<br/>domain events"| GC
+    BUS -->|"graph-relevant<br/>domain events"| WEAVER
     BUS -->|"yield:clone-token-requested<br/>yield:clone-resource-requested<br/>yield:clone-create"| CTM
 
     STOWER -->|"yield:create-ok, yield:update-ok, yield:move-ok<br/>mark:delete-ok, *-failed replies<br/>(domain events are republished onto the bus<br/>by the EventStore: yield:created, mark:added, ...)"| BUS
@@ -150,7 +150,7 @@ graph TB
 
     class BUS bus
     classDef vectorstore fill:#6b8e9d,stroke:#4a6a7a,stroke-width:2px,color:#fff
-    class STOWER,BROWSER,GATHERER,MATCHER,SMELTER,GC,CTM actor
+    class STOWER,BROWSER,GATHERER,MATCHER,SMELTER,WEAVER,CTM actor
     class KB kb
     class VECTORS vectorstore
     class Routes,Workers,EBC caller
@@ -168,7 +168,7 @@ The **Knowledge Base** is an inert store — it has no intelligence, no goals, n
 | **Materialized Views** | `ViewStorage` | Denormalized projections for fast reads (materialized synchronously on append) |
 | **Content Store** | `WorkingTreeStore` | Working-tree files addressed by URI |
 | **Graph** | `GraphDatabase` | Eventually consistent relationship projection |
-| **Graph Consumer** | `GraphDBConsumer` | Event-to-graph projection pipeline (one of the two pipeline actors; carried on the KB record because `createKnowledgeBase()` constructs and starts it) |
+| **Weaver** | `Weaver` | Event-to-graph projection pipeline (one of the two pipeline actors; carried on the KB record because `createKnowledgeBase()` constructs and starts it) |
 | **Vectors** *(optional)* | `VectorStore` | Semantic vector index (Qdrant + memory) via `@semiont/vectors` |
 
 Its sibling pipeline, the Smelter (event-to-vector projection), is **not** a KB member — it runs as a standalone process via `@semiont/make-meaning/smelter-main`.
@@ -177,7 +177,7 @@ Its sibling pipeline, the Smelter (event-to-vector projection), is **not** a KB 
 import { createKnowledgeBase } from '@semiont/make-meaning';
 
 const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, logger, options);
-// kb.eventStore, kb.views, kb.content, kb.graph, kb.graphConsumer
+// kb.eventStore, kb.views, kb.content, kb.graph, kb.weaver
 // kb.vectors (optional), kb.projectionsDir
 ```
 
@@ -221,7 +221,7 @@ This pattern (functional core, imperative shell) is shared with `@semiont/event-
 ### Knowledge Base
 
 - `createKnowledgeBase(eventStore, project, graphDb, eventBus, logger, options?)` — Async factory function
-- `KnowledgeBase` — Interface grouping the KB stores (`eventStore`, `views`, `content`, `graph`, optional `vectors`) plus the `graphConsumer` pipeline
+- `KnowledgeBase` — Interface grouping the KB stores (`eventStore`, `views`, `content`, `graph`, optional `vectors`) plus the `weaver` pipeline
 
 ### Actors
 
@@ -232,7 +232,7 @@ This pattern (functional core, imperative shell) is shared with `@semiont/event-
 - `CloneTokenManager` — Clone token lifecycle actor (yield domain)
 - `Smelter` / `createSmelterActorStateUnit` / `WorkerContentTransport` — the embedding pipeline, its domain-event fan-in, and the worker-side content transport; wired together by the standalone `@semiont/make-meaning/smelter-main` entry point, and exported for callers that run the pipeline on their own `WorkerBus`
 
-The Graph Consumer (`GraphDBConsumer`) is not exported — `createKnowledgeBase()` constructs it internally and exposes it as `kb.graphConsumer`.
+The Weaver is not exported — `createKnowledgeBase()` constructs it internally and exposes it as `kb.weaver`.
 
 ### Operations
 

--- a/packages/make-meaning/docs/SCRIPTING.md
+++ b/packages/make-meaning/docs/SCRIPTING.md
@@ -45,7 +45,7 @@ async function main() {
 
   try {
     // Access components:
-    // makeMeaning.knowledgeSystem.kb                — Knowledge Base (eventStore, views, content, graph, graphConsumer, vectors?)
+    // makeMeaning.knowledgeSystem.kb                — Knowledge Base (eventStore, views, content, graph, weaver, vectors?)
     // makeMeaning.knowledgeSystem.stower            — Write gateway actor
     // makeMeaning.knowledgeSystem.browser           — Read actor (browse queries, directory listings)
     // makeMeaning.knowledgeSystem.gatherer          — Context assembly actor

--- a/packages/make-meaning/docs/api-reference.md
+++ b/packages/make-meaning/docs/api-reference.md
@@ -2,7 +2,7 @@
 
 ## Actors
 
-Seven actors in two categories: five **access actors** (Stower, Browser, Gatherer, Matcher, CloneTokenManager) mediate reads and writes; two **projection pipelines** (Graph Consumer, Smelter) follow the event log.
+Seven actors in two categories: five **access actors** (Stower, Browser, Gatherer, Matcher, CloneTokenManager) mediate reads and writes; two **projection pipelines** (Weaver, Smelter) follow the event log.
 
 ### Stower
 
@@ -84,11 +84,11 @@ Responds to:
 
 Referenced-by lookups are handled by the Browser (`browse:referenced-by-requested`), not the Matcher.
 
-### Graph Consumer (projection pipeline)
+### Weaver (projection pipeline)
 
-Event-to-graph projection pipeline. Subscribes to graph-relevant domain events and applies them to the graph database with per-resource ordering and adaptive burst batching. Not exported from the package index — `createKnowledgeBase()` constructs and starts it, exposing it as `kb.graphConsumer` (`initialize()`, `stop()`, `rebuildAll()`).
+Event-to-graph projection pipeline. Subscribes to graph-relevant domain events and applies them to the graph database with per-resource ordering and adaptive burst batching. Not exported from the package index — `createKnowledgeBase()` constructs and starts it, exposing it as `kb.weaver` (`initialize()`, `stop()`, `rebuildAll()`).
 
-**Implementation**: [src/graph/consumer.ts](../src/graph/consumer.ts)
+**Implementation**: [src/weaver.ts](../src/weaver.ts)
 
 ### Smelter (projection pipeline, standalone process)
 
@@ -352,7 +352,7 @@ export interface KnowledgeBase {
   views:          ViewStorage;
   content:        WorkingTreeStore;
   graph:          GraphDatabase;
-  graphConsumer:  GraphDBConsumer;
+  weaver:  Weaver;
   vectors?:       VectorStore;   // Optional — Qdrant or memory (from @semiont/vectors)
   projectionsDir: string;
 }

--- a/packages/make-meaning/docs/architecture.md
+++ b/packages/make-meaning/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ## Actor Model
 
-The package owns the **Knowledge Base** and the seven actors that serve it, in two categories: five **access actors** (Stower, Browser, Gatherer, Matcher, CloneTokenManager) mediate every read and write, and two **projection pipelines** (Graph Consumer, Smelter) follow the event log to keep the eventually-consistent read models (graph, vectors) in sync. All communication flows through the **EventBus** — actors subscribe via RxJS pipelines and expose no public business methods: `initialize()` and `stop()`, plus a startup recovery entry point on the pipelines (`rebuildAll()` / `reconcile()`).
+The package owns the **Knowledge Base** and the seven actors that serve it, in two categories: five **access actors** (Stower, Browser, Gatherer, Matcher, CloneTokenManager) mediate every read and write, and two **projection pipelines** (Weaver, Smelter) follow the event log to keep the eventually-consistent read models (graph, vectors) in sync. All communication flows through the **EventBus** — actors subscribe via RxJS pipelines and expose no public business methods: `initialize()` and `stop()`, plus a startup recovery entry point on the pipelines (`rebuildAll()` / `reconcile()`).
 
 The third derived read model — the materialized views — is **not** pipeline-maintained: the EventStore's `ViewManager` materializes views synchronously inside `appendEvent()`, giving bus subscribers a read-your-writes guarantee.
 
@@ -19,7 +19,7 @@ graph TB
     BUS -->|"gather:*"| GATHERER["Gatherer"]
     BUS -->|"match:search-requested"| MATCHER["Matcher"]
     BUS -->|"domain events:<br/>yield:created, yield:updated,<br/>yield:representation-added,<br/>mark:added, mark:removed, mark:archived"| SMELTER["Smelter<br/>(pipeline, standalone process)"]
-    BUS -->|"graph-relevant<br/>domain events"| GC["Graph Consumer<br/>(pipeline)"]
+    BUS -->|"graph-relevant<br/>domain events"| WEAVER["Weaver<br/>(pipeline)"]
     BUS -->|"yield:clone-*"| CTM["CloneTokenManager"]
 
     STOWER -->|append| EVENTLOG
@@ -37,7 +37,7 @@ graph TB
         EVENTLOG -->|"materialize<br/>(sync, on append)"| VIEWS
     end
 
-    GC -->|project| GRAPH
+    WEAVER -->|project| GRAPH
 
     BROWSER -->|query| VIEWS
     BROWSER -->|search| GRAPH
@@ -71,7 +71,7 @@ graph TB
 
     class BUS bus
     class EVENTLOG,VIEWS,CONTENT,GRAPH,VECTORS store
-    class STOWER,BROWSER,GATHERER,MATCHER,SMELTER,GC,CTM worker
+    class STOWER,BROWSER,GATHERER,MATCHER,SMELTER,WEAVER,CTM worker
     class Routes,Workers,EBC caller
 ```
 
@@ -177,11 +177,11 @@ Manages the lifecycle of temporary clone tokens for resource cloning. In-memory 
 | `yield:clone-resource-requested` | Validate token, look up source resource | `yield:clone-resource-result` / `yield:clone-resource-failed` |
 | `yield:clone-create` | Validate token, create resource via `ResourceOperations` | `yield:clone-created` / `yield:clone-create-failed` |
 
-### Graph Consumer (Projection Pipeline)
+### Weaver (Projection Pipeline)
 
-**Implementation**: [src/graph/consumer.ts](../src/graph/consumer.ts)
+**Implementation**: [src/weaver.ts](../src/weaver.ts)
 
-The `GraphDBConsumer` subscribes to all domain events and projects graph-relevant events into the graph database. It uses an RxJS pipeline with adaptive burst buffering:
+The `Weaver` subscribes to all domain events and projects graph-relevant events into the graph database. It uses an RxJS pipeline with adaptive burst buffering:
 
 ```
 EventBus (callback, fire-and-forget)
@@ -194,13 +194,13 @@ EventBus (callback, fire-and-forget)
             → Batch: processBatch() → batchCreateResources / createAnnotations
 ```
 
-It is carried on the `KnowledgeBase` record (`kb.graphConsumer`) — `createKnowledgeBase()` constructs and starts it, and calls `rebuildAll()` at startup to replay the event log, so a wiped graph volume is recoverable.
+It is carried on the `KnowledgeBase` record (`kb.weaver`) — `createKnowledgeBase()` constructs and starts it, and calls `rebuildAll()` at startup to replay the event log, so a wiped graph volume is recoverable.
 
 ### Smelter (Projection Pipeline, standalone process)
 
 **Implementation**: [src/smelter.ts](../src/smelter.ts), entry point [src/smelter-main.ts](../src/smelter-main.ts)
 
-The Smelter is **not started by `startMakeMeaning()`** — it runs as its own process via `@semiont/make-meaning/smelter-main`, receiving domain events through the [`SmelterActorStateUnit`](../src/smelter-actor-state-unit.ts) fan-in. It reads content from the KB working tree via `WorkerContentTransport` (metadata over the bus, bytes straight off disk), chunks it, computes embeddings via `@semiont/vectors` (Voyage or Ollama), and indexes vectors into the VectorStore (Qdrant or memory). Like the Graph Consumer, it processes strictly in order per resource (`groupBy(resourceId)` + `concatMap`) with `burstBuffer` batching — consecutive same-type runs within a burst share a single `embedBatch()` call.
+The Smelter is **not started by `startMakeMeaning()`** — it runs as its own process via `@semiont/make-meaning/smelter-main`, receiving domain events through the [`SmelterActorStateUnit`](../src/smelter-actor-state-unit.ts) fan-in. It reads content from the KB working tree via `WorkerContentTransport` (metadata over the bus, bytes straight off disk), chunks it, computes embeddings via `@semiont/vectors` (Voyage or Ollama), and indexes vectors into the VectorStore (Qdrant or memory). Like the Weaver, it processes strictly in order per resource (`groupBy(resourceId)` + `concatMap`) with `burstBuffer` batching — consecutive same-type runs within a burst share a single `embedBatch()` call.
 
 | Domain Event | Handler |
 |--------------|---------|
@@ -222,13 +222,13 @@ export interface KnowledgeBase {
   views:          ViewStorage;      // Materialized Views (fast reads)
   content:        WorkingTreeStore; // Content Store (working-tree files, URI-addressed)
   graph:          GraphDatabase;    // Graph (eventually consistent)
-  graphConsumer:  GraphDBConsumer;  // Event-to-graph projection pipeline
+  weaver:  Weaver;  // Event-to-graph projection pipeline
   vectors?:       VectorStore;      // Vector index (Qdrant / memory) — optional
   projectionsDir: string;
 }
 ```
 
-The `createKnowledgeBase(eventStore, project, graphDb, eventBus, logger, options?)` factory instantiates `FilesystemViewStorage` and `WorkingTreeStore` once, starts the `GraphDBConsumer`, and (unless `options.skipRebuild`) rebuilds the materialized views and graph from the event log. Context modules receive `KnowledgeBase` instead of instantiating stores per call.
+The `createKnowledgeBase(eventStore, project, graphDb, eventBus, logger, options?)` factory instantiates `FilesystemViewStorage` and `WorkingTreeStore` once, starts the `Weaver`, and (unless `options.skipRebuild`) rebuilds the materialized views and graph from the event log. Context modules receive `KnowledgeBase` instead of instantiating stores per call.
 
 ## Operations
 
@@ -257,7 +257,7 @@ See [Job Workers](./job-workers.md) for details.
 2. GraphDatabase
 3. EventStore (with EventBus integration)
 4. VectorStore + EmbeddingProvider *(optional — Qdrant or memory, from `@semiont/vectors`)*
-5. **KnowledgeBase** (groups stores including optional vectors; starts GraphDBConsumer; rebuilds views + graph unless `skipRebuild`)
+5. **KnowledgeBase** (groups stores including optional vectors; starts Weaver; rebuilds views + graph unless `skipRebuild`)
 6. **Stower** (must start before reader actors — it handles writes they depend on)
 7. Entity type bootstrap (emits via EventBus, Stower persists)
 8. **Gatherer** (context assembly, vector semantic search; gets its own InferenceClient)

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -78,7 +78,7 @@ describe('AnnotationContext', () => {
       content: new WorkingTreeStore(project, mockLogger),
       graph: mockGraphDb,
       projectionsDir: project.projectionsDir,
-      graphConsumer: {} as any,
+      weaver: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -95,7 +95,7 @@ describe('AnnotationOperations', () => {
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     const { WorkingTreeStore } = await import('@semiont/content');
     const repStore = new WorkingTreeStore(project, mockLogger);
-    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, graphConsumer: {} as any };
+    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any };
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/gatherer.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer.test.ts
@@ -49,7 +49,7 @@ function createMockKb(): KnowledgeBase {
     content: {} as any,
     graph: {} as any,
     projectionsDir: '',
-      graphConsumer: {} as any,
+      weaver: {} as any,
   };
 }
 

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -28,7 +28,7 @@ describe('GraphContext', () => {
     content: {} as any,
     graph: mockGraphDb as any,
     projectionsDir: '',
-      graphConsumer: {} as any,
+      weaver: {} as any,
   };
 
   it('should get backlinks for a resource', async () => {

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -95,7 +95,7 @@ describe('LLM Context', () => {
     // Create KnowledgeBase - share event store's view storage to avoid separate instances
     const { getGraphDatabase } = await import('@semiont/graph');
     const graphDb = await getGraphDatabase(graphConfig);
-    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, graphConsumer: {} as any };
+    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any };
 
     // Start Stower
     stower = new Stower(kb, eventBus, project, mockLogger);
@@ -201,7 +201,7 @@ describe('LLM Context', () => {
       await created$;
 
       // The unified context sources annotations from the graph projection; this test's kb wires no
-      // graph consumer, so add the annotation to the graph store directly.
+      // Weaver, so add the annotation to the graph store directly.
       await kb.graph.createAnnotation({
         id: annotationId('llm-graph-ann'),
         motivation: 'highlighting',

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -132,7 +132,7 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
     views: {} as any,
     content: {} as any,
     projectionsDir: '',
-      graphConsumer: {} as any,
+      weaver: {} as any,
     graph: {
       searchResources: overrides.searchResources ?? vi.fn().mockResolvedValue([]),
       getResourceReferencedBy: overrides.getResourceReferencedBy ?? vi.fn().mockResolvedValue([]),

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -48,7 +48,7 @@ describe('ResourceContext', () => {
       content: mockRepStore,
       graph: mockGraph,
       projectionsDir: '',
-      graphConsumer: {} as any,
+      weaver: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/service.test.ts
+++ b/packages/make-meaning/src/__tests__/service.test.ts
@@ -109,12 +109,12 @@ describe('Make-Meaning Service', () => {
       expect(typeof kb.graph.disconnect).toBe('function');
     });
 
-    it('should initialize graph consumer', async () => {
+    it('should initialize Weaver', async () => {
       service = await startMakeMeaning(project, config, eventBus, mockLogger);
       const { kb } = service.knowledgeSystem;
 
-      expect(kb.graphConsumer).toBeDefined();
-      expect(typeof kb.graphConsumer.stop).toBe('function');
+      expect(kb.weaver).toBeDefined();
+      expect(typeof kb.weaver.stop).toBe('function');
     });
 
     it('should return service handle with stop method', async () => {
@@ -142,11 +142,11 @@ describe('Make-Meaning Service', () => {
       service = null;
     });
 
-    it('should stop graph consumer on service stop', async () => {
+    it('should stop Weaver on service stop', async () => {
       service = await startMakeMeaning(project, config, eventBus, mockLogger);
       const { kb } = service.knowledgeSystem;
 
-      const consumerStopSpy = vi.spyOn(kb.graphConsumer, 'stop');
+      const consumerStopSpy = vi.spyOn(kb.weaver, 'stop');
 
       await service.stop();
 
@@ -179,7 +179,7 @@ describe('Make-Meaning Service', () => {
       expect(service).toBeDefined();
       expect(kb.eventStore).toBeDefined();
       expect(kb.graph).toBeDefined();
-      expect(kb.graphConsumer).toBeDefined();
+      expect(kb.weaver).toBeDefined();
     });
 
     it('should allow multiple service instances with different directories', async () => {

--- a/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
@@ -57,7 +57,7 @@ describe('Stower mark:update-entity-types vocabulary gate', () => {
     await fs.mkdir(systemDir, { recursive: true });
     await fs.writeFile(join(systemDir, 'entitytypes.json'), JSON.stringify({ entityTypes: ['Person', 'Organization'] }));
 
-    // A resource for the tags to live on (log-level, mirrors graph-consumer tests).
+    // A resource for the tags to live on (log-level, mirrors weaver tests).
     rid = resourceId(`tags-res-${Date.now()}`);
     await eventStore.appendEvent({
       type: 'yield:created',

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -1,5 +1,5 @@
 /**
- * GraphDBConsumer Tests
+ * Weaver Tests
  *
  * Tests event type filtering, per-resource serialization,
  * cross-resource parallelism, event application, burst batching, and lifecycle.
@@ -15,7 +15,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } from 'vitest';
 import { EventStore, FilesystemViewStorage } from '@semiont/event-sourcing';
 import { SemiontProject } from '@semiont/core/node';
-import { GraphDBConsumer } from '../graph/consumer';
+import { Weaver } from '../weaver';
 import { resourceId, userId, annotationId, EventBus } from '@semiont/core';
 import type { Logger } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
@@ -75,13 +75,13 @@ function createMockGraphDb(): GraphDatabase {
   } as unknown as GraphDatabase;
 }
 
-describe('GraphDBConsumer', () => {
+describe('Weaver', () => {
   let testDir: string;
   let project: SemiontProject;
   let eventStore: EventStore;
   let coreEventBus: EventBus;
   let graphDb: GraphDatabase;
-  let consumer: GraphDBConsumer;
+  let consumer: Weaver;
 
   beforeAll(async () => {
     testDir = join(tmpdir(), `semiont-consumer-test-${uuidv4()}`);
@@ -106,7 +106,7 @@ describe('GraphDBConsumer', () => {
 
   beforeEach(async () => {
     graphDb = createMockGraphDb();
-    consumer = new GraphDBConsumer(eventStore, graphDb, coreEventBus, mockLogger);
+    consumer = new Weaver(eventStore, graphDb, coreEventBus, mockLogger);
     await consumer.initialize();
     vi.clearAllMocks();
   });
@@ -468,7 +468,7 @@ describe('GraphDBConsumer', () => {
 
     // The -added fold must be idempotent per event, mirroring the view
     // materializer's includes-guard — duplicate adds must not diverge the
-    // graph from the view (bugs/graph-consumer-entity-tag-add-not-idempotent.md).
+    // graph from the view (bugs/weaver-entity-tag-add-not-idempotent.md).
     it('entitytag.added for a tag the graph doc already has leaves a single copy', async () => {
       const docId = resourceId(`apply-entitytag-dup-${Date.now()}`);
 
@@ -707,7 +707,7 @@ describe('GraphDBConsumer', () => {
   describe('lifecycle', () => {
     it('should unsubscribe on stop', async () => {
       const localGraphDb = createMockGraphDb();
-      const localConsumer = new GraphDBConsumer(eventStore, localGraphDb, coreEventBus, mockLogger);
+      const localConsumer = new Weaver(eventStore, localGraphDb, coreEventBus, mockLogger);
       await localConsumer.initialize();
 
       const docId = resourceId(`lifecycle-stop-${Date.now()}`);

--- a/packages/make-meaning/src/batch-utils.ts
+++ b/packages/make-meaning/src/batch-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Shared batch utilities for event-processing actors (GraphDBConsumer, Smelter).
+ * Shared batch utilities for event-processing actors (Weaver, Smelter).
  *
  * Both actors use the same pattern: burst-buffered events arrive as a batch,
  * get partitioned into consecutive same-type runs, and each run is processed

--- a/packages/make-meaning/src/gatherer.ts
+++ b/packages/make-meaning/src/gatherer.ts
@@ -19,7 +19,7 @@
  *
  * `groupBy(resourceId) + concatMap(...)` is the stream-consumer flavor of
  * per-resource serialization — the same invariant enforced by `Smelter`,
- * `GraphDBConsumer`, and (in a different shape) `ViewManager`. See
+ * `Weaver`, and (in a different shape) `ViewManager`. See
  * `packages/core/src/serialize-per-key.ts` for the shared primitive used
  * by RPC-style services.
  */

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -8,7 +8,7 @@
  * - Materialized Views (fast single-doc queries) — via ViewStorage
  * - Content Store (working-tree files, URI-addressed) — via WorkingTreeStore
  * - Graph (eventually consistent relationship projection) — via GraphDatabase
- * - Graph Consumer (event-to-graph projection) — via GraphDBConsumer
+ * - Weaver (event-to-graph projection)
  * - Vectors (semantic search) — via VectorStore (optional, read-only)
  *
  * The Smelter (event-to-vector projection) runs as an external actor
@@ -23,14 +23,14 @@ import type { GraphDatabase } from '@semiont/graph';
 import type { VectorStore } from '@semiont/vectors';
 import type { SemiontProject } from '@semiont/core/node';
 import type { EventBus, Logger } from '@semiont/core';
-import { GraphDBConsumer } from './graph/consumer.js';
+import { Weaver } from './weaver.js';
 
 export interface KnowledgeBase {
   eventStore:    EventStore;
   views:         ViewStorage;
   content:       WorkingTreeStore;
   graph:         GraphDatabase;
-  graphConsumer: GraphDBConsumer;
+  weaver: Weaver;
   vectors?:      VectorStore;
   projectionsDir: string;
 }
@@ -53,26 +53,26 @@ export async function createKnowledgeBase(
     project,
     logger.child({ component: 'working-tree-store' }),
   );
-  const graphConsumer = new GraphDBConsumer(
+  const weaver = new Weaver(
     eventStore,
     graphDb,
     eventBus,
-    logger.child({ component: 'graph-consumer' }),
+    logger.child({ component: 'weaver' }),
   );
-  await graphConsumer.initialize();
+  await weaver.initialize();
 
   if (!options?.skipRebuild) {
     // Rebuild materialized views from the event log first. The Browser actor
     // reads from these views, so they must be populated before any request is
     // served. The views layer is the third derived read model alongside the
-    // graph and vectors; this call mirrors graphConsumer.rebuildAll() so
+    // graph and vectors; this call mirrors weaver.rebuildAll() so
     // that an ephemeral stateDir wipe is recoverable.
     await eventStore.views.rebuildAll(eventStore.log);
-    await graphConsumer.rebuildAll();
+    await weaver.rebuildAll();
   }
 
   const kb: KnowledgeBase = {
-    eventStore, views, content, graph: graphDb, graphConsumer,
+    eventStore, views, content, graph: graphDb, weaver,
     projectionsDir: project.projectionsDir,
   };
 

--- a/packages/make-meaning/src/knowledge-system.ts
+++ b/packages/make-meaning/src/knowledge-system.ts
@@ -12,7 +12,7 @@
  * - cloneTokenManager: token actor — manages resource clone tokens
  *
  * These are the five access actors. Two projection-pipeline actors complete
- * the seven: the Graph Consumer (kb.graphConsumer, started by
+ * the seven: the Weaver (kb.weaver, started by
  * createKnowledgeBase) and the Smelter (standalone process via smelter-main).
  *
  * EventBus, JobQueue, and workers are peers to KnowledgeSystem, not members.
@@ -41,6 +41,6 @@ export async function stopKnowledgeSystem(ks: KnowledgeSystem): Promise<void> {
   await ks.browser.stop();
   await ks.cloneTokenManager.stop();
   await ks.stower.stop();
-  await ks.kb.graphConsumer.stop();
+  await ks.kb.weaver.stop();
   await ks.kb.graph.disconnect();
 }

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -13,7 +13,7 @@
  * Smelter processes events strictly in order per resourceId via
  * `groupBy(resourceId) + concatMap(...)`. This is the stream-consumer
  * flavor of per-resource serialization — the same invariant enforced by
- * `GraphDBConsumer`, `Gatherer`, and (in a different shape) `ViewManager`.
+ * `Weaver`, `Gatherer`, and (in a different shape) `ViewManager`.
  * See `packages/core/src/serialize-per-key.ts` for the shared primitive
  * used by RPC-style services.
  *

--- a/packages/make-meaning/src/stower.ts
+++ b/packages/make-meaning/src/stower.ts
@@ -152,9 +152,9 @@ export class Stower {
       // Auto-bind: when a resource is generated from a reference annotation,
       // resolve the source reference by adding the new resource as a linking
       // body. Emit `mark:update-body`; our own handler appends the
-      // `mark:body-updated` event, and the graph consumer then updates the
+      // `mark:body-updated` event, and the Weaver then updates the
       // annotation body in the graph. Ordering is safe because we've already
-      // appended `yield:created` — by the time the graph consumer processes
+      // appended `yield:created` — by the time the Weaver processes
       // `mark:body-updated`, the target resource exists in the graph.
       if (generatedFrom) {
         this.eventBus.get('mark:update-body').next({

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -1,5 +1,5 @@
 /**
- * GraphDB Consumer
+ * Weaver
  *
  * Subscribes to resource events and updates GraphDB accordingly.
  * Makes GraphDB a projection of Event Store events (single source of truth).
@@ -12,7 +12,7 @@
  * Per-resource ordering is preserved via groupBy(resourceId) + concatMap.
  * Cross-resource parallelism is provided via mergeMap over groups.
  *
- * Burst buffer thresholds (see BATCH-GRAPH-CONSUMER-RX.md for tuning guidance):
+ * Burst buffer thresholds:
  *   BURST_WINDOW_MS  = 50   — debounce window before flushing a batch
  *   MAX_BATCH_SIZE   = 500  — force flush to bound memory
  *   IDLE_TIMEOUT_MS  = 200  — silence before returning to passthrough
@@ -33,12 +33,12 @@ import { didToAgent, burstBuffer, EventBus, errField } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
 import type { PersistedEvent, StoredEvent, EventOfType, ResourceId, Logger} from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId, findBodyItem } from '@semiont/core';
-import { partitionByType } from '../batch-utils.js';
+import { partitionByType } from './batch-utils.js';
 
 import type { Annotation } from '@semiont/core';
 import type { ResourceDescriptor } from '@semiont/core';
 
-export class GraphDBConsumer {
+export class Weaver {
   // Event types that produce GraphDB mutations — filter everything else
   private static readonly GRAPH_RELEVANT_EVENTS: Set<PersistedEvent['type']> = new Set([
     'yield:created', 'mark:archived', 'mark:unarchived',
@@ -46,7 +46,7 @@ export class GraphDBConsumer {
     'mark:entity-tag-added', 'mark:entity-tag-removed', 'frame:entity-type-added',
   ]);
 
-  // Burst buffer thresholds — see class doc and BATCH-GRAPH-CONSUMER-RX.md
+  // Burst buffer thresholds — see class doc
   private static readonly BURST_WINDOW_MS = 50;
   private static readonly MAX_BATCH_SIZE = 500;
   private static readonly IDLE_TIMEOUT_MS = 200;
@@ -67,7 +67,7 @@ export class GraphDBConsumer {
   }
 
   async initialize() {
-    this.logger.info('GraphDB consumer initialized');
+    this.logger.info('Weaver initialized');
     await this.subscribeToGlobalEvents();
   }
 
@@ -77,7 +77,7 @@ export class GraphDBConsumer {
    */
   private async subscribeToGlobalEvents() {
     // Subscribe to each graph-relevant event type on the Core EventBus
-    for (const eventType of GraphDBConsumer.GRAPH_RELEVANT_EVENTS) {
+    for (const eventType of Weaver.GRAPH_RELEVANT_EVENTS) {
       this._globalSubscriptions.push(
         this.coreEventBus.getDomainEvent(eventType).subscribe(
           (storedEvent: StoredEvent) => this.eventSubject.next(storedEvent)
@@ -101,9 +101,9 @@ export class GraphDBConsumer {
         // Resource events: apply burst buffering per resource group
         return group.pipe(
           burstBuffer<StoredEvent>({
-            burstWindowMs: GraphDBConsumer.BURST_WINDOW_MS,
-            maxBatchSize: GraphDBConsumer.MAX_BATCH_SIZE,
-            idleTimeoutMs: GraphDBConsumer.IDLE_TIMEOUT_MS,
+            burstWindowMs: Weaver.BURST_WINDOW_MS,
+            maxBatchSize: Weaver.MAX_BATCH_SIZE,
+            idleTimeoutMs: Weaver.IDLE_TIMEOUT_MS,
           }),
           concatMap((eventOrBatch: StoredEvent | StoredEvent[]) => {
             if (Array.isArray(eventOrBatch)) {
@@ -120,7 +120,7 @@ export class GraphDBConsumer {
       })
     ).subscribe({
       error: (err) => {
-        this.logger.error('GraphDB consumer pipeline error', { error: err });
+        this.logger.error('Weaver pipeline error', { error: err });
       }
     });
 
@@ -152,7 +152,7 @@ export class GraphDBConsumer {
    * Stop the consumer, flush remaining buffered events, and unsubscribe.
    */
   async stop() {
-    this.logger.info('Stopping GraphDB consumer');
+    this.logger.info('Stopping Weaver');
 
     // Unsubscribe from event source (stops feeding the Subject)
     for (const sub of this._globalSubscriptions) sub.unsubscribe();
@@ -170,7 +170,7 @@ export class GraphDBConsumer {
     // Create a fresh Subject for potential re-initialization
     this.eventSubject = new Subject<StoredEvent>();
 
-    this.logger.info('GraphDB consumer stopped');
+    this.logger.info('Weaver stopped');
   }
 
   /**
@@ -505,6 +505,6 @@ export class GraphDBConsumer {
    */
   async shutdown(): Promise<void> {
     await this.stop();
-    this.logger.info('GraphDB consumer shut down');
+    this.logger.info('Weaver shut down');
   }
 }

--- a/packages/sdk/src/namespaces/mark.ts
+++ b/packages/sdk/src/namespaces/mark.ts
@@ -73,7 +73,7 @@ export class MarkNamespace implements IMarkNamespace {
   /**
    * Replace a resource's own entity-type classification. The backend diffs
    * `current` vs `updated` and folds the changes into `resource.entityTypes`
-   * (mark:entity-tag-added/-removed → graph consumer), so the change surfaces in
+   * (mark:entity-tag-added/-removed → Weaver), so the change surfaces in
    * `browse.resources({ entityType })` and `getResourceEntityTypes`. A
    * **replace/diff** operation: pass the resource's current types as `current`,
    * the desired full set as `updated`.


### PR DESCRIPTION
# Pull Request

## Description

Renames the graph projection actor: **`GraphDBConsumer` → `Weaver`**. The actor joins the
naming family it always belonged to (Smelter, Stower, Gatherer, Matcher) and gets a name
that says what it does — it follows the event log and weaves the graph projection. Purely
mechanical; no behavior change. This is also groundwork: giving the actor a stable name
ahead of planned work to run it in its own container alongside the Smelter.

**What renames — and what does not.** Only the actor. The store side is untouched:
`GraphDatabase`, `@semiont/graph`, `kb.graph`, and "GraphDB" as a store name all stay.

Changes, all in one sweep (no aliases, no re-exports, no deprecation shims):

- **File moves:** `packages/make-meaning/src/graph/consumer.ts` → `src/weaver.ts` — the
  actor now sits beside its siblings at top level, and the otherwise-empty `src/graph/`
  directory is gone (one self-import adjusted for the level change).
  `__tests__/graph-consumer.test.ts` → `__tests__/weaver.test.ts`.
- **Symbol sweep:** class `Weaver`; `KnowledgeBase.graphConsumer` → `KnowledgeBase.weaver`
  (interface field on the internal `@semiont/make-meaning` surface — the class itself
  remains unexported from the package index; no wire-protocol or SDK behavior change);
  all call sites including `apps/backend/src/cli/rebuild-graph.ts`, test fixtures, and
  backend's make-meaning mock.
- **Prose sweep:** every "graph consumer" / "GraphDB Consumer" mention across `docs/`,
  package docs, and doc comments (core, event-sourcing, make-meaning, sdk, cli); log
  strings and the logger component (`graph-consumer` → `weaver`); mermaid node IDs
  `GC` → `WEAVER` in six diagrams.
- **Cruft removed in passing:** three stale doc pointers to `BATCH-GRAPH-CONSUMER-RX.md`,
  a file that exists nowhere in the repo (two in the renamed class, one in
  `core/src/operators/burst-buffer.ts`).

## Type of Change

- [x] Code refactoring
- [x] Documentation update

## Areas Changed

- [x] Backend (`apps/backend`)
- [x] CLI (`apps/cli`)
- [x] Core (`packages/core`)
- [x] Documentation (`docs/`)

Also touched (not in the list above): `packages/make-meaning` (the rename's home),
`packages/event-sourcing` (doc comments), `packages/graph` (docs), `packages/sdk`
(one doc comment).

## Security Checklist

Not applicable — rename only; no authentication, authorization, or admin functionality
touched.

## Verification

- Grep gates all return zero outside untracked planning notes: `GraphDBConsumer` /
  `graphConsumer` (symbols), case-insensitive "graph consumer" / "graphdb consumer"
  (prose), `graph/consumer` / `graph-consumer` / `BATCH-GRAPH-CONSUMER` (paths).
- `npm run build:packages` + full workspace `tsc --noEmit`: green (node:24).
- Renamed test file: 19/19 passing.
