### PR TITLE
graph projection sync: fix the gather race and build the applied-offset barrier

### DIFF
--- a/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
+++ b/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
@@ -26,6 +26,7 @@ export function stubKnowledgeBase(overrides: Partial<KnowledgeBase> = {}): Knowl
     content:        { store: vi.fn(), retrieve: vi.fn() } as unknown as KnowledgeBase['content'],
     graph:          {} as KnowledgeBase['graph'],
     weaver:  { stop: vi.fn().mockResolvedValue(undefined) } as unknown as KnowledgeBase['weaver'],
+    weaveProgress: { dispose: vi.fn() } as unknown as KnowledgeBase['weaveProgress'],
     projectionsDir: '',
     ...overrides,
   };

--- a/apps/backend/src/__tests__/integration/annotation-crud.test.ts
+++ b/apps/backend/src/__tests__/integration/annotation-crud.test.ts
@@ -35,7 +35,7 @@ describe('Annotation CRUD Integration Tests - W3C multi-body annotation', () => 
 
     // Create KnowledgeBase for AnnotationContext calls
     const viewStorage = new FilesystemViewStorage(project);
-    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaver: {} as any };
+    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaver: {} as any, weaveProgress: {} as any };
 
     // Create test resources in event store
     const eventStore = createEventStore(project, new EventBus(), mockLogger);

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -330,6 +330,20 @@ export type EventMap = {
   'job:cancel-failed': components['schemas']['CommandError'];
 
   // ========================================================================
+  // WEAVE FLOW — graph projection progress (GRAPH-PROJECTION-SYNC, D2 = push)
+  // ========================================================================
+
+  /**
+   * Emitted by the Weaver after applying an event (or a batch's last event)
+   * for a resource to the graph. `sequenceNumber` is the resource-stream
+   * sequence of the last applied event. Folded by `WeaveProgress`
+   * (make-meaning) into the backend-local applied map that the
+   * `whenApplied` barrier awaits. In-process signal today; crosses the
+   * bus gateway after WEAVER-ISOLATION.
+   */
+  'weave:applied': { resourceId: string; sequenceNumber: number };
+
+  // ========================================================================
   // SETTINGS (frontend-only)
   // ========================================================================
 
@@ -610,6 +624,9 @@ export const CHANNEL_SCHEMAS = {
   'settings:line-numbers-toggled':    null, // void
   'settings:locale-changed':          'SettingsLocaleChangedEvent',
   'settings:hover-delay-changed':     'SettingsHoverDelayChangedEvent',
+
+  // ── WEAVE FLOW ──────────────────────────────────────────────────
+  'weave:applied':                    null, // { resourceId; sequenceNumber }
 
   // ── SSE infrastructure ──────────────────────────────────────────
   'stream-connected':                 null, // Record<string, never>

--- a/packages/event-sourcing/src/__tests__/view-manager.integration.test.ts
+++ b/packages/event-sourcing/src/__tests__/view-manager.integration.test.ts
@@ -149,7 +149,7 @@ describe('ViewManager — integration (real FilesystemViewStorage)', () => {
 
     // Seed the view with a yield:created so the incremental path is taken
     const created = createdEvent(rid);
-    await manager.materializeResource(rid, created, async () => [stored(created, 1)]);
+    await manager.materializeResource(rid, stored(created, 1), async () => [stored(created, 1)]);
 
     // Fire 10 concurrent mark:added events
     const marks = Array.from({ length: 10 }, (_, i) => markAddedEvent(rid, i));
@@ -157,11 +157,12 @@ describe('ViewManager — integration (real FilesystemViewStorage)', () => {
 
     await Promise.all(
       marks.map((m, i) => {
-        history.push(stored(m, i + 2));
+        const s = stored(m, i + 2);
+        history.push(s);
         // getAllEvents returns the full history at call time — the incremental
         // path won't typically use it, but it's what materializeIncremental
         // needs if it decides to rebuild.
-        return manager.materializeResource(rid, m, async () => [...history]);
+        return manager.materializeResource(rid, s, async () => [...history]);
       }),
     );
 
@@ -186,7 +187,7 @@ describe('ViewManager — integration (real FilesystemViewStorage)', () => {
     const rid = resourceId('doc-burst');
 
     const created = createdEvent(rid);
-    await manager.materializeResource(rid, created, async () => [stored(created, 1)]);
+    await manager.materializeResource(rid, stored(created, 1), async () => [stored(created, 1)]);
 
     const mark = markAddedEvent(rid, 0);
     const progress = jobProgressEvent(rid, 100);
@@ -201,9 +202,9 @@ describe('ViewManager — integration (real FilesystemViewStorage)', () => {
 
     // Fire all three at once — this is the race window
     await Promise.all([
-      manager.materializeResource(rid, mark, async () => history),
-      manager.materializeResource(rid, progress, async () => history),
-      manager.materializeResource(rid, complete, async () => history),
+      manager.materializeResource(rid, stored(mark, 2), async () => history),
+      manager.materializeResource(rid, stored(progress, 3), async () => history),
+      manager.materializeResource(rid, stored(complete, 4), async () => history),
     ]);
 
     const view = await viewStorage.get(rid);
@@ -219,8 +220,8 @@ describe('ViewManager — integration (real FilesystemViewStorage)', () => {
     const created1 = createdEvent(rid1);
     const created2 = createdEvent(rid2);
     await Promise.all([
-      manager.materializeResource(rid1, created1, async () => [stored(created1, 1)]),
-      manager.materializeResource(rid2, created2, async () => [stored(created2, 1)]),
+      manager.materializeResource(rid1, stored(created1, 1), async () => [stored(created1, 1)]),
+      manager.materializeResource(rid2, stored(created2, 1), async () => [stored(created2, 1)]),
     ]);
 
     // Fire 5 concurrent mark:added events on each resource, interleaved
@@ -232,12 +233,14 @@ describe('ViewManager — integration (real FilesystemViewStorage)', () => {
 
     const all: Promise<void>[] = [];
     marks1.forEach((m, i) => {
-      hist1.push(stored(m, i + 2));
-      all.push(manager.materializeResource(rid1, m, async () => [...hist1]));
+      const s = stored(m, i + 2);
+      hist1.push(s);
+      all.push(manager.materializeResource(rid1, s, async () => [...hist1]));
     });
     marks2.forEach((m, i) => {
-      hist2.push(stored(m, i + 2));
-      all.push(manager.materializeResource(rid2, m, async () => [...hist2]));
+      const s = stored(m, i + 2);
+      hist2.push(s);
+      all.push(manager.materializeResource(rid2, s, async () => [...hist2]));
     });
 
     await Promise.all(all);
@@ -256,15 +259,16 @@ describe('ViewManager — integration (real FilesystemViewStorage)', () => {
     const rid = resourceId('doc-valid-json');
 
     const created = createdEvent(rid);
-    await manager.materializeResource(rid, created, async () => [stored(created, 1)]);
+    await manager.materializeResource(rid, stored(created, 1), async () => [stored(created, 1)]);
 
     const events = Array.from({ length: 20 }, (_, i) => markAddedEvent(rid, i));
     const history: StoredEvent[] = [stored(created, 1)];
 
     await Promise.all(
       events.map((e, i) => {
-        history.push(stored(e, i + 2));
-        return manager.materializeResource(rid, e, async () => [...history]);
+        const s = stored(e, i + 2);
+        history.push(s);
+        return manager.materializeResource(rid, s, async () => [...history]);
       }),
     );
 

--- a/packages/event-sourcing/src/__tests__/view-manager.test.ts
+++ b/packages/event-sourcing/src/__tests__/view-manager.test.ts
@@ -76,7 +76,7 @@ describe('ViewManager', () => {
         metadata: createEventMetadata(1),
       }]);
 
-      await manager.materializeResource(rid, event, getAllEvents);
+      await manager.materializeResource(rid, { ...event, metadata: createEventMetadata(1) }, getAllEvents);
 
       // Should call save on view storage
       expect(mockViewStorage.save).toHaveBeenCalled();
@@ -123,7 +123,7 @@ describe('ViewManager', () => {
         },
       ] as any);
 
-      await manager.materializeResource(rid, event, getAllEvents);
+      await manager.materializeResource(rid, { ...event, metadata: createEventMetadata(2) }, getAllEvents);
 
       expect(getAllEvents).toHaveBeenCalled();
       expect(mockViewStorage.save).toHaveBeenCalled();
@@ -246,9 +246,10 @@ describe('ViewManager', () => {
       // Spy on materializer method
       const materializeIncrementalSpy = vi.spyOn(manager.materializer, 'materializeIncremental');
 
-      await manager.materializeResource(rid, event, getAllEvents);
+      const storedEvent = { ...event, metadata: createEventMetadata(1) };
+      await manager.materializeResource(rid, storedEvent, getAllEvents);
 
-      expect(materializeIncrementalSpy).toHaveBeenCalledWith(rid, event, getAllEvents);
+      expect(materializeIncrementalSpy).toHaveBeenCalledWith(rid, storedEvent, getAllEvents);
     });
 
     it('should delegate to materializer for entity types', async () => {
@@ -280,6 +281,7 @@ describe('ViewManager', () => {
         format: 'text/plain' as const,
         contentChecksum: 'cs',
       },
+      metadata: createEventMetadata(1),
     });
 
     it('serializes concurrent calls for the same resource', async () => {

--- a/packages/event-sourcing/src/__tests__/views/view-materializer.test.ts
+++ b/packages/event-sourcing/src/__tests__/views/view-materializer.test.ts
@@ -626,7 +626,7 @@ describe('ViewMaterializer', () => {
         },
       };
 
-      await materializer.materializeIncremental(rid, createEvent, async () => [
+      await materializer.materializeIncremental(rid, { ...createEvent, metadata: createEventMetadata(1) }, async () => [
         { ...createEvent, metadata: createEventMetadata(1) },
       ] as any);
 
@@ -650,7 +650,7 @@ describe('ViewMaterializer', () => {
         },
       };
 
-      await materializer.materializeIncremental(rid, addRepEvent, async () => [
+      await materializer.materializeIncremental(rid, { ...addRepEvent, metadata: createEventMetadata(2) }, async () => [
         { ...createEvent, metadata: createEventMetadata(1) },
         { ...addRepEvent, metadata: createEventMetadata(2) },
       ] as any);
@@ -682,7 +682,7 @@ describe('ViewMaterializer', () => {
         },
       };
 
-      await materializer.materializeIncremental(rid, event, async () => [
+      await materializer.materializeIncremental(rid, { ...event, metadata: createEventMetadata(1) }, async () => [
         { ...event, metadata: createEventMetadata(1) },
       ] as any);
 

--- a/packages/event-sourcing/src/storage/view-storage.ts
+++ b/packages/event-sourcing/src/storage/view-storage.ts
@@ -17,6 +17,13 @@ import type { ResourceAnnotations, ResourceDescriptor, ResourceId, Logger } from
 export interface ResourceView {
   resource: ResourceDescriptor;
   annotations: ResourceAnnotations;
+  /**
+   * Sequence number of the last event applied to this view — the parity
+   * target the graph-projection barrier waits on (GRAPH-PROJECTION-SYNC).
+   * Absent only in view files written before the stamp existed; the
+   * startup rebuild restamps them.
+   */
+  lastSequence?: number;
 }
 
 export interface ViewStorage {

--- a/packages/event-sourcing/src/view-manager.ts
+++ b/packages/event-sourcing/src/view-manager.ts
@@ -11,7 +11,7 @@
  * - Pub/sub notifications (see EventBus)
  */
 
-import { type ResourceId, type PersistedEvent, type StoredEvent, type Logger, serializePerKey } from '@semiont/core';
+import { type ResourceId, type StoredEvent, type Logger, serializePerKey } from '@semiont/core';
 import { ViewMaterializer, type ViewMaterializerConfig, type RebuildEventSource } from './views/view-materializer';
 import type { ViewStorage, ResourceView } from './storage/view-storage';
 
@@ -80,12 +80,12 @@ export class ViewManager {
    * Serialized per resource — see class doc.
    *
    * @param resourceId - Branded ResourceId (from @semiont/core)
-   * @param event - Resource event (from @semiont/core)
+   * @param event - Stored resource event (with storage metadata, from @semiont/core)
    * @param getAllEvents - Function to retrieve all events for rebuild if needed
    */
   async materializeResource(
     resourceId: ResourceId,
-    event: PersistedEvent,
+    event: StoredEvent,
     getAllEvents: () => Promise<StoredEvent[]>
   ): Promise<void> {
     await serializePerKey(String(resourceId), this.resourceChains, () =>

--- a/packages/event-sourcing/src/views/view-materializer.ts
+++ b/packages/event-sourcing/src/views/view-materializer.ts
@@ -84,7 +84,7 @@ export class ViewMaterializer {
    */
   async materializeIncremental(
     resourceId: ResourceId,
-    event: PersistedEvent,
+    event: StoredEvent,
     getAllEvents: () => Promise<StoredEvent[]>
   ): Promise<void> {
     this.logger?.info('[ViewMaterializer] Updating view for resource with event', { resourceId, eventType: event.type });
@@ -104,6 +104,9 @@ export class ViewMaterializer {
       this.applyEventToAnnotations(view.annotations, event);
       view.annotations.version++;
       view.annotations.updatedAt = event.timestamp;
+      // Parity stamp for the graph-projection barrier (GRAPH-PROJECTION-SYNC).
+      // Monotonic: an out-of-order apply never regresses the stamp.
+      view.lastSequence = Math.max(view.lastSequence ?? 0, event.metadata.sequenceNumber);
     }
 
     // Save updated view
@@ -165,7 +168,12 @@ export class ViewMaterializer {
       annotations.updatedAt = storedEvent.timestamp;
     }
 
-    return { resource, annotations };
+    const view: ResourceView = { resource, annotations };
+    if (events.length > 0) {
+      // Parity stamp for the graph-projection barrier (GRAPH-PROJECTION-SYNC).
+      view.lastSequence = events[events.length - 1].metadata.sequenceNumber;
+    }
+    return view;
   }
 
   /**

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -78,7 +78,7 @@ describe('AnnotationContext', () => {
       content: new WorkingTreeStore(project, mockLogger),
       graph: mockGraphDb,
       projectionsDir: project.projectionsDir,
-      weaver: {} as any,
+      weaver: {} as any, weaveProgress: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -95,7 +95,7 @@ describe('AnnotationOperations', () => {
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     const { WorkingTreeStore } = await import('@semiont/content');
     const repStore = new WorkingTreeStore(project, mockLogger);
-    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any };
+    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaveProgress: {} as any };
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/gatherer.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer.test.ts
@@ -49,7 +49,7 @@ function createMockKb(): KnowledgeBase {
     content: {} as any,
     graph: {} as any,
     projectionsDir: '',
-      weaver: {} as any,
+      weaver: {} as any, weaveProgress: {} as any,
   };
 }
 

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -21,6 +21,8 @@ const mockGraphDb = {
 
 const mockViews = { get: vi.fn() };
 
+const mockWeaveProgress = { whenApplied: vi.fn(), appliedUpTo: vi.fn(), dispose: vi.fn() };
+
 describe('GraphContext', () => {
   const mockKb: KnowledgeBase = {
     eventStore: {} as any,
@@ -29,6 +31,7 @@ describe('GraphContext', () => {
     graph: mockGraphDb as any,
     projectionsDir: '',
     weaver: {} as any,
+    weaveProgress: mockWeaveProgress as any,
   };
 
   it('should get backlinks for a resource', async () => {
@@ -314,6 +317,62 @@ describe('GraphContext', () => {
       // Bounded: more than one attempt, but not unbounded polling.
       expect(mockGraphDb.getResource.mock.calls.length).toBeGreaterThan(1);
       expect(mockGraphDb.getResource.mock.calls.length).toBeLessThanOrEqual(6);
+    });
+  });
+
+  describe('applied-offset barrier (GRAPH-PROJECTION-SYNC P2, D2 = push)', () => {
+    const mainDoc = { '@id': 'res-main', name: 'Main', entityTypes: [] };
+
+    it('awaits weave:applied parity and re-reads once — zero backoff polls', async () => {
+      // The view carries its applied sequence; the barrier waits for the
+      // Weaver to report parity, then a single re-read hits. No sleep-poll
+      // iterations — the wake is event-driven.
+      mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc, lastSequence: 7 });
+      mockWeaveProgress.whenApplied.mockReset().mockResolvedValue(undefined);
+      mockGraphDb.getResource
+        .mockReset()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(mainDoc);
+      mockGraphDb.getResourceConnections.mockResolvedValue([]);
+      mockGraphDb.getResourceReferencedBy.mockResolvedValue([]);
+      mockGraphDb.getResourceAnnotations.mockResolvedValue([]);
+
+      const graph = await GraphContext.buildKnowledgeGraph(resourceId('res-main'), mockKb);
+
+      expect(graph.nodes.find((n) => n.id === 'res-main')).toMatchObject({ type: 'resource' });
+      expect(mockWeaveProgress.whenApplied).toHaveBeenCalledTimes(1);
+      expect(mockWeaveProgress.whenApplied).toHaveBeenCalledWith('res-main', 7, expect.any(Number));
+      expect(mockGraphDb.getResource).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the bounded poll when the barrier times out', async () => {
+      mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc, lastSequence: 7 });
+      mockWeaveProgress.whenApplied.mockReset().mockRejectedValue(new Error('WeaveProgressTimeout'));
+      mockGraphDb.getResource
+        .mockReset()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(mainDoc);
+
+      const graph = await GraphContext.buildKnowledgeGraph(resourceId('res-main'), mockKb);
+
+      expect(graph.nodes.find((n) => n.id === 'res-main')).toMatchObject({ type: 'resource' });
+      expect(mockGraphDb.getResource.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('skips the barrier for views without a sequence stamp — straight to the poll floor', async () => {
+      // Pre-stamp view files (written before lastSequence existed) carry no
+      // parity target; the barrier cannot engage and must not block.
+      mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc });
+      mockWeaveProgress.whenApplied.mockReset().mockResolvedValue(undefined);
+      mockGraphDb.getResource
+        .mockReset()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(mainDoc);
+
+      await GraphContext.buildKnowledgeGraph(resourceId('res-main'), mockKb);
+
+      expect(mockWeaveProgress.whenApplied).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -28,7 +28,7 @@ describe('GraphContext', () => {
     content: {} as any,
     graph: mockGraphDb as any,
     projectionsDir: '',
-      weaver: {} as any,
+    weaver: {} as any,
   };
 
   it('should get backlinks for a resource', async () => {
@@ -269,6 +269,51 @@ describe('GraphContext', () => {
 
       expect(graph.nodes.find((n) => n.id === 'ann-sib')).toMatchObject({ type: 'annotation' });
       expect(graph.edges).toContainEqual({ source: 'ann-sib', target: 'res-main', type: 'annotation-of' });
+    });
+  });
+
+  describe('projection-lag grace (GRAPH-PROJECTION-SYNC P1)', () => {
+    const mainDoc = { '@id': 'res-main', name: 'Main', entityTypes: [] };
+
+    it('retries the graph read while the view has the resource, and succeeds once the Weaver catches up', async () => {
+      // The view materializer applies on the append path; the Weaver lags.
+      // "In the view, not yet in the graph" is projection lag, not a 404.
+      mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc });
+      mockGraphDb.getResource
+        .mockReset()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(mainDoc);
+      mockGraphDb.getResourceConnections.mockResolvedValue([]);
+      mockGraphDb.getResourceReferencedBy.mockResolvedValue([]);
+      mockGraphDb.getResourceAnnotations.mockResolvedValue([]);
+
+      const graph = await GraphContext.buildKnowledgeGraph(resourceId('res-main'), mockKb);
+
+      expect(graph.nodes.find((n) => n.id === 'res-main')).toMatchObject({ type: 'resource', label: 'Main' });
+      expect(mockGraphDb.getResource.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('does not retry when the view lacks the resource — a true unknown throws on the first read', async () => {
+      mockViews.get.mockReset().mockResolvedValue(null);
+      mockGraphDb.getResource.mockReset().mockResolvedValue(null);
+
+      await expect(
+        GraphContext.buildKnowledgeGraph(resourceId('res-ghost'), mockKb),
+      ).rejects.toThrow('Resource not found');
+      expect(mockGraphDb.getResource).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after the bounded backoff when the graph never catches up', async () => {
+      mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc });
+      mockGraphDb.getResource.mockReset().mockResolvedValue(null);
+
+      await expect(
+        GraphContext.buildKnowledgeGraph(resourceId('res-main'), mockKb),
+      ).rejects.toThrow('Resource not found');
+      // Bounded: more than one attempt, but not unbounded polling.
+      expect(mockGraphDb.getResource.mock.calls.length).toBeGreaterThan(1);
+      expect(mockGraphDb.getResource.mock.calls.length).toBeLessThanOrEqual(6);
     });
   });
 });

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -95,7 +95,7 @@ describe('LLM Context', () => {
     // Create KnowledgeBase - share event store's view storage to avoid separate instances
     const { getGraphDatabase } = await import('@semiont/graph');
     const graphDb = await getGraphDatabase(graphConfig);
-    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any };
+    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaveProgress: {} as any };
 
     // Start Stower
     stower = new Stower(kb, eventBus, project, mockLogger);

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -132,7 +132,7 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
     views: {} as any,
     content: {} as any,
     projectionsDir: '',
-      weaver: {} as any,
+      weaver: {} as any, weaveProgress: {} as any,
     graph: {
       searchResources: overrides.searchResources ?? vi.fn().mockResolvedValue([]),
       getResourceReferencedBy: overrides.getResourceReferencedBy ?? vi.fn().mockResolvedValue([]),

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -48,7 +48,7 @@ describe('ResourceContext', () => {
       content: mockRepStore,
       graph: mockGraph,
       projectionsDir: '',
-      weaver: {} as any,
+      weaver: {} as any, weaveProgress: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/weave-progress.test.ts
+++ b/packages/make-meaning/src/__tests__/weave-progress.test.ts
@@ -1,0 +1,87 @@
+/**
+ * WeaveProgress Tests (GRAPH-PROJECTION-SYNC P2, D2 = push)
+ *
+ * The backend-local fold of `weave:applied` signals. `whenApplied` is the
+ * applied-offset barrier: it resolves as soon as the Weaver's applied
+ * sequence for a resource reaches the requested one, event-driven — no
+ * polling quantum — and rejects with a distinct error on the bounded
+ * timeout so callers can fall back to the Phase 1 retry floor.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@semiont/core';
+import { assertStateUnitAxioms } from '@semiont/core/testing';
+import { createWeaveProgress, WeaveProgressTimeout } from '../weave-progress';
+
+describe('WeaveProgress', () => {
+  it('resolves immediately when the applied map already covers the sequence', async () => {
+    const bus = new EventBus();
+    const progress = createWeaveProgress(bus);
+    bus.get('weave:applied').next({ resourceId: 'res-1', sequenceNumber: 5 });
+
+    await expect(progress.whenApplied('res-1', 3, 1000)).resolves.toBeUndefined();
+    await expect(progress.whenApplied('res-1', 5, 1000)).resolves.toBeUndefined();
+    expect(progress.appliedUpTo('res-1')).toBe(5);
+
+    progress.dispose();
+  });
+
+  it('resolves when the signal arrives while waiting — event-driven, not polled', async () => {
+    const bus = new EventBus();
+    const progress = createWeaveProgress(bus);
+
+    const wait = progress.whenApplied('res-1', 7, 1000);
+    bus.get('weave:applied').next({ resourceId: 'res-1', sequenceNumber: 7 });
+
+    await expect(wait).resolves.toBeUndefined();
+    progress.dispose();
+  });
+
+  it('ignores signals for other resources and lower sequences', async () => {
+    const bus = new EventBus();
+    const progress = createWeaveProgress(bus);
+
+    const wait = progress.whenApplied('res-1', 7, 50);
+    bus.get('weave:applied').next({ resourceId: 'res-other', sequenceNumber: 9 });
+    bus.get('weave:applied').next({ resourceId: 'res-1', sequenceNumber: 6 });
+
+    await expect(wait).rejects.toBeInstanceOf(WeaveProgressTimeout);
+    progress.dispose();
+  });
+
+  it('rejects with the distinct timeout error when the signal never comes', async () => {
+    const bus = new EventBus();
+    const progress = createWeaveProgress(bus);
+
+    await expect(progress.whenApplied('res-ghost', 1, 20)).rejects.toBeInstanceOf(WeaveProgressTimeout);
+    progress.dispose();
+  });
+
+  it('applied sequences only advance — a stale lower signal never regresses the map', async () => {
+    const bus = new EventBus();
+    const progress = createWeaveProgress(bus);
+
+    bus.get('weave:applied').next({ resourceId: 'res-1', sequenceNumber: 9 });
+    bus.get('weave:applied').next({ resourceId: 'res-1', sequenceNumber: 4 });
+
+    expect(progress.appliedUpTo('res-1')).toBe(9);
+    progress.dispose();
+  });
+
+  it('post-dispose whenApplied is inert — resolves so callers degrade to the retry floor', async () => {
+    const bus = new EventBus();
+    const progress = createWeaveProgress(bus);
+    progress.dispose();
+
+    await expect(progress.whenApplied('res-1', 99, 1000)).resolves.toBeUndefined();
+  });
+
+  describe('StateUnit axioms', () => {
+    it('satisfies the StateUnit axioms', () => {
+      assertStateUnitAxioms({
+        setup: () => createWeaveProgress(new EventBus()),
+        invocations: (u) => [() => u.appliedUpTo('res-1')],
+      });
+    });
+  });
+});

--- a/packages/make-meaning/src/graph-context.ts
+++ b/packages/make-meaning/src/graph-context.ts
@@ -33,6 +33,14 @@ export class GraphContext {
   private static readonly PROJECTION_LAG_BACKOFF_MS = [25, 50, 100, 200];
 
   /**
+   * Bounded wait for the applied-offset barrier (GRAPH-PROJECTION-SYNC P2).
+   * The Weaver applies in tens of milliseconds when merely lagging; a
+   * barrier that hasn't woken in 500 ms means signals have stalled and the
+   * poll floor above owns the remainder.
+   */
+  private static readonly PROJECTION_BARRIER_TIMEOUT_MS = 500;
+
+  /**
    * Get all resources referencing this resource (backlinks)
    * Requires graph traversal - must use graph database
    */
@@ -90,15 +98,38 @@ export class GraphContext {
     // Read-your-writes grace for the graph projection: the view materializer
     // applies on the append path, the Weaver lags behind it (see
     // .plans/bugs/gather-resource-races-graph-projection.md). "Present in the
-    // view, absent in the graph" precisely identifies projection lag, so only
-    // that state earns a bounded retry; a resource the view doesn't know is
-    // genuinely unknown and throws on the first read.
+    // view, absent in the graph" precisely identifies projection lag; a
+    // resource the view doesn't know is genuinely unknown and throws on the
+    // first read.
     let mainDoc = await kb.graph.getResource(resourceId);
-    if (!mainDoc && await kb.views.get(resourceId)) {
-      for (const delayMs of GraphContext.PROJECTION_LAG_BACKOFF_MS) {
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-        mainDoc = await kb.graph.getResource(resourceId);
-        if (mainDoc) break;
+    if (!mainDoc) {
+      const view = await kb.views.get(resourceId);
+      if (view) {
+        // Applied-offset barrier first (P2, D2 = push): an event-driven wake
+        // at the moment the Weaver reports parity with the view's sequence.
+        // Views without a stamp (written pre-stamp) cannot name a parity
+        // target and skip straight to the poll floor.
+        if (view.lastSequence !== undefined) {
+          try {
+            await kb.weaveProgress.whenApplied(
+              String(resourceId),
+              view.lastSequence,
+              GraphContext.PROJECTION_BARRIER_TIMEOUT_MS,
+            );
+            mainDoc = await kb.graph.getResource(resourceId);
+          } catch {
+            // Barrier timed out — signals stalled; the poll floor owns it.
+          }
+        }
+        // Bounded-poll floor (P1): the fallback when the barrier cannot
+        // engage or its signals stall.
+        if (!mainDoc) {
+          for (const delayMs of GraphContext.PROJECTION_LAG_BACKOFF_MS) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            mainDoc = await kb.graph.getResource(resourceId);
+            if (mainDoc) break;
+          }
+        }
       }
     }
     if (!mainDoc) {

--- a/packages/make-meaning/src/graph-context.ts
+++ b/packages/make-meaning/src/graph-context.ts
@@ -25,6 +25,14 @@ type KnowledgeGraph = components['schemas']['KnowledgeGraph'];
 
 export class GraphContext {
   /**
+   * Backoff schedule for the projection-lag grace in `buildKnowledgeGraph`
+   * (GRAPH-PROJECTION-SYNC P1). Total wait is bounded at 375 ms — the Weaver
+   * applies in tens of milliseconds when merely lagging; anything slower is
+   * treated as a real miss.
+   */
+  private static readonly PROJECTION_LAG_BACKOFF_MS = [25, 50, 100, 200];
+
+  /**
    * Get all resources referencing this resource (backlinks)
    * Requires graph traversal - must use graph database
    */
@@ -79,7 +87,20 @@ export class GraphContext {
     resourceId: ResourceId,
     kb: KnowledgeBase,
   ): Promise<KnowledgeGraph> {
-    const mainDoc = await kb.graph.getResource(resourceId);
+    // Read-your-writes grace for the graph projection: the view materializer
+    // applies on the append path, the Weaver lags behind it (see
+    // .plans/bugs/gather-resource-races-graph-projection.md). "Present in the
+    // view, absent in the graph" precisely identifies projection lag, so only
+    // that state earns a bounded retry; a resource the view doesn't know is
+    // genuinely unknown and throws on the first read.
+    let mainDoc = await kb.graph.getResource(resourceId);
+    if (!mainDoc && await kb.views.get(resourceId)) {
+      for (const delayMs of GraphContext.PROJECTION_LAG_BACKOFF_MS) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        mainDoc = await kb.graph.getResource(resourceId);
+        if (mainDoc) break;
+      }
+    }
     if (!mainDoc) {
       throw new Error('Resource not found');
     }

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -24,13 +24,15 @@ import type { VectorStore } from '@semiont/vectors';
 import type { SemiontProject } from '@semiont/core/node';
 import type { EventBus, Logger } from '@semiont/core';
 import { Weaver } from './weaver.js';
+import { createWeaveProgress, type WeaveProgress } from './weave-progress.js';
 
 export interface KnowledgeBase {
   eventStore:    EventStore;
   views:         ViewStorage;
   content:       WorkingTreeStore;
   graph:         GraphDatabase;
-  weaver: Weaver;
+  weaver:        Weaver;
+  weaveProgress: WeaveProgress;
   vectors?:      VectorStore;
   projectionsDir: string;
 }
@@ -53,6 +55,9 @@ export async function createKnowledgeBase(
     project,
     logger.child({ component: 'working-tree-store' }),
   );
+  // Fold of `weave:applied` signals — must exist before the Weaver starts
+  // applying so no early signal is missed (GRAPH-PROJECTION-SYNC P2).
+  const weaveProgress = createWeaveProgress(eventBus);
   const weaver = new Weaver(
     eventStore,
     graphDb,
@@ -72,7 +77,7 @@ export async function createKnowledgeBase(
   }
 
   const kb: KnowledgeBase = {
-    eventStore, views, content, graph: graphDb, weaver,
+    eventStore, views, content, graph: graphDb, weaver, weaveProgress,
     projectionsDir: project.projectionsDir,
   };
 

--- a/packages/make-meaning/src/knowledge-system.ts
+++ b/packages/make-meaning/src/knowledge-system.ts
@@ -42,5 +42,6 @@ export async function stopKnowledgeSystem(ks: KnowledgeSystem): Promise<void> {
   await ks.cloneTokenManager.stop();
   await ks.stower.stop();
   await ks.kb.weaver.stop();
+  ks.kb.weaveProgress.dispose();
   await ks.kb.graph.disconnect();
 }

--- a/packages/make-meaning/src/weave-progress.ts
+++ b/packages/make-meaning/src/weave-progress.ts
@@ -1,0 +1,110 @@
+/**
+ * WeaveProgress — backend-local fold of `weave:applied` signals
+ * (GRAPH-PROJECTION-SYNC P2, D2 = push).
+ *
+ * The Weaver emits `weave:applied` after applying an event (or a batch's
+ * last event) for a resource. This unit folds those signals into a
+ * per-resource applied-sequence map and exposes `whenApplied` — the
+ * applied-offset barrier: an event-driven await that resolves the moment
+ * the graph projection reaches parity with a known sequence (typically the
+ * view's `lastSequence`), and rejects with `WeaveProgressTimeout` on the
+ * bounded timeout so callers can fall back to the bounded-poll floor.
+ *
+ * Deliberately transport-blind: it subscribes to the channel, not to the
+ * Weaver. In-process the signal rides the core EventBus; after
+ * WEAVER-ISOLATION the same channel arrives through the bus gateway and
+ * this unit does not change.
+ *
+ * The map is ephemeral by design — on backend restart it rebuilds lazily
+ * from live signals. That loses nothing: a waiter only ever waits for an
+ * apply that has not happened yet, and those signals are still to come.
+ */
+
+import type { EventBus, StateUnit } from '@semiont/core';
+
+/** Distinct rejection for a barrier that hit its bounded timeout. */
+export class WeaveProgressTimeout extends Error {
+  constructor(resourceId: string, sequenceNumber: number, timeoutMs: number) {
+    super(`weave:applied parity not reached for ${resourceId} (seq ${sequenceNumber}) within ${timeoutMs}ms`);
+    this.name = 'WeaveProgressTimeout';
+  }
+}
+
+interface Waiter {
+  resourceId: string;
+  sequenceNumber: number;
+  resolve: () => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface WeaveProgress extends StateUnit {
+  /** Highest applied sequence seen for a resource, if any signal arrived. */
+  appliedUpTo(resourceId: string): number | undefined;
+  /**
+   * Resolve when the Weaver has applied at least `sequenceNumber` for
+   * `resourceId` — immediately if the fold already covers it. Rejects with
+   * `WeaveProgressTimeout` after `timeoutMs`. After dispose it resolves
+   * immediately (inert): barrier callers degrade to their poll floor.
+   */
+  whenApplied(resourceId: string, sequenceNumber: number, timeoutMs: number): Promise<void>;
+}
+
+export function createWeaveProgress(eventBus: EventBus): WeaveProgress {
+  const applied = new Map<string, number>();
+  const waiters = new Set<Waiter>();
+  let disposed = false;
+
+  const subscription = eventBus.get('weave:applied').subscribe(({ resourceId, sequenceNumber }) => {
+    // Monotonic fold: a stale lower signal (e.g. redelivery) never
+    // regresses the high-water mark.
+    const current = applied.get(resourceId);
+    if (current !== undefined && current >= sequenceNumber) return;
+    applied.set(resourceId, sequenceNumber);
+
+    for (const waiter of waiters) {
+      if (waiter.resourceId === resourceId && sequenceNumber >= waiter.sequenceNumber) {
+        clearTimeout(waiter.timer);
+        waiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+  });
+
+  return {
+    appliedUpTo: (resourceId) => applied.get(resourceId),
+
+    whenApplied: (resourceId, sequenceNumber, timeoutMs) => {
+      if (disposed) return Promise.resolve();
+
+      const current = applied.get(resourceId);
+      if (current !== undefined && current >= sequenceNumber) return Promise.resolve();
+
+      return new Promise<void>((resolve, reject) => {
+        const waiter: Waiter = {
+          resourceId,
+          sequenceNumber,
+          resolve,
+          timer: setTimeout(() => {
+            waiters.delete(waiter);
+            reject(new WeaveProgressTimeout(resourceId, sequenceNumber, timeoutMs));
+          }, timeoutMs),
+        };
+        waiters.add(waiter);
+      });
+    },
+
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      subscription.unsubscribe();
+      // Release pending waiters by resolving: shutdown must not throw through
+      // a gather in flight — the caller re-reads and lands on its poll floor.
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timer);
+        waiter.resolve();
+      }
+      waiters.clear();
+      applied.clear();
+    },
+  };
+}

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -110,7 +110,7 @@ export class Weaver {
               return from(this.processBatch(eventOrBatch));
             }
             return from(this.safeApplyEvent(eventOrBatch).then(() => {
-              this.lastProcessed.set(
+              this.noteApplied(
                 eventOrBatch.resourceId!,
                 eventOrBatch.metadata.sequenceNumber
               );
@@ -125,6 +125,16 @@ export class Weaver {
     });
 
     this.logger.info('Subscribed to global events with burst-buffered pipeline');
+  }
+
+  /**
+   * Record an applied event's sequence and signal `weave:applied` — the
+   * push half of the applied-offset barrier (GRAPH-PROJECTION-SYNC P2):
+   * `WeaveProgress` folds these signals into the map `whenApplied` awaits.
+   */
+  private noteApplied(resourceId: string, sequenceNumber: number): void {
+    this.lastProcessed.set(resourceId, sequenceNumber);
+    this.coreEventBus.get('weave:applied').next({ resourceId, sequenceNumber });
   }
 
   /**
@@ -196,7 +206,7 @@ export class Weaver {
       }
       const last = run[run.length - 1];
       if (last.resourceId) {
-        this.lastProcessed.set(last.resourceId, last.metadata.sequenceNumber);
+        this.noteApplied(last.resourceId, last.metadata.sequenceNumber);
       }
     }
 


### PR DESCRIPTION
# Pull Request

## Description

Read-your-writes over the graph projection (`.plans/GRAPH-PROJECTION-SYNC.md`, both
phases). The event log is the system of record; the view and the graph are
projections that consume it at different rates — and `gather.resource()` on a
just-created resource could read the graph ~5 ms before the Weaver applied the
creation event, surfacing as an intermittent **"Resource not found"** on the first
chat turn (`bugs/gather-resource-races-graph-projection.md`, diagnosed from live
container logs: view applies +14 ms, graph +36 ms). This PR closes that race twice
over, and its second half is the consistency machinery the Weaver-isolation split
(#984) depends on.

**Phase 1 — bounded view-gated retry (the filed bug's option #1).** In
`GraphContext.buildKnowledgeGraph` — the single graph builder, so the gather,
matcher-ranking, and viz consumers all inherit it — a null graph read now probes the
view first. Present in the view → projection lag: retry on a 25/50/100/200 ms
backoff (375 ms cap). Absent from the view → genuinely unknown: throw on the first
read, no retry tax on true 404s. No client or SDK changes — clients never
compensate for a backend race.

**Phase 2 — the applied-offset barrier (option #2, the principled fix).**
Event-driven, not polled:

- The Weaver emits a **`weave:applied`** `{resourceId, sequenceNumber}` signal after
  every apply/batch (new channel; `noteApplied` helper).
- The backend folds signals into **`WeaveProgress`** (`kb.weaveProgress`, a
  StateUnit-axioms-conformant factory): a monotonic per-resource applied map with
  **`whenApplied(resourceId, seq, timeoutMs)`** — resolves the moment parity is
  reached, rejects with a distinct `WeaveProgressTimeout` on the 500 ms cap.
- The parity target comes from a new **`ResourceView.lastSequence`** stamp written
  by the materializer on both incremental and rebuild paths (which honestly widened
  its event params from `PersistedEvent` to `StoredEvent` — the append path always
  passed one; event-sourcing test fixtures updated to carry real storage metadata).
- `buildKnowledgeGraph` now runs: optimistic read → barrier wait → single re-read,
  with the Phase 1 poll floor kept as the fallback when signals stall or a
  pre-stamp view can't name a target. Unstamped views skip the barrier entirely.

Deliberately transport-blind (decision D2 = push, recorded in the plan): the fold
subscribes to the channel, not to the Weaver, so the identical code works after the
Weaver moves out of process — in #984 the same signal rides the SSE gateway and
`whenApplied` keeps working mid-catch-up.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Areas Changed

- [x] Core (`packages/core`)

Also touched (not in the list above): `packages/make-meaning` (retry, fold,
barrier, Weaver signals), `packages/event-sourcing` (view sequence stamp + type
widening).

## Security Checklist

Not applicable — no authentication, authorization, or admin surface touched; one
new in-process bus channel.

## Verification

- TDD-first throughout: Phase 1's RED was the filed bug's own prophylactic spec
  (observed failing, "expected 1 to be greater than 1"); Phase 2 added seven
  `WeaveProgress` specs (including the StateUnit axioms harness, which rejected the
  first class-based implementation under A1 — the shipped factory shape is the
  harness's doing) and three barrier specs (parity-wait with exactly two graph
  reads and zero backoff polls; timeout falls back to the floor; stampless views
  skip the barrier).
- Final state: build + full workspace `tsc --noEmit` clean; 69/69 targeted
  make-meaning + 108/108 event-sourcing view suites (node:24 container).
- The bug doc is marked FIXED for the in-process topology with the diagnosis and
  timestamped trace preserved.
