### PR TITLE
weaver axioms: fast-check property suite + compliance gate (found 3 product bugs)

### DIFF
--- a/packages/make-meaning/src/__tests__/helpers/weaver-harness.ts
+++ b/packages/make-meaning/src/__tests__/helpers/weaver-harness.ts
@@ -1,0 +1,403 @@
+/**
+ * Weaver axiom harness (WEAVER-AXIOMS R0).
+ *
+ * Pure in-memory rig for the property suite: no EventStore, no filesystem,
+ * no tmp dirs. Histories σ are generated arrays of StoredEvents; the
+ * `browse:*` responders serve THEM (the Weaver's only view of history),
+ * the reference fold `foldModel(σ)` is the independent oracle for the
+ * differential axioms (deliberately sharing no code with any projection
+ * under test), and the fault-injecting graph wrapper supplies the
+ * schedules φ for the soundness axioms.
+ *
+ * Spec and ledger: `.plans/WEAVER-AXIOMS.md`.
+ */
+
+import { Subject } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { Annotation, EventMap, Logger, ResourceDescriptor, StoredEvent } from '@semiont/core';
+import { MemoryGraphDatabase } from '@semiont/graph';
+import type { GraphDatabase } from '@semiont/graph';
+import { DEFAULT_ENTITY_TYPES } from '@semiont/ontology';
+import { Weaver, type WeaverTiming } from '../../weaver';
+import { asBusRequestPrimitive } from '../../bus-request-local';
+import type { WeaverCheckpoint } from '../../weaver-checkpoint';
+
+export const noopLogger: Logger = {
+  debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  child: () => noopLogger,
+};
+
+/** Generator-speed timings (SMELTER-AXIOMS D4 precedent). */
+export const TIMING_FAST: WeaverTiming = {
+  burstWindowMs: 1,
+  maxBatchSize: 500,
+  idleTimeoutMs: 2,
+  drainTimeoutMs: 3_000,
+  drainPollMs: 2,
+  drainStallPolls: 50,
+  checkpointFlushMs: 60_000, // flushes are explicit in the harness
+};
+
+export class MemoryWeaverCheckpoint implements WeaverCheckpoint {
+  private map: Record<string, number> = {};
+  async load(): Promise<Record<string, number>> { return { ...this.map }; }
+  async save(applied: Record<string, number>): Promise<void> { this.map = { ...applied }; }
+  seed(map: Record<string, number>): void { this.map = { ...map }; }
+  snapshot(): Record<string, number> { return { ...this.map }; }
+}
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+let eventCounter = 0;
+
+export function storedEvent(
+  type: string,
+  rid: string | undefined,
+  payload: unknown,
+  seq: number,
+): StoredEvent {
+  return {
+    id: `evt-${++eventCounter}`,
+    type,
+    timestamp: new Date().toISOString(),
+    userId: 'did:web:test:users:axioms',
+    ...(rid ? { resourceId: rid } : {}),
+    version: 1,
+    payload,
+    metadata: { sequenceNumber: seq },
+  } as unknown as StoredEvent;
+}
+
+export const makeAnnotationPayload = (aid: string, rid: string) => ({
+  id: aid,
+  motivation: 'commenting',
+  target: { source: rid },
+  body: [],
+});
+
+// ── The reference fold (the model M in W4/W5) ───────────────────────────────
+
+export interface ModelResource {
+  archived: boolean;
+  tags: Set<string>;
+  annotations: Set<string>;
+}
+
+export interface ModelState {
+  resources: Map<string, ModelResource>;
+  entityTypes: Set<string>;
+}
+
+export function foldModel(events: StoredEvent[]): ModelState {
+  const resources = new Map<string, ModelResource>();
+  // Every graph store seeds its registry with the ontology baseline
+  // (MemoryGraphDatabase.initializeTagCollections and friends) — the model
+  // starts from the same vocabulary; frame:entity-type-added adds on top.
+  const entityTypes = new Set<string>(DEFAULT_ENTITY_TYPES);
+
+  for (const e of events) {
+    const rid = e.resourceId ? String(e.resourceId) : undefined;
+    const payload = e.payload as Record<string, unknown>;
+    switch (e.type) {
+      case 'yield:created': {
+        if (!rid) break;
+        resources.set(rid, {
+          archived: false,
+          tags: new Set((payload.entityTypes as string[] | undefined) ?? []),
+          annotations: new Set(),
+        });
+        break;
+      }
+      case 'mark:archived':
+        if (rid) { const r = resources.get(rid); if (r) r.archived = true; }
+        break;
+      case 'mark:unarchived':
+        if (rid) { const r = resources.get(rid); if (r) r.archived = false; }
+        break;
+      case 'mark:added': {
+        if (!rid) break;
+        const r = resources.get(rid);
+        const ann = payload.annotation as { id: string } | undefined;
+        if (r && ann?.id) r.annotations.add(String(ann.id));
+        break;
+      }
+      case 'mark:removed': {
+        if (!rid) break;
+        const r = resources.get(rid);
+        if (r && payload.annotationId) r.annotations.delete(String(payload.annotationId));
+        break;
+      }
+      case 'mark:entity-tag-added': {
+        if (!rid) break;
+        const r = resources.get(rid);
+        if (r && payload.entityType) r.tags.add(String(payload.entityType));
+        break;
+      }
+      case 'mark:entity-tag-removed': {
+        if (!rid) break;
+        const r = resources.get(rid);
+        if (r && payload.entityType) r.tags.delete(String(payload.entityType));
+        break;
+      }
+      case 'frame:entity-type-added':
+        if (payload.entityType) entityTypes.add(String(payload.entityType));
+        break;
+      // mark:body-updated: body contents are outside the v1 model scope
+      // (identity + facets) — a deliberate boundary, see WEAVER-AXIOMS W9.
+    }
+  }
+
+  return { resources, entityTypes };
+}
+
+// ── Normalized dumps (≡ in the axioms) ──────────────────────────────────────
+
+export interface NormalizedDump {
+  resources: Array<{ id: string; archived: boolean; tags: string[]; annotations: string[] }>;
+  entityTypes: string[];
+}
+
+export function dumpModel(state: ModelState): NormalizedDump {
+  return {
+    resources: [...state.resources.entries()]
+      .map(([id, r]) => ({
+        id,
+        archived: r.archived,
+        tags: [...r.tags].sort(),
+        annotations: [...r.annotations].sort(),
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    entityTypes: [...state.entityTypes].sort(),
+  };
+}
+
+export async function dumpGraph(db: GraphDatabase): Promise<NormalizedDump> {
+  const { resources } = await db.listResources({ limit: 100_000 });
+  const out: NormalizedDump['resources'] = [];
+  for (const doc of resources) {
+    const id = String(doc['@id']);
+    const annotations = await db.getResourceAnnotations(makeResourceId(id));
+    out.push({
+      id,
+      archived: doc.archived ?? false,
+      tags: [...(doc.entityTypes ?? [])].sort(),
+      annotations: annotations.map((a) => String(a.id)).sort(),
+    });
+  }
+  return {
+    resources: out.sort((a, b) => a.id.localeCompare(b.id)),
+    entityTypes: [...(await db.getEntityTypes())].sort(),
+  };
+}
+
+// ── Fault injection (the schedules φ) ───────────────────────────────────────
+
+export interface FaultSchedule {
+  /** Return true to fail this mutation. `key` is the op's primary id. */
+  shouldFail(op: string, key: string): boolean;
+}
+
+export const NO_FAULTS: FaultSchedule = { shouldFail: () => false };
+
+/** Fail exactly the mutations whose key is in `keys` (every attempt). */
+export function failKeys(keys: Iterable<string>): FaultSchedule {
+  const set = new Set(keys);
+  return { shouldFail: (_op, key) => set.has(key) };
+}
+
+/** Fail each key's FIRST attempt only — the transient-fault shape. */
+export function failKeysOnce(keys: Iterable<string>): FaultSchedule {
+  const pending = new Set(keys);
+  return {
+    shouldFail: (_op, key) => {
+      if (!pending.has(key)) return false;
+      pending.delete(key);
+      return true;
+    },
+  };
+}
+
+const MUTATIONS: Record<string, (args: unknown[]) => string[]> = {
+  createResource: (a) => [String((a[0] as ResourceDescriptor)['@id'])],
+  batchCreateResources: (a) => (a[0] as ResourceDescriptor[]).map((r) => String(r['@id'])),
+  updateResource: (a) => [String(a[0])],
+  deleteResource: (a) => [String(a[0])],
+  createAnnotation: (a) => [String((a[0] as { id: string }).id)],
+  createAnnotations: (a) => (a[0] as Array<{ id: string }>).map((i) => String(i.id)),
+  updateAnnotation: (a) => [String(a[0])],
+  deleteAnnotation: (a) => [String(a[0])],
+  addEntityType: (a) => [String(a[0])],
+  addEntityTypes: (a) => (a[0] as string[]).map(String),
+};
+
+export interface FaultingGraph {
+  graph: GraphDatabase;
+  injectedFailures: () => number;
+}
+
+/**
+ * Wrap a graph store so mutations can fail per schedule. Reads pass
+ * through untouched; a scheduled failure throws before the inner store is
+ * touched, so a "failed" mutation never partially lands.
+ */
+export function faultingGraph(inner: GraphDatabase, schedule: FaultSchedule): FaultingGraph {
+  let injected = 0;
+  const graph = new Proxy(inner, {
+    get(target, prop, receiver) {
+      const name = String(prop);
+      const keysOf = MUTATIONS[name];
+      const original = Reflect.get(target, prop, receiver);
+      if (!keysOf || typeof original !== 'function') {
+        return typeof original === 'function' ? original.bind(target) : original;
+      }
+      return (...args: unknown[]) => {
+        for (const key of keysOf(args)) {
+          if (schedule.shouldFail(name, key)) {
+            injected++;
+            return Promise.reject(new Error(`injected fault: ${name}(${key})`));
+          }
+        }
+        return (original as (...a: unknown[]) => unknown).apply(target, args);
+      };
+    },
+  }) as GraphDatabase;
+  return { graph, injectedFailures: () => injected };
+}
+
+// ── Browse responders serving a generated history ───────────────────────────
+
+/**
+ * Serve `browse:resources-requested` (paged), `browse:events-requested`,
+ * and `browse:annotations-requested` from a history σ — the harness stands
+ * in for the Browser exactly where catch-up, rebuild, and reconcile read.
+ * Annotations answer with the MODEL's current live set for the resource.
+ */
+export function serveHistory(eventBus: EventBus, history: StoredEvent[]): () => void {
+  const byRid = new Map<string, StoredEvent[]>();
+  for (const e of history) {
+    if (!e.resourceId) continue;
+    const rid = String(e.resourceId);
+    const list = byRid.get(rid);
+    if (list) list.push(e);
+    else byRid.set(rid, [e]);
+  }
+  const rids = [...byRid.keys()];
+  const model = foldModel(history);
+
+  const subs = [
+    eventBus.get('browse:resources-requested').subscribe((req) => {
+      const offset = (req as { offset?: number }).offset ?? 0;
+      const limit = (req as { limit?: number }).limit ?? 20;
+      const page = rids.slice(offset, offset + limit).map((id) => {
+        const m = model.resources.get(id);
+        return {
+          '@id': id,
+          name: id,
+          representations: [],
+          archived: m?.archived ?? false,
+          entityTypes: m ? [...m.tags] : [],
+        };
+      });
+      eventBus.get('browse:resources-result').next({
+        correlationId: (req as { correlationId: string }).correlationId,
+        response: { resources: page, total: rids.length },
+      } as unknown as EventMap['browse:resources-result']);
+    }),
+    eventBus.get('browse:events-requested').subscribe((req) => {
+      const rid = String((req as { resourceId: string }).resourceId);
+      const events = byRid.get(rid) ?? [];
+      eventBus.get('browse:events-result').next({
+        correlationId: (req as { correlationId: string }).correlationId,
+        response: { events, total: events.length, resourceId: rid },
+      } as unknown as EventMap['browse:events-result']);
+    }),
+    eventBus.get('browse:annotations-requested').subscribe((req) => {
+      const rid = String((req as { resourceId: string }).resourceId);
+      const live = model.resources.get(rid)?.annotations ?? new Set<string>();
+      const annotations = [...live].map((aid) => makeAnnotationPayload(aid, rid)) as unknown as Annotation[];
+      eventBus.get('browse:annotations-result').next({
+        correlationId: (req as { correlationId: string }).correlationId,
+        response: { annotations },
+      } as unknown as EventMap['browse:annotations-result']);
+    }),
+  ];
+  return () => subs.forEach((s) => s.unsubscribe());
+}
+
+// ── Weaver rig ───────────────────────────────────────────────────────────────
+
+export interface WeaverRig {
+  weaver: Weaver;
+  graph: GraphDatabase;
+  eventBus: EventBus;
+  checkpoint: MemoryWeaverCheckpoint;
+  push: (e: StoredEvent) => void;
+  pushRebuild: (cmd: EventMap['weave:rebuild']) => void;
+  dispose: () => Promise<void>;
+}
+
+export async function buildWeaverRig(opts?: {
+  graph?: GraphDatabase;
+  eventBus?: EventBus;
+  checkpoint?: MemoryWeaverCheckpoint;
+  timing?: WeaverTiming;
+}): Promise<WeaverRig> {
+  const graph = opts?.graph ?? new MemoryGraphDatabase();
+  const eventBus = opts?.eventBus ?? new EventBus();
+  const checkpoint = opts?.checkpoint ?? new MemoryWeaverCheckpoint();
+  const events$ = new Subject<StoredEvent>();
+  const rebuilds$ = new Subject<EventMap['weave:rebuild']>();
+
+  const weaver = new Weaver(
+    graph,
+    events$.asObservable(),
+    rebuilds$.asObservable(),
+    asBusRequestPrimitive(eventBus),
+    checkpoint,
+    opts?.timing ?? TIMING_FAST,
+    noopLogger,
+  );
+  await weaver.initialize();
+
+  return {
+    weaver,
+    graph,
+    eventBus,
+    checkpoint,
+    push: (e) => events$.next(e),
+    pushRebuild: (cmd) => rebuilds$.next(cmd),
+    dispose: async () => {
+      await weaver.stop();
+    },
+  };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll until every resource's applied mark reaches its target sequence. */
+export async function awaitMarks(
+  weaver: Weaver,
+  targets: Map<string, number>,
+  maxMs = 3_000,
+): Promise<boolean> {
+  const t0 = Date.now();
+  const reached = () =>
+    [...targets].every(([rid, seq]) => (weaver.appliedUpTo(rid) ?? -1) >= seq);
+  while (Date.now() - t0 < maxMs) {
+    if (reached()) return true;
+    await sleep(2);
+  }
+  return reached();
+}
+
+/** Per-resource max sequence in a history — the parity targets. */
+export function maxSeqs(history: StoredEvent[]): Map<string, number> {
+  const targets = new Map<string, number>();
+  for (const e of history) {
+    if (!e.resourceId) continue;
+    const rid = String(e.resourceId);
+    const seq = e.metadata.sequenceNumber;
+    if ((targets.get(rid) ?? -1) < seq) targets.set(rid, seq);
+  }
+  return targets;
+}

--- a/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
@@ -18,7 +18,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SemiontProject } from '@semiont/core/node';
 import { EventBus, type Logger, type SupportedMediaType, userId, resourceId as makeResourceId } from '@semiont/core';
 import { startMakeMeaning, ResourceOperations, AnnotationOperations, type MakeMeaningConfig } from '../..';
-import { Weaver } from '../../weaver';
+import { Weaver, type WeaverTiming } from '../../weaver';
+
+const PROD_TIMING: WeaverTiming = {
+  burstWindowMs: 50, maxBatchSize: 500, idleTimeoutMs: 200,
+  drainTimeoutMs: 30_000, drainPollMs: 25, drainStallPolls: 40, checkpointFlushMs: 5_000,
+};
 import { createWeaverActorStateUnit, type WeaverActorStateUnit } from '../../weaver-actor-state-unit';
 import { workerBusOverEventBus } from '../../worker-bus-local';
 import { asBusRequestPrimitive } from '../../bus-request-local';
@@ -111,6 +116,7 @@ describe('Scripting Example: Query Graph Database', () => {
       weaverUnit.rebuilds$,
       asBusRequestPrimitive(eventBus),
       new FileWeaverCheckpoint(join(testDir, 'weaver-checkpoint.json')),
+      PROD_TIMING,
       mockLogger,
     );
     await weaver.initialize();

--- a/packages/make-meaning/src/__tests__/weaver-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver-axioms.test.ts
@@ -1,0 +1,696 @@
+/**
+ * Weaver Axioms — fast-check property suite.
+ *
+ * Spec and ledger: `.plans/WEAVER-AXIOMS.md`. Every axiom carries its FOPL
+ * statement as a comment directly above the property so spec and test cannot
+ * drift. Axioms the current code falsifies are `it.fails(...)`: the property
+ * runs, is expected to fail, and the suite stays green. When a refactor makes
+ * the behavior correct, `it.fails` errors ("expected to fail but passed") and
+ * MUST be promoted to `it(...)` in the same diff.
+ *
+ * Vocabulary and generators: WEAVER-AXIOMS.md "Vocabulary". σ ranges over
+ * well-formed histories (created precedes other ops per resource,
+ * per-resource ascending sequence numbers); `foldModel(σ)` is the
+ * independent oracle (identity + facets — archived flag, tag set,
+ * annotation-id set, entity-type registry; annotation BODIES are outside
+ * the v1 model, see W9-deep).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { EventBus } from '@semiont/core';
+import type { StoredEvent } from '@semiont/core';
+import { MemoryGraphDatabase } from '@semiont/graph';
+import { createWeaveProgress } from '../weave-progress';
+import {
+  buildWeaverRig,
+  dumpGraph,
+  dumpModel,
+  foldModel,
+  maxSeqs,
+  awaitMarks,
+  serveHistory,
+  storedEvent,
+  makeAnnotationPayload,
+  faultingGraph,
+  failKeys,
+  failKeysOnce,
+} from './helpers/weaver-harness';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// System-lane (frame:*) applies produce no marks — give them a moment to
+// settle after resource marks reach parity, before dumping.
+const SETTLE_MS = 25;
+
+// ── Generators (see WEAVER-AXIOMS.md "Vocabulary") ──────────────────────────
+
+interface Catalog { rids: string[]; tags: string[] }
+
+const catalogArb: fc.Arbitrary<Catalog> = fc.record({
+  rids: fc.uniqueArray(fc.nat(20).map((n) => `res-${n}`), { minLength: 1, maxLength: 4 }),
+  tags: fc.uniqueArray(fc.nat(8).map((n) => `Tag${n}`), { minLength: 1, maxLength: 3 }),
+});
+
+interface OpDescriptor {
+  rid: string;
+  kind: 'archive' | 'unarchive' | 'mark+' | 'mark-' | 'tag+' | 'tag-' | 'frame+';
+  tag: string;
+  annIdx: number;
+}
+
+const opArb = (cat: Catalog): fc.Arbitrary<OpDescriptor> =>
+  fc.record({
+    rid: fc.constantFrom(...cat.rids),
+    kind: fc.constantFrom<OpDescriptor['kind']>(
+      'archive', 'unarchive', 'mark+', 'mark-', 'tag+', 'tag-', 'frame+',
+    ),
+    tag: fc.constantFrom(...cat.tags),
+    annIdx: fc.nat(4),
+  });
+
+/**
+ * Well-formed histories: every catalog resource is created first (seq 1),
+ * subsequent ops carry per-resource ascending sequence numbers in emission
+ * order. Duplicate adds/removes/tags are deliberately reachable — the folds
+ * must tolerate them (W3 relies on it).
+ */
+function toHistory(cat: Catalog, ops: OpDescriptor[]): StoredEvent[] {
+  const seqs = new Map<string, number>(cat.rids.map((r) => [r, 1]));
+  let systemSeq = 1000;
+  const next = (rid: string): number => {
+    const n = (seqs.get(rid) ?? 1) + 1;
+    seqs.set(rid, n);
+    return n;
+  };
+
+  const history: StoredEvent[] = cat.rids.map((rid) =>
+    storedEvent('yield:created', rid, {
+      name: `Resource ${rid}`,
+      format: 'text/plain',
+      contentChecksum: `cs-${rid}`,
+    }, 1),
+  );
+
+  for (const op of ops) {
+    const annId = `${op.rid}-ann-${op.annIdx}`;
+    switch (op.kind) {
+      case 'archive':
+        history.push(storedEvent('mark:archived', op.rid, {}, next(op.rid)));
+        break;
+      case 'unarchive':
+        history.push(storedEvent('mark:unarchived', op.rid, {}, next(op.rid)));
+        break;
+      case 'mark+':
+        history.push(storedEvent('mark:added', op.rid, {
+          annotation: makeAnnotationPayload(annId, op.rid),
+        }, next(op.rid)));
+        break;
+      case 'mark-':
+        history.push(storedEvent('mark:removed', op.rid, { annotationId: annId }, next(op.rid)));
+        break;
+      case 'tag+':
+        history.push(storedEvent('mark:entity-tag-added', op.rid, { entityType: op.tag }, next(op.rid)));
+        break;
+      case 'tag-':
+        history.push(storedEvent('mark:entity-tag-removed', op.rid, { entityType: op.tag }, next(op.rid)));
+        break;
+      case 'frame+':
+        history.push(storedEvent('frame:entity-type-added', undefined, { entityType: op.tag }, ++systemSeq));
+        break;
+    }
+  }
+  return history;
+}
+
+const historyArb: fc.Arbitrary<StoredEvent[]> = catalogArb.chain((cat) =>
+  fc.array(opArb(cat), { maxLength: 25 }).map((ops) => toHistory(cat, ops)),
+);
+
+/** σ with redelivery: fc picks indices to duplicate adjacently and to replay displaced at the end. */
+const historyWithDupsArb: fc.Arbitrary<{ history: StoredEvent[]; delivered: StoredEvent[] }> =
+  historyArb.chain((history) =>
+    fc.record({
+      adjacent: fc.array(fc.nat(Math.max(0, history.length - 1)), { maxLength: 5 }),
+      displaced: fc.array(fc.nat(Math.max(0, history.length - 1)), { maxLength: 5 }),
+    }).map(({ adjacent, displaced }) => {
+      const delivered: StoredEvent[] = [];
+      history.forEach((e, i) => {
+        delivered.push(e);
+        if (adjacent.includes(i)) delivered.push(e);
+      });
+      for (const i of displaced) {
+        if (history[i]) delivered.push(history[i]);
+      }
+      return { history, delivered };
+    }),
+  );
+
+async function runLive(events: StoredEvent[], targets: Map<string, number>, markBudgetMs = 3_000) {
+  const rig = await buildWeaverRig();
+  try {
+    for (const e of events) rig.push(e);
+    const reached = await awaitMarks(rig.weaver, targets, markBudgetMs);
+    expect(reached).toBe(true);
+    await sleep(SETTLE_MS);
+    return await dumpGraph(rig.graph);
+  } finally {
+    await rig.dispose();
+  }
+}
+
+// ── W4 — Graph ≡ model over arbitrary histories ─────────────────────────────
+
+describe('W4 — graph ≡ model (live pipeline)', () => {
+  // ∀ σ: G(σ) ≡ fold(σ)
+  it('W4: the live pipeline projects exactly the reference fold', async () => {
+    await fc.assert(
+      fc.asyncProperty(historyArb, async (history) => {
+        const dump = await runLive(history, maxSeqs(history));
+        expect(dump).toEqual(dumpModel(foldModel(history)));
+      }),
+      { numRuns: 50 },
+    );
+  });
+});
+
+// ── W3 — Redelivery idempotence ─────────────────────────────────────────────
+
+describe('W3 — redelivery idempotence', () => {
+  // ∀ σ, ∀ σ′ ∈ duplication(σ): G(σ′) ≡ G(σ) (≡ fold(σ) by W4)
+  it('W3: adjacent and displaced redelivery leave the projection unchanged', async () => {
+    await fc.assert(
+      fc.asyncProperty(historyWithDupsArb, async ({ history, delivered }) => {
+        // Tight mark budget: a genuine stall IS the falsification — fail
+        // fast so fc can shrink instead of tripping the suite timeout.
+        const dump = await runLive(delivered, maxSeqs(history), 700);
+        expect(dump).toEqual(dumpModel(foldModel(history)));
+      }),
+      { numRuns: 25 },
+    );
+  }, 120_000);
+});
+
+// ── W5 — Rebuild ≡ replay ───────────────────────────────────────────────────
+
+describe('W5 — rebuild ≡ replay', () => {
+  // ∀ σ: RB(σ)|resources ≡ fold(σ)|resources — two roads, one graph.
+  // Rebuild's only view of history is the browse responders, exactly as in
+  // production. RESOURCE scope: the entity-type registry is excluded here
+  // and pinned RED below (W5-frames).
+  it('W5: rebuildAll over the served log projects exactly the reference fold (resource scope)', async () => {
+    await fc.assert(
+      fc.asyncProperty(historyArb, async (history) => {
+        const rig = await buildWeaverRig();
+        const stopServing = serveHistory(rig.eventBus, history);
+        try {
+          const result = await rig.weaver.rebuildAll();
+          expect(result.eventsFailed).toBe(0);
+          await sleep(SETTLE_MS);
+          expect((await dumpGraph(rig.graph)).resources)
+            .toEqual(dumpModel(foldModel(history)).resources);
+        } finally {
+          stopServing();
+          await rig.dispose();
+        }
+      }),
+      { numRuns: 25 },
+    );
+  });
+
+  // ∀ σ: RB(σ) ≡ fold(σ) INCLUDING the entity-type registry. KNOWN false
+  // (found by this axiom's first run, 2026-07-13): `frame:entity-type-added`
+  // is a system event — it lives in no resource stream, so rebuildAll never
+  // replays it, while clearDatabase wiped the registry back to the ontology
+  // baseline. Consequence: `weave:rebuild` DROPS custom entity types.
+  // No bus read serves system events today; flips when one exists (or when
+  // rebuild preserves/re-registers the registry). Ledgered in
+  // WEAVER-AXIOMS.md; tracked on #845.
+  it.fails('W5-frames: rebuild restores frame-added entity types', async () => {
+    const rig = await buildWeaverRig();
+    const history = [
+      storedEvent('yield:created', 'res-f', {
+        name: 'F', format: 'text/plain', contentChecksum: 'cs-f',
+      }, 1),
+      storedEvent('frame:entity-type-added', undefined, { entityType: 'CustomFrameType' }, 1001),
+    ];
+    const stopServing = serveHistory(rig.eventBus, history);
+    try {
+      // Seed the registry the way live traffic would, then rebuild.
+      rig.push(history[1]);
+      await sleep(SETTLE_MS);
+      await rig.weaver.rebuildAll();
+      await sleep(SETTLE_MS);
+      expect(await rig.graph.getEntityTypes()).toContain('CustomFrameType');
+    } finally {
+      stopServing();
+      await rig.dispose();
+    }
+  });
+});
+
+// ── W6 / W10 — mark soundness + honest accounting under faults ──────────────
+
+/** mark:added victims with first-occurrence-unique annotation ids. */
+function uniqueMarkAdds(history: StoredEvent[]): StoredEvent[] {
+  const seen = new Set<string>();
+  const out: StoredEvent[] = [];
+  for (const e of history) {
+    if (e.type !== 'mark:added') continue;
+    const aid = String((e.payload as { annotation: { id: string } }).annotation.id);
+    if (seen.has(aid)) continue;
+    seen.add(aid);
+    out.push(e);
+  }
+  return out;
+}
+
+const annIdOf = (e: StoredEvent): string =>
+  String((e.payload as { annotation: { id: string } }).annotation.id);
+
+describe('W6/W10 — the mark never lies; accounting is honest', () => {
+  // W6: ∀ φ, r, s: mark(r) = s ⇒ ∀ e (rid(e) = r ∧ seq(e) ≤ s ⇒ applied(e)).
+  // W7 coupling: every emitted weave:applied carries a sequence the mark
+  // honestly held at emission (signals collected here never exceed the
+  // final mark, by monotonicity).
+  // W10: applyFailures ≥ injected faults, and zero injected ⇒ zero counted
+  // (batch collateral makes strict equality deliberately unattainable —
+  // a thrown batch marks its whole live run failed).
+  it('W6/W10: failed events pin the mark below them; failures are counted', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        historyArb,
+        fc.array(fc.nat(30), { maxLength: 3 }),
+        async (history, picks) => {
+          const candidates = uniqueMarkAdds(history);
+          const victims = [...new Set(picks.map((p) => candidates[p % Math.max(1, candidates.length)]))]
+            .filter((v): v is StoredEvent => !!v);
+          const schedule = failKeys(victims.map(annIdOf));
+          const { graph, injectedFailures } = faultingGraph(new MemoryGraphDatabase(), schedule);
+          const rig = await buildWeaverRig({ graph });
+
+          const signals: Array<{ resourceId: string; sequenceNumber: number }> = [];
+          const signalSub = rig.eventBus.get('weave:applied').subscribe((s) => signals.push(s));
+          try {
+            for (const e of history) rig.push(e);
+            await sleep(150);
+
+            // W6 — the mark stays strictly below every failed sequence.
+            for (const v of victims) {
+              const rid = String(v.resourceId);
+              expect(rig.weaver.appliedUpTo(rid) ?? -1).toBeLessThan(v.metadata.sequenceNumber);
+            }
+            // W10 — honest counting.
+            const metrics = rig.weaver.getHealthMetrics();
+            expect(injectedFailures()).toBeGreaterThanOrEqual(victims.length > 0 ? 1 : 0);
+            expect(metrics.applyFailures).toBeGreaterThanOrEqual(injectedFailures());
+            if (victims.length === 0) expect(metrics.applyFailures).toBe(0);
+            // W7 coupling — no signal ever exceeded what the mark can claim.
+            for (const s of signals) {
+              expect(s.sequenceNumber).toBeLessThanOrEqual(rig.weaver.appliedUpTo(s.resourceId) ?? -1);
+            }
+          } finally {
+            signalSub.unsubscribe();
+            await rig.dispose();
+          }
+        },
+      ),
+      { numRuns: 25 },
+    );
+  });
+
+  // The floor's payoff: a TRANSIENT fault heals — catch-up re-replays from
+  // the pinned mark, the retry succeeds, the floor clears, and the
+  // projection converges to the model (the W8 recovery shape, single-fault
+  // strength here; the full divergence family is W8).
+  it('W6-recovery: transient faults converge to the model via catch-up', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        historyArb,
+        fc.nat(30),
+        async (history, pick) => {
+          const candidates = uniqueMarkAdds(history);
+          const victim = candidates[pick % Math.max(1, candidates.length)];
+          const schedule = failKeysOnce(victim ? [annIdOf(victim)] : []);
+          const { graph } = faultingGraph(new MemoryGraphDatabase(), schedule);
+          const rig = await buildWeaverRig({ graph });
+          const stopServing = serveHistory(rig.eventBus, history);
+          try {
+            for (const e of history) rig.push(e);
+            await sleep(150);
+
+            await rig.weaver.catchUp();
+            await sleep(SETTLE_MS);
+
+            expect(await dumpGraph(rig.graph)).toEqual(dumpModel(foldModel(history)));
+            for (const [rid, seq] of maxSeqs(history)) {
+              expect(rig.weaver.appliedUpTo(rid)).toBe(seq);
+            }
+          } finally {
+            stopServing();
+            await rig.dispose();
+          }
+        },
+      ),
+      { numRuns: 15 },
+    );
+  });
+});
+
+// ── W2 — Cross-resource progress ────────────────────────────────────────────
+
+describe('W2 — cross-resource progress', () => {
+  // ∀ σ, r ≠ r′: faults confined to r never prevent mark(r′) reaching its max.
+  it('W2: a failing resource never blocks another resource\'s parity', async () => {
+    await fc.assert(
+      fc.asyncProperty(historyArb, async (history) => {
+        const targets = maxSeqs(history);
+        const rids = [...targets.keys()];
+        fc.pre(rids.length >= 2);
+        const victimRid = rids[0];
+
+        // Fail EVERY mutation that keys on the victim resource or its
+        // annotations — its lane wedges completely.
+        const victimKeys = new Set<string>([victimRid]);
+        for (const e of history) {
+          if (String(e.resourceId) === victimRid && e.type === 'mark:added') {
+            victimKeys.add(annIdOf(e));
+          }
+        }
+        const { graph } = faultingGraph(new MemoryGraphDatabase(), failKeys(victimKeys));
+        const rig = await buildWeaverRig({ graph });
+        try {
+          for (const e of history) rig.push(e);
+          const others = new Map([...targets].filter(([rid]) => rid !== victimRid));
+          expect(await awaitMarks(rig.weaver, others)).toBe(true);
+        } finally {
+          await rig.dispose();
+        }
+      }),
+      { numRuns: 15 },
+    );
+  });
+});
+
+// ── W8 — Recovery convergence over the divergence family ───────────────────
+
+type Divergence = 'lost-checkpoint' | 'stale-checkpoint' | 'rewound-log';
+
+describe('W8 — recovery convergence', () => {
+  // ∀ σ, d ∈ {lost ckpt, stale ckpt, rewound log}: a restarted weaver's
+  // catchUp() from d converges to fold(σ) with full parity. (A wiped GRAPH
+  // under intact marks is deliberately NOT here — that is unwitnessable by
+  // catch-up and belongs to reconcile, W9.)
+  it('W8: catch-up converges from checkpoint divergence after a restart', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        historyArb,
+        fc.constantFrom<Divergence>('lost-checkpoint', 'stale-checkpoint', 'rewound-log'),
+        async (history, divergence) => {
+          const graph = new MemoryGraphDatabase();
+          const eventBus = new EventBus();
+
+          // First life: process σ live, then stop (the restart shape).
+          const rig1 = await buildWeaverRig({ graph, eventBus });
+          for (const e of history) rig1.push(e);
+          expect(await awaitMarks(rig1.weaver, maxSeqs(history))).toBe(true);
+          await rig1.dispose();
+
+          // Second life: fresh weaver over the SAME graph, divergent checkpoint.
+          const { MemoryWeaverCheckpoint } = await import('./helpers/weaver-harness');
+          const checkpoint = new MemoryWeaverCheckpoint();
+          const targets = maxSeqs(history);
+          if (divergence === 'stale-checkpoint') {
+            checkpoint.seed(Object.fromEntries([...targets].map(([r, s]) => [r, Math.floor(s / 2)])));
+          } else if (divergence === 'rewound-log') {
+            const [firstRid] = targets.keys();
+            checkpoint.seed({ [firstRid]: (targets.get(firstRid) ?? 0) + 100 });
+          } // lost-checkpoint: stays empty
+
+          const rig2 = await buildWeaverRig({ graph, eventBus, checkpoint });
+          const stopServing = serveHistory(rig2.eventBus, history);
+          try {
+            const summary = await rig2.weaver.catchUp();
+            await sleep(SETTLE_MS);
+            expect(summary.eventsFailed).toBe(0);
+            expect(await dumpGraph(graph)).toEqual(dumpModel(foldModel(history)));
+            for (const [rid, seq] of targets) {
+              expect(rig2.weaver.appliedUpTo(rid)).toBe(seq);
+            }
+          } finally {
+            stopServing();
+            await rig2.dispose();
+          }
+        },
+      ),
+      { numRuns: 15 },
+    );
+  });
+});
+
+// ── W9 — Reconcile fixed point + v1 detection completeness ─────────────────
+
+type OobMutation = 'delete-node' | 'flip-archived' | 'mutate-tags' | 'drop-annotation';
+
+describe('W9 — reconcile detects and heals out-of-band divergence', () => {
+  // ∀ σ, ∀ single oob mutation δ in the v1 class: reconcile detects δ and
+  // heals to fold(σ); an immediate second pass reports divergent = 0.
+  it('W9: any single v1-class mutation is detected, healed, and the fixed point holds', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        historyArb,
+        fc.constantFrom<OobMutation>('delete-node', 'flip-archived', 'mutate-tags', 'drop-annotation'),
+        fc.nat(10),
+        async (history, mutation, pick) => {
+          const rig = await buildWeaverRig();
+          const stopServing = serveHistory(rig.eventBus, history);
+          try {
+            for (const e of history) rig.push(e);
+            expect(await awaitMarks(rig.weaver, maxSeqs(history))).toBe(true);
+            await sleep(SETTLE_MS);
+
+            const model = foldModel(history);
+            const rids = [...model.resources.keys()];
+            const rid = rids[pick % rids.length];
+            const { resourceId: mkRid, annotationId: mkAid } = await import('@semiont/core');
+
+            // One out-of-band mutation the Weaver never witnesses.
+            let mutated = true;
+            switch (mutation) {
+              case 'delete-node':
+                await rig.graph.deleteResource(mkRid(rid));
+                break;
+              case 'flip-archived': {
+                const doc = await rig.graph.getResource(mkRid(rid));
+                if (!doc) { mutated = false; break; }
+                await rig.graph.updateResource(mkRid(rid), { archived: !(doc.archived ?? false) });
+                break;
+              }
+              case 'mutate-tags':
+                await rig.graph.updateResource(mkRid(rid), { entityTypes: ['OobPhantomTag'] });
+                break;
+              case 'drop-annotation': {
+                const anns = model.resources.get(rid)?.annotations ?? new Set<string>();
+                const [first] = anns;
+                if (!first) { mutated = false; break; }
+                await rig.graph.deleteAnnotation(mkAid(first));
+                break;
+              }
+            }
+            // A mutation that changes nothing observable (e.g. phantom tag
+            // equal to current set) may legitimately not diverge.
+            const before = dumpModel(model);
+            const changed = mutated &&
+              JSON.stringify((await dumpGraph(rig.graph)).resources) !== JSON.stringify(before.resources);
+
+            const summary = await rig.weaver.reconcile();
+            if (changed) expect(summary.divergent).toBeGreaterThanOrEqual(1);
+            expect((await dumpGraph(rig.graph)).resources).toEqual(before.resources);
+
+            const second = await rig.weaver.reconcile();
+            expect(second.divergent).toBe(0);
+          } finally {
+            stopServing();
+            await rig.dispose();
+          }
+        },
+      ),
+      { numRuns: 15 },
+    );
+  });
+
+  // KNOWN v1 boundary: annotation bodies are outside the detectable class —
+  // a corrupted-in-place body reconciles as clean. Flips when #845's
+  // deep-equality checkbox lands.
+  it.fails('W9-deep: reconcile detects in-place annotation body corruption', async () => {
+    const rig = await buildWeaverRig();
+    const rid = 'res-deep';
+    const history = [
+      storedEvent('yield:created', rid, { name: 'Deep', format: 'text/plain', contentChecksum: 'cs-d' }, 1),
+      storedEvent('mark:added', rid, { annotation: makeAnnotationPayload('ann-deep', rid) }, 2),
+    ];
+    const stopServing = serveHistory(rig.eventBus, history);
+    try {
+      for (const e of history) rig.push(e);
+      expect(await awaitMarks(rig.weaver, maxSeqs(history))).toBe(true);
+
+      const { annotationId: mkAid } = await import('@semiont/core');
+      await rig.graph.updateAnnotation(mkAid('ann-deep'), {
+        body: [{ type: 'TextualBody', value: 'CORRUPTED', purpose: 'commenting' }],
+      } as never);
+
+      const summary = await rig.weaver.reconcile();
+      expect(summary.divergent).toBeGreaterThanOrEqual(1);
+    } finally {
+      stopServing();
+      await rig.dispose();
+    }
+  });
+});
+
+// ── W1 / W1-strict — mutual exclusion ───────────────────────────────────────
+
+describe('W1 — per-resource mutual exclusion (pipeline path)', () => {
+  // ∀ execution, r, m₁ ≠ m₂ ∈ mut_pipeline(r): the mutation intervals never
+  // overlap — groupBy + concatMap serialize each lane even when the store
+  // is slow. The wrapper stretches every mutation across real time so an
+  // overlap, if possible, would be observed.
+  it('W1: pipeline mutations for one resource never overlap in time', async () => {
+    await fc.assert(
+      fc.asyncProperty(historyArb, async (history) => {
+        const inner = new MemoryGraphDatabase();
+        const intervals = new Map<string, Array<{ start: number; end: number }>>();
+        let clock = 0;
+        const MUTS = new Set([
+          'createResource', 'batchCreateResources', 'updateResource', 'deleteResource',
+          'createAnnotation', 'createAnnotations', 'updateAnnotation', 'deleteAnnotation',
+        ]);
+        const slow = new Proxy(inner, {
+          get(target, prop, receiver) {
+            const name = String(prop);
+            const original = Reflect.get(target, prop, receiver);
+            if (!MUTS.has(name) || typeof original !== 'function') {
+              return typeof original === 'function' ? original.bind(target) : original;
+            }
+            return async (...args: unknown[]) => {
+              // Key intervals by the resource the weaver's lane owns: the
+              // harness histories key annotations as `${rid}-ann-…`.
+              const raw = name === 'createAnnotation' ? String((args[0] as { id: string }).id)
+                : name === 'createAnnotations' ? String((args[0] as Array<{ id: string }>)[0]?.id ?? '')
+                : name === 'batchCreateResources' ? String((args[0] as Array<{ '@id': string }>)[0]?.['@id'] ?? '')
+                : String((args[0] as { '@id'?: string })?.['@id'] ?? args[0]);
+              const rid = raw.includes('-ann-') ? raw.slice(0, raw.indexOf('-ann-')) : raw;
+              const start = ++clock;
+              await new Promise((r) => setTimeout(r, 3));
+              const result = await (original as (...a: unknown[]) => Promise<unknown>).apply(target, args);
+              const end = ++clock;
+              const list = intervals.get(rid) ?? [];
+              list.push({ start, end });
+              intervals.set(rid, list);
+              return result;
+            };
+          },
+        }) as MemoryGraphDatabase;
+
+        const rig = await buildWeaverRig({ graph: slow });
+        try {
+          for (const e of history) rig.push(e);
+          expect(await awaitMarks(rig.weaver, maxSeqs(history))).toBe(true);
+          for (const [, list] of intervals) {
+            const sorted = [...list].sort((a, b) => a.start - b.start);
+            for (let i = 1; i < sorted.length; i++) {
+              expect(sorted[i].start).toBeGreaterThan(sorted[i - 1].end);
+            }
+          }
+        } finally {
+          await rig.dispose();
+        }
+      }),
+      { numRuns: 10 },
+    );
+  });
+
+  // KNOWN false: heals (weave:rebuild, reconcile's rebuildResource) bypass
+  // the pipeline lanes — a heal racing a live write on the same resource
+  // can stale-overwrite it (found deterministic shape: clear-then-replay
+  // drops a live event applied mid-rebuild, and the monotone mark still
+  // claims it). Flips when #845's "lane-clean heals" checkbox lands.
+  it.fails('W1-strict: a rebuild racing live traffic never loses the live write', async () => {
+    const rid = 'res-race';
+    const history = [
+      storedEvent('yield:created', rid, { name: 'Race', format: 'text/plain', contentChecksum: 'cs-r' }, 1),
+    ];
+    const inner = new MemoryGraphDatabase();
+    let releaseClear: () => void = () => {};
+    const gated = new Proxy(inner, {
+      get(target, prop, receiver) {
+        const original = Reflect.get(target, prop, receiver);
+        if (String(prop) !== 'clearDatabase' || typeof original !== 'function') {
+          return typeof original === 'function' ? original.bind(target) : original;
+        }
+        return async (...args: unknown[]) => {
+          await new Promise<void>((resolve) => { releaseClear = resolve; });
+          return (original as (...a: unknown[]) => Promise<unknown>).apply(target, args);
+        };
+      },
+    }) as MemoryGraphDatabase;
+
+    const rig = await buildWeaverRig({ graph: gated });
+    const stopServing = serveHistory(rig.eventBus, history);
+    try {
+      rig.push(history[0]);
+      expect(await awaitMarks(rig.weaver, maxSeqs(history))).toBe(true);
+
+      // Rebuild starts and parks inside clearDatabase…
+      const rebuild = rig.weaver.rebuildAll();
+      await sleep(20);
+      // …a live tag lands mid-rebuild…
+      rig.push(storedEvent('mark:entity-tag-added', rid, { entityType: 'LiveTag' }, 2));
+      expect(await awaitMarks(rig.weaver, new Map([[rid, 2]]))).toBe(true);
+      // …then the rebuild clears and replays the SERVED history (no tag).
+      releaseClear();
+      await rebuild;
+      await sleep(SETTLE_MS);
+
+      const doc = await inner.getResource((await import('@semiont/core')).resourceId(rid));
+      // The live write must survive a racing heal — today it does not.
+      expect(doc?.entityTypes ?? []).toContain('LiveTag');
+    } finally {
+      stopServing();
+      await rig.dispose();
+    }
+  });
+});
+
+// ── W7 — WeaveProgress fold monotonicity ────────────────────────────────────
+
+describe('W7 — the barrier fold is monotone', () => {
+  // ∀ signal sequences: appliedUpTo(r) never decreases.
+  it('W7: appliedUpTo never regresses under arbitrary signal sequences', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({ rid: fc.nat(3).map((n) => `res-${n}`), seq: fc.nat(50) }),
+          { maxLength: 60 },
+        ),
+        (signals) => {
+          const bus = new EventBus();
+          const progress = createWeaveProgress(bus);
+          try {
+            const high = new Map<string, number>();
+            for (const { rid, seq } of signals) {
+              bus.get('weave:applied').next({ resourceId: rid, sequenceNumber: seq });
+              const now = progress.appliedUpTo(rid) ?? -1;
+              expect(now).toBeGreaterThanOrEqual(high.get(rid) ?? -1);
+              expect(now).toBeGreaterThanOrEqual(seq > (high.get(rid) ?? -1) ? seq : -1);
+              high.set(rid, Math.max(high.get(rid) ?? -1, now));
+            }
+          } finally {
+            progress.dispose();
+          }
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+});

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -15,7 +15,19 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } from 'vitest';
 import { EventStore, FilesystemViewStorage } from '@semiont/event-sourcing';
 import { SemiontProject } from '@semiont/core/node';
