### PR TITLE
weaver isolation: the graph projection becomes a standalone actor

### DIFF
--- a/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
+++ b/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
@@ -26,6 +26,7 @@ export function stubKnowledgeBase(overrides: Partial<KnowledgeBase> = {}): Knowl
     content:        { store: vi.fn(), retrieve: vi.fn() } as unknown as KnowledgeBase['content'],
     graph:          {} as KnowledgeBase['graph'],
     weaver:  { stop: vi.fn().mockResolvedValue(undefined) } as unknown as KnowledgeBase['weaver'],
+    weaverEvents: { dispose: vi.fn() } as unknown as KnowledgeBase['weaverEvents'],
     weaveProgress: { dispose: vi.fn() } as unknown as KnowledgeBase['weaveProgress'],
     projectionsDir: '',
     ...overrides,

--- a/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
+++ b/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
@@ -25,8 +25,6 @@ export function stubKnowledgeBase(overrides: Partial<KnowledgeBase> = {}): Knowl
     views:          {} as KnowledgeBase['views'],
     content:        { store: vi.fn(), retrieve: vi.fn() } as unknown as KnowledgeBase['content'],
     graph:          {} as KnowledgeBase['graph'],
-    weaver:  { stop: vi.fn().mockResolvedValue(undefined) } as unknown as KnowledgeBase['weaver'],
-    weaverEvents: { dispose: vi.fn() } as unknown as KnowledgeBase['weaverEvents'],
     weaveProgress: { dispose: vi.fn() } as unknown as KnowledgeBase['weaveProgress'],
     projectionsDir: '',
     ...overrides,

--- a/apps/backend/src/__tests__/integration/annotation-crud.test.ts
+++ b/apps/backend/src/__tests__/integration/annotation-crud.test.ts
@@ -35,7 +35,7 @@ describe('Annotation CRUD Integration Tests - W3C multi-body annotation', () => 
 
     // Create KnowledgeBase for AnnotationContext calls
     const viewStorage = new FilesystemViewStorage(project);
-    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaver: {} as any, weaveProgress: {} as any };
+    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any };
 
     // Create test resources in event store
     const eventStore = createEventStore(project, new EventBus(), mockLogger);

--- a/apps/backend/src/__tests__/integration/annotation-crud.test.ts
+++ b/apps/backend/src/__tests__/integration/annotation-crud.test.ts
@@ -35,7 +35,7 @@ describe('Annotation CRUD Integration Tests - W3C multi-body annotation', () => 
 
     // Create KnowledgeBase for AnnotationContext calls
     const viewStorage = new FilesystemViewStorage(project);
-    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any };
+    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaveProgress: {} as any };
 
     // Create test resources in event store
     const eventStore = createEventStore(project, new EventBus(), mockLogger);

--- a/apps/backend/src/cli/rebuild-graph.ts
+++ b/apps/backend/src/cli/rebuild-graph.ts
@@ -1,93 +1,98 @@
 #!/usr/bin/env node
 /**
- * CLI Tool: Rebuild Neo4j Graph from Events
+ * CLI Tool: Rebuild the Graph from Events
  *
- * Rebuilds the Neo4j graph database from Event Store event streams.
- * Proves that events are the source of truth and Neo4j is a projection.
+ * Emits `weave:rebuild` to the RUNNING stack's bus — the standalone Weaver
+ * (WEAVER-ISOLATION D3/D4) clears and replays the graph projection from the
+ * event log. Proves that events are the source of truth and the graph is a
+ * projection. Requires the backend and weaver to be running.
  *
  * Usage:
  *   npm run rebuild-graph              # Rebuild entire graph
  *   npm run rebuild-graph <resourceId> # Rebuild specific resource
+ *
+ * Configuration:
+ *   ~/.semiontconfig       — services.backend.publicURL
+ *   SEMIONT_WORKER_SECRET  — shared secret for the token exchange
  */
 
-import { startMakeMeaning, asBusRequestPrimitive } from '@semiont/make-meaning';
-import { SemiontProject, loadEnvironmentConfig } from '@semiont/core/node';
-import { EventBus, busRequest } from '@semiont/core';
-import { makeMeaningConfigFrom } from '../utils/config';
+import { BehaviorSubject } from 'rxjs';
+import { HttpTransport } from '@semiont/http-transport';
+import {
+  busRequest,
+  baseUrl as makeBaseUrl,
+  accessToken as makeAccessToken,
+  createTomlConfigLoader,
+  type AccessToken,
+} from '@semiont/core';
+import { readFileSync, existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
 import { initializeLogger, getLogger } from '../logger';
 
 /** Rebuilds replay full histories — allow far more than the 30 s bus default. */
 const REBUILD_TIMEOUT_MS = 10 * 60 * 1000;
 
-async function rebuildGraph(rId?: string, environment?: string) {
-  const projectRoot = process.env.SEMIONT_ROOT;
-  if (!projectRoot) {
-    throw new Error('SEMIONT_ROOT environment variable is not set');
-  }
-  // environment: --environment flag > SEMIONT_ENV > fallback
-  const env = environment ?? process.env.SEMIONT_ENV ?? 'development';
-
-  const config = loadEnvironmentConfig(projectRoot, env);
-
-  // Initialize logger
-  initializeLogger(config.logLevel);
+async function rebuildGraph(rId?: string) {
+  initializeLogger();
   const logger = getLogger();
 
-  logger.info('Rebuilding Neo4j graph from events');
+  const configPath = join(homedir(), '.semiontconfig');
+  const tomlReader = {
+    readIfExists: (p: string): string | null => existsSync(p) ? readFileSync(p, 'utf-8') : null,
+  };
+  const envConfig = createTomlConfigLoader(tomlReader, configPath, process.env)(null, 'local');
 
-  // Create EventBus
-  const eventBus = new EventBus();
+  const backendPublicURL = envConfig.services?.backend?.publicURL;
+  if (!backendPublicURL) {
+    throw new Error('services.backend.publicURL is required in ~/.semiontconfig');
+  }
 
-  // Start make-meaning; the explicit rebuild below makes startup catch-up
-  // redundant work, so skip it.
-  const makeMeaning = await startMakeMeaning(
-    new SemiontProject(projectRoot), makeMeaningConfigFrom(config), eventBus, logger,
-    { skipRebuild: true },
-  );
-  const bus = asBusRequestPrimitive(eventBus);
+  const workerSecret = process.env.SEMIONT_WORKER_SECRET;
+  if (!workerSecret) {
+    throw new Error('SEMIONT_WORKER_SECRET is required to authenticate with the backend');
+  }
 
-  // The rebuild is a bus command served by the Weaver (WEAVER-ISOLATION D3)
-  // — the same shape that survives the container split.
+  const response = await fetch(`${backendPublicURL}/api/tokens/agent`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ secret: workerSecret, provider: 'semiont', model: 'rebuild-graph' }),
+  });
+  if (!response.ok) {
+    throw new Error(`Authentication failed: ${response.status} ${response.statusText}`);
+  }
+  const { token } = await response.json() as { token: string };
+
+  const tokenSubject = new BehaviorSubject<AccessToken | null>(makeAccessToken(token));
+  const transport = new HttpTransport({
+    baseUrl: makeBaseUrl(backendPublicURL),
+    token$: tokenSubject,
+  });
+
   try {
     if (rId) {
       logger.info('Rebuilding graph for resource', { resourceId: rId });
-      await busRequest(bus, 'weave:rebuild', { resourceId: rId }, REBUILD_TIMEOUT_MS);
+      await busRequest(transport, 'weave:rebuild', { resourceId: rId }, REBUILD_TIMEOUT_MS);
       logger.info('Resource rebuilt successfully', { resourceId: rId });
     } else {
       logger.info('Rebuilding entire graph');
       logger.info('Note: This clears the database and replays all events');
-      await busRequest(bus, 'weave:rebuild', {}, REBUILD_TIMEOUT_MS);
+      await busRequest(transport, 'weave:rebuild', {}, REBUILD_TIMEOUT_MS);
       logger.info('Graph rebuilt successfully');
-
-      const health = makeMeaning.knowledgeSystem.kb.weaver.getHealthMetrics();
-      logger.info('Weaver health metrics', {
-        activeSubscriptions: health.subscriptions,
-        resourcesProcessed: Object.keys(health.lastProcessed).length
-      });
     }
-  } catch (error) {
-    logger.error('Failed to rebuild graph', {
-      ...(rId ? { resourceId: rId } : {}),
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined
-    });
-    process.exit(1);
+  } finally {
+    transport.dispose();
   }
-
-  // Shutdown make-meaning
-  await makeMeaning.stop();
-  eventBus.destroy();
 
   logger.info('Rebuild graph completed');
 }
 
-// Parse command line arguments: [resourceId] [--environment <env>]
+// Parse command line arguments: [resourceId]
 const args = process.argv.slice(2);
 const envFlagIdx = args.indexOf('--environment');
-const envArg = envFlagIdx !== -1 ? args[envFlagIdx + 1] : undefined;
 const rId = args.find((_, i) => i !== envFlagIdx && i !== envFlagIdx + 1);
 
