### PR TITLE
smelter: unarchive re-embeds + entity-tag restamps (S13); branded browse replies

### DIFF
--- a/apps/backend/src/__tests__/routes/resource-pipe.test.ts
+++ b/apps/backend/src/__tests__/routes/resource-pipe.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { Hono } from 'hono';
 import type { User } from '@prisma/client';
 import { EventBus, resourceId as makeResourceId } from '@semiont/core';
-import type { EventBus as EventBusType, Logger, components } from '@semiont/core';
+import type { EventBus as EventBusType, EventMap, Logger } from '@semiont/core';
 import { SemiontProject } from '@semiont/core/node';
 import { FilesystemViewStorage } from '@semiont/event-sourcing';
 import { WorkingTreeStore, calculateChecksum } from '@semiont/content';
@@ -153,7 +153,9 @@ describe('resource routes pipe contract (SIMPLER-JSON-LD.md Phase 1)', () => {
   });
 
   it('serves the JSON-LD description at /resources/:id/jsonld', async () => {
-    const graph: components['schemas']['GetResourceResponse'] = {
+    // The branded reply flavor the protocol declares (bus-protocol.ts) — the
+    // fixture's ids are built with the real constructors, so it satisfies it.
+    const graph: EventMap['browse:resource-result']['response'] = {
       resource: {
         '@context': 'https://schema.org',
         '@id': makeResourceId('res-pipe-graph'),

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -19,6 +19,8 @@
 
 import type { components } from './types';
 import type { AnnotationId, ResourceId } from './identifiers';
+import type { Annotation } from './annotation-types';
+import type { ResourceDescriptor } from './graph';
 import type { StoredEvent } from './event-base';
 import type { EventOfType } from './persisted-events';
 
@@ -217,21 +219,52 @@ export type EventMap = {
   // BROWSE FLOW — knowledge base reads + UI navigation
   // ========================================================================
 
-  // Reads
+  // Reads.
+  //
+  // Reply `response` payloads carry DOMAIN-flavored documents: the KS serves
+  // real, validated ids, so these declare the branded `Annotation` /
+  // `ResourceDescriptor` (annotation-types.ts / graph.ts) rather than the raw
+  // OpenAPI flavors — consumers must never need to re-brand (`as Annotation[]`)
+  // what the protocol already guarantees. Field overrides via Omit +
+  // intersection; envelope shape per .plans/REPLY-SHAPE-STANDARD.md.
   'browse:resource-requested': components['schemas']['BrowseResourceRequest'];
-  'browse:resource-result': components['schemas']['BrowseResourceResult'];
+  'browse:resource-result': {
+    correlationId: string;
+    response: Omit<components['schemas']['GetResourceResponse'], 'resource' | 'annotations' | 'entityReferences'> & {
+      resource: ResourceDescriptor;
+      annotations: Annotation[];
+      entityReferences: Annotation[];
+    };
+  };
   'browse:resource-failed': { correlationId: string } & components['schemas']['CommandError'];
 
   'browse:resources-requested': components['schemas']['BrowseResourcesRequest'];
-  'browse:resources-result': components['schemas']['BrowseResourcesResult'];
+  'browse:resources-result': {
+    correlationId: string;
+    response: Omit<components['schemas']['ListResourcesResponse'], 'resources'> & {
+      resources: ResourceDescriptor[];
+    };
+  };
   'browse:resources-failed': { correlationId: string } & components['schemas']['CommandError'];
 
   'browse:annotations-requested': components['schemas']['BrowseAnnotationsRequest'];
-  'browse:annotations-result': components['schemas']['BrowseAnnotationsResult'];
+  'browse:annotations-result': {
+    correlationId: string;
+    response: Omit<components['schemas']['GetAnnotationsResponse'], 'annotations'> & {
+      annotations: Annotation[];
+    };
+  };
   'browse:annotations-failed': { correlationId: string } & components['schemas']['CommandError'];
 
   'browse:annotation-requested': components['schemas']['BrowseAnnotationRequest'];
-  'browse:annotation-result': components['schemas']['BrowseAnnotationResult'];
+  'browse:annotation-result': {
+    correlationId: string;
+    response: Omit<components['schemas']['GetAnnotationResponse'], 'annotation' | 'resource' | 'resolvedResource'> & {
+      annotation: Annotation;
+      resource: ResourceDescriptor | null;
+      resolvedResource: ResourceDescriptor | null;
+    };
+  };
   'browse:annotation-failed': { correlationId: string } & components['schemas']['CommandError'];
 
   'browse:events-requested': components['schemas']['BrowseEventsRequest'];

--- a/packages/make-meaning/src/__tests__/smelter-actor-state-unit.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter-actor-state-unit.test.ts
@@ -50,7 +50,7 @@ describe('createSmelterActorStateUnit', () => {
     h = fakeBus();
   });
 
-  it('extends the shared bus with all 6 smelter channels on start', () => {
+  it('extends the shared bus with all 9 smelter channels on start', () => {
     const stateUnit = createSmelterActorStateUnit({ bus: h.bus });
     stateUnit.start();
 
@@ -58,8 +58,11 @@ describe('createSmelterActorStateUnit', () => {
     expect(h.channels.has('yield:updated')).toBe(true);
     expect(h.channels.has('yield:representation-added')).toBe(true);
     expect(h.channels.has('mark:archived')).toBe(true);
+    expect(h.channels.has('mark:unarchived')).toBe(true);
     expect(h.channels.has('mark:added')).toBe(true);
     expect(h.channels.has('mark:removed')).toBe(true);
+    expect(h.channels.has('mark:entity-tag-added')).toBe(true);
+    expect(h.channels.has('mark:entity-tag-removed')).toBe(true);
 
     stateUnit.dispose();
   });

--- a/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
@@ -10,7 +10,8 @@
  *
  * Current ledger: all GREEN. (S9b flipped by R2; S1 and S2 flipped by R3 —
  * reconcile became a planner whose work items flow through the mailbox;
- * S12 flipped by R5 — checksum-stamped vectors + staleness diff.)
+ * S12 flipped by R5 — checksum-stamped vectors + staleness diff; S13 flipped
+ * by R6 — payload-only tag restamps, live and via the reconcile tag diff.)
  */
 
 import { describe, it, expect } from 'vitest';
@@ -91,6 +92,8 @@ interface CatalogEntry {
   mediaType: string;
   text: string;
   annotations: { aid: string; exact: string }[];
+  /** Catalog entity types — the discriminator the stamps must track (S13). */
+  entityTypes?: string[];
 }
 
 function toCatalog(raw: { rid: string; mediaType: string; text: string; exacts: string[] }[]): CatalogEntry[] {
@@ -122,7 +125,7 @@ function eventArbFor(catalog: CatalogEntry[]): fc.Arbitrary<SmelterEvent> {
       entry: fc.constantFrom(...catalog),
       kind: fc.constantFrom(
         'yield:created', 'yield:updated', 'yield:representation-added',
-        'mark:archived', 'mark:added', 'mark:removed',
+        'mark:archived', 'mark:unarchived', 'mark:added', 'mark:removed',
       ),
       annIdx: fc.nat(2),
     })
@@ -171,6 +174,15 @@ function modelFold(catalog: CatalogEntry[], seq: SmelterEvent[]): ModelIds {
         for (const [aid, anchor] of anchorOf) if (anchor === rid) annotations.delete(aid);
         break;
       }
+      case 'mark:unarchived': {
+        const entry = byRid.get(rid);
+        if (!entry) break;
+        if (embeds(entry.mediaType)) resources.add(rid);
+        // The handler restores the CURRENT catalog annotations — including
+        // any previously removed; the catalog is the authority on unarchive.
+        for (const a of entry.annotations) annotations.add(a.aid);
+        break;
+      }
       case 'mark:added': {
         const annotation = ev.payload.annotation as { id?: string } | undefined;
         if (annotation?.id) annotations.add(annotation.id);
@@ -207,6 +219,7 @@ interface InstrumentState {
 function instrument(inner: MemoryVectorStore, state: InstrumentState): MemoryVectorStore {
   const keyOf = new Map<PropertyKey, (args: unknown[]) => string>([
     ['upsertResourceVectors', (a) => String(a[0])],
+    ['updateResourceEntityTypes', (a) => String(a[0])],
     ['deleteResourceVectors', (a) => String(a[0])],
     ['upsertAnnotationVector', (a) => String((a[2] as AnnotationPayload).resourceId)],
     ['deleteAnnotationVector', (a) => state.aidAnchor.get(String(a[0])) ?? String(a[0])],
@@ -286,7 +299,7 @@ async function makeHarness(opts: {
     wrap: opts.schedule ? (p, label) => opts.schedule!.schedule(p, label) : undefined,
   });
   const bus = createFakeKsBus(
-    opts.catalog.map((e) => resourceDescriptor(e.rid, e.mediaType, calculateChecksum(e.text))),
+    opts.catalog.map((e) => resourceDescriptor(e.rid, e.mediaType, calculateChecksum(e.text), e.entityTypes ?? [])),
     new Map(opts.catalog.map((e) => [e.rid, e.annotations.map((a) => makeAnnotation(e.rid, a.aid, a.exact))])),
   );
 
@@ -306,7 +319,7 @@ async function makeHarness(opts: {
       entries.set(rid, { text, mediaType: entry?.mediaType ?? 'text/plain' });
     },
     ids: async () => ({
-      resources: [...(await inner.listResourceChecksums()).keys()].sort(),
+      resources: [...(await inner.listResourceStamps()).keys()].sort(),
       annotations: [...(await inner.listAnnotationIds())].sort(),
     }),
     settle: async (quietMs = 30, maxMs = 5000) => {
@@ -672,6 +685,53 @@ describe('Smelter axioms', () => {
               } else {
                 expect(h2.upsertCounts.get(rid) ?? 0).toBe(0);
               }
+            }
+          } finally {
+            h2.stop();
+          }
+        },
+      ),
+      { numRuns: 20 },
+    );
+  }, 30_000);
+
+  // S13 (FOPL): ∀ K, ∀ tag histories, after reconcile with no concurrent
+  // traffic, ∀ r ∈ K with gate(media(r)) ∧ r indexed:
+  //   stampTypes(S*, r) = entityTypes(r, K)
+  // — and stamp updates never invoke the embedding provider (restamp ≠
+  // re-embed). S12's sibling: tag edits change no bytes, so the checksum
+  // diff alone is blind to them.
+  it('S13: reconcile restamps tag drift without re-embedding', async () => {
+    const TAG_SETS: string[][] = [[], ['Question'], ['Person'], ['Question', 'Person']];
+    await fc.assert(
+      fc.asyncProperty(
+        nonEmptyTextCatalogArb,
+        fc.array(fc.constantFrom(...TAG_SETS), { minLength: 4, maxLength: 4 }),
+        async (catalog, newTagSets) => {
+          // Phase 1 — the worker indexes an untagged catalog, then "goes down".
+          const store = new MemoryVectorStore();
+          await store.connect();
+          const h1 = await makeHarness({ catalog, store });
+          try {
+            for (const e of catalog) h1.events$.next({ type: 'yield:created', resourceId: e.rid, payload: {} });
+            await h1.settle();
+          } finally {
+            h1.stop();
+          }
+
+          // Downtime — tags move on; content does not.
+          const catalog2 = catalog.map((e, i) => ({ ...e, entityTypes: newTagSets[i] ?? [] }));
+
+          // Phase 2 — restart: reconcile against the retagged catalog.
+          const h2 = await makeHarness({ catalog: catalog2, store });
+          try {
+            await h2.smelter.reconcile();
+            const stamps = await store.listResourceStamps();
+            for (const e of catalog2) {
+              expect([...(stamps.get(e.rid)?.entityTypes ?? [])].sort())
+                .toEqual([...(e.entityTypes ?? [])].sort());
+              // Content unchanged ⇒ zero re-embeds; the heal is payload-only.
+              expect(h2.upsertCounts.get(e.rid) ?? 0).toBe(0);
             }
           } finally {
             h2.stop();

--- a/packages/make-meaning/src/__tests__/smelter.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter.test.ts
@@ -30,6 +30,7 @@ import {
   mockLogger,
   deterministicEmbed,
   createMockEmbeddingProvider,
+  makeAnnotation,
   annotationEvent,
   resourceDescriptor,
   createMockContentTransport,
@@ -209,6 +210,107 @@ describe('Smelter', () => {
   });
 });
 
+describe('Smelter mark:unarchived', () => {
+  // bugs/smelter-misses-unarchive.md — the live path must agree with what a
+  // restart's reconcile() would rebuild: unarchive restores the resource's
+  // vectors AND its current exact-text annotations' vectors.
+  it('re-embeds the resource and its current annotations after archive→unarchive', async () => {
+    const events$ = new Subject<SmelterEvent>();
+    const vectorStore = new MemoryVectorStore();
+    await vectorStore.connect();
+    const embeddingProvider = createMockEmbeddingProvider();
+    const text = 'Content that survives an archive cycle.';
+    const contentByResourceId = new Map([['res-cycle', text]]);
+    const smelter = new Smelter(
+      events$,
+      vectorStore,
+      embeddingProvider,
+      createMockContentTransport(contentByResourceId),
+      createFakeKsBus(
+        [resourceDescriptor('res-cycle', 'text/plain', calculateChecksum(text))],
+        new Map([['res-cycle', [makeAnnotation('res-cycle', 'ann-cycle', 'exact text that returns')]]]),
+      ),
+      { chunkSize: 512, overlap: 64 },
+      { burstWindowMs: 50, maxBatchSize: 100, idleTimeoutMs: 200 },
+      mockLogger,
+    );
+    smelter.initialize();
+    try {
+      events$.next({ type: 'yield:created', resourceId: 'res-cycle', payload: {} });
+      events$.next(annotationEvent('res-cycle', 'ann-cycle', 'exact text that returns'));
+      await tick();
+      expect((await vectorStore.listResourceStamps()).has('res-cycle')).toBe(true);
+      expect((await vectorStore.listAnnotationIds()).has('ann-cycle')).toBe(true);
+
+      // Archive deletes both — pins existing behavior.
+      events$.next({ type: 'mark:archived', resourceId: 'res-cycle', payload: {} });
+      await tick();
+      expect((await vectorStore.listResourceStamps()).has('res-cycle')).toBe(false);
+      expect((await vectorStore.listAnnotationIds()).has('ann-cycle')).toBe(false);
+
+      // Unarchive must bring both back without waiting for a restart.
+      events$.next({ type: 'mark:unarchived', resourceId: 'res-cycle', payload: {} });
+      await tick();
+      expect((await vectorStore.listResourceStamps()).has('res-cycle')).toBe(true);
+      expect((await vectorStore.listAnnotationIds()).has('ann-cycle')).toBe(true);
+    } finally {
+      smelter.stop();
+    }
+  });
+});
+
+describe('Smelter entity-tag stamps', () => {
+  // bugs/smelter-stale-entity-type-stamps.md — tag edits must reach the
+  // vector stamps without re-embedding: the stamp is the discriminator
+  // `searchResources` filters on (EXCLUDE-VECTORS), and embedding calls are
+  // the expensive external resource a tag edit must never trigger.
+  it('updates the entityTypes stamp on mark:entity-tag-added / -removed without re-embedding', async () => {
+    const events$ = new Subject<SmelterEvent>();
+    const vectorStore = new MemoryVectorStore();
+    await vectorStore.connect();
+    const embeddingProvider = createMockEmbeddingProvider();
+    const text = 'Tagged content to restamp.';
+    const descriptor = resourceDescriptor('res-tags', 'text/plain', calculateChecksum(text));
+    const smelter = new Smelter(
+      events$,
+      vectorStore,
+      embeddingProvider,
+      createMockContentTransport(new Map([['res-tags', text]])),
+      createFakeKsBus([descriptor]),
+      { chunkSize: 512, overlap: 64 },
+      { burstWindowMs: 50, maxBatchSize: 100, idleTimeoutMs: 200 },
+      mockLogger,
+    );
+    smelter.initialize();
+    try {
+      events$.next({ type: 'yield:created', resourceId: 'res-tags', payload: {} });
+      await tick();
+      const queryVec = deterministicEmbed(text);
+      expect((await vectorStore.searchResources(queryVec, { limit: 5 })).length).toBeGreaterThan(0);
+      const embedCallsAfterCreate = (embeddingProvider.embedBatch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      // The catalog moves on: the resource is tagged Question…
+      descriptor.entityTypes = ['Question'];
+      events$.next({ type: 'mark:entity-tag-added', resourceId: 'res-tags', payload: { entityType: 'Question' } });
+      await tick();
+
+      // …and the stamp must follow: question-exclusion recall drops it,
+      expect(await vectorStore.searchResources(queryVec, { limit: 5, filter: { excludeEntityTypes: ['Question'] } })).toEqual([]);
+      // without an embedding call (restamp ≠ re-embed).
+      expect((embeddingProvider.embedBatch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(embedCallsAfterCreate);
+
+      // Tag removed: the stamp follows back.
+      descriptor.entityTypes = [];
+      events$.next({ type: 'mark:entity-tag-removed', resourceId: 'res-tags', payload: { entityType: 'Question' } });
+      await tick();
+      expect((await vectorStore.searchResources(queryVec, { limit: 5, filter: { excludeEntityTypes: ['Question'] } })).length).toBeGreaterThan(0);
+      expect((embeddingProvider.embedBatch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(embedCallsAfterCreate);
+    } finally {
+      smelter.stop();
+    }
+  });
+});
+
 describe('Smelter.reconcile', () => {
   let vectorStore: MemoryVectorStore;
   let embeddingProvider: EmbeddingProvider;
@@ -272,6 +374,27 @@ describe('Smelter.reconcile', () => {
     expect(excluded.some((r) => r.resourceId === 'res-q')).toBe(false);
   });
 
+  it('restamps entity types that changed while the worker was down (content unchanged)', async () => {
+    const text = 'Stamped content, tags changed offline.';
+    const checksum = calculateChecksum(text);
+    contentByResourceId.set('res-restamp', text);
+    await vectorStore.upsertResourceVectors(
+      makeResourceId('res-restamp'),
+      [{ chunkIndex: 0, text, embedding: deterministicEmbed(text) }],
+      checksum,
+      ['OldTag'],
+    );
+
+    const smelter = createSmelter([resourceDescriptor('res-restamp', 'text/plain', checksum, ['Question'])]);
+    await smelter.reconcile();
+
+    const queryVec = deterministicEmbed(text);
+    // The stamp must now say Question: question-exclusion recall drops it…
+    expect(await vectorStore.searchResources(queryVec, { limit: 5, filter: { excludeEntityTypes: ['Question'] } })).toEqual([]);
+    // …and content didn't change, so nothing re-embeds (restamp ≠ re-embed).
+    expect(embeddingProvider.embedBatch).not.toHaveBeenCalled();
+  });
+
   it('leaves already-indexed resources alone', async () => {
     const text = 'Already indexed.';
     const checksum = calculateChecksum(text);
@@ -303,7 +426,7 @@ describe('Smelter.reconcile', () => {
     const summary = await smelter.reconcile();
 
     expect(summary.resourcesEmbedded).toBe(250);
-    expect((await vectorStore.listResourceChecksums()).size).toBe(250);
+    expect((await vectorStore.listResourceStamps()).size).toBe(250);
   });
 
   it('records failure state when the catalog is unreachable', async () => {

--- a/packages/make-meaning/src/resource-graph.ts
+++ b/packages/make-meaning/src/resource-graph.ts
@@ -8,18 +8,27 @@
  * See `.plans/SIMPLER-JSON-LD.md` (Phase 2, decision 7).
  */
 
-import type { ResourceId, components } from '@semiont/core';
+import type { Annotation, ResourceDescriptor, ResourceId } from '@semiont/core';
 import { EventQuery } from '@semiont/event-sourcing';
 import { getEntityTypes } from '@semiont/ontology';
 import type { KnowledgeBase } from './knowledge-base';
 
-type GetResourceResponse = components['schemas']['GetResourceResponse'];
-type Annotation = components['schemas']['Annotation'];
+/**
+ * `GetResourceResponse` with the domain-flavored (branded) documents the
+ * materialized views actually hold — the same shape the branded
+ * `browse:resource-result` reply declares (bus-protocol.ts). The raw OpenAPI
+ * flavor exists only at the HTTP boundary (annotation-types.ts).
+ */
+export interface ResourceGraph {
+  resource: ResourceDescriptor;
+  annotations: Annotation[];
+  entityReferences: Annotation[];
+}
 
 export async function assembleResourceGraph(
   kb: KnowledgeBase,
   resourceId: ResourceId,
-): Promise<GetResourceResponse | null> {
+): Promise<ResourceGraph | null> {
   // Materialize from the event store (matches the get-uri.ts JSON-LD path).
   const eventQuery = new EventQuery(kb.eventStore.log.storage);
   const events = await eventQuery.getResourceEvents(resourceId);

--- a/packages/make-meaning/src/smelter-actor-state-unit.ts
+++ b/packages/make-meaning/src/smelter-actor-state-unit.ts
@@ -1,7 +1,7 @@
 /**
  * SmelterActorStateUnit — domain-event fan-in for the Smelter worker.
  *
- * Subscribes to the six smelter-relevant channels on a shared bus and
+ * Subscribes to the nine smelter-relevant channels on a shared bus and
  * exposes them as a single typed `events$` stream. Transport-neutral —
  * the caller passes a `WorkerBus` (HTTP `ActorStateUnit` today, an in-process
  * bus shim if/when one exists). The state unit does not own the bus and does
@@ -33,8 +33,11 @@ const SMELTER_CHANNELS = [
   'yield:updated',
   'yield:representation-added',
   'mark:archived',
+  'mark:unarchived',
   'mark:added',
   'mark:removed',
+  'mark:entity-tag-added',
+  'mark:entity-tag-removed',
 ] as const;
 
 export interface SmelterActorStateUnit extends StateUnit {

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -27,11 +27,12 @@
  * Qdrant is an ephemeral projection of the event log. `reconcile()` brings
  * it back in sync at startup — after a wiped volume, or after events missed
  * while the worker was down. It is a planner: it diffs the store against the
- * catalog (over the `browse:*` RPC channels) — both membership AND content
- * freshness, via the checksum stamped onto every resource upsert — and
+ * catalog (over the `browse:*` RPC channels) — membership, content freshness
+ * (via the checksum stamped onto every resource upsert), and tag-stamp
+ * freshness (payload-only restamps; tag edits change no bytes) — and
  * enqueues `smelt:*` work items through the same mailbox as live events, so
- * per-resource ordering holds across the two paths (axioms S1/S2/S11/S12 in
- * `.plans/SMELTER-AXIOMS.md`).
+ * per-resource ordering holds across the two paths (axioms S1/S2/S11/S12/S13
+ * in `.plans/SMELTER-AXIOMS.md`).
  */
 
 import { Observable, Subject, Subscription, from } from 'rxjs';
@@ -58,6 +59,8 @@ import type { SmelterEvent } from './smelter-actor-state-unit';
 
 export interface ReconcileSummary {
   resourcesEmbedded: number;
+  /** Tag-only drift healed by payload restamps — never embedding calls (S13). */
+  resourcesRestamped: number;
   resourceVectorsDeleted: number;
   annotationsEmbedded: number;
   annotationVectorsDeleted: number;
@@ -87,9 +90,16 @@ export interface SmelterTiming {
  * lanes and batch paths serve both kinds of input.
  */
 export interface SmelterWorkItem {
-  type: 'smelt:embed' | 'smelt:purge' | 'smelt:embed-annotation' | 'smelt:purge-annotation';
+  type: 'smelt:embed' | 'smelt:restamp' | 'smelt:purge' | 'smelt:embed-annotation' | 'smelt:purge-annotation';
   resourceId: string;
   payload: Record<string, unknown>;
+}
+
+/** Set equality over tag lists — order-insensitive, duplicate-tolerant. */
+function sameStringSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((t) => set.has(t));
 }
 
 export type SmelterInput = SmelterEvent | SmelterWorkItem;
@@ -265,15 +275,25 @@ export class Smelter {
       case 'mark:archived':
         await this.handleResourceArchived(event);
         break;
+      case 'mark:unarchived':
+        await this.handleResourceUnarchived(event);
+        break;
       case 'mark:added':
         await this.handleAnnotationAdded(event);
         break;
       case 'mark:removed':
         await this.handleAnnotationRemoved(event);
         break;
+      case 'mark:entity-tag-added':
+      case 'mark:entity-tag-removed':
+        await this.restampResource(event);
+        break;
       // Reconcile work items — same handlers, distinct provenance.
       case 'smelt:embed':
         await this.embedResource(event, 'Reconcile-indexed resource');
+        break;
+      case 'smelt:restamp':
+        await this.restampResource(event);
         break;
       case 'smelt:purge':
         await this.handleResourcePurge(event);
@@ -285,6 +305,22 @@ export class Smelter {
         await this.handleAnnotationRemoved(event);
         break;
     }
+  }
+
+  /**
+   * Payload-only stamp refresh: re-read the resource's CURRENT entity types
+   * (one code path — `resolveEntityTypes` — so any prior drift self-corrects
+   * on first touch) and rewrite the stamp on its existing points. Never calls
+   * the embedding provider (S13): content is unchanged by definition on every
+   * path that lands here. A resource with no points is a no-op — the stamp
+   * rides the next embed.
+   */
+  private async restampResource(event: SmelterInput): Promise<void> {
+    const rid = event.resourceId;
+    if (!rid) return;
+    const entityTypes = await this.resolveEntityTypes(rid);
+    await this.vectorStore.updateResourceEntityTypes(makeResourceId(rid), entityTypes);
+    this.logger.info('Restamped resource entity types', { resourceId: rid, entityTypes });
   }
 
   private async handleResourcePurge(event: SmelterInput): Promise<void> {
@@ -337,7 +373,7 @@ export class Smelter {
       'browse:resource-requested',
       { resourceId },
     );
-    return getResourceEntityTypes(resource as ResourceDescriptor);
+    return getResourceEntityTypes(resource);
   }
 
   private async embedResource(event: SmelterInput, logMessage: string): Promise<void> {
@@ -371,12 +407,40 @@ export class Smelter {
     this.logger.info('Deleted vectors for archived resource', { resourceId: rid });
   }
 
+  /**
+   * Restore what `handleResourceArchived` deleted, from CURRENT state: the
+   * resource's vectors (media-gated, full-replace) and its current exact-text
+   * annotations — the same catalog read `reconcile()` uses, so the live path
+   * and a restart agree (bugs/smelter-misses-unarchive.md).
+   */
+  private async handleResourceUnarchived(event: SmelterInput): Promise<void> {
+    const rid = event.resourceId;
+    if (!rid) return;
+
+    await this.embedResource(event, 'Re-embedded unarchived resource');
+
+    const { annotations } = await busRequest(
+      this.bus,
+      'browse:annotations-requested',
+      { resourceId: rid },
+    );
+    for (const annotation of annotations) {
+      await this.indexAnnotation(rid, annotation);
+    }
+  }
+
   private async handleAnnotationAdded(event: SmelterInput): Promise<void> {
     const annotation = event.payload.annotation as Annotation | undefined;
     if (!annotation?.id) return;
 
     const rid = event.resourceId;
     if (!rid) return;
+
+    await this.indexAnnotation(rid, annotation);
+  }
+
+  private async indexAnnotation(rid: string, annotation: Annotation): Promise<void> {
+    if (!annotation.id) return;
 
     const selector = getTargetSelector(annotation.target);
     const exactText = getExactText(selector);
@@ -523,7 +587,7 @@ export class Smelter {
     this._reconcileState = { phase: 'running' };
     try {
       const [indexedResources, indexedAnnotations] = await Promise.all([
-        this.vectorStore.listResourceChecksums(),
+        this.vectorStore.listResourceStamps(),
         this.vectorStore.listAnnotationIds(),
       ]);
       const resources = await this.listAllResources();
@@ -533,13 +597,17 @@ export class Smelter {
         liveResources: resources.length,
       });
 
-      // Embeddable live resources, each with the catalog's claim about its
-      // primary representation's checksum (the bytes the smelter would read).
-      const embeddable = new Map<string, string | undefined>();
+      // Embeddable live resources, each with the catalog's claims: the primary
+      // representation's checksum (the bytes the smelter would read) and the
+      // current entity-type set (the discriminator the stamps must carry).
+      const embeddable = new Map<string, { checksum: string | undefined; entityTypes: string[] }>();
       for (const resource of resources) {
         const mediaType = getPrimaryMediaType(resource);
         if (resource['@id'] && mediaType && textExtractionOf(mediaType) === 'decode') {
-          embeddable.set(resource['@id'], getPrimaryRepresentation(resource)?.checksum);
+          embeddable.set(resource['@id'], {
+            checksum: getPrimaryRepresentation(resource)?.checksum,
+            entityTypes: getResourceEntityTypes(resource),
+          });
         }
       }
 
@@ -548,13 +616,20 @@ export class Smelter {
       for (const rid of indexedResources.keys()) {
         if (!embeddable.has(rid)) work.push({ type: 'smelt:purge', resourceId: rid, payload: {} });
       }
-      for (const [rid, catalogChecksum] of embeddable) {
-        if (!indexedResources.has(rid)) {
+      for (const [rid, catalog] of embeddable) {
+        const indexed = indexedResources.get(rid);
+        if (!indexed) {
           work.push({ type: 'smelt:embed', resourceId: rid, payload: {} });
-        } else if (catalogChecksum !== undefined && indexedResources.get(rid) !== catalogChecksum) {
-          // Stale-but-present: indexed from earlier bytes (or from a pre-stamp
-          // deployment, where the stamp reads as undefined) — re-embed (S12).
+        } else if (catalog.checksum !== undefined && indexed.contentChecksum !== catalog.checksum) {
+          // Stale-but-present content: indexed from earlier bytes (or from a
+          // pre-stamp deployment, where the stamp reads as undefined) —
+          // re-embed (S12). The fresh embed re-reads the tags too.
           work.push({ type: 'smelt:embed', resourceId: rid, payload: {} });
+        } else if (!sameStringSet(indexed.entityTypes, catalog.entityTypes)) {
+          // Content current, tags drifted: tag edits change no bytes, so the
+          // checksum diff is blind to them — payload-only restamp (S13),
+          // never an embedding call.
+          work.push({ type: 'smelt:restamp', resourceId: rid, payload: {} });
         }
       }
 
@@ -591,6 +666,7 @@ export class Smelter {
 
       const summary: ReconcileSummary = {
         resourcesEmbedded: work.filter((w) => w.type === 'smelt:embed').length,
+        resourcesRestamped: work.filter((w) => w.type === 'smelt:restamp').length,
         resourceVectorsDeleted: work.filter((w) => w.type === 'smelt:purge').length,
         annotationsEmbedded: work.filter((w) => w.type === 'smelt:embed-annotation').length,
         annotationVectorsDeleted: work.filter((w) => w.type === 'smelt:purge-annotation').length,
@@ -634,7 +710,7 @@ export class Smelter {
         'browse:resources-requested',
         { archived: false, offset: all.length, limit: Smelter.RECONCILE_PAGE_SIZE },
       );
-      all.push(...(page.resources as ResourceDescriptor[]));
+      all.push(...page.resources);
       if (page.resources.length === 0 || all.length >= page.total) return all;
     }
   }

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -204,7 +204,7 @@ export class Weaver {
         offset: resources.length,
         limit: Weaver.CATCHUP_PAGE_SIZE,
       });
-      resources.push(...(page.resources as ResourceDescriptor[]));
+      resources.push(...page.resources);
       if (page.resources.length === 0 || resources.length >= page.total) break;
     }
     return resources;
@@ -383,7 +383,7 @@ export class Weaver {
 
     const { annotations } = await busRequest(this.bus, 'browse:annotations-requested', { resourceId: rid });
     const graphAnnotations = await graphDb.getResourceAnnotations(makeResourceId(rid));
-    const viewIds = new Set((annotations as Annotation[]).map((a) => String(a.id)));
+    const viewIds = new Set(annotations.map((a) => String(a.id)));
     const graphIds = new Set(graphAnnotations.map((a) => String(a.id)));
     if (viewIds.size !== graphIds.size) return 'annotation-set-mismatch';
     for (const id of viewIds) {

--- a/packages/vectors/src/__tests__/memory-store.test.ts
+++ b/packages/vectors/src/__tests__/memory-store.test.ts
@@ -257,31 +257,59 @@ describe('MemoryVectorStore', () => {
   });
 
   describe('enumeration', () => {
-    it('lists distinct resource ids with their stamped checksums', async () => {
+    it('lists distinct resource ids with their stamps (checksum + entity types)', async () => {
       const vecs = await embedding.embedBatch(['alpha', 'beta']);
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'alpha', embedding: vecs[0] },
-      ], 'cs-alpha', []);
+      ], 'cs-alpha', ['Question']);
       await store.upsertResourceVectors('res-2' as ResourceId, [
         { chunkIndex: 0, text: 'beta', embedding: vecs[1] },
       ], 'cs-beta', []);
 
-      expect(await store.listResourceChecksums()).toEqual(new Map([
-        ['res-1', 'cs-alpha'],
-        ['res-2', 'cs-beta'],
+      expect(await store.listResourceStamps()).toEqual(new Map([
+        ['res-1', { contentChecksum: 'cs-alpha', entityTypes: ['Question'] }],
+        ['res-2', { contentChecksum: 'cs-beta', entityTypes: [] }],
       ]));
     });
 
-    it('re-upsert replaces the stamped checksum', async () => {
+    it('re-upsert replaces the stamps', async () => {
       const vec = await embedding.embed('gamma');
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'gamma', embedding: vec },
-      ], 'cs-old', []);
+      ], 'cs-old', ['OldTag']);
       await store.upsertResourceVectors('res-1' as ResourceId, [
         { chunkIndex: 0, text: 'gamma', embedding: vec },
-      ], 'cs-new', []);
+      ], 'cs-new', ['NewTag']);
 
-      expect((await store.listResourceChecksums()).get('res-1')).toBe('cs-new');
+      expect((await store.listResourceStamps()).get('res-1')).toEqual({
+        contentChecksum: 'cs-new',
+        entityTypes: ['NewTag'],
+      });
+    });
+
+    it('updateResourceEntityTypes restamps every point without touching vectors', async () => {
+      const vec = await embedding.embed('delta');
+      await store.upsertResourceVectors('res-1' as ResourceId, [
+        { chunkIndex: 0, text: 'delta', embedding: vec },
+      ], 'cs-delta', []);
+
+      await store.updateResourceEntityTypes('res-1' as ResourceId, ['Question']);
+
+      expect((await store.listResourceStamps()).get('res-1')).toEqual({
+        contentChecksum: 'cs-delta',
+        entityTypes: ['Question'],
+      });
+      // The stamp is the filter discriminator: exclusion now drops the resource…
+      expect(await store.searchResources(vec, { limit: 5, filter: { excludeEntityTypes: ['Question'] } })).toEqual([]);
+      // …while the vectors themselves are untouched and still searchable.
+      const results = await store.searchResources(vec, { limit: 5 });
+      expect(results).toHaveLength(1);
+      expect(results[0].score).toBeCloseTo(1.0, 3);
+    });
+
+    it('updateResourceEntityTypes on an unindexed resource is a no-op', async () => {
+      await store.updateResourceEntityTypes('res-ghost' as ResourceId, ['Question']);
+      expect((await store.listResourceStamps()).has('res-ghost')).toBe(false);
     });
   });
 

--- a/packages/vectors/src/store/interface.ts
+++ b/packages/vectors/src/store/interface.ts
@@ -69,6 +69,13 @@ export interface VectorStore {
    * discriminate by kind (e.g. exclude `['Question']` from recall).
    */
   upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[]): Promise<void>;
+  /**
+   * Rewrite the `entityTypes` stamp on a resource's existing points —
+   * payload-only, no embedding involved (SMELTER-AXIOMS.md, S13: a tag edit
+   * must never trigger an embedding call). No-op when the resource has no
+   * points: the stamp rides the next embed.
+   */
+  updateResourceEntityTypes(resourceId: ResourceId, entityTypes: string[]): Promise<void>;
   upsertAnnotationVector(annotationId: AnnotationId, embedding: number[], payload: AnnotationPayload): Promise<void>;
   deleteResourceVectors(resourceId: ResourceId): Promise<void>;
   deleteAnnotationVector(annotationId: AnnotationId): Promise<void>;
@@ -104,10 +111,12 @@ export interface VectorStore {
   // KS says should exist.
   /**
    * Distinct resourceIds present in the resources collection, each with its
-   * stamped content checksum (undefined for points written before stamping
-   * existed — reconciliation treats those as stale and re-embeds them).
+   * stamps: the content checksum (undefined for points written before
+   * stamping existed — reconciliation treats those as stale and re-embeds)
+   * and the entity-type set (missing stamp reads as `[]`). Drives both the
+   * S12 content-staleness diff and the S13 tag-staleness diff.
    */
-  listResourceChecksums(): Promise<Map<string, string | undefined>>;
+  listResourceStamps(): Promise<Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>>;
   /** Distinct annotationIds present in the annotations collection. */
   listAnnotationIds(): Promise<Set<string>>;
 }

--- a/packages/vectors/src/store/memory.ts
+++ b/packages/vectors/src/store/memory.ts
@@ -111,14 +111,25 @@ export class MemoryVectorStore implements VectorStore {
     return this.resources.length + this.annotations.length;
   }
 
-  async listResourceChecksums(): Promise<Map<string, string | undefined>> {
-    const checksums = new Map<string, string | undefined>();
+  async updateResourceEntityTypes(resourceId: ResourceId, entityTypes: string[]): Promise<void> {
     for (const p of this.resources) {
-      if (!checksums.has(p.payload.resourceId)) {
-        checksums.set(p.payload.resourceId, p.payload.contentChecksum);
+      if (p.payload.resourceId === String(resourceId)) {
+        p.payload.entityTypes = entityTypes;
       }
     }
-    return checksums;
+  }
+
+  async listResourceStamps(): Promise<Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>> {
+    const stamps = new Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>();
+    for (const p of this.resources) {
+      if (!stamps.has(p.payload.resourceId)) {
+        stamps.set(p.payload.resourceId, {
+          contentChecksum: p.payload.contentChecksum,
+          entityTypes: p.payload.entityTypes ?? [],
+        });
+      }
+    }
+    return stamps;
   }
 
   async listAnnotationIds(): Promise<Set<string>> {

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -165,25 +165,43 @@ export class QdrantVectorStore implements VectorStore {
     return resources.count + annotations.count;
   }
 
-  async listResourceChecksums(): Promise<Map<string, string | undefined>> {
-    const checksums = new Map<string, string | undefined>();
+  async updateResourceEntityTypes(resourceId: ResourceId, entityTypes: string[]): Promise<void> {
+    // Payload-only rewrite across the resource's points — no vectors touched,
+    // no embedding involved (S13). Qdrant set_payload with a filter is a
+    // no-op when the resource has no points.
+    await this.qdrant.setPayload('resources', {
+      payload: { entityTypes },
+      filter: {
+        must: [{ key: 'resourceId', match: { value: String(resourceId) } }],
+      },
+    });
+  }
+
+  async listResourceStamps(): Promise<Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>> {
+    const stamps = new Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>();
     let offset: Schemas['ScrollRequest']['offset'] = undefined;
     do {
       const page = await this.qdrant.scroll('resources', {
         limit: 1000,
         offset,
-        with_payload: ['resourceId', 'contentChecksum'],
+        with_payload: ['resourceId', 'contentChecksum', 'entityTypes'],
         with_vector: false,
       });
       for (const point of page.points) {
         const rid = point.payload?.resourceId;
-        if (typeof rid !== 'string' || checksums.has(rid)) continue;
+        if (typeof rid !== 'string' || stamps.has(rid)) continue;
         const checksum = point.payload?.contentChecksum;
-        checksums.set(rid, typeof checksum === 'string' ? checksum : undefined);
+        const entityTypes = point.payload?.entityTypes;
+        stamps.set(rid, {
+          contentChecksum: typeof checksum === 'string' ? checksum : undefined,
+          entityTypes: Array.isArray(entityTypes)
+            ? entityTypes.filter((t): t is string => typeof t === 'string')
+            : [],
+        });
       }
       offset = page.next_page_offset ?? undefined;
     } while (offset !== undefined && offset !== null);
-    return checksums;
+    return stamps;
   }
 
   async listAnnotationIds(): Promise<Set<string>> {


### PR DESCRIPTION
## Description

Fixes the two vector-projection gaps filed in `.plans/bugs/smelter-misses-unarchive.md` and `.plans/bugs/smelter-stale-entity-type-stamps.md` (both from the 2026-07-12 Smelter ↔ graph-consumer architecture comparison; both share the same root cause — `SMELTER_CHANNELS` was deaf to events the graph and view projections fold). TDD throughout: every behavior change was a failing test first, confirmed RED in the node:24 container, then flipped GREEN.

### 1. `mark:unarchived` re-embeds (bug: unarchived resources invisible to vector search until restart)

Archive deletes a resource's vectors and its annotations' vectors — but unarchive was never delivered, so recall stayed empty until the next smelter restart's reconcile. Now:

- `mark:unarchived` joins `SMELTER_CHANNELS`; `handleResourceUnarchived` re-embeds the resource (existing media-gated, full-replace path) and re-indexes its **current** exact-text annotations via the same `browse:annotations-requested` read `reconcile()` uses — the live path and a restart agree by construction.
- Rides the existing `groupBy(resourceId)` lanes, so it serializes against concurrent live events (axioms S1/S2 hold by construction).
- S7 (store ≡ model) extended: `mark:unarchived` in the generator; the model folds *unarchive ⇒ live again + current catalog annotations restored*.

### 2. Entity-tag restamps, axiom S13 (bug: tag edits never reach vector stamps; reconcile can't heal them)

The `entityTypes` stamp is the discriminator `searchResources` filters on (EXCLUDE-VECTORS, #910), but it was embed-time-only: tag edits (user-reachable since #974) never updated it, and since tag edits change no bytes, the checksum-only staleness diff meant the stale stamp survived every restart, indefinitely. Now, per the archive handler's principle — *the live path and a restart must agree*:

- **Live:** `mark:entity-tag-added` / `-removed` join the channels; both dispatch to `restampResource`, which re-reads the full current set (`resolveEntityTypes` — one code path, so prior drift self-corrects on first touch) and calls the new payload-only `VectorStore.updateResourceEntityTypes` (Qdrant `set_payload`; memory backend rewrites point payloads). **Restamp ≠ re-embed:** no path here ever invokes the embedding provider, asserted in every test.
- **Reconcile:** `listResourceChecksums` widened into `listResourceStamps` (checksum + entityTypes per resource; all call sites updated, old method deleted — no alias). The staleness diff gains a third clause: content current but tags drifted → `smelt:restamp` work item through the same pipeline mailbox. `ReconcileSummary` gains `resourcesRestamped`.
- **Axiom S13 (stamp convergence)** joins the ledger in `.plans/SMELTER-AXIOMS.md` (R6), with a fast-check property mirroring S12's two-phase downtime shape: index an untagged catalog, retag it "offline", reconcile — every stamp converges to the new catalog with zero re-embeds, over generated catalogs × tag sets.

### 3. Branded `browse:*` replies (type-safety root fix, no runtime change)

Adding the unarchive handler surfaced a protocol-wide laundering pattern: the `browse:*` reply types declared raw OpenAPI shapes, forcing every domain consumer to cast (`as Annotation[]`, `as ResourceDescriptor[]`) what the KS actually serves — branded documents. The four reply envelopes in `bus-protocol.ts` now declare the branded `Annotation`/`ResourceDescriptor` flavors, per core's own convention that raw shapes live only at the HTTP boundary. This deleted every such cast (smelter ×2, weaver ×2, plus the would-be new one) and fixed `resource-graph.ts`, which was *widening* already-branded materializer output to raw. Producers compiled unchanged — they held branded values all along. One backend test fixture retyped to the branded reply (its ids already used the real constructors).

**Migration note:** deployments carry stamps minted before this fix; the first reconcile after deploy detects any tag drift as stamp mismatches and heals them (`resourcesRestamped` in the `/health` reconcile summary) — no manual step.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (branded reply types; `listResourceStamps` rename)

## Areas Changed

- [x] Make-meaning (`packages/make-meaning`) — smelter, state unit, weaver (cast removal), resource-graph
- [x] Vectors (`packages/vectors`) — `updateResourceEntityTypes`, `listResourceStamps` (memory + qdrant)
- [x] Core (`packages/core`) — branded `browse:*` reply types
- [x] Backend (`apps/backend`) — one test fixture retyped

## Testing

RED-first: 6 failing tests confirmed before implementation (3 per bug: example + channel-set + axiom), then flipped. Local gates (node:24 container): vectors typecheck + 39/39; make-meaning typecheck + smelter-targeted 37/37 (includes the S13 property and the extended S7); core/sdk/backend typechecks clean after the branded-reply change. Full suites are CI's job.

Not verified here (honest residue): no live event has flowed through the new channels end-to-end (SSE gateway → worker), and `updateResourceEntityTypes` against a **real** Qdrant is compile-verified only. Suggested post-merge smoke: archive→unarchive a resource and watch it return to semantic search without a restart; tag-edit via the #974 UI and watch `excludeEntityTypes` recall flip without an embedding call.