-import { Weaver } from '../weaver';
+import { Weaver, type WeaverTiming } from '../weaver';
+
+// Production-shaped timings: this suite's specs assume the real burst window
+// semantics (tick(350) flushes). The axiom suite runs ~1ms timings instead.
+const PROD_TIMING: WeaverTiming = {
+  burstWindowMs: 50,
+  maxBatchSize: 500,
+  idleTimeoutMs: 200,
+  drainTimeoutMs: 30_000,
+  drainPollMs: 25,
+  drainStallPolls: 40,
+  checkpointFlushMs: 5_000,
+};
 import { createWeaverActorStateUnit, type WeaverActorStateUnit } from '../weaver-actor-state-unit';
 import { workerBusOverEventBus } from '../worker-bus-local';
 import { asBusRequestPrimitive } from '../bus-request-local';
@@ -122,6 +134,7 @@ describe('Weaver', () => {
       weaverUnit.rebuilds$,
       asBusRequestPrimitive(coreEventBus),
       new FileWeaverCheckpoint(checkpointPath ?? join(testDir, `weaver-checkpoint-${uuidv4()}.json`)),
+      PROD_TIMING,
       mockLogger,
     );
     await weaver.initialize();
@@ -778,6 +791,7 @@ describe('Weaver', () => {
         localUnit.rebuilds$,
         asBusRequestPrimitive(coreEventBus),
         new FileWeaverCheckpoint(join(testDir, `weaver-checkpoint-${uuidv4()}.json`)),
+        PROD_TIMING,
         mockLogger,
       );
       await localConsumer.initialize();

--- a/packages/make-meaning/src/weaver-main.ts
+++ b/packages/make-meaning/src/weaver-main.ts
@@ -20,7 +20,7 @@
 
 import { BehaviorSubject } from 'rxjs';
 import { createWeaverActorStateUnit, type WeaverActorStateUnit } from './weaver-actor-state-unit';
-import { Weaver } from './weaver';
+import { Weaver, type WeaverTiming } from './weaver';
 import { FileWeaverCheckpoint } from './weaver-checkpoint';
 import { HttpTransport } from '@semiont/http-transport';
 import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader } from '@semiont/core';
@@ -144,12 +144,24 @@ async function main() {
     bus: httpTransport.actor,
   });
 