-rebuildGraph(rId, envArg)
+rebuildGraph(rId)
   .catch(err => {
     const logger = getLogger();
     logger.error('Rebuild graph failed', {

--- a/apps/backend/src/cli/rebuild-graph.ts
+++ b/apps/backend/src/cli/rebuild-graph.ts
@@ -10,11 +10,14 @@
  *   npm run rebuild-graph <resourceId> # Rebuild specific resource
  */
 
-import { startMakeMeaning } from '@semiont/make-meaning';
+import { startMakeMeaning, asBusRequestPrimitive } from '@semiont/make-meaning';
 import { SemiontProject, loadEnvironmentConfig } from '@semiont/core/node';
-import { resourceId as makeResourceId, EventBus } from '@semiont/core';
+import { EventBus, busRequest } from '@semiont/core';
 import { makeMeaningConfigFrom } from '../utils/config';
 import { initializeLogger, getLogger } from '../logger';
+
+/** Rebuilds replay full histories — allow far more than the 30 s bus default. */
+const REBUILD_TIMEOUT_MS = 10 * 60 * 1000;
 
 async function rebuildGraph(rId?: string, environment?: string) {
   const projectRoot = process.env.SEMIONT_ROOT;
@@ -35,49 +38,40 @@ async function rebuildGraph(rId?: string, environment?: string) {
   // Create EventBus
   const eventBus = new EventBus();
 
-  // Start make-meaning to get eventStore and weaver
-  const makeMeaning = await startMakeMeaning(new SemiontProject(projectRoot), makeMeaningConfigFrom(config), eventBus, logger);
-  const { knowledgeSystem: { kb: { weaver } } } = makeMeaning;
+  // Start make-meaning; the explicit rebuild below makes startup catch-up
+  // redundant work, so skip it.
+  const makeMeaning = await startMakeMeaning(
+    new SemiontProject(projectRoot), makeMeaningConfigFrom(config), eventBus, logger,
+    { skipRebuild: true },
+  );
+  const bus = asBusRequestPrimitive(eventBus);
 
-  if (rId) {
-    // Rebuild single resource
-    logger.info('Rebuilding graph for resource', { resourceId: rId });
-
-    try {
-      await weaver.rebuildResource(makeResourceId(rId));
+  // The rebuild is a bus command served by the Weaver (WEAVER-ISOLATION D3)
+  // — the same shape that survives the container split.
+  try {
+    if (rId) {
+      logger.info('Rebuilding graph for resource', { resourceId: rId });
+      await busRequest(bus, 'weave:rebuild', { resourceId: rId }, REBUILD_TIMEOUT_MS);
       logger.info('Resource rebuilt successfully', { resourceId: rId });
-    } catch (error) {
-      logger.error('Failed to rebuild resource', {
-        resourceId: rId,
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined
-      });
-      process.exit(1);
-    }
-
-  } else {
-    // Rebuild entire graph
-    logger.info('Rebuilding entire Neo4j graph');
-    logger.info('Note: This clears the database and replays all events');
-
-    try {
-      await weaver.rebuildAll();
+    } else {
+      logger.info('Rebuilding entire graph');
+      logger.info('Note: This clears the database and replays all events');
+      await busRequest(bus, 'weave:rebuild', {}, REBUILD_TIMEOUT_MS);
       logger.info('Graph rebuilt successfully');
 
-      // Show health metrics
-      const health = weaver.getHealthMetrics();
-      logger.info('Consumer health metrics', {
+      const health = makeMeaning.knowledgeSystem.kb.weaver.getHealthMetrics();
+      logger.info('Weaver health metrics', {
         activeSubscriptions: health.subscriptions,
         resourcesProcessed: Object.keys(health.lastProcessed).length
       });
-
-    } catch (error) {
-      logger.error('Failed to rebuild graph', {
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined
-      });
-      process.exit(1);
     }
+  } catch (error) {
+    logger.error('Failed to rebuild graph', {
+      ...(rId ? { resourceId: rId } : {}),
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined
+    });
+    process.exit(1);
   }
 
   // Shutdown make-meaning

--- a/docs/system/CONTAINER-TOPOLOGY.md
+++ b/docs/system/CONTAINER-TOPOLOGY.md
@@ -10,7 +10,7 @@ For the actor responsibilities running inside the backend / worker / smelter con
 
 ## Multi-container layout
 
-A local deployment runs three containers of Semiont code, four if you include the frontend, or eight if you also count the infrastructure dependencies:
+A local deployment runs four containers of Semiont code, five if you include the frontend, or nine if you also count the infrastructure dependencies:
 
 ```mermaid
 graph TB
@@ -24,7 +24,6 @@ graph TB
         BROWSER["Browser"]
         GATHERER["Gatherer"]
         MATCHER["Matcher"]
-        WEAVER["Weaver"]
         VIEWS[("Materialized Views")]
     end
 
@@ -36,6 +35,10 @@ graph TB
 
     subgraph smelter_c ["semiont-smelter"]
         SMELTER["Smelter"]
+    end
+
+    subgraph weaver_c ["semiont-weaver"]
+        WEAVER["Weaver"]
     end
 
     subgraph pg_c ["semiont-postgres"]
@@ -57,11 +60,11 @@ graph TB
     SPA --- BUS
     WORKERS --- BUS
     SMELTER --- BUS
+    WEAVER --- BUS
 
     STOWER --- GIT
     STOWER --- VIEWS
     VIEWS --- GIT
-    WEAVER --- GIT
     WEAVER --- NEO
     SMELTER --- QD
     BUS --- PG
@@ -87,7 +90,7 @@ graph TB
     class OL service
 ```
 
-The three Semiont-code backend containers communicate exclusively through the unified bus exposed by `semiont-backend` (`/bus/emit`, `/bus/subscribe`). Workers and the smelter authenticate via `POST /api/tokens/worker`, which exchanges a shared secret (`SEMIONT_WORKER_SECRET`) for a JWT with `role: worker`; the existing auth middleware validates that JWT exactly as it would a user's. This split isolates long-running LLM and embedding work from the request-serving event loop — the backend stays responsive to human users while workers and the smelter run in separate V8 isolates.
+The four Semiont-code backend containers communicate exclusively through the unified bus exposed by `semiont-backend` (`/bus/emit`, `/bus/subscribe`). Workers, the smelter, and the weaver authenticate via `POST /api/tokens/agent`, which exchanges a shared secret (`SEMIONT_WORKER_SECRET`) plus a `(provider, model)` identity for a JWT carrying a typed Software-agent DID (the smelter presents its embedding config; the weaver presents `(semiont, weaver)`); the existing auth middleware validates that JWT exactly as it would a user's. This split isolates long-running LLM, embedding, and graph-projection work from the request-serving event loop — the backend stays responsive to human users while workers, the smelter, and the weaver run in separate V8 isolates.
 
 ## Unified bus and SemiontSession
 

--- a/docs/system/KNOWLEDGE-SYSTEM.md
+++ b/docs/system/KNOWLEDGE-SYSTEM.md
@@ -7,7 +7,7 @@ The knowledge base itself is not an intelligent actor. It has no goals, preferen
 - **Five access actors** mediate every read and write: **Stower** (write), **Browser** (read), **Gatherer** (context assembly), **Matcher** (search), and **CloneTokenManager** (clone tokens). They are the bus-facing interface of the knowledge base — commands and requests in, replies out, correlated by `correlationId`.
 - **Two projection pipelines** keep the eventually-consistent read models in sync with the event log: the **Weaver** (events → graph) and the **Smelter** (events → vectors). Pipelines are addressed by no one and reply to nothing; they consume already-persisted domain events.
 
-All seven subscribe to the bus via RxJS pipelines and expose no public business methods — `initialize()` and `stop()` for lifecycle, plus a startup recovery entry point on the pipelines (`Weaver.rebuildAll()`, `Smelter.reconcile()`). Callers never call into an actor directly; they put a message on the bus and trust the actor is listening.
+All seven subscribe to the bus via RxJS pipelines and expose no public business methods — `initialize()` and `stop()` for lifecycle, plus a startup recovery entry point on the pipelines (`Weaver.catchUp()`, `Smelter.reconcile()`). Both pipelines run standalone (weaver-main, smelter-main): the projections are part of their stores' stacks, not of the backend process. Callers never call into an actor directly; they put a message on the bus and trust the actor is listening.
 
 The third derived read model — the materialized views — is deliberately **not** pipeline-maintained: the EventStore's `ViewManager` materializes views synchronously inside `appendEvent()`, before the event is published, so subscribers get a read-your-writes guarantee that a fire-and-forget pipeline cannot provide.
 
@@ -119,7 +119,7 @@ The CloneTokenManager handles the clone-token lifecycle in the yield flow. On `y
 
 ### Weaver (projection pipeline)
 
-The Weaver follows the event log and keeps the graph projection in sync. It subscribes to the graph-relevant domain events on the bus, batches bursts per resource (`groupBy(resourceId)` + adaptive burst buffering + `concatMap`), and applies them to the graph database. Because the graph is eventually consistent and rebuildable, `rebuildAll()` replays the entire event log at startup — a wiped graph volume recovers by restarting the backend. It lives on the `KnowledgeBase` record (`kb.weaver`), constructed inside `createKnowledgeBase()`.
+The Weaver follows the event log and keeps the graph projection in sync. It runs in its own container (`semiont-weaver`) — not in the backend process — and reaches the backend through the unified bus, the same way workers and the smelter do; beyond the bus its single privileged attachment is the graph database. It subscribes to the graph-relevant domain events, batches bursts per resource (`groupBy(resourceId)` + adaptive burst buffering + `concatMap`), and applies them to the graph. Every apply emits a `weave:applied` signal; the backend folds these into `kb.weaveProgress`, whose `whenApplied` barrier lets graph readers wait out projection lag. On startup it runs a **checkpointed catch-up** over the `browse:*` read channels (its only view of history — no event-store attachment), replaying just the gap since its persisted checkpoint; a full rebuild is the `weave:rebuild` bus command. A wiped graph volume recovers by command, or by wiping the checkpoint and restarting the weaver.
 
 ### Smelter (projection pipeline)
 

--- a/packages/core/src/__tests__/bus-invariants.test.ts
+++ b/packages/core/src/__tests__/bus-invariants.test.ts
@@ -69,6 +69,7 @@ const FROZEN_BRIDGED = [
   'mark:unarchive-ok', 'mark:unarchive-failed',
   'mark:update-entity-types-ok', 'mark:update-entity-types-failed',
   'match:search-results', 'match:search-failed',
+  'weave:rebuild-ok', 'weave:rebuild-failed',
   'gather:complete', 'gather:failed',
   'gather:resource-complete', 'gather:resource-failed',
   'gather:annotation-progress',

--- a/packages/core/src/bus-operations.ts
+++ b/packages/core/src/bus-operations.ts
@@ -76,6 +76,10 @@ export const BUS_OPERATIONS = {
   // take-1 dressed as an Observable in the SDK; no progress channel
   'match:search-requested':              { result: 'match:search-results',           failure: 'match:search-failed' },
 
+  // ── WEAVE ───────────────────────────────────────────────────────
+  // Graph-projection rebuild, served by the Weaver (WEAVER-ISOLATION D3)
+  'weave:rebuild':                       { result: 'weave:rebuild-ok',               failure: 'weave:rebuild-failed' },
+
   // ── YIELD ───────────────────────────────────────────────────────
   // live in-process (resource-operations.ts emits + awaits via race()); the
   // client also .on()-subscribes -ok for cache invalidation

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -343,6 +343,15 @@ export type EventMap = {
    */
   'weave:applied': { resourceId: string; sequenceNumber: number };
 
+  // Command — rebuild the graph projection from the event log (full when
+  // resourceId is absent, one resource when present). Served by the Weaver;
+  // replaces direct `rebuildAll()`/`rebuildResource()` access, which does
+  // not survive the container split (WEAVER-ISOLATION D3). Correlated
+  // request/reply via the BUS_OPERATIONS registry.
+  'weave:rebuild': components['schemas']['WeaveRebuildCommand'];
+  'weave:rebuild-ok': { correlationId?: string };
+  'weave:rebuild-failed': { correlationId?: string; message: string };
+
   // ========================================================================
   // SETTINGS (frontend-only)
   // ========================================================================
@@ -627,6 +636,9 @@ export const CHANNEL_SCHEMAS = {
 
   // ── WEAVE FLOW ──────────────────────────────────────────────────
   'weave:applied':                    null, // { resourceId; sequenceNumber }
+  'weave:rebuild':                    'WeaveRebuildCommand',
+  'weave:rebuild-ok':                 null, // { correlationId }
+  'weave:rebuild-failed':             null, // { correlationId; message }
 
   // ── SSE infrastructure ──────────────────────────────────────────
   'stream-connected':                 null, // Record<string, never>

--- a/packages/graph/src/__tests__/interface-contract.test.ts
+++ b/packages/graph/src/__tests__/interface-contract.test.ts
@@ -242,15 +242,21 @@ describe('GraphDatabase Interface Contract', () => {
       expect(annotation.motivation).toBe('linking');
     });
 
-    it('createAnnotation() should generate unique id', async () => {
+    it('createAnnotation() stores the annotation under the caller-supplied id', async () => {
+      // The id is the system of record's (the event log's), never the
+      // store's to mint — deletes and lookups arrive under it, and
+      // re-creating the same id must not multiply annotations.
       const resource = createTestResource();
       await db.createResource(resource);
 
       const input = createTestHighlight(resource['@id']);
-      const ann1 = await db.createAnnotation(input);
-      const ann2 = await db.createAnnotation(input);
+      const created = await db.createAnnotation(input);
+      await db.createAnnotation(input);
 
-      expect(ann1.id).not.toBe(ann2.id);
+      expect(String(created.id)).toBe(String(input.id));
+      expect(await db.getAnnotation(input.id)).not.toBeNull();
+      const { annotations } = await db.listAnnotations({ resourceId: resourceId(resource['@id']) });
+      expect(annotations.filter((a) => String(a.id) === String(input.id))).toHaveLength(1);
     });
 
     it('getAnnotation() should retrieve existing annotation', async () => {

--- a/packages/graph/src/factory.ts
+++ b/packages/graph/src/factory.ts
@@ -62,6 +62,9 @@ export function createGraphDatabase(config: GraphDatabaseConfig): GraphDatabase 
     }
 
     case 'memory':
+      // Hermetic TEST sink only (WEAVER-ISOLATION D4 refinement): a heap-
+      // local graph cannot be shared with a standalone Weaver, so no
+      // deployment configures it — and none does. weaver-main refuses it.
       return new MemoryGraphDatabase({});
 
     default:

--- a/packages/graph/src/implementations/janusgraph.ts
+++ b/packages/graph/src/implementations/janusgraph.ts
@@ -2,6 +2,7 @@
 // This replaces the mock in-memory implementation
 
 import { GraphDatabase } from '../interface';
+import { assertMutableResourceUpdate } from '../interface';
 import type { Logger } from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId } from '@semiont/core';
 import { getBodySource, getPrimaryRepresentation, getResourceId, getExactText } from '@semiont/core';
@@ -287,16 +288,19 @@ export class JanusGraphDatabase implements GraphDatabase {
   }
   
   async updateResource(id: ResourceId, input: UpdateResourceInput): Promise<ResourceDescriptor> {
-    // Resources are immutable - only archiving is allowed
-    if (Object.keys(input).length !== 1 || input.archived === undefined) {
-      throw new Error('Resources are immutable. Only archiving is allowed.');
-    }
+    assertMutableResourceUpdate(input);
 
-    await this.g!
+    let traversal = this.g!
       .V()
-      .has('Resource', 'id', id)
-      .property('archived', input.archived)
-      .next();
+      .has('Resource', 'id', id);
+    if (input.archived !== undefined) {
+      traversal = traversal.property('archived', input.archived);
+    }
+    if (input.entityTypes !== undefined) {
+      // Mirrors createResource's storage idiom: entityTypes ride as JSON.
+      traversal = traversal.property('entityTypes', JSON.stringify(input.entityTypes));
+    }
+    await traversal.next();
 
     const updatedResource = await this.getResource(id);
     if (!updatedResource) {
@@ -356,7 +360,9 @@ export class JanusGraphDatabase implements GraphDatabase {
   }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {
-    const id = this.generateId();
+    // The caller's id is the system of record's — never mint a fresh one
+    // (the event-log id is what deletes and lookups arrive under).
+    const id = input.id;
 
     // Only linking motivation with SpecificResource or empty array (stub)
     const motivation = input.motivation;

--- a/packages/graph/src/implementations/memorygraph.ts
+++ b/packages/graph/src/implementations/memorygraph.ts
@@ -2,6 +2,7 @@
 // Used for development and testing without requiring a real graph database
 
 import { GraphDatabase } from '../interface';
+import { assertMutableResourceUpdate } from '../interface';
 import type { Logger } from '@semiont/core';
 import type {
   AnnotationCategory,
@@ -78,15 +79,13 @@ export class MemoryGraphDatabase implements GraphDatabase {
   }
 
   async updateResource(id: ResourceId, input: UpdateResourceInput): Promise<ResourceDescriptor> {
-    // Resources are immutable - only archiving is allowed
-    if (Object.keys(input).length !== 1 || input.archived === undefined) {
-      throw new Error('Resources are immutable. Only archiving is allowed.');
-    }
+    assertMutableResourceUpdate(input);
 
     const doc = this.resources.get(String(id));
     if (!doc) throw new Error('Resource not found');
 
-    doc.archived = input.archived;
+    if (input.archived !== undefined) doc.archived = input.archived;
+    if (input.entityTypes !== undefined) doc.entityTypes = input.entityTypes;
     return doc;
   }
 
@@ -141,7 +140,9 @@ export class MemoryGraphDatabase implements GraphDatabase {
   }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {
-    const id = this.generateId();
+    // The caller's id is the system of record's — never mint a fresh one
+    // (the event-log id is what deletes and lookups arrive under).
+    const id = input.id;
 
     // Only linking motivation with SpecificResource or empty array (stub)
     const annotation: Annotation = {

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -3,6 +3,7 @@
 
 import type { Driver, Session } from 'neo4j-driver';
 import { GraphDatabase } from '../interface';
+import { assertMutableResourceUpdate } from '../interface';
 import type { Logger } from '@semiont/core';
 import { annotationId as makeAnnotationId } from '@semiont/core';
 import type {
@@ -248,18 +249,26 @@ export class Neo4jGraphDatabase implements GraphDatabase {
   }
 
   async updateResource(id: ResourceId, input: UpdateResourceInput): Promise<ResourceDescriptor> {
-    // Resources are immutable - only archiving is allowed
-    if (Object.keys(input).length !== 1 || input.archived === undefined) {
-      throw new Error('Resources are immutable. Only archiving is allowed.');
+    assertMutableResourceUpdate(input);
+
+    const sets: string[] = [];
+    const params: Record<string, unknown> = { id };
+    if (input.archived !== undefined) {
+      sets.push('d.archived = $archived');
+      params.archived = input.archived;
+    }
+    if (input.entityTypes !== undefined) {
+      sets.push('d.entityTypes = $entityTypes');
+      params.entityTypes = input.entityTypes;
     }
 
     const session = this.getSession();
     try {
       const result = await session.run(
         `MATCH (d:Resource {id: $id})
-         SET d.archived = $archived
+         SET ${sets.join(', ')}
          RETURN d`,
-        { id, archived: input.archived }
+        params
       );
 
       if (result.records.length === 0) {

--- a/packages/graph/src/implementations/neptune.ts
+++ b/packages/graph/src/implementations/neptune.ts
@@ -2,6 +2,7 @@
 // Uses Gremlin for graph traversal
 
 import { GraphDatabase } from '../interface';
+import { assertMutableResourceUpdate } from '../interface';
 import { getEntityTypes } from '@semiont/ontology';
 import type { Logger } from '@semiont/core';
 import { annotationId as makeAnnotationId } from '@semiont/core';
@@ -405,16 +406,20 @@ export class NeptuneGraphDatabase implements GraphDatabase {
   }
   
   async updateResource(id: ResourceId, input: UpdateResourceInput): Promise<ResourceDescriptor> {
-    // Resources are immutable - only archiving is allowed
-    if (Object.keys(input).length !== 1 || input.archived === undefined) {
-      throw new Error('Resources are immutable. Only archiving is allowed.');
-    }
+    assertMutableResourceUpdate(input);
 
     try {
-      const result = await this.g.V()
+      let traversal = this.g.V()
         .hasLabel('Resource')
-        .has('id', id)
-        .property('archived', input.archived)
+        .has('id', id);
+      if (input.archived !== undefined) {
+        traversal = traversal.property('archived', input.archived);
+      }
+      if (input.entityTypes !== undefined) {
+        // Mirrors createResource's storage idiom: entityTypes ride as JSON.
+        traversal = traversal.property('entityTypes', JSON.stringify(input.entityTypes));
+      }
+      const result = await traversal
         .elementMap()
         .next();
 
@@ -518,7 +523,9 @@ export class NeptuneGraphDatabase implements GraphDatabase {
   }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {
-    const id = this.generateId();
+    // The caller's id is the system of record's — never mint a fresh one
+    // (the event-log id is what deletes and lookups arrive under).
+    const id = input.id;
 
     // Only linking motivation with SpecificResource or empty array (stub)
     const annotation: Annotation = {

--- a/packages/graph/src/interface.ts
+++ b/packages/graph/src/interface.ts
@@ -14,6 +14,22 @@ import type {
   UpdateResourceInput,
 } from '@semiont/core';
 
+const MUTABLE_RESOURCE_FACETS = new Set<string>(['archived', 'entityTypes']);
+
+/**
+ * Resources are immutable apart from two facets: archival state, and entity
+ * tags (mutable since the controlled-vocabulary decision — the Weaver folds
+ * `mark:archived`/`mark:unarchived` and `mark:entity-tag-added`/`-removed`
+ * through `updateResource`). Every implementation validates its input with
+ * this one guard so the mutability contract cannot drift per backend.
+ */
+export function assertMutableResourceUpdate(input: UpdateResourceInput): void {
+  const keys = Object.keys(input);
+  if (keys.length === 0 || keys.some((k) => !MUTABLE_RESOURCE_FACETS.has(k))) {
+    throw new Error('Resources are immutable apart from archival state and entity tags.');
+  }
+}
+
 export interface GraphDatabase {
   // Connection management
   connect(): Promise<void>;

--- a/packages/make-meaning/docs/architecture.md
+++ b/packages/make-meaning/docs/architecture.md
@@ -177,24 +177,23 @@ Manages the lifecycle of temporary clone tokens for resource cloning. In-memory 
 | `yield:clone-resource-requested` | Validate token, look up source resource | `yield:clone-resource-result` / `yield:clone-resource-failed` |
 | `yield:clone-create` | Validate token, create resource via `ResourceOperations` | `yield:clone-created` / `yield:clone-create-failed` |
 
-### Weaver (Projection Pipeline)
+### Weaver (Projection Pipeline, standalone process)
 
-**Implementation**: [src/weaver.ts](../src/weaver.ts)
+**Implementation**: [src/weaver.ts](../src/weaver.ts), entry point [src/weaver-main.ts](../src/weaver-main.ts)
 
-The `Weaver` subscribes to all domain events and projects graph-relevant events into the graph database. It uses an RxJS pipeline with adaptive burst buffering:
+The Weaver is **not started by `startMakeMeaning()`** — it runs as its own process via `@semiont/make-meaning/weaver-main`, receiving graph-relevant domain events and `weave:rebuild` commands through the [`WeaverActorStateUnit`](../src/weaver-actor-state-unit.ts) fan-in (the graph projection is part of the graph stack, not the embedding process). It projects the nine graph-relevant event types into the graph database through an RxJS pipeline with adaptive burst buffering:
 
 ```
-EventBus (callback, fire-and-forget)
-  → Pre-filter: 9 graph-relevant event types
-    → Subject<StoredEvent> (callback-to-RxJS bridge)
-      → groupBy(resourceId)        — one stream per resource
-        → burstBuffer(50ms, 500, 200ms) — adaptive batching per resource
-          → concatMap               — sequential per resource
-            → Single event: applyEventToGraph()
-            → Batch: processBatch() → batchCreateResources / createAnnotations
+WeaverActorStateUnit.events$ (9 channels, StoredEvents)
+  → Subject<StoredEvent>
+    → groupBy(resourceId)        — one stream per resource
+      → burstBuffer(50ms, 500, 200ms) — adaptive batching per resource
+        → concatMap               — sequential per resource
+          → Single event: applyEventToGraph()
+          → Batch: processBatch() → batchCreateResources / createAnnotations
 ```
 
-It is carried on the `KnowledgeBase` record (`kb.weaver`) — `createKnowledgeBase()` constructs and starts it, and calls `rebuildAll()` at startup to replay the event log, so a wiped graph volume is recoverable.
+Every apply advances a per-resource high-water mark and emits a `weave:applied` signal; the backend's `WeaveProgress` fold (`kb.weaveProgress`) turns those into the `whenApplied` barrier the gatherer's graph reads use. At startup the Weaver runs a **checkpointed catch-up**: it discovers resources via `browse:resources-requested`, fetches gap events via `browse:events-requested` (its ONLY view of history — it has no event-store attachment), and replays them through the normal pipeline; a checkpoint ahead of the log (restore) triggers a per-resource rebuild. Full rebuilds are the `weave:rebuild` bus command — so a wiped graph volume recovers by command or by wiping the checkpoint and restarting.
 
 ### Smelter (Projection Pipeline, standalone process)
 
@@ -222,13 +221,13 @@ export interface KnowledgeBase {
   views:          ViewStorage;      // Materialized Views (fast reads)
   content:        WorkingTreeStore; // Content Store (working-tree files, URI-addressed)
   graph:          GraphDatabase;    // Graph (eventually consistent)
-  weaver:  Weaver;  // Event-to-graph projection pipeline
+  weaveProgress:  WeaveProgress;    // weave:applied fold — the graph-projection barrier
   vectors?:       VectorStore;      // Vector index (Qdrant / memory) — optional
   projectionsDir: string;
 }
 ```
 
-The `createKnowledgeBase(eventStore, project, graphDb, eventBus, logger, options?)` factory instantiates `FilesystemViewStorage` and `WorkingTreeStore` once, starts the `Weaver`, and (unless `options.skipRebuild`) rebuilds the materialized views and graph from the event log. Context modules receive `KnowledgeBase` instead of instantiating stores per call.
+The `createKnowledgeBase(eventStore, project, graphDb, eventBus, logger, options?)` factory instantiates `FilesystemViewStorage` and `WorkingTreeStore` once, constructs the `WeaveProgress` fold, and (unless `options.skipRebuild`) rebuilds the materialized views from the event log. The graph is NOT rebuilt here — the standalone Weaver catches up from its checkpoint. Context modules receive `KnowledgeBase` instead of instantiating stores per call.
 
 ## Operations
 
@@ -257,7 +256,7 @@ See [Job Workers](./job-workers.md) for details.
 2. GraphDatabase
 3. EventStore (with EventBus integration)
 4. VectorStore + EmbeddingProvider *(optional — Qdrant or memory, from `@semiont/vectors`)*
-5. **KnowledgeBase** (groups stores including optional vectors; starts Weaver; rebuilds views + graph unless `skipRebuild`)
+5. **KnowledgeBase** (groups stores including optional vectors; constructs the WeaveProgress fold; rebuilds views unless `skipRebuild` — the graph belongs to the standalone Weaver)
 6. **Stower** (must start before reader actors — it handles writes they depend on)
 7. Entity type bootstrap (emits via EventBus, Stower persists)
 8. **Gatherer** (context assembly, vector semantic search; gets its own InferenceClient)

--- a/packages/make-meaning/package.json
+++ b/packages/make-meaning/package.json
@@ -16,6 +16,10 @@
     "./smelter-main": {
       "types": "./dist/smelter-main.d.ts",
       "import": "./dist/smelter-main.js"
+    },
+    "./weaver-main": {
+      "types": "./dist/weaver-main.d.ts",
+      "import": "./dist/weaver-main.js"
     }
   },
   "files": [

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -78,7 +78,7 @@ describe('AnnotationContext', () => {
       content: new WorkingTreeStore(project, mockLogger),
       graph: mockGraphDb,
       projectionsDir: project.projectionsDir,
-      weaver: {} as any, weaveProgress: {} as any,
+      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -78,7 +78,7 @@ describe('AnnotationContext', () => {
       content: new WorkingTreeStore(project, mockLogger),
       graph: mockGraphDb,
       projectionsDir: project.projectionsDir,
-      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
+      weaveProgress: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -95,7 +95,7 @@ describe('AnnotationOperations', () => {
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     const { WorkingTreeStore } = await import('@semiont/content');
     const repStore = new WorkingTreeStore(project, mockLogger);
-    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaveProgress: {} as any };
+    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any };
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -95,7 +95,7 @@ describe('AnnotationOperations', () => {
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     const { WorkingTreeStore } = await import('@semiont/content');
     const repStore = new WorkingTreeStore(project, mockLogger);
-    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any };
+    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any };
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/gatherer.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer.test.ts
@@ -49,7 +49,7 @@ function createMockKb(): KnowledgeBase {
     content: {} as any,
     graph: {} as any,
     projectionsDir: '',
-      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
+      weaveProgress: {} as any,
   };
 }
 

--- a/packages/make-meaning/src/__tests__/gatherer.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer.test.ts
@@ -49,7 +49,7 @@ function createMockKb(): KnowledgeBase {
     content: {} as any,
     graph: {} as any,
     projectionsDir: '',
-      weaver: {} as any, weaveProgress: {} as any,
+      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
   };
 }
 

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -31,6 +31,7 @@ describe('GraphContext', () => {
     graph: mockGraphDb as any,
     projectionsDir: '',
     weaver: {} as any,
+    weaverEvents: {} as any,
     weaveProgress: mockWeaveProgress as any,
   };
 

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -30,8 +30,6 @@ describe('GraphContext', () => {
     content: {} as any,
     graph: mockGraphDb as any,
     projectionsDir: '',
-    weaver: {} as any,
-    weaverEvents: {} as any,
     weaveProgress: mockWeaveProgress as any,
   };
 

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -95,7 +95,7 @@ describe('LLM Context', () => {
     // Create KnowledgeBase - share event store's view storage to avoid separate instances
     const { getGraphDatabase } = await import('@semiont/graph');
     const graphDb = await getGraphDatabase(graphConfig);
-    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaveProgress: {} as any };
+    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any };
 
     // Start Stower
     stower = new Stower(kb, eventBus, project, mockLogger);

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -95,7 +95,7 @@ describe('LLM Context', () => {
     // Create KnowledgeBase - share event store's view storage to avoid separate instances
     const { getGraphDatabase } = await import('@semiont/graph');
     const graphDb = await getGraphDatabase(graphConfig);
-    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any };
+    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any };
 
     // Start Stower
     stower = new Stower(kb, eventBus, project, mockLogger);

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -132,7 +132,7 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
     views: {} as any,
     content: {} as any,
     projectionsDir: '',
-      weaver: {} as any, weaveProgress: {} as any,
+      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
     graph: {
       searchResources: overrides.searchResources ?? vi.fn().mockResolvedValue([]),
       getResourceReferencedBy: overrides.getResourceReferencedBy ?? vi.fn().mockResolvedValue([]),

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -132,7 +132,7 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
     views: {} as any,
     content: {} as any,
     projectionsDir: '',
-      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
+      weaveProgress: {} as any,
     graph: {
       searchResources: overrides.searchResources ?? vi.fn().mockResolvedValue([]),
       getResourceReferencedBy: overrides.getResourceReferencedBy ?? vi.fn().mockResolvedValue([]),

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -48,7 +48,7 @@ describe('ResourceContext', () => {
       content: mockRepStore,
       graph: mockGraph,
       projectionsDir: '',
-      weaver: {} as any, weaveProgress: {} as any,
+      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -48,7 +48,7 @@ describe('ResourceContext', () => {
       content: mockRepStore,
       graph: mockGraph,
       projectionsDir: '',
-      weaver: {} as any, weaverEvents: {} as any, weaveProgress: {} as any,
+      weaveProgress: {} as any,
     };
   });
 

--- a/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
@@ -18,6 +18,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SemiontProject } from '@semiont/core/node';
 import { EventBus, type Logger, type SupportedMediaType, userId, resourceId as makeResourceId } from '@semiont/core';
 import { startMakeMeaning, ResourceOperations, AnnotationOperations, type MakeMeaningConfig } from '../..';
+import { Weaver } from '../../weaver';
+import { createWeaverActorStateUnit, type WeaverActorStateUnit } from '../../weaver-actor-state-unit';
+import { workerBusOverEventBus } from '../../worker-bus-local';
+import { asBusRequestPrimitive } from '../../bus-request-local';
+import { FileWeaverCheckpoint } from '../../weaver-checkpoint';
 import { deriveStorageUri } from '@semiont/content';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
@@ -53,6 +58,8 @@ describe('Scripting Example: Query Graph Database', () => {
   let config: MakeMeaningConfig;
   let makeMeaning: Awaited<ReturnType<typeof startMakeMeaning>>;
   let eventBus: EventBus;
+  let weaver: Weaver;
+  let weaverUnit: WeaverActorStateUnit;
 
   async function create(
     opts: { name: string; content: Buffer; format: SupportedMediaType; language?: string },
@@ -91,9 +98,32 @@ describe('Scripting Example: Query Graph Database', () => {
 
     eventBus = new EventBus();
     makeMeaning = await startMakeMeaning(project, config, eventBus, mockLogger);
+
+    // The service no longer runs a Weaver (D4: the graph projection is part
+    // of the graph stack). A hermetic test that wants projection wires one
+    // directly against the service's own graph instance and bus — exactly
+    // what weaver-main does in a deployment.
+    const workerBus = workerBusOverEventBus(eventBus);
+    weaverUnit = createWeaverActorStateUnit({ bus: workerBus });
+    weaver = new Weaver(
+      makeMeaning.knowledgeSystem.kb.graph,
+      weaverUnit.events$,
+      weaverUnit.rebuilds$,
+      asBusRequestPrimitive(eventBus),
+      new FileWeaverCheckpoint(join(testDir, 'weaver-checkpoint.json')),
+      mockLogger,
+    );
+    await weaver.initialize();
+    weaverUnit.start();
   });
 
   afterEach(async () => {
+    // Stop the test-wired Weaver first (it consumes the bus the service owns)
+    if (weaver) {
+      await weaver.stop();
+    }
+    weaverUnit?.dispose();
+
     // Stop service
     if (makeMeaning) {
       await makeMeaning.stop();

--- a/packages/make-meaning/src/__tests__/service.test.ts
+++ b/packages/make-meaning/src/__tests__/service.test.ts
@@ -109,12 +109,16 @@ describe('Make-Meaning Service', () => {
       expect(typeof kb.graph.disconnect).toBe('function');
     });
 
-    it('should initialize Weaver', async () => {
+    it('should initialize WeaveProgress but no in-process Weaver (D4: standalone-only)', async () => {
       service = await startMakeMeaning(project, config, eventBus, mockLogger);
       const { kb } = service.knowledgeSystem;
 
-      expect(kb.weaver).toBeDefined();
-      expect(typeof kb.weaver.stop).toBe('function');
+      // The graph projection is part of the graph stack, not the embedding
+      // process — the Weaver runs via @semiont/make-meaning/weaver-main.
+      // The backend keeps only the weave:applied fold.
+      expect(kb.weaveProgress).toBeDefined();
+      expect(typeof kb.weaveProgress.whenApplied).toBe('function');
+      expect('weaver' in kb).toBe(false);
     });
 
     it('should return service handle with stop method', async () => {
@@ -142,15 +146,15 @@ describe('Make-Meaning Service', () => {
       service = null;
     });
 
-    it('should stop Weaver on service stop', async () => {
+    it('should dispose WeaveProgress on service stop', async () => {
       service = await startMakeMeaning(project, config, eventBus, mockLogger);
       const { kb } = service.knowledgeSystem;
 
-      const consumerStopSpy = vi.spyOn(kb.weaver, 'stop');
+      const disposeSpy = vi.spyOn(kb.weaveProgress, 'dispose');
 
       await service.stop();
 
-      expect(consumerStopSpy).toHaveBeenCalled();
+      expect(disposeSpy).toHaveBeenCalled();
 
       service = null;
     });
@@ -179,7 +183,7 @@ describe('Make-Meaning Service', () => {
       expect(service).toBeDefined();
       expect(kb.eventStore).toBeDefined();
       expect(kb.graph).toBeDefined();
-      expect(kb.weaver).toBeDefined();
+      expect(kb.weaveProgress).toBeDefined();
     });
 
     it('should allow multiple service instances with different directories', async () => {

--- a/packages/make-meaning/src/__tests__/weaver-actor-state-unit.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver-actor-state-unit.test.ts
@@ -50,7 +50,7 @@ describe('createWeaverActorStateUnit', () => {
     h = fakeBus();
   });
 
-  it('extends the shared bus with all 9 graph-relevant channels on start', () => {
+  it('extends the shared bus with all 9 graph-relevant channels plus the rebuild command on start', () => {
     const unit = createWeaverActorStateUnit({ bus: h.bus });
     unit.start();
 
@@ -60,10 +60,26 @@ describe('createWeaverActorStateUnit', () => {
       'mark:added', 'mark:removed', 'mark:body-updated',
       'mark:entity-tag-added', 'mark:entity-tag-removed',
       'frame:entity-type-added',
+      'weave:rebuild',
     ]) {
       expect(h.channels.has(channel)).toBe(true);
     }
     expect(WEAVER_CHANNELS).toHaveLength(9);
+  });
+
+  it('exposes weave:rebuild commands on rebuilds$ — not mixed into events$', () => {
+    const unit = createWeaverActorStateUnit({ bus: h.bus });
+    const commands: any[] = [];
+    const events: any[] = [];
+    unit.rebuilds$.subscribe((c) => commands.push(c));
+    unit.events$.subscribe((e) => events.push(e));
+    unit.start();
+
+    const cmd = { resourceId: 'res-1', correlationId: 'corr-1' };
+    h.pushEvent('weave:rebuild', cmd);
+
+    expect(commands).toEqual([cmd]);
+    expect(events).toHaveLength(0);
   });
 
   it('passes StoredEvents through verbatim — metadata intact for the fold', () => {

--- a/packages/make-meaning/src/__tests__/weaver-actor-state-unit.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver-actor-state-unit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * WeaverActorStateUnit Tests (WEAVER-ISOLATION P2)
+ *
+ * Domain-event fan-in for the Weaver: the 9 graph-relevant channels merged
+ * into one `StoredEvent`-typed `events$`. Transport-neutral over WorkerBus —
+ * in-process today (core EventBus via the local shim), the bus gateway after
+ * the split, with this unit unchanged.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Subject } from 'rxjs';
+import type { WorkerBus } from '@semiont/sdk';
+import { assertStateUnitAxioms } from '@semiont/core/testing';
+import { createWeaverActorStateUnit, WEAVER_CHANNELS } from '../weaver-actor-state-unit';
+
+function fakeBus() {
+  const channels = new Set<string>();
+  const streams = new Map<string, Subject<any>>();
+
+  const getStream = (channel: string): Subject<any> => {
+    let s = streams.get(channel);
+    if (!s) {
+      s = new Subject();
+      streams.set(channel, s);
+    }
+    return s;
+  };
+
+  const bus: WorkerBus = {
+    addChannels: vi.fn((cs: readonly string[]) => {
+      cs.forEach((c) => channels.add(c));
+    }),
+    on$: vi.fn((channel: string) => getStream(channel).asObservable()),
+    // Required by the WorkerBus shape; the fan-in never emits — the Weaver
+    // itself emits weave:applied through its own bus handle.
+    emit: vi.fn(async () => {}),
+  };
+
+  return {
+    bus,
+    channels,
+    pushEvent: (channel: string, payload: any) => getStream(channel).next(payload),
+  };
+}
+
+describe('createWeaverActorStateUnit', () => {
+  let h: ReturnType<typeof fakeBus>;
+
+  beforeEach(() => {
+    h = fakeBus();
+  });
+
+  it('extends the shared bus with all 9 graph-relevant channels on start', () => {
+    const unit = createWeaverActorStateUnit({ bus: h.bus });
+    unit.start();
+
+    for (const channel of [
+      'yield:created',
+      'mark:archived', 'mark:unarchived',
+      'mark:added', 'mark:removed', 'mark:body-updated',
+      'mark:entity-tag-added', 'mark:entity-tag-removed',
+      'frame:entity-type-added',
+    ]) {
+      expect(h.channels.has(channel)).toBe(true);
+    }
+    expect(WEAVER_CHANNELS).toHaveLength(9);
+  });
+
+  it('passes StoredEvents through verbatim — metadata intact for the fold', () => {
+    const unit = createWeaverActorStateUnit({ bus: h.bus });
+    const seen: any[] = [];
+    unit.events$.subscribe((e) => seen.push(e));
+    unit.start();
+
+    const stored = {
+      id: 'evt-1',
+      type: 'mark:added',
+      resourceId: 'res-1',
+      payload: { annotation: { id: 'ann-1' } },
+      metadata: { sequenceNumber: 7 },
+    };
+    h.pushEvent('mark:added', stored);
+
+    expect(seen).toHaveLength(1);
+    // Verbatim — no re-shaping: the Weaver's fold needs payload AND
+    // metadata.sequenceNumber (lastProcessed / weave:applied).
+    expect(seen[0]).toBe(stored);
+  });
+
+  it('merges events across channels into one stream', () => {
+    const unit = createWeaverActorStateUnit({ bus: h.bus });
+    const seen: string[] = [];
+    unit.events$.subscribe((e: any) => seen.push(e.type));
+    unit.start();
+
+    h.pushEvent('yield:created', { type: 'yield:created', metadata: { sequenceNumber: 1 } });
+    h.pushEvent('frame:entity-type-added', { type: 'frame:entity-type-added', metadata: { sequenceNumber: 2 } });
+
+    expect(seen).toEqual(['yield:created', 'frame:entity-type-added']);
+  });
+
+  it('start() is idempotent — channels widened once', () => {
+    const unit = createWeaverActorStateUnit({ bus: h.bus });
+    unit.start();
+    unit.start();
+
+    expect(h.bus.addChannels).toHaveBeenCalledTimes(1);
+  });
+
+  describe('StateUnit axioms', () => {
+    it('satisfies the StateUnit axioms', () => {
+      // No owned surfaces: `events$` is derived from the injected bus's `on$`.
+      assertStateUnitAxioms({
+        setup: () => createWeaverActorStateUnit({ bus: fakeBus().bus }),
+        invocations: (u) => [() => u.start()],
+      });
+    });
+  });
+});

--- a/packages/make-meaning/src/__tests__/weaver-checkpoint.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver-checkpoint.test.ts
@@ -1,0 +1,53 @@
+/**
+ * FileWeaverCheckpoint Tests (WEAVER-ISOLATION P3, D1 = checkpointed replay)
+ *
+ * The Weaver's persisted per-resource applied-sequence map. Lives in the
+ * project stateDir — wiping it degrades the next catch-up to a full replay
+ * through the pipeline (idempotent folds absorb it), never to wrongness.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { FileWeaverCheckpoint } from '../weaver-checkpoint';
+
+describe('FileWeaverCheckpoint', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'weaver-checkpoint-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('load() returns an empty map when no checkpoint file exists', async () => {
+    const store = new FileWeaverCheckpoint(join(dir, 'absent.json'));
+    expect(await store.load()).toEqual({});
+  });
+
+  it('round-trips saved sequences', async () => {
+    const store = new FileWeaverCheckpoint(join(dir, 'cp.json'));
+    await store.save({ 'res-a': 7, 'res-b': 3 });
+
+    expect(await store.load()).toEqual({ 'res-a': 7, 'res-b': 3 });
+  });
+
+  it('save() replaces the previous checkpoint wholesale', async () => {
+    const store = new FileWeaverCheckpoint(join(dir, 'cp.json'));
+    await store.save({ 'res-a': 1 });
+    await store.save({ 'res-b': 2 });
+
+    expect(await store.load()).toEqual({ 'res-b': 2 });
+  });
+
+  it('load() of a corrupt file degrades to empty — full replay, not a crash', async () => {
+    const path = join(dir, 'cp.json');
+    await fs.writeFile(path, 'not json{', 'utf-8');
+    const store = new FileWeaverCheckpoint(path);
+
+    expect(await store.load()).toEqual({});
+  });
+});

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -16,6 +16,8 @@ import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } 
 import { EventStore, FilesystemViewStorage } from '@semiont/event-sourcing';
 import { SemiontProject } from '@semiont/core/node';
 import { Weaver } from '../weaver';
+import { createWeaverActorStateUnit, type WeaverActorStateUnit } from '../weaver-actor-state-unit';
+import { workerBusOverEventBus } from '../worker-bus-local';
 import { resourceId, userId, annotationId, EventBus } from '@semiont/core';
 import type { Logger } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
@@ -106,15 +108,26 @@ describe('Weaver', () => {
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
+  let weaverUnit: WeaverActorStateUnit;
+
+  const wireWeaver = async (db: GraphDatabase): Promise<Weaver> => {
+    const workerBus = workerBusOverEventBus(coreEventBus);
+    weaverUnit = createWeaverActorStateUnit({ bus: workerBus });
+    const weaver = new Weaver(eventStore, db, weaverUnit.events$, workerBus, mockLogger);
+    await weaver.initialize();
+    weaverUnit.start();
+    return weaver;
+  };
+
   beforeEach(async () => {
     graphDb = createMockGraphDb();
-    consumer = new Weaver(eventStore, graphDb, coreEventBus, mockLogger);
-    await consumer.initialize();
+    consumer = await wireWeaver(graphDb);
     vi.clearAllMocks();
   });
 
   afterEach(async () => {
     await consumer?.stop();
+    weaverUnit?.dispose();
   });
 
   describe('event type filtering', () => {
@@ -709,8 +722,11 @@ describe('Weaver', () => {
   describe('lifecycle', () => {
     it('should unsubscribe on stop', async () => {
       const localGraphDb = createMockGraphDb();
-      const localConsumer = new Weaver(eventStore, localGraphDb, coreEventBus, mockLogger);
+      const localWorkerBus = workerBusOverEventBus(coreEventBus);
+      const localUnit = createWeaverActorStateUnit({ bus: localWorkerBus });
+      const localConsumer = new Weaver(eventStore, localGraphDb, localUnit.events$, localWorkerBus, mockLogger);
       await localConsumer.initialize();
+      localUnit.start();
 
       const docId = resourceId(`lifecycle-stop-${Date.now()}`);
 
@@ -746,7 +762,7 @@ describe('Weaver', () => {
     it('should report health metrics', async () => {
       const metrics = consumer.getHealthMetrics();
 
-      expect(metrics.subscriptions).toBe(9); // One per GRAPH_RELEVANT_EVENTS entry
+      expect(metrics.subscriptions).toBe(1); // One injected source stream — channel fan-in (9) lives in WeaverActorStateUnit
       expect(metrics.pipelineActive).toBe(true);
       expect(typeof metrics.lastProcessed).toBe('object');
     });
@@ -789,11 +805,12 @@ describe('Weaver', () => {
 
     beforeEach(async () => {
       // Swap the outer mock-based consumer for one wired to a real memory
-      // graph — the outer afterEach still stops whatever `consumer` holds.
+      // graph — the outer afterEach still stops whatever `consumer` and
+      // `weaverUnit` hold.
       await consumer.stop();
+      weaverUnit.dispose();
       graphDb = new MemoryGraphDatabase();
-      consumer = new Weaver(eventStore, graphDb, coreEventBus, mockLogger);
-      await consumer.initialize();
+      consumer = await wireWeaver(graphDb);
     });
 
     it('yield:created twice → one resource', async () => {

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -19,6 +19,8 @@ import { Weaver } from '../weaver';
 import { resourceId, userId, annotationId, EventBus } from '@semiont/core';
 import type { Logger } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
+import { MemoryGraphDatabase } from '@semiont/graph';
+import type { StoredEvent } from '@semiont/core';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -747,6 +749,182 @@ describe('Weaver', () => {
       expect(metrics.subscriptions).toBe(9); // One per GRAPH_RELEVANT_EVENTS entry
       expect(metrics.pipelineActive).toBe(true);
       expect(typeof metrics.lastProcessed).toBe('object');
+    });
+  });
+
+  describe('duplicate-delivery idempotency (WEAVER-ISOLATION P1)', () => {
+    // At-least-once delivery (SSE reconnect with Last-Event-ID replay after
+    // the split) means every fold must tolerate the same StoredEvent arriving
+    // twice. These specs push identical events straight onto the bus — the
+    // redelivery shape — against a REAL memory graph so state, not call
+    // counts alone, is the oracle.
+    let seq = 0;
+    const nextSeq = () => ++seq;
+
+    const stored = (type: string, rid: string | undefined, payload: unknown): StoredEvent => ({
+      id: uuidv4(),
+      type,
+      timestamp: new Date().toISOString(),
+      userId: userId('user-dup'),
+      ...(rid ? { resourceId: resourceId(rid) } : {}),
+      version: 1,
+      payload,
+      metadata: { sequenceNumber: nextSeq() },
+    } as unknown as StoredEvent);
+
+    const deliver = async (e: StoredEvent) => {
+      coreEventBus.getDomainEvent(e.type as Parameters<EventBus['getDomainEvent']>[0]).next(e);
+      await tick();
+    };
+
+    const createdEvent = (rid: string) =>
+      stored('yield:created', rid, { name: 'Dup Test', format: 'text/plain', contentChecksum: 'h-dup' });
+
+    const annotation = (aid: string, rid: string) => ({
+      id: annotationId(aid),
+      motivation: 'commenting',
+      target: { source: rid },
+      body: [],
+    });
+
+    beforeEach(async () => {
+      // Swap the outer mock-based consumer for one wired to a real memory
+      // graph — the outer afterEach still stops whatever `consumer` holds.
+      await consumer.stop();
+      graphDb = new MemoryGraphDatabase();
+      consumer = new Weaver(eventStore, graphDb, coreEventBus, mockLogger);
+      await consumer.initialize();
+    });
+
+    it('yield:created twice → one resource', async () => {
+      const e = createdEvent('dup-created');
+      await deliver(e);
+      await deliver(e);
+
+      const { total } = await graphDb.listResources({});
+      expect(total).toBe(1);
+    });
+
+    it('mark:added twice (sequential redelivery) → one annotation, under the event\'s own id, one create call', async () => {
+      await deliver(createdEvent('dup-add'));
+      const createSpy = vi.spyOn(graphDb, 'createAnnotation');
+
+      const e = stored('mark:added', 'dup-add', { annotation: annotation('ann-dup-1', 'dup-add') });
+      await deliver(e);
+      await deliver(e);
+
+      const { annotations } = await graphDb.listAnnotations({ resourceId: resourceId('dup-add') });
+      expect(annotations).toHaveLength(1);
+      // The graph must store the annotation under the event's id — the id is
+      // the system of record's, not the store's to mint (Neo4j already
+      // honors this; the fold and every backend must agree).
+      expect(String(annotations[0]!.id)).toBe('ann-dup-1');
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('mark:added duplicated within one burst (batch path) → one annotation, one created input', async () => {
+      await deliver(createdEvent('dup-add-burst'));
+      const singleSpy = vi.spyOn(graphDb, 'createAnnotation');
+      const batchSpy = vi.spyOn(graphDb, 'createAnnotations');
+
+      const e = stored('mark:added', 'dup-add-burst', { annotation: annotation('ann-dup-burst', 'dup-add-burst') });
+      // Same event twice in the same burst window — no tick between.
+      coreEventBus.getDomainEvent('mark:added').next(e);
+      coreEventBus.getDomainEvent('mark:added').next(e);
+      await tick();
+
+      const { annotations } = await graphDb.listAnnotations({ resourceId: resourceId('dup-add-burst') });
+      expect(annotations).toHaveLength(1);
+      const createdInputs =
+        singleSpy.mock.calls.length +
+        batchSpy.mock.calls.reduce((n, [inputs]) => n + inputs.length, 0);
+      expect(createdInputs).toBe(1);
+    });
+
+    it('mark:removed twice → annotation gone, second delivery inert', async () => {
+      await deliver(createdEvent('dup-rm'));
+      await deliver(stored('mark:added', 'dup-rm', { annotation: annotation('ann-dup-rm', 'dup-rm') }));
+
+      const e = stored('mark:removed', 'dup-rm', { annotationId: 'ann-dup-rm' });
+      await deliver(e);
+      await deliver(e);
+
+      const { annotations } = await graphDb.listAnnotations({ resourceId: resourceId('dup-rm') });
+      expect(annotations).toHaveLength(0);
+    });
+
+    it('mark:archived twice → archived once, still one resource', async () => {
+      await deliver(createdEvent('dup-arch'));
+
+      const e = stored('mark:archived', 'dup-arch', {});
+      await deliver(e);
+      await deliver(e);
+
+      const doc = await graphDb.getResource(resourceId('dup-arch'));
+      expect(doc?.archived).toBe(true);
+      const { total } = await graphDb.listResources({});
+      expect(total).toBe(1);
+    });
+
+    it('mark:unarchived twice → unarchived, stable', async () => {
+      await deliver(createdEvent('dup-unarch'));
+      await deliver(stored('mark:archived', 'dup-unarch', {}));
+
+      const e = stored('mark:unarchived', 'dup-unarch', {});
+      await deliver(e);
+      await deliver(e);
+
+      const doc = await graphDb.getResource(resourceId('dup-unarch'));
+      expect(doc?.archived).toBe(false);
+    });
+
+    it('mark:body-updated (add op) twice → body item added once', async () => {
+      await deliver(createdEvent('dup-body'));
+      await deliver(stored('mark:added', 'dup-body', { annotation: annotation('ann-dup-body', 'dup-body') }));
+
+      const item = { type: 'TextualBody', value: 'dup-comment', purpose: 'commenting' };
+      const e = stored('mark:body-updated', 'dup-body', {
+        annotationId: 'ann-dup-body',
+        operations: [{ op: 'add', item }],
+      });
+      await deliver(e);
+      await deliver(e);
+
+      const ann = await graphDb.getAnnotation(annotationId('ann-dup-body'));
+      const body = Array.isArray(ann?.body) ? ann.body : ann?.body ? [ann.body] : [];
+      expect(body).toHaveLength(1);
+    });
+
+    it('mark:entity-tag-added twice → tag applied once (#974 pin)', async () => {
+      await deliver(createdEvent('dup-tag'));
+
+      const e = stored('mark:entity-tag-added', 'dup-tag', { entityType: 'DupTag' });
+      await deliver(e);
+      await deliver(e);
+
+      const doc = await graphDb.getResource(resourceId('dup-tag'));
+      expect(doc?.entityTypes).toEqual(['DupTag']);
+    });
+
+    it('mark:entity-tag-removed twice → tag gone, second delivery inert', async () => {
+      await deliver(createdEvent('dup-untag'));
+      await deliver(stored('mark:entity-tag-added', 'dup-untag', { entityType: 'DupTag' }));
+
+      const e = stored('mark:entity-tag-removed', 'dup-untag', { entityType: 'DupTag' });
+      await deliver(e);
+      await deliver(e);
+
+      const doc = await graphDb.getResource(resourceId('dup-untag'));
+      expect(doc?.entityTypes).toEqual([]);
+    });
+
+    it('frame:entity-type-added twice → one registry entry', async () => {
+      const e = stored('frame:entity-type-added', undefined, { entityType: 'DupEntityType' });
+      await deliver(e);
+      await deliver(e);
+
+      const types = await graphDb.getEntityTypes();
+      expect(types.filter((t) => t === 'DupEntityType')).toHaveLength(1);
     });
   });
 });

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -18,6 +18,9 @@ import { SemiontProject } from '@semiont/core/node';
 import { Weaver } from '../weaver';
 import { createWeaverActorStateUnit, type WeaverActorStateUnit } from '../weaver-actor-state-unit';
 import { workerBusOverEventBus } from '../worker-bus-local';
+import { asBusRequestPrimitive } from '../bus-request-local';
+import { FileWeaverCheckpoint } from '../weaver-checkpoint';
+import { busRequest } from '@semiont/core';
 import { resourceId, userId, annotationId, EventBus } from '@semiont/core';
 import type { Logger } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
@@ -110,10 +113,18 @@ describe('Weaver', () => {
 
   let weaverUnit: WeaverActorStateUnit;
 
-  const wireWeaver = async (db: GraphDatabase): Promise<Weaver> => {
+  const wireWeaver = async (db: GraphDatabase, checkpointPath?: string): Promise<Weaver> => {
     const workerBus = workerBusOverEventBus(coreEventBus);
     weaverUnit = createWeaverActorStateUnit({ bus: workerBus });
-    const weaver = new Weaver(eventStore, db, weaverUnit.events$, workerBus, mockLogger);
+    const weaver = new Weaver(
+      eventStore,
+      db,
+      weaverUnit.events$,
+      weaverUnit.rebuilds$,
+      asBusRequestPrimitive(coreEventBus),
+      new FileWeaverCheckpoint(checkpointPath ?? join(testDir, `weaver-checkpoint-${uuidv4()}.json`)),
+      mockLogger,
+    );
     await weaver.initialize();
     weaverUnit.start();
     return weaver;
@@ -724,7 +735,15 @@ describe('Weaver', () => {
       const localGraphDb = createMockGraphDb();
       const localWorkerBus = workerBusOverEventBus(coreEventBus);
       const localUnit = createWeaverActorStateUnit({ bus: localWorkerBus });
-      const localConsumer = new Weaver(eventStore, localGraphDb, localUnit.events$, localWorkerBus, mockLogger);
+      const localConsumer = new Weaver(
+        eventStore,
+        localGraphDb,
+        localUnit.events$,
+        localUnit.rebuilds$,
+        asBusRequestPrimitive(coreEventBus),
+        new FileWeaverCheckpoint(join(testDir, `weaver-checkpoint-${uuidv4()}.json`)),
+        mockLogger,
+      );
       await localConsumer.initialize();
       localUnit.start();
 
@@ -942,6 +961,162 @@ describe('Weaver', () => {
 
       const types = await graphDb.getEntityTypes();
       expect(types.filter((t) => t === 'DupEntityType')).toHaveLength(1);
+    });
+  });
+
+  describe('checkpointed catch-up + weave:rebuild (WEAVER-ISOLATION P3)', () => {
+    // Catch-up rides EXISTING read channels: resources discovered via
+    // browse:resources-requested, gap events fetched via
+    // browse:events-requested (full StoredEvents), filtered client-side by
+    // the persisted checkpoint, then pushed through the normal pipeline —
+    // per-resource lanes serialize against live traffic, idempotent folds
+    // absorb overlap, and noteApplied signals fire during replay so the
+    // whenApplied barrier keeps working mid-recovery.
+    let stopServing: (() => void) | null = null;
+
+    const serveBrowseReads = (rids: string[]) => {
+      const subs = [
+        coreEventBus.get('browse:resources-requested').subscribe((req: any) => {
+          coreEventBus.get('browse:resources-result').next({
+            correlationId: req.correlationId,
+            response: {
+              resources: rids.map((id) => ({
+                '@id': id, name: id, representations: [], archived: false, entityTypes: [],
+              })),
+              total: rids.length,
+            },
+          } as any);
+        }),
+        coreEventBus.get('browse:events-requested').subscribe((req: any) => {
+          void eventStore.log.getEvents(resourceId(req.resourceId)).then((events) => {
+            coreEventBus.get('browse:events-result').next({
+              correlationId: req.correlationId,
+              response: { events, total: events.length, resourceId: req.resourceId },
+            } as any);
+          });
+        }),
+      ];
+      stopServing = () => subs.forEach((s) => s.unsubscribe());
+    };
+
+    afterEach(() => {
+      stopServing?.();
+      stopServing = null;
+    });
+
+    it('replays events missed while down, then a second catch-up is a checkpointed no-op', async () => {
+      // Down: stop the live weaver, then append events nobody hears.
+      await consumer.stop();
+      weaverUnit.dispose();
+
+      const rid = `catchup-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Missed While Down', format: 'text/plain', contentChecksum: 'h-cu' },
+      });
+      await eventStore.appendEvent({
+        type: 'mark:archived',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: {},
+      });
+
+      // Back up: wire a fresh weaver on a real graph, live first, then catch up.
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+      serveBrowseReads([rid]);
+
+      const summary = await consumer.catchUp();
+
+      const doc = await graphDb.getResource(resourceId(rid));
+      expect(doc?.name).toBe('Missed While Down');
+      expect(doc?.archived).toBe(true);
+      expect(summary.eventsReplayed).toBeGreaterThanOrEqual(2);
+
+      // Second pass: the checkpoint covers everything — nothing replays.
+      const createSpy = vi.spyOn(graphDb, 'createResource');
+      const summary2 = await consumer.catchUp();
+      expect(summary2.eventsReplayed).toBe(0);
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('a rewound log (restore) triggers a per-resource rebuild instead of trusting the checkpoint', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+
+      const rid = `rewound-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Restored', format: 'text/plain', contentChecksum: 'h-rw' },
+      });
+
+      // A checkpoint claiming we are FAR ahead of the log — the restore shape.
+      const checkpointPath = join(testDir, `weaver-checkpoint-${uuidv4()}.json`);
+      await new FileWeaverCheckpoint(checkpointPath).save({ [rid]: 999 });
+
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb, checkpointPath);
+      serveBrowseReads([rid]);
+
+      const summary = await consumer.catchUp();
+
+      expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Restored');
+      expect(summary.resourcesRebuilt).toBe(1);
+    });
+
+    it('weave:rebuild (full) clears and rebuilds the graph, replying ok', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `rebuild-full-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Rebuilt', format: 'text/plain', contentChecksum: 'h-rb' },
+      });
+      await tick();
+
+      const clearSpy = vi.spyOn(graphDb, 'clearDatabase');
+      await busRequest(asBusRequestPrimitive(coreEventBus), 'weave:rebuild', {});
+
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Rebuilt');
+    });
+
+    it('weave:rebuild scoped to a resource rebuilds just that resource', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `rebuild-one-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Rebuilt One', format: 'text/plain', contentChecksum: 'h-r1' },
+      });
+      await tick();
+
+      const deleteSpy = vi.spyOn(graphDb, 'deleteResource');
+      const clearSpy = vi.spyOn(graphDb, 'clearDatabase');
+      await busRequest(asBusRequestPrimitive(coreEventBus), 'weave:rebuild', { resourceId: rid });
+
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Rebuilt One');
     });
   });
 });

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -117,7 +117,6 @@ describe('Weaver', () => {
     const workerBus = workerBusOverEventBus(coreEventBus);
     weaverUnit = createWeaverActorStateUnit({ bus: workerBus });
     const weaver = new Weaver(
-      eventStore,
       db,
       weaverUnit.events$,
       weaverUnit.rebuilds$,
@@ -736,7 +735,6 @@ describe('Weaver', () => {
       const localWorkerBus = workerBusOverEventBus(coreEventBus);
       const localUnit = createWeaverActorStateUnit({ bus: localWorkerBus });
       const localConsumer = new Weaver(
-        eventStore,
         localGraphDb,
         localUnit.events$,
         localUnit.rebuilds$,
@@ -1087,6 +1085,9 @@ describe('Weaver', () => {
       });
       await tick();
 
+      // Rebuild reads history over the bus — the Weaver has no event-store
+      // attachment (P4); these responders are its only view of the log.
+      serveBrowseReads([rid]);
       const clearSpy = vi.spyOn(graphDb, 'clearDatabase');
       await busRequest(asBusRequestPrimitive(coreEventBus), 'weave:rebuild', {});
 
@@ -1110,6 +1111,7 @@ describe('Weaver', () => {
       });
       await tick();
 
+      serveBrowseReads([rid]);
       const deleteSpy = vi.spyOn(graphDb, 'deleteResource');
       const clearSpy = vi.spyOn(graphDb, 'clearDatabase');
       await busRequest(asBusRequestPrimitive(coreEventBus), 'weave:rebuild', { resourceId: rid });

--- a/packages/make-meaning/src/__tests__/worker-bus-local.test.ts
+++ b/packages/make-meaning/src/__tests__/worker-bus-local.test.ts
@@ -1,0 +1,46 @@
+/**
+ * workerBusOverEventBus Tests (WEAVER-ISOLATION P2)
+ *
+ * The in-process WorkerBus shim over the core EventBus — the "in-process
+ * bus shim" the smelter's fan-in anticipated. Lets any WorkerBus consumer
+ * (WeaverActorStateUnit today) run inside the backend unchanged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@semiont/core';
+import { workerBusOverEventBus } from '../worker-bus-local';
+
+describe('workerBusOverEventBus', () => {
+  it('on$ delivers what the EventBus carries, verbatim', () => {
+    const eventBus = new EventBus();
+    const bus = workerBusOverEventBus(eventBus);
+
+    const seen: unknown[] = [];
+    bus.on$('mark:added').subscribe((e) => seen.push(e));
+
+    const stored = { type: 'mark:added', resourceId: 'r1', payload: {}, metadata: { sequenceNumber: 3 } };
+    eventBus.get('mark:added').next(stored as never);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe(stored);
+  });
+
+  it('emit lands on EventBus subscribers', async () => {
+    const eventBus = new EventBus();
+    const bus = workerBusOverEventBus(eventBus);
+
+    const seen: unknown[] = [];
+    eventBus.get('weave:applied').subscribe((e) => seen.push(e));
+
+    await bus.emit('weave:applied', { resourceId: 'r1', sequenceNumber: 4 });
+
+    expect(seen).toEqual([{ resourceId: 'r1', sequenceNumber: 4 }]);
+  });
+
+  it('addChannels is a no-op — the in-process bus already delivers every emit', () => {
+    const eventBus = new EventBus();
+    const bus = workerBusOverEventBus(eventBus);
+
+    expect(() => bus.addChannels?.(['mark:added'])).not.toThrow();
+  });
+});

--- a/packages/make-meaning/src/index.ts
+++ b/packages/make-meaning/src/index.ts
@@ -12,6 +12,10 @@ export { stopKnowledgeSystem } from './knowledge-system';
 // Local transport (in-process ITransport / IContentTransport for the SemiontClient)
 export { LocalTransport, type LocalTransportConfig } from './local-transport';
 export { LocalContentTransport } from './local-content-transport';
+// In-process BusRequestPrimitive over a raw EventBus — backend-internal
+// callers (e.g. the rebuild-graph CLI's weave:rebuild) share busRequest's
+// correlated request/reply path.
+export { asBusRequestPrimitive } from './bus-request-local';
 
 // Bus command handlers — registered automatically by `startMakeMeaning`;
 // also exported individually for callers that bring their own bootstrap.

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -27,6 +27,9 @@ import { Weaver } from './weaver.js';
 import { createWeaveProgress, type WeaveProgress } from './weave-progress.js';
 import { createWeaverActorStateUnit, type WeaverActorStateUnit } from './weaver-actor-state-unit.js';
 import { workerBusOverEventBus } from './worker-bus-local.js';
+import { asBusRequestPrimitive } from './bus-request-local.js';
+import { FileWeaverCheckpoint } from './weaver-checkpoint.js';
+import { join } from 'path';
 
 export interface KnowledgeBase {
   eventStore:    EventStore;
@@ -70,7 +73,9 @@ export async function createKnowledgeBase(
     eventStore,
     graphDb,
     weaverEvents.events$,
-    workerBus,
+    weaverEvents.rebuilds$,
+    asBusRequestPrimitive(eventBus),
+    new FileWeaverCheckpoint(join(project.stateDir, 'weaver-checkpoint.json')),
     logger.child({ component: 'weaver' }),
   );
   await weaver.initialize();
@@ -79,11 +84,11 @@ export async function createKnowledgeBase(
   if (!options?.skipRebuild) {
     // Rebuild materialized views from the event log first. The Browser actor
     // reads from these views, so they must be populated before any request is
-    // served. The views layer is the third derived read model alongside the
-    // graph and vectors; this call mirrors weaver.rebuildAll() so
-    // that an ephemeral stateDir wipe is recoverable.
+    // served. The graph projection no longer full-rebuilds here — the Weaver
+    // catches up incrementally via its checkpoint (WEAVER-ISOLATION P3),
+    // called from startMakeMeaning once the Browser is serving the
+    // `browse:*` reads catch-up rides on.
     await eventStore.views.rebuildAll(eventStore.log);
-    await weaver.rebuildAll();
   }
 
   const kb: KnowledgeBase = {

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -25,6 +25,8 @@ import type { SemiontProject } from '@semiont/core/node';
 import type { EventBus, Logger } from '@semiont/core';
 import { Weaver } from './weaver.js';
 import { createWeaveProgress, type WeaveProgress } from './weave-progress.js';
+import { createWeaverActorStateUnit, type WeaverActorStateUnit } from './weaver-actor-state-unit.js';
+import { workerBusOverEventBus } from './worker-bus-local.js';
 
 export interface KnowledgeBase {
   eventStore:    EventStore;
@@ -32,6 +34,7 @@ export interface KnowledgeBase {
   content:       WorkingTreeStore;
   graph:         GraphDatabase;
   weaver:        Weaver;
+  weaverEvents:  WeaverActorStateUnit;
   weaveProgress: WeaveProgress;
   vectors?:      VectorStore;
   projectionsDir: string;
@@ -58,13 +61,20 @@ export async function createKnowledgeBase(
   // Fold of `weave:applied` signals — must exist before the Weaver starts
   // applying so no early signal is missed (GRAPH-PROJECTION-SYNC P2).
   const weaveProgress = createWeaveProgress(eventBus);
+  // Transport seam (WEAVER-ISOLATION P2): the Weaver consumes the fan-in's
+  // events$ and emits through a WorkerBus — in-process both are the core
+  // EventBus behind the local shim; standalone they become the gateway.
+  const workerBus = workerBusOverEventBus(eventBus);
+  const weaverEvents = createWeaverActorStateUnit({ bus: workerBus });
   const weaver = new Weaver(
     eventStore,
     graphDb,
-    eventBus,
+    weaverEvents.events$,
+    workerBus,
     logger.child({ component: 'weaver' }),
   );
   await weaver.initialize();
+  weaverEvents.start();
 
   if (!options?.skipRebuild) {
     // Rebuild materialized views from the event log first. The Browser actor
@@ -77,7 +87,7 @@ export async function createKnowledgeBase(
   }
 
   const kb: KnowledgeBase = {
-    eventStore, views, content, graph: graphDb, weaver, weaveProgress,
+    eventStore, views, content, graph: graphDb, weaver, weaverEvents, weaveProgress,
     projectionsDir: project.projectionsDir,
   };
 

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -8,7 +8,8 @@
  * - Materialized Views (fast single-doc queries) — via ViewStorage
  * - Content Store (working-tree files, URI-addressed) — via WorkingTreeStore
  * - Graph (eventually consistent relationship projection) — via GraphDatabase
- * - Weaver (event-to-graph projection)
+ * - WeaveProgress (weave:applied fold — the graph-projection barrier; the
+ *   Weaver itself runs standalone via @semiont/make-meaning/weaver-main)
  * - Vectors (semantic search) — via VectorStore (optional, read-only)
  *
  * The Smelter (event-to-vector projection) runs as an external actor
@@ -23,21 +24,13 @@ import type { GraphDatabase } from '@semiont/graph';
 import type { VectorStore } from '@semiont/vectors';
 import type { SemiontProject } from '@semiont/core/node';
 import type { EventBus, Logger } from '@semiont/core';
-import { Weaver } from './weaver.js';
 import { createWeaveProgress, type WeaveProgress } from './weave-progress.js';
-import { createWeaverActorStateUnit, type WeaverActorStateUnit } from './weaver-actor-state-unit.js';
-import { workerBusOverEventBus } from './worker-bus-local.js';
-import { asBusRequestPrimitive } from './bus-request-local.js';
-import { FileWeaverCheckpoint } from './weaver-checkpoint.js';
-import { join } from 'path';
 
 export interface KnowledgeBase {
   eventStore:    EventStore;
   views:         ViewStorage;
   content:       WorkingTreeStore;
   graph:         GraphDatabase;
-  weaver:        Weaver;
-  weaverEvents:  WeaverActorStateUnit;
   weaveProgress: WeaveProgress;
   vectors?:      VectorStore;
   projectionsDir: string;
@@ -61,25 +54,12 @@ export async function createKnowledgeBase(
     project,
     logger.child({ component: 'working-tree-store' }),
   );
-  // Fold of `weave:applied` signals — must exist before the Weaver starts
-  // applying so no early signal is missed (GRAPH-PROJECTION-SYNC P2).
+  // Fold of `weave:applied` signals. The Weaver itself is NOT constructed
+  // here (WEAVER-ISOLATION D4, refined): the graph projection is part of
+  // the graph stack, not the embedding process — `weaver-main` runs it as
+  // a standalone actor, and its signals arrive over the bus. This fold is
+  // the backend-side half, wherever the Weaver runs.
   const weaveProgress = createWeaveProgress(eventBus);
-  // Transport seam (WEAVER-ISOLATION P2): the Weaver consumes the fan-in's
-  // events$ and emits through a WorkerBus — in-process both are the core
-  // EventBus behind the local shim; standalone they become the gateway.
-  const workerBus = workerBusOverEventBus(eventBus);
-  const weaverEvents = createWeaverActorStateUnit({ bus: workerBus });
-  const weaver = new Weaver(
-    eventStore,
-    graphDb,
-    weaverEvents.events$,
-    weaverEvents.rebuilds$,
-    asBusRequestPrimitive(eventBus),
-    new FileWeaverCheckpoint(join(project.stateDir, 'weaver-checkpoint.json')),
-    logger.child({ component: 'weaver' }),
-  );
-  await weaver.initialize();
-  weaverEvents.start();
 
   if (!options?.skipRebuild) {
     // Rebuild materialized views from the event log first. The Browser actor
@@ -92,7 +72,7 @@ export async function createKnowledgeBase(
   }
 
   const kb: KnowledgeBase = {
-    eventStore, views, content, graph: graphDb, weaver, weaverEvents, weaveProgress,
+    eventStore, views, content, graph: graphDb, weaveProgress,
     projectionsDir: project.projectionsDir,
   };
 

--- a/packages/make-meaning/src/knowledge-system.ts
+++ b/packages/make-meaning/src/knowledge-system.ts
@@ -42,6 +42,7 @@ export async function stopKnowledgeSystem(ks: KnowledgeSystem): Promise<void> {
   await ks.cloneTokenManager.stop();
   await ks.stower.stop();
   await ks.kb.weaver.stop();
+  ks.kb.weaverEvents.dispose();
   ks.kb.weaveProgress.dispose();
   await ks.kb.graph.disconnect();
 }

--- a/packages/make-meaning/src/knowledge-system.ts
+++ b/packages/make-meaning/src/knowledge-system.ts
@@ -12,8 +12,10 @@
  * - cloneTokenManager: token actor — manages resource clone tokens
  *
  * These are the five access actors. Two projection-pipeline actors complete
- * the seven: the Weaver (kb.weaver, started by
- * createKnowledgeBase) and the Smelter (standalone process via smelter-main).
+ * the seven, and BOTH run standalone (D4: the projections are part of their
+ * stores' stacks, not of the embedding process): the Weaver (weaver-main →
+ * graph) and the Smelter (smelter-main → vectors). The backend keeps only
+ * the Weaver's `weave:applied` fold (kb.weaveProgress).
  *
  * EventBus, JobQueue, and workers are peers to KnowledgeSystem, not members.
  */
@@ -41,8 +43,6 @@ export async function stopKnowledgeSystem(ks: KnowledgeSystem): Promise<void> {
   await ks.browser.stop();
   await ks.cloneTokenManager.stop();
   await ks.stower.stop();
-  await ks.kb.weaver.stop();
-  ks.kb.weaverEvents.dispose();
   ks.kb.weaveProgress.dispose();
   await ks.kb.graph.disconnect();
 }

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -193,14 +193,6 @@ export async function startMakeMeaning(
   // (HTTP gateway, LocalTransport, future ones) gets the same contract.
   registerBusHandlers(eventBus, knowledgeSystem, jobQueue, project, logger);
 
-  // Graph catch-up (WEAVER-ISOLATION P3): checkpointed replay of whatever
-  // the Weaver missed. Runs HERE — after the Browser is serving the
-  // `browse:*` reads it rides on, and after the live subscription attached
-  // (in createKnowledgeBase), so nothing falls in the gap.
-  if (!skipRebuild) {
-    await knowledgeSystem.kb.weaver.catchUp();
-  }
-
   return {
     knowledgeSystem,
     jobQueue,

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -193,6 +193,14 @@ export async function startMakeMeaning(
   // (HTTP gateway, LocalTransport, future ones) gets the same contract.
   registerBusHandlers(eventBus, knowledgeSystem, jobQueue, project, logger);
 
+  // Graph catch-up (WEAVER-ISOLATION P3): checkpointed replay of whatever
+  // the Weaver missed. Runs HERE — after the Browser is serving the
+  // `browse:*` reads it rides on, and after the live subscription attached
+  // (in createKnowledgeBase), so nothing falls in the gap.
+  if (!skipRebuild) {
+    await knowledgeSystem.kb.weaver.catchUp();
+  }
+
   return {
     knowledgeSystem,
     jobQueue,

--- a/packages/make-meaning/src/weaver-actor-state-unit.ts
+++ b/packages/make-meaning/src/weaver-actor-state-unit.ts
@@ -17,7 +17,7 @@
 
 import { Observable, merge } from 'rxjs';
 import type { WorkerBus } from '@semiont/sdk';
-import type { StateUnit, StoredEvent } from '@semiont/core';
+import type { EventMap, StateUnit, StoredEvent } from '@semiont/core';
 
 export const WEAVER_CHANNELS = [
   'yield:created',
@@ -31,12 +31,17 @@ export const WEAVER_CHANNELS = [
   'frame:entity-type-added',
 ] as const;
 
+/** Commands addressed to the Weaver actor — separate from the domain-event fold. */
+const WEAVER_COMMAND_CHANNELS = ['weave:rebuild'] as const;
+
 export interface WeaverActorStateUnitOptions {
   bus: WorkerBus;
 }
 
 export interface WeaverActorStateUnit extends StateUnit {
   events$: Observable<StoredEvent>;
+  /** `weave:rebuild` commands (WEAVER-ISOLATION D3) — never mixed into the fold. */
+  rebuilds$: Observable<EventMap['weave:rebuild']>;
   start(): void;
 }
 
@@ -53,12 +58,15 @@ export function createWeaverActorStateUnit(options: WeaverActorStateUnitOptions)
     ...WEAVER_CHANNELS.map((channel) => bus.on$<StoredEvent>(channel)),
   );
 
+  const rebuilds$ = bus.on$<EventMap['weave:rebuild']>('weave:rebuild');
+
   return {
     events$,
+    rebuilds$,
     start: () => {
       if (started) return;
       started = true;
-      bus.addChannels?.([...WEAVER_CHANNELS]);
+      bus.addChannels?.([...WEAVER_CHANNELS, ...WEAVER_COMMAND_CHANNELS]);
     },
     dispose: () => {
       // The bus is owned by the caller; the state unit only releases its own

--- a/packages/make-meaning/src/weaver-actor-state-unit.ts
+++ b/packages/make-meaning/src/weaver-actor-state-unit.ts
@@ -1,0 +1,69 @@
+/**
+ * WeaverActorStateUnit — domain-event fan-in for the Weaver
+ * (WEAVER-ISOLATION P2).
+ *
+ * Subscribes to the nine graph-relevant channels on a shared bus and
+ * exposes them as a single `StoredEvent`-typed `events$` stream.
+ * Transport-neutral — the caller passes a `WorkerBus` (the in-process
+ * `workerBusOverEventBus` shim today, the HTTP `ActorStateUnit` once the
+ * Weaver runs standalone). The state unit does not own the bus and does
+ * not dispose it.
+ *
+ * `start()` widens the bus's channel-subscription set to include the
+ * weaver channels. On HTTP this extends the SSE subscription URL; on the
+ * in-process shim it is a no-op (the underlying `EventBus` already
+ * delivers every emit).
+ */
+
+import { Observable, merge } from 'rxjs';
+import type { WorkerBus } from '@semiont/sdk';
+import type { StateUnit, StoredEvent } from '@semiont/core';
+
+export const WEAVER_CHANNELS = [
+  'yield:created',
+  'mark:archived',
+  'mark:unarchived',
+  'mark:added',
+  'mark:removed',
+  'mark:body-updated',
+  'mark:entity-tag-added',
+  'mark:entity-tag-removed',
+  'frame:entity-type-added',
+] as const;
+
+export interface WeaverActorStateUnitOptions {
+  bus: WorkerBus;
+}
+
+export interface WeaverActorStateUnit extends StateUnit {
+  events$: Observable<StoredEvent>;
+  start(): void;
+}
+
+export function createWeaverActorStateUnit(options: WeaverActorStateUnitOptions): WeaverActorStateUnit {
+  const { bus } = options;
+  let started = false;
+
+  // Domain channels carry full `StoredEvent`s on every transport —
+  // in-process Subjects and the SSE gateway alike (EVENT-BUS.md, payload
+  // categories) — so the fan-in passes them through verbatim: the Weaver's
+  // fold needs payload AND storage metadata (sequence numbers feed
+  // `lastProcessed` / `weave:applied`).
+  const events$ = merge(
+    ...WEAVER_CHANNELS.map((channel) => bus.on$<StoredEvent>(channel)),
+  );
+
+  return {
+    events$,
+    start: () => {
+      if (started) return;
+      started = true;
+      bus.addChannels?.([...WEAVER_CHANNELS]);
+    },
+    dispose: () => {
+      // The bus is owned by the caller; the state unit only releases its own
+      // local state, of which there is none beyond the `started` flag.
+      started = false;
+    },
+  };
+}

--- a/packages/make-meaning/src/weaver-checkpoint.ts
+++ b/packages/make-meaning/src/weaver-checkpoint.ts
@@ -1,0 +1,53 @@
+/**
+ * WeaverCheckpoint — the Weaver's persisted per-resource applied-sequence
+ * map (WEAVER-ISOLATION P3, D1 = checkpointed replay).
+ *
+ * `catchUp()` seeds `lastProcessed` from it and replays only the gap;
+ * `noteApplied` marks it dirty and the Weaver flushes on an interval and
+ * on stop. Losing the file is safe by construction: the next catch-up
+ * degrades to a full replay through the pipeline, which the idempotent
+ * folds (P1) absorb — the checkpoint is an optimization, never a
+ * correctness input. A checkpoint AHEAD of the log (restore rewound
+ * history) is detected per resource and answered with a rebuild.
+ *
+ * Lives in the project stateDir in-process; a container volume path once
+ * the Weaver runs standalone (P4).
+ */
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+export interface WeaverCheckpoint {
+  /** Persisted map, or `{}` when absent/unreadable (degrade to full replay). */
+  load(): Promise<Record<string, number>>;
+  save(applied: Record<string, number>): Promise<void>;
+}
+
+export class FileWeaverCheckpoint implements WeaverCheckpoint {
+  constructor(private readonly filePath: string) {}
+
+  async load(): Promise<Record<string, number>> {
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+      const map: Record<string, number> = {};
+      for (const [rid, seq] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof seq === 'number' && Number.isFinite(seq)) map[rid] = seq;
+      }
+      return map;
+    } catch {
+      // Absent or corrupt — either way the answer is a full replay, not a crash.
+      return {};
+    }
+  }
+
+  async save(applied: Record<string, number>): Promise<void> {
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    // Write-then-rename so a crash mid-write leaves the previous checkpoint
+    // intact rather than a truncated file.
+    const tmp = `${this.filePath}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(applied), 'utf-8');
+    await fs.rename(tmp, this.filePath);
+  }
+}

--- a/packages/make-meaning/src/weaver-main.ts
+++ b/packages/make-meaning/src/weaver-main.ts
@@ -1,0 +1,211 @@
+/**
+ * Weaver Main — standalone entry point (WEAVER-ISOLATION P4)
+ *
+ * Thin wiring for the `Weaver` pipeline: loads configuration from
+ * ~/.semiontconfig (TOML) via the canonical `createTomlConfigLoader`,
+ * authenticates with the KS via shared secret, connects the graph
+ * database, hands the WeaverActorStateUnit's streams to the Weaver, and
+ * runs a startup catch-up. All event processing lives in `./weaver`.
+ *
+ * The weaver is a pure network peer: events and rebuild commands arrive
+ * over SSE, history reads (`browse:*`) and `weave:applied` signals ride
+ * the same bus, and its single privileged attachment beyond the bus is
+ * the graph database. The graph projection is part of the graph stack,
+ * not of the backend process (D4) — this entry point IS that stack
+ * membership.
+ *
+ * Environment variables:
+ *   SEMIONT_WORKER_SECRET — shared secret for JWT auth with the KS
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import { createWeaverActorStateUnit, type WeaverActorStateUnit } from './weaver-actor-state-unit';
+import { Weaver } from './weaver';
+import { FileWeaverCheckpoint } from './weaver-checkpoint';
+import { HttpTransport } from '@semiont/http-transport';
+import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader } from '@semiont/core';
+import type { AccessToken } from '@semiont/core';
+import { getGraphDatabase } from '@semiont/graph';
+import { createServer } from 'http';
+import { readFileSync, existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const configPath = join(homedir(), '.semiontconfig');
+const tomlReader = {
+  readIfExists: (p: string): string | null => existsSync(p) ? readFileSync(p, 'utf-8') : null,
+};
+const envConfig = createTomlConfigLoader(
+  tomlReader,
+  configPath,
+  process.env,
+)(null, 'local');
+
+const backendPublicURL = envConfig.services?.backend?.publicURL;
+if (!backendPublicURL) {
+  throw new Error('services.backend.publicURL is required in ~/.semiontconfig');
+}
+const baseUrl: string = backendPublicURL;
+
+const maybeGraphConfig = envConfig.services?.graph;
+if (!maybeGraphConfig?.type) {
+  throw new Error('services.graph.type is required in ~/.semiontconfig');
+}
+if (maybeGraphConfig.type === 'memory') {
+  // The in-memory graph is a hermetic TEST sink — it lives in a single
+  // process's heap and cannot be shared with the backend's readers.
+  throw new Error("services.graph.type 'memory' is a test-only sink; the weaver requires a server-backed graph");
+}
+// Re-bind after the guards: module-level narrowing does not carry into main().
+const graphConfig = maybeGraphConfig;
+
+const workerSecret = process.env.SEMIONT_WORKER_SECRET ?? '';
+
+const healthPort = 9092;
+
+// The checkpoint is an optimization, never a correctness input — losing it
+// degrades the next catch-up to a full replay. XDG state dir, matching the
+// platform convention SemiontProject already follows.
+const stateHome = process.env.XDG_STATE_HOME ?? join(homedir(), '.local', 'state');
+const checkpointPath = join(stateHome, 'semiont', 'weaver-checkpoint.json');
+
+import { createProcessLogger } from '@semiont/observability/process-logger';
+const logger = createProcessLogger('weaver');
+
+// ── Auth ─────────────────────────────────────────────────────────────
+
+async function authenticate(): Promise<string> {
+  if (!workerSecret) {
+    logger.warn('No SEMIONT_WORKER_SECRET set — using empty token');
+    return '';
+  }
+
+  // The weaver is a Software peer (D2: the Smelter's exchange). It has no
+  // inference (provider, model), so it authenticates under the stable
+  // identity (semiont, weaver) — DID did:web:<host>:agents:semiont:weaver —
+  // and the bus stamps that onto every signal it emits.
+  const response = await fetch(`${baseUrl}/api/tokens/agent`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      secret: workerSecret,
+      provider: 'semiont',
+      model: 'weaver',
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Authentication failed: ${response.status} ${response.statusText}`);
+  }
+
+  const { token } = await response.json() as { token: string; did: string };
+  return token;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  const { initObservabilityNode } = await import('@semiont/observability/node');
+  initObservabilityNode({ serviceName: 'semiont-weaver' });
+
+  logger.info('Authenticating', { baseUrl });
+  const tokenSubject = new BehaviorSubject<AccessToken | null>(makeAccessToken(await authenticate()));
+  logger.info('Authenticated');
+
+  // Agent tokens expire (24h — POST /api/tokens/agent). Two recovery paths
+  // keep a long-lived worker authenticated: `tokenRefresher` re-authenticates
+  // and retries once when any HTTP request 401s, and a proactive re-auth at
+  // half the TTL covers the listen-only case — SSE reconnects read `token$`
+  // fresh, so pushing here is what keeps the event feed alive.
+  const refreshToken = async (): Promise<string | null> => {
+    const token = await authenticate();
+    tokenSubject.next(makeAccessToken(token));
+    return token;
+  };
+  const reauthTimer = setInterval(() => {
+    refreshToken().catch((error) => {
+      logger.error('Proactive re-authentication failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }, 12 * 60 * 60 * 1000);
+
+  const graphDb = await getGraphDatabase(graphConfig);
+  logger.info('Graph database ready', { type: graphConfig.type });
+
+  const httpTransport = new HttpTransport({
+    baseUrl: makeBaseUrl(baseUrl),
+    token$: tokenSubject,
+    tokenRefresher: refreshToken,
+  });
+  const actorStateUnit: WeaverActorStateUnit = createWeaverActorStateUnit({
+    bus: httpTransport.actor,
+  });
+
+  const weaver = new Weaver(
+    graphDb,
+    actorStateUnit.events$,
+    actorStateUnit.rebuilds$,
+    httpTransport,
+    new FileWeaverCheckpoint(checkpointPath),
+    logger,
+  );
+  await weaver.initialize();
+
+  actorStateUnit.start();
+  logger.info('Subscribed to graph-relevant events and rebuild commands');
+
+  let catchUpState: Record<string, unknown> = { phase: 'pending' };
+
+  const health = createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok',
+        ...weaver.getHealthMetrics(),
+        catchUp: catchUpState,
+      }));
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  health.listen(healthPort, () => {
+    logger.info('Health endpoint ready', { port: healthPort });
+  });
+
+  const shutdown = () => {
+    logger.info('Shutting down');
+    clearInterval(reauthTimer);
+    actorStateUnit.dispose();
+    httpTransport.dispose();
+    void weaver.stop().then(() => {
+      health.close();
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+
+  // Catch-up pass: the live subscription is attached, so anything that
+  // changed while this weaver was down is brought back in sync here —
+  // checkpointed replay, full replay if the checkpoint is gone. Fatal on
+  // failure: a weaver that cannot catch up is projecting a graph of
+  // unknown freshness. (A restart re-runs it — catch-up is idempotent.)
+  catchUpState = { phase: 'running' };
+  try {
+    const summary = await weaver.catchUp();
+    catchUpState = { phase: 'done', summary };
+  } catch (error) {
+    catchUpState = { phase: 'failed', error: error instanceof Error ? error.message : String(error) };
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  logger.error('Fatal', { error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined });
+  process.exit(1);
+});

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -35,7 +35,7 @@ import type { PersistedEvent, StoredEvent, EventOfType, ResourceId, Logger} from
 import { resourceId as makeResourceId, annotationId as makeAnnotationId, findBodyItem } from '@semiont/core';
 import { partitionByType } from './batch-utils.js';
 
-import type { Annotation } from '@semiont/core';
+import type { Annotation, CreateAnnotationInternal } from '@semiont/core';
 import type { ResourceDescriptor } from '@semiont/core';
 
 export class Weaver {
@@ -232,15 +232,28 @@ export class Weaver {
         break;
       }
       case 'mark:added': {
-        const inputs = events.map(e => {
+        // Same idempotent fold as the single-event path, batched: dedupe the
+        // run by annotation id, then skip ids the graph already holds — a
+        // replayed burst (at-least-once delivery) must not create doubles.
+        const byId = new Map<string, CreateAnnotationInternal>();
+        for (const e of events) {
           const event = e as EventOfType<'mark:added'>;
-          return {
+          byId.set(String(event.payload.annotation.id), {
             ...event.payload.annotation,
             creator: didToAgent(event.userId),
-          };
+          });
+        }
+        const inputs: CreateAnnotationInternal[] = [];
+        for (const [id, input] of byId) {
+          if (!(await graphDb.getAnnotation(makeAnnotationId(id)))) inputs.push(input);
+        }
+        if (inputs.length > 0) {
+          await graphDb.createAnnotations(inputs);
+        }
+        this.logger.info('Batch created annotations in graph', {
+          count: inputs.length,
+          duplicatesSkipped: events.length - inputs.length,
         });
-        await graphDb.createAnnotations(inputs);
-        this.logger.info('Batch created annotations in graph', { count: events.length });
         break;
       }
       default:
@@ -316,10 +329,20 @@ export class Weaver {
         });
         break;
 
-      case 'mark:added':
+      case 'mark:added': {
         this.logger.debug('Processing annotation.added event', {
           annotationId: event.payload.annotation.id
         });
+        // Idempotent fold: creation-by-id is not upsert on every backend, so
+        // a redelivered mark:added (at-least-once delivery) must be refused
+        // here — the same guard shape as the entity-tag fold below.
+        const annId = makeAnnotationId(event.payload.annotation.id);
+        if (await graphDb.getAnnotation(annId)) {
+          this.logger.debug('Annotation already in graph — duplicate delivery skipped', {
+            annotationId: String(annId)
+          });
+          break;
+        }
         await graphDb.createAnnotation({
           ...event.payload.annotation,
           creator: didToAgent(event.userId),
@@ -328,6 +351,7 @@ export class Weaver {
           annotationId: event.payload.annotation.id
         });
         break;
+      }
 
       case 'mark:removed':
         await graphDb.deleteAnnotation(makeAnnotationId(event.payload.annotationId));

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -26,11 +26,12 @@
  * by RPC-style services.
  */
 
-import { Subject, Subscription, from } from 'rxjs';
+import { Subject, Subscription, from, type Observable } from 'rxjs';
 import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
 import { EventQuery, type EventStore } from '@semiont/event-sourcing';
-import { didToAgent, burstBuffer, EventBus, errField } from '@semiont/core';
+import { didToAgent, burstBuffer, errField } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
+import type { WorkerBus } from '@semiont/sdk';
 import type { PersistedEvent, StoredEvent, EventOfType, ResourceId, Logger} from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId, findBodyItem } from '@semiont/core';
 import { partitionByType } from './batch-utils.js';
@@ -39,28 +40,29 @@ import type { Annotation, CreateAnnotationInternal } from '@semiont/core';
 import type { ResourceDescriptor } from '@semiont/core';
 
 export class Weaver {
-  // Event types that produce GraphDB mutations — filter everything else
-  private static readonly GRAPH_RELEVANT_EVENTS: Set<PersistedEvent['type']> = new Set([
-    'yield:created', 'mark:archived', 'mark:unarchived',
-    'mark:added', 'mark:removed', 'mark:body-updated',
-    'mark:entity-tag-added', 'mark:entity-tag-removed', 'frame:entity-type-added',
-  ]);
-
   // Burst buffer thresholds — see class doc
   private static readonly BURST_WINDOW_MS = 50;
   private static readonly MAX_BATCH_SIZE = 500;
   private static readonly IDLE_TIMEOUT_MS = 200;
 
-  private _globalSubscriptions: Subscription[] = [];
+  private sourceSubscription: Subscription | null = null;
   private eventSubject = new Subject<StoredEvent>();
   private pipelineSubscription: Subscription | null = null;
   private lastProcessed: Map<string, number> = new Map();
   private readonly logger: Logger;
 
+  /**
+   * Transport-blind by construction (WEAVER-ISOLATION P2): graph-relevant
+   * events arrive as an injected `events$` (the `WeaverActorStateUnit`
+   * fan-in — channel selection lives there), and `weave:applied` leaves
+   * through the injected bus handle. In-process both ride the core
+   * EventBus via `workerBusOverEventBus`; standalone they ride the gateway.
+   */
   constructor(
     private eventStore: EventStore,
     private graphDb: GraphDatabase,
-    private coreEventBus: EventBus,
+    private events$: Observable<StoredEvent>,
+    private bus: Pick<WorkerBus, 'emit'>,
     logger: Logger,
   ) {
     this.logger = logger;
@@ -68,23 +70,13 @@ export class Weaver {
 
   async initialize() {
     this.logger.info('Weaver initialized');
-    await this.subscribeToGlobalEvents();
+    this.buildPipeline();
   }
 
   /**
-   * Subscribe globally to ALL events, pre-filter to graph-relevant types,
-   * and wire through the RxJS burst-buffered pipeline.
+   * Wire the injected event stream through the RxJS burst-buffered pipeline.
    */
-  private async subscribeToGlobalEvents() {
-    // Subscribe to each graph-relevant event type on the Core EventBus
-    for (const eventType of Weaver.GRAPH_RELEVANT_EVENTS) {
-      this._globalSubscriptions.push(
-        this.coreEventBus.getDomainEvent(eventType).subscribe(
-          (storedEvent: StoredEvent) => this.eventSubject.next(storedEvent)
-        )
-      );
-    }
-
+  private buildPipeline() {
     // Build the RxJS pipeline
     this.pipelineSubscription = this.eventSubject.pipe(
       // Split into one inner Observable per resource (system events grouped under '__system__')
@@ -124,7 +116,12 @@ export class Weaver {
       }
     });
 
-    this.logger.info('Subscribed to global events with burst-buffered pipeline');
+    // Subscribe the injected source last so nothing races the pipeline.
+    this.sourceSubscription = this.events$.subscribe(
+      (storedEvent: StoredEvent) => this.eventSubject.next(storedEvent)
+    );
+
+    this.logger.info('Subscribed to graph-relevant events with burst-buffered pipeline');
   }
 
   /**
@@ -134,7 +131,12 @@ export class Weaver {
    */
   private noteApplied(resourceId: string, sequenceNumber: number): void {
     this.lastProcessed.set(resourceId, sequenceNumber);
-    this.coreEventBus.get('weave:applied').next({ resourceId, sequenceNumber });
+    // Fire-and-forget signal: in-process the shim's emit is synchronous;
+    // over HTTP a lost signal only means a barrier timeout (the poll floor
+    // absorbs it), so a warn is the right ceiling.
+    this.bus.emit('weave:applied', { resourceId, sequenceNumber }).catch((err) => {
+      this.logger.warn('weave:applied emit failed', { resourceId, sequenceNumber, error: errField(err) });
+    });
   }
 
   /**
@@ -164,9 +166,9 @@ export class Weaver {
   async stop() {
     this.logger.info('Stopping Weaver');
 
-    // Unsubscribe from event source (stops feeding the Subject)
-    for (const sub of this._globalSubscriptions) sub.unsubscribe();
-    this._globalSubscriptions = [];
+    // Unsubscribe from the injected event source (stops feeding the Subject)
+    this.sourceSubscription?.unsubscribe();
+    this.sourceSubscription = null;
 
     // Complete the Subject — this triggers burst buffer flush of remaining events
     this.eventSubject.complete();
@@ -528,7 +530,9 @@ export class Weaver {
     pipelineActive: boolean;
   } {
     return {
-      subscriptions: this._globalSubscriptions.length,
+      // One injected source stream since WEAVER-ISOLATION P2 — channel
+      // fan-in (9 channels) lives in WeaverActorStateUnit.
+      subscriptions: this.sourceSubscription ? 1 : 0,
       lastProcessed: Object.fromEntries(this.lastProcessed),
       pipelineActive: !!this.pipelineSubscription,
     };

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -28,7 +28,6 @@
 
 import { Subject, Subscription, from, type Observable } from 'rxjs';
 import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
-import { EventQuery, type EventStore } from '@semiont/event-sourcing';
 import { didToAgent, burstBuffer, errField, busRequest } from '@semiont/core';
 import type { BusRequestPrimitive, EventMap } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
@@ -70,7 +69,6 @@ export class Weaver {
    * / `asBusRequestPrimitive`); standalone it all rides the gateway.
    */
   constructor(
-    private eventStore: EventStore,
     private graphDb: GraphDatabase,
     private events$: Observable<StoredEvent>,
     private rebuilds$: Observable<EventMap['weave:rebuild']>,
@@ -191,13 +189,12 @@ export class Weaver {
    * checkpoint. Call after the live subscription is attached so nothing
    * falls in the gap.
    */
-  async catchUp(): Promise<{ resourcesChecked: number; eventsReplayed: number; resourcesRebuilt: number }> {
-    const persisted = await this.checkpoint.load();
-    for (const [rid, seq] of Object.entries(persisted)) {
-      const current = this.lastProcessed.get(rid);
-      if (current === undefined || current < seq) this.lastProcessed.set(rid, seq);
-    }
-
+  /**
+   * The Weaver's only view of history: reads over the bus. It has no event
+   * store attachment — in-process and standalone alike, catch-up and
+   * rebuild ride `browse:resources-requested` / `browse:events-requested`.
+   */
+  private async fetchAllResources(): Promise<ResourceDescriptor[]> {
     const resources: ResourceDescriptor[] = [];
     for (;;) {
       const page = await busRequest(this.bus, 'browse:resources-requested', {
@@ -207,6 +204,24 @@ export class Weaver {
       resources.push(...(page.resources as ResourceDescriptor[]));
       if (page.resources.length === 0 || resources.length >= page.total) break;
     }
+    return resources;
+  }
+
+  /** A resource's full event history over the bus, sorted by sequence. */
+  private async fetchResourceEvents(resourceId: string): Promise<StoredEvent[]> {
+    const reply = await busRequest(this.bus, 'browse:events-requested', { resourceId });
+    return [...(reply.events as StoredEvent[])]
+      .sort((a, b) => a.metadata.sequenceNumber - b.metadata.sequenceNumber);
+  }
+
+  async catchUp(): Promise<{ resourcesChecked: number; eventsReplayed: number; resourcesRebuilt: number }> {
+    const persisted = await this.checkpoint.load();
+    for (const [rid, seq] of Object.entries(persisted)) {
+      const current = this.lastProcessed.get(rid);
+      if (current === undefined || current < seq) this.lastProcessed.set(rid, seq);
+    }
+
+    const resources = await this.fetchAllResources();
 
     let eventsReplayed = 0;
     let resourcesRebuilt = 0;
@@ -216,9 +231,7 @@ export class Weaver {
       const rid = resource['@id'];
       if (!rid) continue;
 
-      const reply = await busRequest(this.bus, 'browse:events-requested', { resourceId: rid });
-      const events = [...(reply.events as StoredEvent[])]
-        .sort((a, b) => a.metadata.sequenceNumber - b.metadata.sequenceNumber);
+      const events = await this.fetchResourceEvents(String(rid));
       if (events.length === 0) continue;
 
       const maxSeq = events[events.length - 1].metadata.sequenceNumber;
@@ -629,8 +642,7 @@ export class Weaver {
       this.logger.debug('No existing resource to delete', { resourceId });
     }
 
-    const query = new EventQuery(this.eventStore.log.storage);
-    const events = await query.getResourceEvents(resourceId);
+    const events = await this.fetchResourceEvents(String(resourceId));
 
     for (const storedEvent of events) {
       await this.safeApplyEvent(storedEvent);
@@ -657,15 +669,18 @@ export class Weaver {
 
     await graphDb.clearDatabase();
 
-    const query = new EventQuery(this.eventStore.log.storage);
-    const allResourceIds = await this.eventStore.log.getAllResourceIds();
+    // Resources are archive-only (never deleted), so the catalog's resource
+    // set matches the event log's — discovery over the bus is complete.
+    const allResourceIds = (await this.fetchAllResources())
+      .map((resource) => resource['@id'])
+      .filter((rid): rid is NonNullable<typeof rid> => !!rid);
 
     this.logger.info('Found resources to rebuild', { count: allResourceIds.length });
 
     // PASS 1: Create all nodes (resources and annotations)
     this.logger.info('PASS 1: Creating all nodes (resources + annotations)');
     for (const resourceId of allResourceIds) {
-      const events = await query.getResourceEvents(makeResourceId(resourceId as string));
+      const events = await this.fetchResourceEvents(String(resourceId));
 
       for (const storedEvent of events) {
         if (storedEvent.type === 'mark:body-updated') {
@@ -685,7 +700,7 @@ export class Weaver {
     // PASS 2: Create all edges (REFERENCES relationships)
     this.logger.info('PASS 2: Creating all REFERENCES edges');
     for (const resourceId of allResourceIds) {
-      const events = await query.getResourceEvents(makeResourceId(resourceId as string));
+      const events = await this.fetchResourceEvents(String(resourceId));
 
       for (const storedEvent of events) {
         if (storedEvent.type === 'mark:body-updated') {

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -29,10 +29,11 @@
 import { Subject, Subscription, from, type Observable } from 'rxjs';
 import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
 import { EventQuery, type EventStore } from '@semiont/event-sourcing';
-import { didToAgent, burstBuffer, errField } from '@semiont/core';
+import { didToAgent, burstBuffer, errField, busRequest } from '@semiont/core';
+import type { BusRequestPrimitive, EventMap } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
-import type { WorkerBus } from '@semiont/sdk';
 import type { PersistedEvent, StoredEvent, EventOfType, ResourceId, Logger} from '@semiont/core';
+import type { WeaverCheckpoint } from './weaver-checkpoint.js';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId, findBodyItem } from '@semiont/core';
 import { partitionByType } from './batch-utils.js';
 
@@ -45,24 +46,36 @@ export class Weaver {
   private static readonly MAX_BATCH_SIZE = 500;
   private static readonly IDLE_TIMEOUT_MS = 200;
 
+  // Catch-up (WEAVER-ISOLATION P3, D1 = checkpointed replay)
+  private static readonly CATCHUP_PAGE_SIZE = 200;
+  private static readonly CATCHUP_DRAIN_TIMEOUT_MS = 30_000;
+  private static readonly CHECKPOINT_FLUSH_MS = 5_000;
+
   private sourceSubscription: Subscription | null = null;
+  private rebuildSubscription: Subscription | null = null;
   private eventSubject = new Subject<StoredEvent>();
   private pipelineSubscription: Subscription | null = null;
   private lastProcessed: Map<string, number> = new Map();
+  private checkpointDirty = false;
+  private checkpointTimer: ReturnType<typeof setInterval> | null = null;
   private readonly logger: Logger;
 
   /**
-   * Transport-blind by construction (WEAVER-ISOLATION P2): graph-relevant
-   * events arrive as an injected `events$` (the `WeaverActorStateUnit`
-   * fan-in — channel selection lives there), and `weave:applied` leaves
-   * through the injected bus handle. In-process both ride the core
-   * EventBus via `workerBusOverEventBus`; standalone they ride the gateway.
+   * Transport-blind by construction (WEAVER-ISOLATION P2/P3): graph-relevant
+   * events arrive as an injected `events$` and rebuild commands as
+   * `rebuilds$` (the `WeaverActorStateUnit` fan-in — channel selection
+   * lives there); `weave:applied` signals, rebuild replies, and the
+   * catch-up's `browse:*` reads all ride the injected `BusRequestPrimitive`.
+   * In-process everything rides the core EventBus (`workerBusOverEventBus`
+   * / `asBusRequestPrimitive`); standalone it all rides the gateway.
    */
   constructor(
     private eventStore: EventStore,
     private graphDb: GraphDatabase,
     private events$: Observable<StoredEvent>,
-    private bus: Pick<WorkerBus, 'emit'>,
+    private rebuilds$: Observable<EventMap['weave:rebuild']>,
+    private bus: BusRequestPrimitive,
+    private checkpoint: WeaverCheckpoint,
     logger: Logger,
   ) {
     this.logger = logger;
@@ -71,6 +84,18 @@ export class Weaver {
   async initialize() {
     this.logger.info('Weaver initialized');
     this.buildPipeline();
+
+    // Rebuild commands run strictly one at a time — a full rebuild must
+    // never interleave with another rebuild.
+    this.rebuildSubscription = this.rebuilds$.pipe(
+      concatMap((command) => from(this.handleRebuildCommand(command))),
+    ).subscribe({
+      error: (err) => this.logger.error('Weaver rebuild stream error', { error: errField(err) }),
+    });
+
+    this.checkpointTimer = setInterval(() => {
+      void this.flushCheckpoint();
+    }, Weaver.CHECKPOINT_FLUSH_MS);
   }
 
   /**
@@ -131,12 +156,143 @@ export class Weaver {
    */
   private noteApplied(resourceId: string, sequenceNumber: number): void {
     this.lastProcessed.set(resourceId, sequenceNumber);
+    this.checkpointDirty = true;
     // Fire-and-forget signal: in-process the shim's emit is synchronous;
     // over HTTP a lost signal only means a barrier timeout (the poll floor
     // absorbs it), so a warn is the right ceiling.
     this.bus.emit('weave:applied', { resourceId, sequenceNumber }).catch((err) => {
       this.logger.warn('weave:applied emit failed', { resourceId, sequenceNumber, error: errField(err) });
     });
+  }
+
+  private async flushCheckpoint(): Promise<void> {
+    if (!this.checkpointDirty) return;
+    this.checkpointDirty = false;
+    try {
+      await this.checkpoint.save(Object.fromEntries(this.lastProcessed));
+    } catch (error) {
+      this.checkpointDirty = true;
+      this.logger.warn('Weaver checkpoint flush failed', { error: errField(error) });
+    }
+  }
+
+  /**
+   * Checkpointed catch-up (WEAVER-ISOLATION P3, D1). Rides EXISTING read
+   * channels: resources discovered via `browse:resources-requested`
+   * (archived included — no filter), each resource's events fetched via
+   * `browse:events-requested` (full StoredEvents), filtered client-side
+   * against the persisted checkpoint, and pushed through the normal
+   * pipeline — per-resource lanes serialize against live traffic,
+   * idempotent folds (P1) absorb any overlap, and `noteApplied` fires per
+   * apply so the `whenApplied` barrier keeps working mid-recovery.
+   *
+   * A checkpoint AHEAD of a resource's log (restore rewound history) is
+   * answered with a per-resource rebuild instead of trusting the
+   * checkpoint. Call after the live subscription is attached so nothing
+   * falls in the gap.
+   */
+  async catchUp(): Promise<{ resourcesChecked: number; eventsReplayed: number; resourcesRebuilt: number }> {
+    const persisted = await this.checkpoint.load();
+    for (const [rid, seq] of Object.entries(persisted)) {
+      const current = this.lastProcessed.get(rid);
+      if (current === undefined || current < seq) this.lastProcessed.set(rid, seq);
+    }
+
+    const resources: ResourceDescriptor[] = [];
+    for (;;) {
+      const page = await busRequest(this.bus, 'browse:resources-requested', {
+        offset: resources.length,
+        limit: Weaver.CATCHUP_PAGE_SIZE,
+      });
+      resources.push(...(page.resources as ResourceDescriptor[]));
+      if (page.resources.length === 0 || resources.length >= page.total) break;
+    }
+
+    let eventsReplayed = 0;
+    let resourcesRebuilt = 0;
+    const parityTargets = new Map<string, number>();
+
+    for (const resource of resources) {
+      const rid = resource['@id'];
+      if (!rid) continue;
+
+      const reply = await busRequest(this.bus, 'browse:events-requested', { resourceId: rid });
+      const events = [...(reply.events as StoredEvent[])]
+        .sort((a, b) => a.metadata.sequenceNumber - b.metadata.sequenceNumber);
+      if (events.length === 0) continue;
+
+      const maxSeq = events[events.length - 1].metadata.sequenceNumber;
+      const since = this.lastProcessed.get(String(rid)) ?? 0;
+
+      if (since > maxSeq) {
+        // The log is BEHIND the checkpoint — history was rewound (restore).
+        // The checkpoint lies for this resource; rebuild it from the log.
+        this.logger.warn('Checkpoint ahead of event log — rebuilding resource', {
+          resourceId: String(rid), checkpoint: since, logMax: maxSeq,
+        });
+        this.lastProcessed.delete(String(rid));
+        await this.rebuildResource(makeResourceId(String(rid)));
+        resourcesRebuilt++;
+        continue;
+      }
+
+      const gap = events.filter((e) => e.metadata.sequenceNumber > since);
+      if (gap.length === 0) continue;
+      for (const event of gap) this.eventSubject.next(event);
+      eventsReplayed += gap.length;
+      parityTargets.set(String(rid), maxSeq);
+    }
+
+    await this.awaitParity(parityTargets, Weaver.CATCHUP_DRAIN_TIMEOUT_MS);
+    this.checkpointDirty = true;
+    await this.flushCheckpoint();
+
+    const summary = { resourcesChecked: resources.length, eventsReplayed, resourcesRebuilt };
+    this.logger.info('Weaver catch-up complete', summary);
+    return summary;
+  }
+
+  /**
+   * Wait until `lastProcessed` reaches every target sequence — the drain
+   * for catch-up's pushes through the async pipeline. Bounded: on timeout
+   * we log the laggards and proceed (the live pipeline finishes them; the
+   * whenApplied barrier and poll floor cover readers meanwhile).
+   */
+  private async awaitParity(targets: Map<string, number>, timeoutMs: number): Promise<void> {
+    if (targets.size === 0) return;
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      let pending = 0;
+      for (const [rid, seq] of targets) {
+        if ((this.lastProcessed.get(rid) ?? -1) < seq) pending++;
+      }
+      if (pending === 0) return;
+      if (Date.now() >= deadline) {
+        this.logger.warn('Weaver catch-up drain timed out; live pipeline will finish', { pending });
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  private async handleRebuildCommand(command: EventMap['weave:rebuild']): Promise<void> {
+    try {
+      if (command.resourceId) {
+        await this.rebuildResource(makeResourceId(command.resourceId));
+      } else {
+        await this.rebuildAll();
+      }
+      await this.flushCheckpoint();
+      await this.bus.emit('weave:rebuild-ok', { correlationId: command.correlationId });
+    } catch (error) {
+      this.logger.error('Weaver rebuild command failed', {
+        resourceId: command.resourceId, error: errField(error),
+      });
+      await this.bus.emit('weave:rebuild-failed', {
+        correlationId: command.correlationId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**
@@ -166,6 +322,13 @@ export class Weaver {
   async stop() {
     this.logger.info('Stopping Weaver');
 
+    if (this.checkpointTimer) {
+      clearInterval(this.checkpointTimer);
+      this.checkpointTimer = null;
+    }
+    this.rebuildSubscription?.unsubscribe();
+    this.rebuildSubscription = null;
+
     // Unsubscribe from the injected event source (stops feeding the Subject)
     this.sourceSubscription?.unsubscribe();
     this.sourceSubscription = null;
@@ -181,6 +344,8 @@ export class Weaver {
 
     // Create a fresh Subject for potential re-initialization
     this.eventSubject = new Subject<StoredEvent>();
+
+    await this.flushCheckpoint();
 
     this.logger.info('Weaver stopped');
   }
@@ -471,6 +636,12 @@ export class Weaver {
       await this.safeApplyEvent(storedEvent);
     }
 
+    if (events.length > 0) {
+      // Advance the applied mark through noteApplied so the checkpoint and
+      // the whenApplied barrier both see rebuild progress.
+      this.noteApplied(String(resourceId), Math.max(...events.map((e) => e.metadata.sequenceNumber)));
+    }
+
     this.logger.info('Resource rebuild complete', { resourceId, eventCount: events.length });
   }
 
@@ -501,6 +672,12 @@ export class Weaver {
           continue;
         }
         await this.safeApplyEvent(storedEvent);
+      }
+
+      if (events.length > 0) {
+        // Advance the applied mark through noteApplied so the checkpoint and
+        // the whenApplied barrier both see rebuild progress.
+        this.noteApplied(String(resourceId), Math.max(...events.map((e) => e.metadata.sequenceNumber)));
       }
     }
     this.logger.info('Pass 1 complete - all nodes created');

--- a/packages/make-meaning/src/worker-bus-local.ts
+++ b/packages/make-meaning/src/worker-bus-local.ts
@@ -1,0 +1,34 @@
+/**
+ * workerBusOverEventBus — the in-process WorkerBus shim over the core
+ * EventBus (WEAVER-ISOLATION P2).
+ *
+ * `WorkerBus` is the transport seam actor fan-ins consume
+ * (`SmelterActorStateUnit`, `WeaverActorStateUnit`): HTTP `ActorStateUnit`
+ * in a standalone worker, this shim inside the backend process. The
+ * smelter fan-in's doc anticipated exactly this ("an in-process bus shim
+ * if/when one exists").
+ *
+ * The WorkerBus surface is stringly-typed by design — channel names are
+ * wire strings on every transport — so the EventMap typing is re-asserted
+ * at the consumer boundary (e.g. the fan-in's `on$<StoredEvent>`), not here.
+ */
+
+import type { Observable } from 'rxjs';
+import type { EventBus, EventMap, EventName } from '@semiont/core';
+import type { WorkerBus } from '@semiont/sdk';
+
+export function workerBusOverEventBus(eventBus: EventBus): WorkerBus {
+  return {
+    on$: <T = Record<string, unknown>>(channel: string): Observable<T> =>
+      eventBus.get(channel as EventName) as unknown as Observable<T>,
+
+    emit: async (channel: string, payload: Record<string, unknown>): Promise<void> => {
+      eventBus.get(channel as EventName).next(payload as EventMap[EventName]);
+    },
+
+    addChannels: () => {
+      // No-op: the in-process bus already delivers every emit; channel
+      // subscription sets are an SSE-gateway concern.
+    },
+  };
+}

--- a/packages/make-meaning/tsup.config.ts
+++ b/packages/make-meaning/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/smelter-main.ts'],
+  entry: ['src/index.ts', 'src/smelter-main.ts', 'src/weaver-main.ts'],
   format: ['esm'],
   dts: false,
   sourcemap: true,

--- a/specs/src/components/schemas/WeaveRebuildCommand.json
+++ b/specs/src/components/schemas/WeaveRebuildCommand.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "description": "Bus command to rebuild the graph projection from the event log — the whole graph when resourceId is absent, one resource when present. Served by the Weaver; replaces direct rebuild access, which does not survive the Weaver's container split.",
+  "properties": {
+    "correlationId": {
+      "type": "string",
+      "description": "Correlation id for request/reply matching, set by busRequest so the ok/failed reply routes back."
+    },
+    "resourceId": {
+      "type": "string",
+      "description": "When present, rebuild only this resource; otherwise clear and rebuild the entire graph."
+    },
+    "_userId": {
+      "type": "string",
+      "description": "Authenticated user's DID, injected by the /bus/emit gateway. Clients do not set this."
+    }
+  }
+}

--- a/specs/src/openapi.json
+++ b/specs/src/openapi.json
@@ -450,6 +450,7 @@
       "SvgSelector": { "$ref": "components/schemas/SvgSelector.json" },
       "TagCategory": { "$ref": "components/schemas/TagCategory.json" },
       "TagSchema": { "$ref": "components/schemas/TagSchema.json" },
+      "WeaveRebuildCommand": { "$ref": "components/schemas/WeaveRebuildCommand.json" },
       "YieldCloneCreateCommand": { "$ref": "components/schemas/YieldCloneCreateCommand.json" },
       "YieldCloneCreated": { "$ref": "components/schemas/YieldCloneCreated.json" },
       "YieldCloneResourceRequest": { "$ref": "components/schemas/YieldCloneResourceRequest.json" },


### PR DESCRIPTION
# Pull Request

## Description

The Weaver (event-to-graph projection, née `GraphDBConsumer`) becomes a **standalone
actor** — its own container (`semiont-weaver`), its own entry point
(`@semiont/make-meaning/weaver-main`), same bus, same auth, same lifecycle as the
Smelter. Doctrine: **the graph projection is part of the graph stack, not of the
backend process.** Builds on the rename (#982) and the projection-sync barrier work
(`weave:applied` → `WeaveProgress.whenApplied`) that landed before it.

Four phases, each RED-first and independently green:

**Phase 1 — duplicate-delivery idempotency audit.** At-least-once delivery (SSE
replay after the split) requires every fold to tolerate redelivery. Ten specs
against a real memory graph found more than fold gaps — **two pre-existing store
bugs**: (a) three of four `GraphDatabase` backends minted their own annotation ids,
ignoring the required `CreateAnnotationInternal.id` (breaking `mark:removed` /
`mark:body-updated` round-trips); (b) all four backends — **including production
Neo4j** — still enforced a pre-#974 "resources are immutable" guard, so the Weaver's
entity-tag folds have been silently throwing and the graph has been dropping every
post-creation tag change. Fixed at the source: stores honor the event's id, one
shared `assertMutableResourceUpdate` guard admits exactly the two mutable facets
(archival, entity tags) across all four backends, and the `mark:added` fold gained
existence guards on both single and batch paths. Existing deployments heal on their
next graph rebuild.

**Phase 2 — transport seam.** New `WeaverActorStateUnit` (nine graph-relevant
channels → one `StoredEvent`-typed `events$`, smelter-shaped, StateUnit-axioms
covered) and `workerBusOverEventBus`, the in-process `WorkerBus` shim the smelter
fan-in's doc anticipated. The Weaver went transport-blind: injected streams in,
bus handle out.

**Phase 3 — checkpointed catch-up + rebuild command.** Catch-up rides EXISTING read
channels (`browse:resources-requested` for discovery, `browse:events-requested` for
gap events — no new served capability needed), filters against a persisted
checkpoint (`FileWeaverCheckpoint`, write-then-rename; corrupt/absent degrades to
full replay, never to wrongness), and replays through the normal pipeline — lanes
serialize against live traffic, the Phase 1 idempotent folds absorb overlap, and
`weave:applied` fires during replay so the barrier works mid-recovery. A checkpoint
AHEAD of the log (restore) triggers a per-resource rebuild. Full rebuilds are the
new `weave:rebuild` bus operation (OpenAPI `WeaveRebuildCommand`; replies
auto-bridge via the operations registry).

**Phase 4 — the split.** The Weaver lost its event-store attachment (rebuilds read
over the bus too; the graph driver + checkpoint file are its only privileged
attachments). `weaver-main.ts` mirrors smelter-main: TOML config, worker-secret
exchange at `/api/tokens/agent` as `(semiont, weaver)`, dual token refresh, health
on :9092, subscribe-then-catch-up, fatal on catch-up failure. `createKnowledgeBase`
constructs no Weaver (`kb.weaver`/`kb.weaverEvents` deleted; the `weaveProgress`
fold stays, unconditional); `rebuild-graph.ts` is now a thin HTTP bus client
commanding the running stack. The in-memory graph is declared what it always was —
a hermetic TEST sink (zero deployments configure it); `weaver-main` refuses it and
hermetic tests that want projection wire a Weaver directly (the query-graph
scripting example now demonstrates exactly that).

Decisions (all user-settled, recorded in the plan doc): D1 checkpointed replay,
D2 the Smelter's token exchange, D3 rebuild-as-bus-command, D4 standalone-only with
the memory-graph-is-a-test-sink refinement. One doc correction along the way:
CONTAINER-TOPOLOGY described a `/api/tokens/worker` route that never existed in
code; it now matches reality (`/api/tokens/agent`).

## Type of Change

- [x] Bug fix (the two store bugs above)
- [x] Code refactoring
- [x] Documentation update

## Areas Changed

- [x] Backend (`apps/backend`)
- [x] Core (`packages/core`)
- [x] OpenAPI Specs (`specs/`)
- [x] Documentation (`docs/`)

Also touched (not in the list above): `packages/make-meaning` (the initiative's
home), `packages/graph` (all four store implementations + shared guard).

## Security Checklist

No authentication or authorization logic modified. The weaver and the converted
rebuild CLI are new *consumers* of the existing `/api/tokens/agent` exchange
(shared `SEMIONT_WORKER_SECRET`, typed Software-agent DIDs), identical in shape to
the smelter's existing flow.

## Verification

- Every phase RED-first with observed failures before GREEN; every phase left the
  tree green.
- Final state: `build:packages` + full workspace `tsc --noEmit` clean;
  make-meaning 36 files / 432 tests; graph 105/105 (node:24 container).
- Full suites are CI's job — this PR is where the broad net gets cast.

## Operator notes

- The `semiont-weaver` container needs a platform entry in `~/.semiontconfig`
  (`services.graph` + `services.backend.publicURL` + `SEMIONT_WORKER_SECRET`).
- Import/restore flows now heal the graph via `weave:rebuild` against the live
  stack rather than next-backend-start rebuild.
- Existing deployments pick up the dropped entity-tag folds' backlog on their next
  graph rebuild (`npm run rebuild-graph`).
