### PR TITLE
weaver completeness for #845: accounting, checkpoint honesty, reconcile

### DIFF
--- a/packages/make-meaning/src/__tests__/weave-progress.test.ts
+++ b/packages/make-meaning/src/__tests__/weave-progress.test.ts
@@ -8,7 +8,7 @@
  * timeout so callers can fall back to the Phase 1 retry floor.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EventBus } from '@semiont/core';
 import { assertStateUnitAxioms } from '@semiont/core/testing';
 import { createWeaveProgress, WeaveProgressTimeout } from '../weave-progress';
@@ -66,6 +66,29 @@ describe('WeaveProgress', () => {
 
     expect(progress.appliedUpTo('res-1')).toBe(9);
     progress.dispose();
+  });
+
+  it('evicts applied entries older than the TTL — the fold only ever serves recent applies', () => {
+    // Eviction is free correctness-wise: the barrier only engages when a
+    // graph read came back null, which cannot happen for an apply minutes
+    // old — and a missed immediate-resolve just degrades to the poll floor.
+    // Without eviction the map grows with every resource ever signaled
+    // (#845 scalability wart).
+    vi.useFakeTimers();
+    try {
+      const bus = new EventBus();
+      const progress = createWeaveProgress(bus);
+
+      bus.get('weave:applied').next({ resourceId: 'res-old', sequenceNumber: 1 });
+      vi.advanceTimersByTime(6 * 60_000);
+      bus.get('weave:applied').next({ resourceId: 'res-new', sequenceNumber: 2 });
+
+      expect(progress.appliedUpTo('res-old')).toBeUndefined();
+      expect(progress.appliedUpTo('res-new')).toBe(2);
+      progress.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('post-dispose whenApplied is inert — resolves so callers degrade to the retry floor', async () => {

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -819,7 +819,9 @@ describe('Weaver', () => {
 
       expect(metrics.subscriptions).toBe(1); // One injected source stream — channel fan-in (9) lives in WeaverActorStateUnit
       expect(metrics.pipelineActive).toBe(true);
-      expect(typeof metrics.lastProcessed).toBe('object');
+      // A count, deliberately not the map — the full per-resource map made
+      // /health an O(resources) payload (#845 scalability wart).
+      expect(typeof metrics.resourcesTracked).toBe('number');
     });
   });
 
@@ -1157,9 +1159,8 @@ describe('Weaver', () => {
       await tick();
       signalSub.unsubscribe();
 
-      const metrics = consumer.getHealthMetrics();
-      expect(metrics.lastProcessed[rid]).toBeUndefined();
-      expect(metrics.applyFailures).toBeGreaterThanOrEqual(1);
+      expect(consumer.appliedUpTo(rid)).toBeUndefined();
+      expect(consumer.getHealthMetrics().applyFailures).toBeGreaterThanOrEqual(1);
       expect(signals).not.toContain(rid);
     });
 
@@ -1178,7 +1179,7 @@ describe('Weaver', () => {
         payload: { name: 'Batch Base', format: 'text/plain', contentChecksum: 'h-ab' },
       });
       await tick();
-      const seqAfterCreate = consumer.getHealthMetrics().lastProcessed[rid];
+      const seqAfterCreate = consumer.appliedUpTo(rid);
       expect(seqAfterCreate).toBeDefined();
 
       vi.spyOn(graphDb, 'createAnnotations').mockRejectedValueOnce(new Error('neo4j hiccup'));
@@ -1202,7 +1203,7 @@ describe('Weaver', () => {
       // The passthrough single advanced to 2 (honest); the batched run
       // failed — the checkpoint must stop THERE, never skipping to 4, so
       // catch-up revisits the dropped events.
-      expect(consumer.getHealthMetrics().lastProcessed[rid]).toBe(2);
+      expect(consumer.appliedUpTo(rid)).toBe(2);
     });
 
     it('weave:rebuild replies FAILED, not ok, when applies dropped events', async () => {

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -135,9 +135,47 @@ describe('Weaver', () => {
     vi.clearAllMocks();
   });
 
+  // Bus responders standing in for the Browser: the Weaver's catch-up,
+  // rebuild, and reconcile paths read history and views exclusively over
+  // `browse:*` — these are their only view of the log in this harness.
+  let stopServing: (() => void) | null = null;
+
+  const serveBrowseReads = (rids: string[], annotationsByRid: Record<string, unknown[]> = {}) => {
+    const subs = [
+      coreEventBus.get('browse:resources-requested').subscribe((req: any) => {
+        coreEventBus.get('browse:resources-result').next({
+          correlationId: req.correlationId,
+          response: {
+            resources: rids.map((id) => ({
+              '@id': id, name: id, representations: [], archived: false, entityTypes: [],
+            })),
+            total: rids.length,
+          },
+        } as any);
+      }),
+      coreEventBus.get('browse:events-requested').subscribe((req: any) => {
+        void eventStore.log.getEvents(resourceId(req.resourceId)).then((events) => {
+          coreEventBus.get('browse:events-result').next({
+            correlationId: req.correlationId,
+            response: { events, total: events.length, resourceId: req.resourceId },
+          } as any);
+        });
+      }),
+      coreEventBus.get('browse:annotations-requested').subscribe((req: any) => {
+        coreEventBus.get('browse:annotations-result').next({
+          correlationId: req.correlationId,
+          response: { annotations: annotationsByRid[req.resourceId] ?? [] },
+        } as any);
+      }),
+    ];
+    stopServing = () => subs.forEach((s) => s.unsubscribe());
+  };
+
   afterEach(async () => {
     await consumer?.stop();
     weaverUnit?.dispose();
+    stopServing?.();
+    stopServing = null;
   });
 
   describe('event type filtering', () => {
@@ -970,38 +1008,6 @@ describe('Weaver', () => {
     // per-resource lanes serialize against live traffic, idempotent folds
     // absorb overlap, and noteApplied signals fire during replay so the
     // whenApplied barrier keeps working mid-recovery.
-    let stopServing: (() => void) | null = null;
-
-    const serveBrowseReads = (rids: string[]) => {
-      const subs = [
-        coreEventBus.get('browse:resources-requested').subscribe((req: any) => {
-          coreEventBus.get('browse:resources-result').next({
-            correlationId: req.correlationId,
-            response: {
-              resources: rids.map((id) => ({
-                '@id': id, name: id, representations: [], archived: false, entityTypes: [],
-              })),
-              total: rids.length,
-            },
-          } as any);
-        }),
-        coreEventBus.get('browse:events-requested').subscribe((req: any) => {
-          void eventStore.log.getEvents(resourceId(req.resourceId)).then((events) => {
-            coreEventBus.get('browse:events-result').next({
-              correlationId: req.correlationId,
-              response: { events, total: events.length, resourceId: req.resourceId },
-            } as any);
-          });
-        }),
-      ];
-      stopServing = () => subs.forEach((s) => s.unsubscribe());
-    };
-
-    afterEach(() => {
-      stopServing?.();
-      stopServing = null;
-    });
-
     it('replays events missed while down, then a second catch-up is a checkpointed no-op', async () => {
       // Down: stop the live weaver, then append events nobody hears.
       await consumer.stop();
@@ -1119,6 +1125,193 @@ describe('Weaver', () => {
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(clearSpy).not.toHaveBeenCalled();
       expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Rebuilt One');
+    });
+  });
+
+  describe('completeness accounting + reconcile (#845)', () => {
+    // The projection must never silently under-materialize: witnessed apply
+    // failures are counted and hold the checkpoint back (so catch-up
+    // revisits them), rebuilds that dropped events reply FAILED instead of
+    // ok, and reconcile() backstops the failures nothing witnessed —
+    // out-of-band graph mutations, wiped volumes, historical damage.
+
+    it('a failed apply counts, does not advance lastProcessed, and emits no weave:applied', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const signals: string[] = [];
+      const signalSub = coreEventBus.get('weave:applied').subscribe((s) => signals.push(s.resourceId));
+
+      vi.spyOn(graphDb, 'createResource').mockRejectedValueOnce(new Error('neo4j hiccup'));
+
+      const rid = `acct-fail-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Dropped', format: 'text/plain', contentChecksum: 'h-af' },
+      });
+      await tick();
+      signalSub.unsubscribe();
+
+      const metrics = consumer.getHealthMetrics();
+      expect(metrics.lastProcessed[rid]).toBeUndefined();
+      expect(metrics.applyFailures).toBeGreaterThanOrEqual(1);
+      expect(signals).not.toContain(rid);
+    });
+
+    it('a failed batch run blocks checkpoint advance for the whole batch', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `acct-batch-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Batch Base', format: 'text/plain', contentChecksum: 'h-ab' },
+      });
+      await tick();
+      const seqAfterCreate = consumer.getHealthMetrics().lastProcessed[rid];
+      expect(seqAfterCreate).toBeDefined();
+
+      vi.spyOn(graphDb, 'createAnnotations').mockRejectedValueOnce(new Error('neo4j hiccup'));
+
+      // Three annotations back-to-back: burst passthrough applies the first
+      // singly, then the remaining two flush as one batched run through
+      // createAnnotations — the mocked failure.
+      const ann = (aid: string) => ({
+        id: annotationId(aid), motivation: 'commenting', target: { source: rid }, body: [],
+      });
+      const pushMark = (aid: string, seq: number) => coreEventBus.getDomainEvent('mark:added').next({
+        id: uuidv4(), type: 'mark:added', timestamp: new Date().toISOString(),
+        userId: userId('user1'), resourceId: resourceId(rid), version: 1,
+        payload: { annotation: ann(aid) }, metadata: { sequenceNumber: seq },
+      } as unknown as StoredEvent);
+      pushMark('ann-b1', 2);
+      pushMark('ann-b2', 3);
+      pushMark('ann-b3', 4);
+      await tick();
+
+      // The passthrough single advanced to 2 (honest); the batched run
+      // failed — the checkpoint must stop THERE, never skipping to 4, so
+      // catch-up revisits the dropped events.
+      expect(consumer.getHealthMetrics().lastProcessed[rid]).toBe(2);
+    });
+
+    it('weave:rebuild replies FAILED, not ok, when applies dropped events', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `acct-rebuild-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Will Drop', format: 'text/plain', contentChecksum: 'h-ar' },
+      });
+      await tick();
+
+      serveBrowseReads([rid]);
+      vi.spyOn(graphDb, 'createResource').mockRejectedValue(new Error('neo4j down'));
+
+      await expect(
+        busRequest(asBusRequestPrimitive(coreEventBus), 'weave:rebuild', {}),
+      ).rejects.toThrow();
+    });
+
+    it('catch-up reports failures, holds the checkpoint, and the next pass re-replays', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+
+      const rid = `acct-catchup-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Retry Me', format: 'text/plain', contentChecksum: 'h-ac' },
+      });
+
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+      serveBrowseReads([rid]);
+
+      // First pass: the store hiccups once — the event is counted as failed
+      // and the checkpoint must NOT advance past it.
+      vi.spyOn(graphDb, 'createResource').mockRejectedValueOnce(new Error('neo4j hiccup'));
+      const first = await consumer.catchUp();
+      expect(first.eventsFailed).toBeGreaterThanOrEqual(1);
+      expect(await graphDb.getResource(resourceId(rid))).toBeNull();
+
+      // Second pass: the store is healthy — the held-back event replays.
+      const second = await consumer.catchUp();
+      expect(second.eventsReplayed).toBeGreaterThanOrEqual(1);
+      expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Retry Me');
+    });
+
+    it('reconcile detects an out-of-band deletion and heals it from the log', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `rec-heal-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Healed', format: 'text/plain', contentChecksum: 'h-rh' },
+      });
+      await tick();
+      expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Healed');
+
+      // Out-of-band mutation: nothing the Weaver witnesses. The checkpoint
+      // says "applied"; only a state diff can notice.
+      await graphDb.deleteResource(resourceId(rid));
+
+      serveBrowseReads([rid]);
+      const summary = await consumer.reconcile();
+
+      expect(summary.divergent).toBe(1);
+      expect(summary.healed).toBe(1);
+      expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Healed');
+    });
+
+    it('a clean graph reconciles with zero divergence and no heals', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `rec-clean-${Date.now()}`;
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: resourceId(rid),
+        userId: userId('user1'),
+        version: 1,
+        payload: { name: 'Clean', format: 'text/plain', contentChecksum: 'h-rc' },
+      });
+      await tick();
+
+      serveBrowseReads([rid]);
+      const deleteSpy = vi.spyOn(graphDb, 'deleteResource');
+      const summary = await consumer.reconcile();
+
+      expect(summary.resourcesChecked).toBe(1);
+      expect(summary.divergent).toBe(0);
+      expect(summary.healed).toBe(0);
+      expect(deleteSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/make-meaning/src/weave-progress.ts
+++ b/packages/make-meaning/src/weave-progress.ts
@@ -49,17 +49,37 @@ export interface WeaveProgress extends StateUnit {
   whenApplied(resourceId: string, sequenceNumber: number, timeoutMs: number): Promise<void>;
 }
 
+/**
+ * Entries older than this are evicted (lazily, at most one sweep per
+ * SWEEP_INTERVAL_MS). Eviction is free correctness-wise: the barrier only
+ * engages when a graph read came back null, which cannot happen for an
+ * apply minutes old — and a missed immediate-resolve merely degrades to
+ * the caller's poll floor. Without it the map grows with every resource
+ * ever signaled (#845 scalability).
+ */
+const APPLIED_TTL_MS = 5 * 60_000;
+const SWEEP_INTERVAL_MS = 60_000;
+
 export function createWeaveProgress(eventBus: EventBus): WeaveProgress {
-  const applied = new Map<string, number>();
+  const applied = new Map<string, { seq: number; at: number }>();
   const waiters = new Set<Waiter>();
   let disposed = false;
+  let lastSweep = Date.now();
 
   const subscription = eventBus.get('weave:applied').subscribe(({ resourceId, sequenceNumber }) => {
+    const now = Date.now();
+    if (now - lastSweep >= SWEEP_INTERVAL_MS) {
+      lastSweep = now;
+      for (const [rid, entry] of applied) {
+        if (now - entry.at >= APPLIED_TTL_MS) applied.delete(rid);
+      }
+    }
+
     // Monotonic fold: a stale lower signal (e.g. redelivery) never
     // regresses the high-water mark.
     const current = applied.get(resourceId);
-    if (current !== undefined && current >= sequenceNumber) return;
-    applied.set(resourceId, sequenceNumber);
+    if (current !== undefined && current.seq >= sequenceNumber) return;
+    applied.set(resourceId, { seq: sequenceNumber, at: now });
 
     for (const waiter of waiters) {
       if (waiter.resourceId === resourceId && sequenceNumber >= waiter.sequenceNumber) {
@@ -71,12 +91,12 @@ export function createWeaveProgress(eventBus: EventBus): WeaveProgress {
   });
 
   return {
-    appliedUpTo: (resourceId) => applied.get(resourceId),
+    appliedUpTo: (resourceId) => applied.get(resourceId)?.seq,
 
     whenApplied: (resourceId, sequenceNumber, timeoutMs) => {
       if (disposed) return Promise.resolve();
 
-      const current = applied.get(resourceId);
+      const current = applied.get(resourceId)?.seq;
       if (current !== undefined && current >= sequenceNumber) return Promise.resolve();
 
       return new Promise<void>((resolve, reject) => {

--- a/packages/make-meaning/src/weaver-main.ts
+++ b/packages/make-meaning/src/weaver-main.ts
@@ -158,6 +158,7 @@ async function main() {
   logger.info('Subscribed to graph-relevant events and rebuild commands');
 
   let catchUpState: Record<string, unknown> = { phase: 'pending' };
+  let reconcileState: Record<string, unknown> = { phase: 'pending' };
 
   const health = createServer((req, res) => {
     if (req.url === '/health') {
@@ -166,6 +167,7 @@ async function main() {
         status: 'ok',
         ...weaver.getHealthMetrics(),
         catchUp: catchUpState,
+        reconcile: reconcileState,
       }));
     } else {
       res.writeHead(404);
@@ -201,6 +203,19 @@ async function main() {
     catchUpState = { phase: 'done', summary };
   } catch (error) {
     catchUpState = { phase: 'failed', error: error instanceof Error ? error.message : String(error) };
+    throw error;
+  }
+
+  // Reconcile pass (#845): the state-diff backstop for divergence the
+  // accounting cannot witness — out-of-band mutations, wiped/rolled-back
+  // graph volumes, historical damage. Fatal on a thrown reconcile (bus
+  // unreachable); heal failures are reported in the summary, not fatal.
+  reconcileState = { phase: 'running' };
+  try {
+    const summary = await weaver.reconcile();
+    reconcileState = { phase: 'done', summary };
+  } catch (error) {
+    reconcileState = { phase: 'failed', error: error instanceof Error ? error.message : String(error) };
     throw error;
   }
 }

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -55,6 +55,7 @@ export class Weaver {
   private eventSubject = new Subject<StoredEvent>();
   private pipelineSubscription: Subscription | null = null;
   private lastProcessed: Map<string, number> = new Map();
+  private _applyFailures = 0;
   private checkpointDirty = false;
   private checkpointTimer: ReturnType<typeof setInterval> | null = null;
   private readonly logger: Logger;
@@ -124,11 +125,13 @@ export class Weaver {
             if (Array.isArray(eventOrBatch)) {
               return from(this.processBatch(eventOrBatch));
             }
-            return from(this.safeApplyEvent(eventOrBatch).then(() => {
-              this.noteApplied(
-                eventOrBatch.resourceId!,
-                eventOrBatch.metadata.sequenceNumber
-              );
+            return from(this.safeApplyEvent(eventOrBatch).then((applied) => {
+              if (applied) {
+                this.noteApplied(
+                  eventOrBatch.resourceId!,
+                  eventOrBatch.metadata.sequenceNumber
+                );
+              }
             }));
           })
         );
@@ -214,7 +217,17 @@ export class Weaver {
       .sort((a, b) => a.metadata.sequenceNumber - b.metadata.sequenceNumber);
   }
 
-  async catchUp(): Promise<{ resourcesChecked: number; eventsReplayed: number; resourcesRebuilt: number }> {
+  async catchUp(): Promise<{
+    resourcesChecked: number;
+    eventsReplayed: number;
+    resourcesRebuilt: number;
+    eventsFailed: number;
+    parityPending: number;
+  }> {
+    // Failure accounting is a window over the shared counter — concurrent
+    // live-apply failures land in the same number, which is the honest
+    // reading: they too are events the checkpoint refused to pass.
+    const failuresBefore = this._applyFailures;
     const persisted = await this.checkpoint.load();
     for (const [rid, seq] of Object.entries(persisted)) {
       const current = this.lastProcessed.get(rid);
@@ -256,46 +269,145 @@ export class Weaver {
       parityTargets.set(String(rid), maxSeq);
     }
 
-    await this.awaitParity(parityTargets, Weaver.CATCHUP_DRAIN_TIMEOUT_MS);
+    const parityPending = await this.awaitParity(parityTargets, Weaver.CATCHUP_DRAIN_TIMEOUT_MS);
     this.checkpointDirty = true;
     await this.flushCheckpoint();
 
-    const summary = { resourcesChecked: resources.length, eventsReplayed, resourcesRebuilt };
-    this.logger.info('Weaver catch-up complete', summary);
+    const summary = {
+      resourcesChecked: resources.length,
+      eventsReplayed,
+      resourcesRebuilt,
+      eventsFailed: this._applyFailures - failuresBefore,
+      parityPending,
+    };
+    if (summary.eventsFailed > 0 || summary.parityPending > 0) {
+      this.logger.error('Weaver catch-up incomplete — events failed to apply', summary);
+    } else {
+      this.logger.info('Weaver catch-up complete', summary);
+    }
     return summary;
   }
 
   /**
    * Wait until `lastProcessed` reaches every target sequence — the drain
-   * for catch-up's pushes through the async pipeline. Bounded: on timeout
-   * we log the laggards and proceed (the live pipeline finishes them; the
-   * whenApplied barrier and poll floor cover readers meanwhile).
+   * for catch-up's pushes through the async pipeline. Returns the number
+   * of targets still unreached at exit. Failed applies hold their sequence
+   * back BY DESIGN (#845), so parity may never arrive for them — once the
+   * pending set stops shrinking for ~1s we stop draining and report,
+   * rather than burning the timeout on events that will not land.
    */
-  private async awaitParity(targets: Map<string, number>, timeoutMs: number): Promise<void> {
-    if (targets.size === 0) return;
+  private async awaitParity(targets: Map<string, number>, timeoutMs: number): Promise<number> {
+    if (targets.size === 0) return 0;
     const deadline = Date.now() + timeoutMs;
+    let lastPending = -1;
+    let stablePolls = 0;
     for (;;) {
       let pending = 0;
       for (const [rid, seq] of targets) {
         if ((this.lastProcessed.get(rid) ?? -1) < seq) pending++;
       }
-      if (pending === 0) return;
+      if (pending === 0) return 0;
+      stablePolls = pending === lastPending ? stablePolls + 1 : 0;
+      lastPending = pending;
+      if (stablePolls >= 40) {
+        this.logger.warn('Weaver catch-up drain stalled — reporting pending parity', { pending });
+        return pending;
+      }
       if (Date.now() >= deadline) {
         this.logger.warn('Weaver catch-up drain timed out; live pipeline will finish', { pending });
-        return;
+        return pending;
       }
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
   }
 
+  /**
+   * State-diff audit of the graph against the catalog (#845) — the backstop
+   * for divergence nothing witnessed: out-of-band graph mutations, wiped or
+   * rolled-back volumes (post-split the checkpoint and the graph live in
+   * SEPARATE failure domains), and historical damage from old fold bugs
+   * that no future event will re-touch.
+   *
+   * Detection uses the VIEW as the cheap authority — descriptor facets plus
+   * the annotation-id set, over the same `browse:*` reads everything else
+   * rides. Healing replays the LOG (`rebuildResource`), so repairs stay
+   * log-truthful even if the view itself were wrong. V1 compares identity
+   * and facets, not annotation bodies. Heals bypass the pipeline lanes like
+   * all rebuilds — the idempotent folds make a race with live traffic
+   * benign. Run after `catchUp()`, mirroring the Smelter's
+   * subscribe → catch-up → reconcile startup order.
+   */
+  async reconcile(): Promise<{ resourcesChecked: number; divergent: number; healed: number; healFailures: number }> {
+    const resources = await this.fetchAllResources();
+    let divergent = 0;
+    let healed = 0;
+    let healFailures = 0;
+
+    for (const resource of resources) {
+      const rid = resource['@id'];
+      if (!rid) continue;
+
+      const reason = await this.divergenceOf(resource);
+      if (!reason) continue;
+
+      divergent++;
+      this.logger.warn('Reconcile divergence — healing from the log', { resourceId: String(rid), reason });
+      const result = await this.rebuildResource(makeResourceId(String(rid)));
+      if (result.eventsFailed === 0) healed++;
+      else healFailures++;
+    }
+
+    const summary = { resourcesChecked: resources.length, divergent, healed, healFailures };
+    if (divergent > 0 || healFailures > 0) {
+      this.logger.warn('Weaver reconcile found divergence', summary);
+    } else {
+      this.logger.info('Weaver reconcile complete — projection matches the catalog', summary);
+    }
+    return summary;
+  }
+
+  /** Compare one resource's graph state against its view; null = in sync. */
+  private async divergenceOf(resource: ResourceDescriptor): Promise<string | null> {
+    const graphDb = this.ensureInitialized();
+    const rid = String(resource['@id']);
+
+    const doc = await graphDb.getResource(makeResourceId(rid));
+    if (!doc) return 'missing-node';
+    if ((doc.archived ?? false) !== (resource.archived ?? false)) return 'archived-mismatch';
+
+    const docTags = [...(doc.entityTypes ?? [])].sort();
+    const viewTags = [...(resource.entityTypes ?? [])].sort();
+    if (docTags.length !== viewTags.length || docTags.some((tag, i) => tag !== viewTags[i])) {
+      return 'entity-types-mismatch';
+    }
+
+    const { annotations } = await busRequest(this.bus, 'browse:annotations-requested', { resourceId: rid });
+    const graphAnnotations = await graphDb.getResourceAnnotations(makeResourceId(rid));
+    const viewIds = new Set((annotations as Annotation[]).map((a) => String(a.id)));
+    const graphIds = new Set(graphAnnotations.map((a) => String(a.id)));
+    if (viewIds.size !== graphIds.size) return 'annotation-set-mismatch';
+    for (const id of viewIds) {
+      if (!graphIds.has(id)) return 'annotation-set-mismatch';
+    }
+
+    return null;
+  }
+
   private async handleRebuildCommand(command: EventMap['weave:rebuild']): Promise<void> {
     try {
-      if (command.resourceId) {
-        await this.rebuildResource(makeResourceId(command.resourceId));
-      } else {
-        await this.rebuildAll();
-      }
+      const result = command.resourceId
+        ? await this.rebuildResource(makeResourceId(command.resourceId))
+        : await this.rebuildAll();
       await this.flushCheckpoint();
+      if (result.eventsFailed > 0) {
+        // A rebuild that dropped events must FAIL, not claim success —
+        // silent under-materialization is the #845 failure mode.
+        await this.bus.emit('weave:rebuild-failed', {
+          correlationId: command.correlationId,
+          message: `rebuild dropped ${result.eventsFailed} event(s) — the graph is incomplete; see weaver logs`,
+        });
+        return;
+      }
       await this.bus.emit('weave:rebuild-ok', { correlationId: command.correlationId });
     } catch (error) {
       this.logger.error('Weaver rebuild command failed', {
@@ -309,19 +421,26 @@ export class Weaver {
   }
 
   /**
-   * Wrap applyEventToGraph in try/catch so one failed event doesn't kill the pipeline.
+   * Apply one event; returns true iff it landed cleanly. Failures are
+   * logged AND counted, and callers must not advance the applied mark past
+   * them — `lastProcessed`/checkpoint never skip an event that did not
+   * land (#845); catch-up re-replays from the last clean sequence.
+   *
+   * (The old pre-split `setTimeout(0)` politeness yield is gone — the
+   * Weaver owns its isolate now; there is no HTTP loop to starve.)
    */
-  private async safeApplyEvent(storedEvent: StoredEvent): Promise<void> {
-    // Yield the event loop so HTTP requests aren't starved by graph work
-    await new Promise(resolve => setTimeout(resolve, 0));
+  private async safeApplyEvent(storedEvent: StoredEvent): Promise<boolean> {
     try {
       await this.applyEventToGraph(storedEvent);
+      return true;
     } catch (error) {
+      this._applyFailures++;
       this.logger.error('Failed to apply event to graph', {
         eventType: storedEvent.type,
         resourceId: storedEvent.resourceId,
         error: errField(error),
       });
+      return false;
     }
   }
 
@@ -370,23 +489,34 @@ export class Weaver {
   private async processBatch(events: StoredEvent[]): Promise<void> {
     const runs = partitionByType(events);
 
+    // A failed run blocks checkpoint advance for the REST of the batch:
+    // the applied mark must never skip past events that did not land
+    // (#845). Catch-up re-replays from the last clean sequence, and the
+    // idempotent folds absorb the runs that did land.
+    let blocked = false;
     for (const run of runs) {
+      let runFailures = 0;
       try {
         if (run.length === 1) {
-          await this.applyEventToGraph(run[0]);
+          runFailures = (await this.safeApplyEvent(run[0])) ? 0 : 1;
         } else {
-          await this.applyBatchByType(run);
+          runFailures = await this.applyBatchByType(run);
         }
       } catch (error) {
+        runFailures = run.length;
+        this._applyFailures += run.length;
         this.logger.error('Failed to process batch run', {
           eventType: run[0].type,
           runSize: run.length,
           error: errField(error),
         });
       }
-      const last = run[run.length - 1];
-      if (last.resourceId) {
-        this.noteApplied(last.resourceId, last.metadata.sequenceNumber);
+      if (runFailures > 0) blocked = true;
+      if (!blocked) {
+        const last = run[run.length - 1];
+        if (last.resourceId) {
+          this.noteApplied(last.resourceId, last.metadata.sequenceNumber);
+        }
       }
     }
 
@@ -400,7 +530,8 @@ export class Weaver {
    * Batch-optimized processing for consecutive events of the same type.
    * Uses batch graph methods where available, falls back to sequential.
    */
-  private async applyBatchByType(events: StoredEvent[]): Promise<void> {
+  /** Returns the number of events in the run that failed to apply (#845). */
+  private async applyBatchByType(events: StoredEvent[]): Promise<number> {
     const graphDb = this.ensureInitialized();
     const type = events[0].type;
 
@@ -409,7 +540,7 @@ export class Weaver {
         const resources = events.map(e => this.buildResourceDescriptor(e));
         await graphDb.batchCreateResources(resources);
         this.logger.info('Batch created resources in graph', { count: events.length });
-        break;
+        return 0;
       }
       case 'mark:added': {
         // Same idempotent fold as the single-event path, batched: dedupe the
@@ -434,13 +565,16 @@ export class Weaver {
           count: inputs.length,
           duplicatesSkipped: events.length - inputs.length,
         });
-        break;
+        return 0;
       }
-      default:
+      default: {
         // For types without batch optimization, fall back to sequential
+        let failed = 0;
         for (const event of events) {
-          await this.applyEventToGraph(event);
+          if (!(await this.safeApplyEvent(event))) failed++;
         }
+        return failed;
+      }
     }
   }
 
@@ -632,7 +766,7 @@ export class Weaver {
    * Rebuild entire resource from events.
    * Bypasses the live pipeline — reads directly from event store.
    */
-  async rebuildResource(resourceId: ResourceId): Promise<void> {
+  async rebuildResource(resourceId: ResourceId): Promise<{ eventsApplied: number; eventsFailed: number }> {
     const graphDb = this.ensureInitialized();
     this.logger.info('Rebuilding resource from events', { resourceId });
 
@@ -644,17 +778,25 @@ export class Weaver {
 
     const events = await this.fetchResourceEvents(String(resourceId));
 
+    let eventsFailed = 0;
     for (const storedEvent of events) {
-      await this.safeApplyEvent(storedEvent);
+      if (!(await this.safeApplyEvent(storedEvent))) eventsFailed++;
     }
 
-    if (events.length > 0) {
+    if (events.length > 0 && eventsFailed === 0) {
       // Advance the applied mark through noteApplied so the checkpoint and
-      // the whenApplied barrier both see rebuild progress.
+      // the whenApplied barrier both see rebuild progress — but only for a
+      // CLEAN rebuild: a mark past dropped events would hide them (#845).
       this.noteApplied(String(resourceId), Math.max(...events.map((e) => e.metadata.sequenceNumber)));
     }
+    if (eventsFailed > 0) {
+      this.logger.error('Resource rebuild dropped events — graph incomplete for this resource', {
+        resourceId, eventsFailed,
+      });
+    }
 
-    this.logger.info('Resource rebuild complete', { resourceId, eventCount: events.length });
+    this.logger.info('Resource rebuild complete', { resourceId, eventCount: events.length, eventsFailed });
+    return { eventsApplied: events.length - eventsFailed, eventsFailed };
   }
 
   /**
@@ -662,7 +804,7 @@ export class Weaver {
    * Uses two-pass approach to ensure all resources exist before creating REFERENCES edges.
    * Bypasses the live pipeline — reads directly from event store.
    */
-  async rebuildAll(): Promise<void> {
+  async rebuildAll(): Promise<{ resources: number; eventsApplied: number; eventsFailed: number }> {
     const graphDb = this.ensureInitialized();
     this.logger.info('Rebuilding entire GraphDB from events');
     this.logger.info('Using two-pass approach: nodes first, then edges');
@@ -677,22 +819,29 @@ export class Weaver {
 
     this.logger.info('Found resources to rebuild', { count: allResourceIds.length });
 
+    // Per-resource completeness ledger (#845): the applied mark advances
+    // only for resources whose BOTH passes were clean.
+    const ledger = new Map<string, { maxSeq: number; attempted: number; failed: number }>();
+
     // PASS 1: Create all nodes (resources and annotations)
     this.logger.info('PASS 1: Creating all nodes (resources + annotations)');
     for (const resourceId of allResourceIds) {
       const events = await this.fetchResourceEvents(String(resourceId));
+      if (events.length === 0) continue;
+
+      const entry = {
+        maxSeq: Math.max(...events.map((e) => e.metadata.sequenceNumber)),
+        attempted: 0,
+        failed: 0,
+      };
+      ledger.set(String(resourceId), entry);
 
       for (const storedEvent of events) {
         if (storedEvent.type === 'mark:body-updated') {
           continue;
         }
-        await this.safeApplyEvent(storedEvent);
-      }
-
-      if (events.length > 0) {
-        // Advance the applied mark through noteApplied so the checkpoint and
-        // the whenApplied barrier both see rebuild progress.
-        this.noteApplied(String(resourceId), Math.max(...events.map((e) => e.metadata.sequenceNumber)));
+        entry.attempted++;
+        if (!(await this.safeApplyEvent(storedEvent))) entry.failed++;
       }
     }
     this.logger.info('Pass 1 complete - all nodes created');
@@ -704,13 +853,31 @@ export class Weaver {
 
       for (const storedEvent of events) {
         if (storedEvent.type === 'mark:body-updated') {
-          await this.safeApplyEvent(storedEvent);
+          const entry = ledger.get(String(resourceId));
+          if (entry) entry.attempted++;
+          if (!(await this.safeApplyEvent(storedEvent))) {
+            if (entry) entry.failed++;
+          }
         }
       }
     }
     this.logger.info('Pass 2 complete - all edges created');
 
-    this.logger.info('Rebuild complete');
+    let eventsApplied = 0;
+    let eventsFailed = 0;
+    for (const [rid, { maxSeq, attempted, failed }] of ledger) {
+      eventsApplied += attempted - failed;
+      eventsFailed += failed;
+      if (failed === 0) {
+        this.noteApplied(rid, maxSeq);
+      }
+    }
+    if (eventsFailed > 0) {
+      this.logger.error('Rebuild dropped events — graph incomplete', { eventsFailed });
+    }
+
+    this.logger.info('Rebuild complete', { resources: allResourceIds.length, eventsApplied, eventsFailed });
+    return { resources: allResourceIds.length, eventsApplied, eventsFailed };
   }
 
   /**
@@ -720,6 +887,7 @@ export class Weaver {
     subscriptions: number;
     lastProcessed: Record<string, number>;
     pipelineActive: boolean;
+    applyFailures: number;
   } {
     return {
       // One injected source stream since WEAVER-ISOLATION P2 — channel
@@ -727,6 +895,10 @@ export class Weaver {
       subscriptions: this.sourceSubscription ? 1 : 0,
       lastProcessed: Object.fromEntries(this.lastProcessed),
       pipelineActive: !!this.pipelineSubscription,
+      // Running count of applies that failed and were therefore NOT
+      // checkpointed (#845) — nonzero means the graph is missing events
+      // the live pipeline witnessed failing.
+      applyFailures: this._applyFailures,
     };
   }
 

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -883,9 +883,14 @@ export class Weaver {
   /**
    * Get consumer health metrics.
    */
+  /** Highest applied sequence for a resource, if any — diagnostics/tests. */
+  appliedUpTo(resourceId: string): number | undefined {
+    return this.lastProcessed.get(resourceId);
+  }
+
   getHealthMetrics(): {
     subscriptions: number;
-    lastProcessed: Record<string, number>;
+    resourcesTracked: number;
     pipelineActive: boolean;
     applyFailures: number;
   } {
@@ -893,7 +898,10 @@ export class Weaver {
       // One injected source stream since WEAVER-ISOLATION P2 — channel
       // fan-in (9 channels) lives in WeaverActorStateUnit.
       subscriptions: this.sourceSubscription ? 1 : 0,
-      lastProcessed: Object.fromEntries(this.lastProcessed),
+      // A count, deliberately not the map: serializing every per-resource
+      // sequence made /health an O(resources) payload (#845 scalability).
+      // Per-resource marks are `appliedUpTo()`.
+      resourcesTracked: this.lastProcessed.size,
       pipelineActive: !!this.pipelineSubscription,
       // Running count of applies that failed and were therefore NOT
       // checkpointed (#845) — nonzero means the graph is missing events


### PR DESCRIPTION
# Pull Request

## Description

Implements the three-layer completeness strategy for **#845** ("neo4j projection
silently under-materializes") against the post-split Weaver, plus the two
scalability warts called out during review. The issue's core demand — *the
projection must never silently under-materialize* — is now enforced; #845 stays
open to track the remaining follow-ups listed there (scale levers for large KBs,
annotation-body deep equality, lane-clean heals, on-demand reconcile), so this PR
deliberately does **not** carry a `Closes` keyword.

**Layer 1 — witnessed-failure accounting.** `safeApplyEvent` counts every failed
apply. The running counter is on `/health` (`applyFailures`); `catchUp()` reports
`eventsFailed` and `parityPending`, logging at error level when nonzero; and
`weave:rebuild` **replies FAILED instead of ok** when any event dropped
(`"rebuild dropped N event(s) — the graph is incomplete"`). No path can claim
success while under-materializing witnessed work.

**Layer 2 — checkpoint honesty.** A failed apply no longer advances
`lastProcessed`/the persisted checkpoint and emits no `weave:applied` signal, so
the read barrier never claims parity that doesn't exist. In batches, a failed run
blocks advance for the rest of the batch — the mark never skips past events that
didn't land. The next catch-up re-replays from the last clean sequence and the
idempotent folds (WEAVER-ISOLATION P1) absorb the overlap: transient failures
self-heal again, which the checkpoint had quietly broken (pre-split, every restart
was a full replay; post-split, a checkpoint that advanced past failures made them
permanent). The catch-up drain gained a stall detector so held-back parity reports
in ~1 s instead of burning the 30 s timeout. Also removes the obsolete pre-split
`setTimeout(0)` politeness yield from the apply path (a #984 leftover).

**Layer 3 — reconcile, the completeness assertion #845 asked for.**
`Weaver.reconcile()` runs at startup after catch-up (the Smelter's
subscribe → catch-up → reconcile order): a per-resource state diff of the graph
against the catalog — node existence, archived flag, entity-type set,
annotation-id set — detecting over the view (cheap authority) and **healing by
per-resource log replay** (`rebuildResource`), so repairs are log-truthful even if
the view were wrong. It backstops what accounting cannot witness: acked-but-lost
writes (the issue's suspected mechanism), out-of-band graph mutations, wiped or
rolled-back Neo4j volumes (post-split the checkpoint and the graph are separate
failure domains), and historical damage. Summary on `/health` as `reconcile`.

**Scalability warts (from the same review):**

- `/health` no longer serializes the entire per-resource applied map (an
  O(resources) payload) — it reports `resourcesTracked`; per-resource marks moved
  to `Weaver.appliedUpTo(resourceId)`.
- `WeaveProgress` entries now TTL out (5 min, lazy sweep, no timer) — eviction is
  correctness-free since the barrier only engages on fresh applies and a missed
  immediate-resolve degrades to the poll floor. Previously the fold grew with
  every resource ever signaled.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Areas Changed

Only `packages/make-meaning` (`weaver.ts`, `weave-progress.ts`, `weaver-main.ts`,
plus their test files).

## Security Checklist

Not applicable — no authentication, authorization, or admin surface touched.

## Verification

- RED-first throughout: six new specs in `weaver.test.ts` ("completeness
  accounting + reconcile (#845)") — failed applies don't advance the mark or emit
  signals; a failed batch run blocks the batch; `weave:rebuild` fails loudly on
  drops; catch-up reports failures and the next pass re-replays; reconcile detects
  an out-of-band deletion and heals it from the log; a clean graph reconciles with
  zero divergence — plus a TTL-eviction spec in `weave-progress.test.ts` and the
  reshaped health assertions. All observed failing before the fixes.
- Final state: build + full workspace `tsc --noEmit` clean; make-meaning 36 files
  / 439 tests (node:24 container). Full suites are CI's job.