+  // Production timings (WEAVER-AXIOMS R0 — the axiom harness runs ~1 ms).
+  const timing: WeaverTiming = {
+    burstWindowMs: 50,
+    maxBatchSize: 500,
+    idleTimeoutMs: 200,
+    drainTimeoutMs: 30_000,
+    drainPollMs: 25,
+    drainStallPolls: 40,
+    checkpointFlushMs: 5_000,
+  };
+
   const weaver = new Weaver(
     graphDb,
     actorStateUnit.events$,
     actorStateUnit.rebuilds$,
     httpTransport,
     new FileWeaverCheckpoint(checkpointPath),
+    timing,
     logger,
   );
   await weaver.initialize();

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -13,9 +13,11 @@
  * Cross-resource parallelism is provided via mergeMap over groups.
  *
  * Burst buffer thresholds:
- *   BURST_WINDOW_MS  = 50   — debounce window before flushing a batch
- *   MAX_BATCH_SIZE   = 500  — force flush to bound memory
- *   IDLE_TIMEOUT_MS  = 200  — silence before returning to passthrough
+ *   burstWindowMs (50 in production) — debounce window before flushing a batch
+ *   maxBatchSize  (500)              — force flush to bound memory
+ *   idleTimeoutMs (200)              — silence before returning to passthrough
+ * All timings are injected via the required `WeaverTiming` constructor param
+ * (WEAVER-AXIOMS R0) — the axiom harness runs them at ~1 ms.
  *
  * ## Per-resource serialization
  *
@@ -24,6 +26,22 @@
  * `Gatherer`, and (in a different shape) `ViewManager`. See
  * `packages/core/src/serialize-per-key.ts` for the shared primitive used
  * by RPC-style services.
+ *
+ * ## Invariants (proven, not merely intended)
+ *
+ * The pipeline holds a set of axioms verified as fast-check properties in
+ * `__tests__/weaver-axioms.test.ts` and pinned structurally by
+ * `scripts/compliance/audit-weaver-invariants.sh` — see
+ * `.plans/WEAVER-AXIOMS.md`. Load-bearing among them:
+ *   - graph ≡ reference fold over arbitrary histories (W4), and rebuild ≡
+ *     replay (W5);
+ *   - redelivery is inert (W3) — the **sequence gate** in the pipeline drops
+ *     anything at/below the applied mark, so an SSE-replayed stale event
+ *     cannot re-fold newer facet state;
+ *   - the applied mark is **monotone and never passes a failed event**
+ *     (W6/W7) — `noteApplied`'s failed-floor cap keeps the mark (and the
+ *     `weave:applied` barrier signal) honest, so catch-up always re-replays
+ *     a dropped event rather than the checkpoint hiding it.
  */
 
 import { Subject, Subscription, from, type Observable } from 'rxjs';
@@ -33,6 +51,27 @@ import type { BusRequestPrimitive, EventMap } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
 import type { PersistedEvent, StoredEvent, EventOfType, ResourceId, Logger} from '@semiont/core';
 import type { WeaverCheckpoint } from './weaver-checkpoint.js';
+
+/**
+ * Pipeline, drain, and flush timings. Required — `weaver-main` passes
+ * production values (50/500/200 burst; 30s/25ms/40 drain; 5s flush); the
+ * axiom harness passes ~1ms values so property suites run at generator
+ * speed. See `.plans/WEAVER-AXIOMS.md` (R0), mirroring SmelterTiming
+ * (SMELTER-AXIOMS D4).
+ */
+export interface WeaverTiming {
+  burstWindowMs: number;
+  maxBatchSize: number;
+  idleTimeoutMs: number;
+  /** Bounded catch-up drain (awaitParity) budget. */
+  drainTimeoutMs: number;
+  /** awaitParity poll interval. */
+  drainPollMs: number;
+  /** Consecutive unchanged-pending polls before declaring the drain stalled. */
+  drainStallPolls: number;
+  /** Dirty-checkpoint flush interval. */
+  checkpointFlushMs: number;
+}
 import { resourceId as makeResourceId, annotationId as makeAnnotationId, findBodyItem } from '@semiont/core';
 import { partitionByType } from './batch-utils.js';
 
@@ -40,21 +79,22 @@ import type { Annotation, CreateAnnotationInternal } from '@semiont/core';
 import type { ResourceDescriptor } from '@semiont/core';
 
 export class Weaver {
-  // Burst buffer thresholds — see class doc
-  private static readonly BURST_WINDOW_MS = 50;
-  private static readonly MAX_BATCH_SIZE = 500;
-  private static readonly IDLE_TIMEOUT_MS = 200;
-
-  // Catch-up (WEAVER-ISOLATION P3, D1 = checkpointed replay)
+  // Catch-up paging (not timing — page size is a payload concern)
   private static readonly CATCHUP_PAGE_SIZE = 200;
-  private static readonly CATCHUP_DRAIN_TIMEOUT_MS = 30_000;
-  private static readonly CHECKPOINT_FLUSH_MS = 5_000;
 
   private sourceSubscription: Subscription | null = null;
   private rebuildSubscription: Subscription | null = null;
   private eventSubject = new Subject<StoredEvent>();
   private pipelineSubscription: Subscription | null = null;
   private lastProcessed: Map<string, number> = new Map();
+  /**
+   * Outstanding failed sequences per resource (W6). The applied mark is
+   * capped BELOW the lowest of these — a success at a later sequence must
+   * not carry the mark past an event that never landed, or the checkpoint
+   * would hide it from catch-up forever. Cleared when the event finally
+   * applies (catch-up re-replays from the capped mark).
+   */
+  private failedSeqs: Map<string, Set<number>> = new Map();
   private _applyFailures = 0;
   private checkpointDirty = false;
   private checkpointTimer: ReturnType<typeof setInterval> | null = null;
@@ -75,6 +115,7 @@ export class Weaver {
     private rebuilds$: Observable<EventMap['weave:rebuild']>,
     private bus: BusRequestPrimitive,
     private checkpoint: WeaverCheckpoint,
+    private timing: WeaverTiming,
     logger: Logger,
   ) {
     this.logger = logger;
@@ -94,7 +135,7 @@ export class Weaver {
 
     this.checkpointTimer = setInterval(() => {
       void this.flushCheckpoint();
-    }, Weaver.CHECKPOINT_FLUSH_MS);
+    }, this.timing.checkpointFlushMs);
   }
 
   /**
@@ -117,13 +158,30 @@ export class Weaver {
         // Resource events: apply burst buffering per resource group
         return group.pipe(
           burstBuffer<StoredEvent>({
-            burstWindowMs: Weaver.BURST_WINDOW_MS,
-            maxBatchSize: Weaver.MAX_BATCH_SIZE,
-            idleTimeoutMs: Weaver.IDLE_TIMEOUT_MS,
+            burstWindowMs: this.timing.burstWindowMs,
+            maxBatchSize: this.timing.maxBatchSize,
+            idleTimeoutMs: this.timing.idleTimeoutMs,
           }),
           concatMap((eventOrBatch: StoredEvent | StoredEvent[]) => {
+            // Sequence gate (WEAVER-AXIOMS W3): at-least-once delivery can
+            // redeliver an event AFTER later ones already applied (SSE
+            // replay overlapping live). Content-idempotent folds tolerate
+            // adjacent duplicates, but a DISPLACED redelivery would clobber
+            // newer facet state (a stale yield:created resets tags/archived)
+            // — so anything at or below the applied mark is skipped, never
+            // re-folded. Failed events sit above the mark and still retry.
             if (Array.isArray(eventOrBatch)) {
-              return from(this.processBatch(eventOrBatch));
+              const fresh = eventOrBatch.filter(
+                (e) => e.metadata.sequenceNumber > (this.lastProcessed.get(e.resourceId!) ?? -1),
+              );
+              if (fresh.length === 0) return from(Promise.resolve());
+              return from(this.processBatch(fresh));
+            }
+            if (
+              eventOrBatch.metadata.sequenceNumber <=
+              (this.lastProcessed.get(eventOrBatch.resourceId!) ?? -1)
+            ) {
+              return from(Promise.resolve());
             }
             return from(this.safeApplyEvent(eventOrBatch).then((applied) => {
               if (applied) {
@@ -155,14 +213,48 @@ export class Weaver {
    * push half of the applied-offset barrier (GRAPH-PROJECTION-SYNC P2):
    * `WeaveProgress` folds these signals into the map `whenApplied` awaits.
    */
+  /** Record an apply outcome for the failed-floor bookkeeping (W6). */
+  private noteOutcome(event: StoredEvent, ok: boolean): void {
+    if (!event.resourceId) return;
+    const rid = String(event.resourceId);
+    const seq = event.metadata.sequenceNumber;
+    if (ok) {
+      const set = this.failedSeqs.get(rid);
+      if (set) {
+        set.delete(seq);
+        if (set.size === 0) this.failedSeqs.delete(rid);
+      }
+    } else {
+      let set = this.failedSeqs.get(rid);
+      if (!set) {
+        set = new Set();
+        this.failedSeqs.set(rid, set);
+      }
+      set.add(seq);
+    }
+  }
+
   private noteApplied(resourceId: string, sequenceNumber: number): void {
-    this.lastProcessed.set(resourceId, sequenceNumber);
+    // Failed-floor cap (W6): the mark asserts "everything at or below me
+    // landed" — it may never reach or pass an outstanding failed sequence,
+    // however many later events succeed.
+    const failed = this.failedSeqs.get(resourceId);
+    let capped = sequenceNumber;
+    if (failed && failed.size > 0) {
+      capped = Math.min(capped, Math.min(...failed) - 1);
+    }
+    // Monotone: a lower-sequence note is always a redelivery echo — the
+    // mark (and the weave:applied signal) must never regress (W7).
+    const current = this.lastProcessed.get(resourceId);
+    if (current !== undefined && current >= capped) return;
+    this.lastProcessed.set(resourceId, capped);
     this.checkpointDirty = true;
-    // Fire-and-forget signal: in-process the shim's emit is synchronous;
-    // over HTTP a lost signal only means a barrier timeout (the poll floor
-    // absorbs it), so a warn is the right ceiling.
-    this.bus.emit('weave:applied', { resourceId, sequenceNumber }).catch((err) => {
-      this.logger.warn('weave:applied emit failed', { resourceId, sequenceNumber, error: errField(err) });
+    // Fire-and-forget signal — always the CAPPED value: the barrier must
+    // never learn a sequence the mark cannot honestly claim (W6/W7).
+    // In-process the shim's emit is synchronous; over HTTP a lost signal
+    // only means a barrier timeout (the poll floor absorbs it).
+    this.bus.emit('weave:applied', { resourceId, sequenceNumber: capped }).catch((err) => {
+      this.logger.warn('weave:applied emit failed', { resourceId, sequenceNumber: capped, error: errField(err) });
     });
   }
 
@@ -269,7 +361,7 @@ export class Weaver {
       parityTargets.set(String(rid), maxSeq);
     }
 
-    const parityPending = await this.awaitParity(parityTargets, Weaver.CATCHUP_DRAIN_TIMEOUT_MS);
+    const parityPending = await this.awaitParity(parityTargets, this.timing.drainTimeoutMs);
     this.checkpointDirty = true;
     await this.flushCheckpoint();
 
@@ -309,7 +401,7 @@ export class Weaver {
       if (pending === 0) return 0;
       stablePolls = pending === lastPending ? stablePolls + 1 : 0;
       lastPending = pending;
-      if (stablePolls >= 40) {
+      if (stablePolls >= this.timing.drainStallPolls) {
         this.logger.warn('Weaver catch-up drain stalled — reporting pending parity', { pending });
         return pending;
       }
@@ -317,7 +409,7 @@ export class Weaver {
         this.logger.warn('Weaver catch-up drain timed out; live pipeline will finish', { pending });
         return pending;
       }
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise((resolve) => setTimeout(resolve, this.timing.drainPollMs));
     }
   }
 
@@ -432,9 +524,11 @@ export class Weaver {
   private async safeApplyEvent(storedEvent: StoredEvent): Promise<boolean> {
     try {
       await this.applyEventToGraph(storedEvent);
+      this.noteOutcome(storedEvent, true);
       return true;
     } catch (error) {
       this._applyFailures++;
+      this.noteOutcome(storedEvent, false);
       this.logger.error('Failed to apply event to graph', {
         eventType: storedEvent.type,
         resourceId: storedEvent.resourceId,
@@ -493,30 +587,41 @@ export class Weaver {
     // the applied mark must never skip past events that did not land
     // (#845). Catch-up re-replays from the last clean sequence, and the
     // idempotent folds absorb the runs that did land.
-    let blocked = false;
     for (const run of runs) {
-      let runFailures = 0;
+      // Re-gate per run (W3): earlier runs in THIS batch advance the mark,
+      // so a displaced duplicate later in the same batch must drop here —
+      // the flush-time filter cannot see intra-batch advancement.
+      const live = run.filter(
+        (e) => e.metadata.sequenceNumber > (this.lastProcessed.get(e.resourceId!) ?? -1),
+      );
+      if (live.length === 0) continue;
+
       try {
-        if (run.length === 1) {
-          runFailures = (await this.safeApplyEvent(run[0])) ? 0 : 1;
+        if (live.length === 1) {
+          await this.safeApplyEvent(live[0]);
         } else {
-          runFailures = await this.applyBatchByType(run);
+          await this.applyBatchByType(live);
         }
       } catch (error) {
-        runFailures = run.length;
-        this._applyFailures += run.length;
+        this._applyFailures += live.length;
+        for (const e of live) this.noteOutcome(e, false);
         this.logger.error('Failed to process batch run', {
-          eventType: run[0].type,
-          runSize: run.length,
+          eventType: live[0].type,
+          runSize: live.length,
           error: errField(error),
         });
       }
-      if (runFailures > 0) blocked = true;
-      if (!blocked) {
-        const last = run[run.length - 1];
-        if (last.resourceId) {
-          this.noteApplied(last.resourceId, last.metadata.sequenceNumber);
-        }
+      // Always note, with the run's MAX sequence — delivery order is not
+      // sequence order under redelivery (a displaced duplicate can sit
+      // last in the run and would otherwise pin the mark below the run's
+      // true high-water; W3 counterexample, 2026-07-13). The failed-floor
+      // cap (W6) keeps a run containing failures from over-claiming.
+      const noted = live[0];
+      if (noted.resourceId) {
+        this.noteApplied(
+          String(noted.resourceId),
+          Math.max(...live.map((e) => e.metadata.sequenceNumber)),
+        );
       }
     }
 
@@ -530,8 +635,12 @@ export class Weaver {
    * Batch-optimized processing for consecutive events of the same type.
    * Uses batch graph methods where available, falls back to sequential.
    */
-  /** Returns the number of events in the run that failed to apply (#845). */
-  private async applyBatchByType(events: StoredEvent[]): Promise<number> {
+  /**
+   * Batch-optimized apply for a same-type run. Outcomes land in the
+   * failed-floor bookkeeping (`noteOutcome`); a thrown batch marks the
+   * whole run failed in `processBatch`'s catch.
+   */
+  private async applyBatchByType(events: StoredEvent[]): Promise<void> {
     const graphDb = this.ensureInitialized();
     const type = events[0].type;
 
@@ -539,8 +648,9 @@ export class Weaver {
       case 'yield:created': {
         const resources = events.map(e => this.buildResourceDescriptor(e));
         await graphDb.batchCreateResources(resources);
+        for (const e of events) this.noteOutcome(e, true);
         this.logger.info('Batch created resources in graph', { count: events.length });
-        return 0;
+        break;
       }
       case 'mark:added': {
         // Same idempotent fold as the single-event path, batched: dedupe the
@@ -561,19 +671,18 @@ export class Weaver {
         if (inputs.length > 0) {
           await graphDb.createAnnotations(inputs);
         }
+        for (const e of events) this.noteOutcome(e, true);
         this.logger.info('Batch created annotations in graph', {
           count: inputs.length,
           duplicatesSkipped: events.length - inputs.length,
         });
-        return 0;
+        break;
       }
       default: {
         // For types without batch optimization, fall back to sequential
-        let failed = 0;
         for (const event of events) {
-          if (!(await this.safeApplyEvent(event))) failed++;
+          await this.safeApplyEvent(event);
         }
-        return failed;
       }
     }
   }

--- a/scripts/compliance/audit-all-compliance.sh
+++ b/scripts/compliance/audit-all-compliance.sh
@@ -39,6 +39,11 @@ echo "🎛️  Checking toolbar-pref storage stays in useToolbarPrefs()..."
 bash "$COMPLIANCE_DIR/audit-toolbar-pref-storage.sh"
 echo ""
 
+# Weaver structural invariants (WEAVER-AXIOMS.md G1–G5)
+echo "🕸️  Checking Weaver invariants (no event-store/fs, standalone-only, single mark/signal writer, channel↔fold sync)..."
+bash "$COMPLIANCE_DIR/audit-weaver-invariants.sh"
+echo ""
+
 # React-UI source code
 echo "📦 Auditing packages/react-ui source..."
 cd "$REPO_ROOT/packages/react-ui"

--- a/scripts/compliance/audit-weaver-invariants.sh
+++ b/scripts/compliance/audit-weaver-invariants.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Audit: Weaver structural invariants G1–G5 (WEAVER-AXIOMS.md "Design
+# constraints"). These are the invariants that hold by construction and
+# cannot be expressed as runtime properties — the static complement of the
+# weaver-axioms.test.ts suite.
+#
+# G1  weaver.ts has no event-store or fs attachment (history via browse:* only)
+# G2  the Weaver is standalone-only (constructed in weaver-main + tests only)
+# G3  the applied mark has a single writer (noteApplied + the catch-up seed)
+# G4  weave:applied has a single emitter (noteApplied)
+# G5  the fan-in channel list and the fold's switch cases stay in sync
+#
+# Exit code: 0 if clean, 1 if violations found.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+WEAVER="packages/make-meaning/src/weaver.ts"
+UNIT="packages/make-meaning/src/weaver-actor-state-unit.ts"
+FAIL=0
+
+# ── G1 — no event-store / fs attachment ─────────────────────────────────────
+G1=$(grep -nE "@semiont/event-sourcing|from ['\"](node:)?fs['\"]" "$WEAVER" || true)
+if [ -n "$G1" ]; then
+  echo "❌ G1: weaver.ts must read history over browse:* only — no event-store or fs imports:"
+  echo "$G1"
+  FAIL=1
+fi
+# Entry points (weaver-main: TOML config bootstrap, like smelter-main) and
+# tests (tmp dirs) are exempt — the invariant governs the runtime modules.
+G1B=$(grep -rlnE "from ['\"](node:)?fs['\"]" packages/make-meaning/src \
+  --include='weaver*.ts' 2>/dev/null \
+  | grep -vE "weaver-checkpoint\.ts|weaver-main\.ts|/__tests__/" || true)
+if [ -n "$G1B" ]; then
+  echo "❌ G1: only weaver-checkpoint.ts may touch the filesystem among weaver files:"
+  echo "$G1B"
+  FAIL=1
+fi
+
+# ── G2 — standalone-only construction ───────────────────────────────────────
+G2=$(grep -rn "new Weaver(" packages apps --include='*.ts' 2>/dev/null \
+  | grep -vE "/node_modules/|/dist/|/__tests__/|weaver-main\.ts" || true)
+if [ -n "$G2" ]; then
+  echo "❌ G2: the Weaver is standalone-only (D4) — constructed in weaver-main.ts and tests, nowhere else:"
+  echo "$G2"
+  FAIL=1
+fi
+G2B=$(grep -rnE "kb\.weaver\b|weaverEvents" packages apps --include='*.ts' 2>/dev/null \
+  | grep -vE "/node_modules/|/dist/" || true)
+if [ -n "$G2B" ]; then
+  echo "❌ G2: kb.weaver / weaverEvents must not exist — the backend keeps only the weaveProgress fold:"
+  echo "$G2B"
+  FAIL=1
+fi
+
+# ── G3 — single writer for the applied mark ─────────────────────────────────
+G3_COUNT=$(grep -c "lastProcessed.set(" "$WEAVER" || true)
+if [ "$G3_COUNT" -ne 2 ]; then
+  echo "❌ G3: expected exactly 2 lastProcessed.set sites in weaver.ts (noteApplied + catch-up seed), found $G3_COUNT:"
+  grep -n "lastProcessed.set(" "$WEAVER" || true
+  FAIL=1
+fi
+
+# ── G4 — single emitter for weave:applied ───────────────────────────────────
+G4_COUNT=$(grep -c "emit('weave:applied'" "$WEAVER" || true)
+if [ "$G4_COUNT" -ne 1 ]; then
+  echo "❌ G4: expected exactly 1 weave:applied emit site in weaver.ts (noteApplied), found $G4_COUNT:"
+  grep -n "weave:applied" "$WEAVER" || true
+  FAIL=1
+fi
+
+# ── G5 — fan-in channels ≡ fold switch cases ────────────────────────────────
+CHANNELS=$(sed -n "/export const WEAVER_CHANNELS = \[/,/\] as const;/p" "$UNIT" \
+  | grep -oE "'[a-z]+:[a-z-]+'" | tr -d "'" | sort -u)
+CASES=$(grep -oE "case '(yield|mark|frame):[a-z-]+'" "$WEAVER" \
+  | grep -oE "'[a-z]+:[a-z-]+'" | tr -d "'" | sort -u)
+if [ "$CHANNELS" != "$CASES" ]; then
+  echo "❌ G5: WEAVER_CHANNELS and the applyEventToGraph switch have drifted"
+  echo "   (the smelter-misses-unarchive bug class — a subscribed channel with no fold, or a fold no one feeds):"
+  echo "   channels only: $(comm -23 <(echo "$CHANNELS") <(echo "$CASES") | tr '\n' ' ')"
+  echo "   cases only:    $(comm -13 <(echo "$CHANNELS") <(echo "$CASES") | tr '\n' ' ')"
+  FAIL=1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+echo "✅ Weaver invariants G1–G5 hold"


### PR DESCRIPTION
# Pull Request

## Description

Adds a **fast-check property suite for the Weaver**, modeled on the existing
Smelter axioms — every invariant is a FOPL statement plus a generated property,
with an `it.fails(...)` RED→GREEN ledger for known gaps. The spec/ledger lives
in `.plans/WEAVER-AXIOMS.md` (untracked, per house convention).

This is not just test coverage: **the properties found five defects, three of
them real correctness bugs in the completeness machinery that shipped in #985**,
which the example-level tests couldn't reach because they don't generate
adversarial redelivery orderings or fault schedules. All fixed at source.

### Enabling refactor

`WeaverTiming` is now a required constructor param (burst/drain/flush timings),
mirroring `SmelterTiming` — `weaver-main` passes production values, the axiom
harness passes ~1 ms so the properties run at generator speed. The three
existing Weaver construction sites (weaver-main, weaver.test, the query-graph
scripting example) pass values.

### Defects the properties found

1. **Displaced-redelivery clobber (product):** an SSE-replayed `yield:created`
   arriving after later facet events re-folded stale state (reset tags /
   archived). Fixed with a **sequence gate** in the pipeline `concatMap` and
   per-run in `processBatch` — anything at/below the applied mark is dropped,
   never re-folded.
2. **Non-monotone mark (product):** `noteApplied` could regress the mark and
   the `weave:applied` barrier signal on a lower-seq echo. Fixed with a
   monotone guard; signals now carry the capped sequence.
3. **Mark-past-failure (product):** a success at seq N carried the mark past an
   *earlier* failed event, hiding it from catch-up forever. Fixed with a
   **failed-floor cap** (`failedSeqs` per resource; the mark stays below the
   lowest outstanding failure) — which also subsumed and deleted the older
   `blocked`-flag logic in `processBatch`. A later shrink caught `processBatch`
   noting the last-*delivered* rather than the max sequence of a run; fixed too.
4. **Rebuild drops custom entity types (ledgered RED, W5-frames):**
   `frame:entity-type-added` lives in no resource stream, so `rebuildAll`
   never replays it while `clearDatabase` wiped the registry to baseline —
   `weave:rebuild` silently loses custom types. No bus read serves system
   events today; committed as `it.fails` and tracked on #845.
5. A harness-oracle bug (model omitted the ontology baseline the store seeds)
   — fixed in the test oracle, not product.

### What the suite proves

10 properties + 3 designed-RED `it.fails`, over generated histories against an
independent reference fold and a fault-injecting graph wrapper:

- graph ≡ reference fold over arbitrary histories (W4); rebuild ≡ replay (W5)
- redelivery is inert (W3); the applied mark is monotone and never passes a
  failed event (W6/W7); honest failure accounting (W10)
- per-resource mutual exclusion (W1); cross-resource progress under a wedged
  lane (W2); catch-up converges from the checkpoint-divergence family (W8);
  reconcile detects + heals the v1 out-of-band mutation class and holds its
  fixed point (W9)

The 3 `it.fails` are trackers that flip loudly when their gaps close:
**W1-strict** (lane-clean heals) and **W9-deep** (annotation body deep-equality)
map to #845 checkboxes; **W5-frames** is the newly-found registry drop above.

### Structural gate

`scripts/compliance/audit-weaver-invariants.sh` (wired into
`audit-all-compliance.sh`) pins the by-construction invariants a runtime
property can't: G1 no event-store/fs attachment, G2 standalone-only
construction, G3/G4 single-writer mark and signal, G5 fan-in channels ≡ fold
switch cases (the weaver-side prophylactic against the channel-drift class
behind the Smelter unarchive bug, #1009).

## Type of Change

- [x] Bug fix (three product correctness fixes above)
- [x] New feature (property suite + compliance gate)

## Areas Changed

Only `packages/make-meaning` (weaver + tests) and `scripts/compliance`.

## Security Checklist

Not applicable — no authentication, authorization, or admin surface touched.

## Verification

- Every property RED-first where it falsified the code; each fix at source,
  logged in the ledger.
- Final: build + full workspace `tsc --noEmit` clean; make-meaning 37 files /
  453 passed + 3 expected-fail; graph 105/105; `audit-weaver-invariants.sh`
  green (node:24 container).
