### PR TITLE
graph read-after-write sweep: every graph reader gets a posture (view-fallback hydration + documented eventual consistency)

### DIFF
--- a/packages/make-meaning/src/__tests__/browser.test.ts
+++ b/packages/make-meaning/src/__tests__/browser.test.ts
@@ -315,12 +315,18 @@ describe('Browser actor', () => {
       (eventBus as any).get('browse:referenced-by-requested').next(payload);
     }
 
+    let mockViewGet: ReturnType<typeof vi.fn>;
+
     beforeEach(async () => {
       await browser.stop();
       vi.clearAllMocks();
       mockReferencedBy = vi.fn();
       mockGetResource = vi.fn();
-      const kb = { graph: { getResourceReferencedBy: mockReferencedBy, getResource: mockGetResource } } as any;
+      mockViewGet = vi.fn().mockResolvedValue(null);
+      const kb = {
+        graph: { getResourceReferencedBy: mockReferencedBy, getResource: mockGetResource },
+        views: { get: mockViewGet },
+      } as any;
       browser = new Browser(makeViews([]) as any, kb, eventBus, { root: PROJECT_ROOT } as any, emptyConfig, mockLogger);
       await browser.initialize();
     });
@@ -343,6 +349,40 @@ describe('Browser actor', () => {
       expect(result.response.referencedBy[0]).toEqual({ id: 'anno-1', resourceName: 'Prometheus Bound', target: { source: DOC_A_URI, selector: { exact: 'Prometheus' } } });
       expect(result.response.referencedBy[1]).toEqual({ id: 'anno-2', resourceName: 'Greek Myths', target: { source: DOC_B_URI, selector: { exact: 'the Titan' } } });
       expect(mockReferencedBy).toHaveBeenCalledWith(TARGET_RESOURCE_ID, undefined);
+    });
+
+    it('hydrates a graph-lagging citer from the view — never "Untitled Resource" for a known resource', async () => {
+      // The read-after-write artifact (graph-read-after-write-coverage.md P1):
+      // the edge is woven but the citing resource's node is not yet — the
+      // view is the fresher projection and must supply the name.
+      const anno = makeAnnotation('anno-lag', DOC_B_URI, String(TARGET_RESOURCE_ID), 'the Titan');
+      mockReferencedBy.mockResolvedValue([anno]);
+      mockGetResource.mockResolvedValue(null); // graph hasn't woven the citer yet
+      mockViewGet.mockImplementation((id: any) =>
+        String(id) === DOC_B_URI
+          ? Promise.resolve({ resource: { '@id': DOC_B_URI, name: 'Greek Myths' }, annotations: {} })
+          : Promise.resolve(null),
+      );
+
+      const p = resultPromise();
+      fire({ correlationId: 'corr-lag', resourceId: TARGET_RESOURCE_ID });
+      const result = await p;
+
+      expect(result.response.referencedBy).toHaveLength(1);
+      expect(result.response.referencedBy[0].resourceName).toBe('Greek Myths');
+    });
+
+    it('a citer neither projection knows still renders the Untitled fallback', async () => {
+      const anno = makeAnnotation('anno-ghost', 'doc-ghost', String(TARGET_RESOURCE_ID));
+      mockReferencedBy.mockResolvedValue([anno]);
+      mockGetResource.mockResolvedValue(null);
+      // mockViewGet default: null
+
+      const p = resultPromise();
+      fire({ correlationId: 'corr-ghost', resourceId: TARGET_RESOURCE_ID });
+      const result = await p;
+
+      expect(result.response.referencedBy[0].resourceName).toBe('Untitled Resource');
     });
 
     it('passes motivation filter to graph query', async () => {
@@ -406,14 +446,27 @@ describe('Browser actor', () => {
       expect(result.message).toBe('Graph unavailable');
     });
 
-    it('emits referenced-by-failed when getResource throws', async () => {
+    it('a throwing citer hydration degrades that entry — the reply still succeeds', async () => {
+      // Changed contract (graph-read-after-write-coverage.md P1): one
+      // citer's store hiccup must not fail the whole references reply.
+      // resourceWithViewGrace absorbs the per-citer read error and falls
+      // back to the view (or Untitled when neither projection answers);
+      // an EDGE-QUERY failure still fails the request (spec above).
       mockReferencedBy.mockResolvedValue([makeAnnotation('anno-1', DOC_A_URI, String(TARGET_RESOURCE_ID), 'text')]);
       mockGetResource.mockRejectedValue(new Error('Resource lookup failed'));
-      const p = failedPromise();
+      mockViewGet.mockImplementation((id: any) =>
+        String(id) === DOC_A_URI
+          ? Promise.resolve({ resource: { '@id': DOC_A_URI, name: 'Prometheus Bound' }, annotations: {} })
+          : Promise.resolve(null),
+      );
+
+      const p = resultPromise();
       fire({ correlationId: 'corr-8', resourceId: TARGET_RESOURCE_ID });
       const result = await p;
+
       expect(result.correlationId).toBe('corr-8');
-      expect(result.message).toBe('Resource lookup failed');
+      expect(result.response.referencedBy).toHaveLength(1);
+      expect(result.response.referencedBy[0].resourceName).toBe('Prometheus Bound');
     });
   });
 

--- a/packages/make-meaning/src/__tests__/browser.test.ts
+++ b/packages/make-meaning/src/__tests__/browser.test.ts
@@ -370,6 +370,9 @@ describe('Browser actor', () => {
 
       expect(result.response.referencedBy).toHaveLength(1);
       expect(result.response.referencedBy[0].resourceName).toBe('Greek Myths');
+      // L4: degradation is observable, never silent — the breadcrumb is
+      // part of the contract, not decoration.
+      expect(mockLogger.info).toHaveBeenCalledWith('[graph lag] citer hydrated from view', { resourceId: DOC_B_URI });
     });
 
     it('a citer neither projection knows still renders the Untitled fallback', async () => {

--- a/packages/make-meaning/src/__tests__/graph-read-grace.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-read-grace.test.ts
@@ -1,0 +1,65 @@
+/**
+ * resourceWithViewGrace Tests (bugs/graph-read-after-write-coverage.md, P1/P2)
+ *
+ * The shared single-resource read-after-write grace for graph consumers:
+ * graph-first, VIEW-fallback. When an id-keyed descriptor read misses the
+ * graph but the resource exists in the view, the caller is racing the
+ * Weaver's apply — and the view is the FRESHER projection, already holding
+ * the full descriptor these call sites need. No waiting, no retry loops.
+ * This is the "third instance" shared helper GRAPH-PROJECTION-SYNC
+ * anticipated (its P1 retry stays exclusive to buildKnowledgeGraph, which
+ * needs the node IN the graph for traversal).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { resourceId } from '@semiont/core';
+import type { KnowledgeBase } from '../knowledge-base';
+import { resourceWithViewGrace } from '../graph-read-grace';
+
+const DOC = { '@id': 'res-1', name: 'From Graph', representations: [], archived: false, entityTypes: [] };
+const VIEW_DOC = { '@id': 'res-1', name: 'From View', representations: [], archived: false, entityTypes: [] };
+
+function kbWith(graphDoc: unknown, viewDoc: unknown): KnowledgeBase {
+  return {
+    graph: { getResource: vi.fn().mockResolvedValue(graphDoc) } as any,
+    views: { get: vi.fn().mockResolvedValue(viewDoc ? { resource: viewDoc, annotations: {} } : null) } as any,
+  } as unknown as KnowledgeBase;
+}
+
+describe('resourceWithViewGrace', () => {
+  it('returns the graph descriptor when the graph has it — no view read, no lag flag', async () => {
+    const kb = kbWith(DOC, VIEW_DOC);
+    const result = await resourceWithViewGrace(kb, resourceId('res-1'));
+
+    expect(result.resource?.name).toBe('From Graph');
+    expect(result.laggedBehindView).toBe(false);
+    expect((kb.views.get as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the view descriptor when the graph lags — flagged for the breadcrumb', async () => {
+    const kb = kbWith(null, VIEW_DOC);
+    const result = await resourceWithViewGrace(kb, resourceId('res-1'));
+
+    expect(result.resource?.name).toBe('From View');
+    expect(result.laggedBehindView).toBe(true);
+  });
+
+  it('returns null for a resource neither projection knows — a true unknown, unflagged', async () => {
+    const kb = kbWith(null, null);
+    const result = await resourceWithViewGrace(kb, resourceId('res-ghost'));
+
+    expect(result.resource).toBeNull();
+    expect(result.laggedBehindView).toBe(false);
+  });
+
+  it('a throwing graph read degrades to the view, not to a rejection', async () => {
+    const kb = {
+      graph: { getResource: vi.fn().mockRejectedValue(new Error('neo4j hiccup')) } as any,
+      views: { get: vi.fn().mockResolvedValue({ resource: VIEW_DOC, annotations: {} }) } as any,
+    } as unknown as KnowledgeBase;
+
+    const result = await resourceWithViewGrace(kb, resourceId('res-1'));
+    expect(result.resource?.name).toBe('From View');
+    expect(result.laggedBehindView).toBe(true);
+  });
+});

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -461,6 +461,44 @@ describe('Matcher', () => {
       const result = await resultPromise;
       const lagging = result!.response.find((r: any) => r.name === 'Lagging Endpoint');
       expect(lagging).toBeDefined();
+      // L4 breadcrumb — degradation observable, never silent.
+      expect(mockLogger.info).toHaveBeenCalledWith('[graph lag] neighborhood candidates hydrated from view', { count: 1 });
+    });
+
+    it('hydrates a graph-lagging semantic candidate from the view instead of dropping it', async () => {
+      // Post-GREEN pin (added after the "is this done?" review — the code
+      // path was fixed alongside the neighborhood loop; this pins it
+      // independently rather than by call-shape similarity).
+      const localBus = new EventBus();
+      const viewGet = vi.fn().mockImplementation((id: unknown) =>
+        String(id) === 'res-sem'
+          ? Promise.resolve({ resource: { '@id': 'res-sem', name: 'Semantic Lag', dateCreated: '2026-07-13T00:00:00Z' }, annotations: {} })
+          : Promise.resolve(null),
+      );
+      const kbLocal = createMockKb({ viewsGet: viewGet });
+      (kbLocal as any).vectors = {
+        searchResources: vi.fn().mockResolvedValue([{ resourceId: 'res-sem', score: 0.9 }]),
+      };
+      const embeddingProvider = { embed: vi.fn().mockResolvedValue([0.1, 0.2]) } as any;
+      const localMatcher = new Matcher(kbLocal, localBus, mockLogger, noopInference, embeddingProvider);
+      await localMatcher.initialize();
+
+      try {
+        const resultPromise = localBus.get('match:search-results').pipe(take(1)).toPromise();
+        localBus.get('match:search-requested').next({
+          resourceId: 'test-resource',
+          correlationId: 'corr-sem-lag',
+          referenceId: 'ref-sem-lag',
+          context: makeContext({ selected: { before: '', text: 'something', after: '' } }),
+        });
+
+        const result = await resultPromise;
+        expect(result!.response.find((r: any) => r.name === 'Semantic Lag')).toBeDefined();
+        expect(mockLogger.info).toHaveBeenCalledWith('[graph lag] semantic candidates hydrated from view', { count: 1 });
+      } finally {
+        await localMatcher.stop();
+        localBus.destroy();
+      }
     });
 
     it('counts missing-view citers in citedByCount (P4 (ii)=A delta)', async () => {

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -124,12 +124,13 @@ interface MockGraphOverrides {
   getResourceReferencedBy?: ReturnType<typeof vi.fn>;
   getResource?: ReturnType<typeof vi.fn>;
   listResources?: ReturnType<typeof vi.fn>;
+  viewsGet?: ReturnType<typeof vi.fn>;
 }
 
 function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
   return {
     eventStore: {} as any,
-    views: {} as any,
+    views: { get: overrides.viewsGet ?? vi.fn().mockResolvedValue(null) } as any,
     content: {} as any,
     projectionsDir: '',
       weaveProgress: {} as any,
@@ -241,6 +242,7 @@ describe('Matcher', () => {
     let mockSearchFn2: ReturnType<typeof vi.fn>;
     let mockListResources: ReturnType<typeof vi.fn>;
     let mockGetResource: ReturnType<typeof vi.fn>;
+    let mockViewGet: ReturnType<typeof vi.fn>;
 
     const RES_A = { '@id': 'res-a', name: 'Alpha', dateCreated: '2026-01-01T00:00:00Z' };
     const RES_B = { '@id': 'res-b', name: 'Beta', dateCreated: '2026-01-15T00:00:00Z' };
@@ -255,10 +257,12 @@ describe('Matcher', () => {
       mockSearchFn2 = vi.fn().mockResolvedValue([]);
       mockListResources = vi.fn().mockResolvedValue({ resources: [], total: 0 });
       mockGetResource = vi.fn().mockResolvedValue(null);
+      mockViewGet = vi.fn().mockResolvedValue(null);
       kb = createMockKb({
         searchResources: mockSearchFn2,
         listResources: mockListResources,
         getResource: mockGetResource,
+        viewsGet: mockViewGet,
       });
       matcher = new Matcher(kb, eventBus, mockLogger, noopInference);
       await matcher.initialize();
@@ -426,6 +430,37 @@ describe('Matcher', () => {
       expect(result!.response.length).toBeGreaterThanOrEqual(1);
       const gamma = result!.response.find((r: any) => r.name === 'Gamma');
       expect(gamma).toBeDefined();
+    });
+
+    it('hydrates a graph-lagging neighborhood candidate from the view instead of dropping it', async () => {
+      // graph-read-after-write-coverage.md P2: the connection endpoint was
+      // just created — its node isn't woven yet, but the view (the fresher
+      // projection) has the descriptor. The candidate must not be dropped.
+      mockSearchFn2.mockResolvedValue([]);
+      mockGetResource.mockResolvedValue(null); // graph lags for everyone
+      mockViewGet.mockImplementation((id: any) =>
+        String(id) === 'res-lag'
+          ? Promise.resolve({ resource: { '@id': 'res-lag', name: 'Lagging Endpoint', dateCreated: '2026-07-13T00:00:00Z' }, annotations: {} })
+          : Promise.resolve(null),
+      );
+
+      const resultPromise = eventBus.get('match:search-results').pipe(take(1)).toPromise();
+
+      eventBus.get('match:search-requested').next({
+        resourceId: 'test-resource',
+        correlationId: 'test-corr-lag',
+        referenceId: 'ref-lag',
+        context: makeContext({
+          selected: { before: '', text: 'something', after: '' },
+          graph: buildGraph({
+            connections: [{ resourceId: 'res-lag', resourceName: 'Lagging Endpoint', bidirectional: false }],
+          }),
+        }),
+      });
+
+      const result = await resultPromise;
+      const lagging = result!.response.find((r: any) => r.name === 'Lagging Endpoint');
+      expect(lagging).toBeDefined();
     });
 
     it('counts missing-view citers in citedByCount (P4 (ii)=A delta)', async () => {

--- a/packages/make-meaning/src/annotation-context.ts
+++ b/packages/make-meaning/src/annotation-context.ts
@@ -212,6 +212,8 @@ export class AnnotationContext {
     const views = deriveViews(graph, String(resourceId), annotationId);
 
     // Global IDF statistic — not graph-derivable, stays in metadata (D4).
+    // Eventually consistent BY DESIGN (graph-read-after-write-coverage.md,
+    // mechanism (d)): a corpus-wide frequency is semantically stale-tolerant.
     const entityTypeStats = await kb.graph.getEntityTypeStats();
     const entityTypeFrequencies: Record<string, number> = {};
     for (const stat of entityTypeStats) {

--- a/packages/make-meaning/src/browser.ts
+++ b/packages/make-meaning/src/browser.ts
@@ -31,6 +31,7 @@ import { getExactText, getTargetSource, getTargetSelector, getResourceEntityType
 import { EventQuery } from '@semiont/event-sourcing';
 import type { ViewStorage } from '@semiont/event-sourcing';
 import type { KnowledgeBase } from './knowledge-base';
+import { resourceWithViewGrace } from './graph-read-grace';
 import { readEntityTypesProjection } from './views/entity-types-reader';
 import { readTagSchemasProjection } from './views/tag-schemas-reader';
 import { AnnotationContext } from './annotation-context';
@@ -316,17 +317,32 @@ export class Browser {
         motivation: event.motivation || 'all',
       });
 
+      // The inbound edge query is eventually consistent BY DESIGN
+      // (graph-read-after-write-coverage.md, mechanism (d)): the racing
+      // write lives in the CITING resource's stream, so no per-resource
+      // wait key exists here — and every consumer sits behind the SDK's
+      // referencedBy cache, whose staleness window dwarfs the Weaver's
+      // ~tens-of-ms apply lag. A just-woven edge appears on the next read.
       const references = await this.kb.graph.getResourceReferencedBy(resourceId(event.resourceId), event.motivation);
 
       const sourceIds = [...new Set(references.map(ref => getTargetSource(ref.target)))];
-      const resources = await Promise.all(sourceIds.map(id => this.kb.graph.getResource(resourceId(id))));
+      // Citer hydration IS id-keyed: graph-first with view fallback
+      // (mechanism (b′)) — a woven edge whose endpoint isn't woven yet must
+      // not render "Untitled Resource"; the view holds the fresher descriptor.
+      const resolved = await Promise.all(
+        sourceIds.map(id => resourceWithViewGrace(this.kb, resourceId(id))),
+      );
 
+      const docMap = new Map(
+        resolved.filter(r => r.resource !== null).map(r => [r.resource!['@id'], r.resource!]),
+      );
       for (let i = 0; i < sourceIds.length; i++) {
-        if (resources[i] === null) {
-          this.logger.warn('Referenced resource not found in graph', { resourceId: sourceIds[i] });
+        if (resolved[i].laggedBehindView) {
+          this.logger.info('[graph lag] citer hydrated from view', { resourceId: sourceIds[i] });
+        } else if (resolved[i].resource === null) {
+          this.logger.warn('Referenced resource not found in graph or view', { resourceId: sourceIds[i] });
         }
       }
-      const docMap = new Map(resources.filter(doc => doc !== null).map(doc => [doc['@id'], doc]));
 
       const referencedBy = references.map(ref => {
         const targetSource = getTargetSource(ref.target);

--- a/packages/make-meaning/src/graph-read-grace.ts
+++ b/packages/make-meaning/src/graph-read-grace.ts
@@ -1,0 +1,41 @@
+/**
+ * Single-resource read-after-write grace for graph consumers
+ * (bugs/graph-read-after-write-coverage.md).
+ *
+ * Graph-first, VIEW-fallback: when an id-keyed `kb.graph.getResource` read
+ * misses (or the store hiccups) but the resource exists in the view, the
+ * caller is racing the Weaver's apply — and the view is the FRESHER
+ * projection, already holding the full `ResourceDescriptor` these call
+ * sites need. No waiting and no retry loops: a bounded backoff inside a
+ * candidate loop would multiply into seconds, while the fallback is one
+ * read of a projection that is already correct.
+ *
+ * This is the "third instance" shared helper GRAPH-PROJECTION-SYNC
+ * anticipated. It deliberately does NOT replace `buildKnowledgeGraph`'s
+ * barrier + bounded retry: traversal needs the node IN the graph — a
+ * fallback descriptor cannot serve edges.
+ *
+ * `laggedBehindView` is the L4 breadcrumb hook — callers log it, so
+ * degradation is observable, never silent.
+ */
+
+import type { ResourceDescriptor, ResourceId } from '@semiont/core';
+import type { KnowledgeBase } from './knowledge-base.js';
+
+export interface GracedResource {
+  resource: ResourceDescriptor | null;
+  laggedBehindView: boolean;
+}
+
+export async function resourceWithViewGrace(
+  kb: KnowledgeBase,
+  rid: ResourceId,
+): Promise<GracedResource> {
+  const fromGraph = await kb.graph.getResource(rid).catch(() => null);
+  if (fromGraph) return { resource: fromGraph, laggedBehindView: false };
+
+  const view = await kb.views.get(rid);
+  if (view) return { resource: view.resource, laggedBehindView: true };
+
+  return { resource: null, laggedBehindView: false };
+}

--- a/packages/make-meaning/src/matcher.ts
+++ b/packages/make-meaning/src/matcher.ts
@@ -20,6 +20,7 @@ import { withActorSpan } from '@semiont/observability';
 import type { InferenceClient } from '@semiont/inference';
 import type { EmbeddingProvider, VectorSearchResult } from '@semiont/vectors';
 import type { KnowledgeBase } from './knowledge-base';
+import { resourceWithViewGrace } from './graph-read-grace';
 
 /** The annotation branch of the unified GatheredContext — the only focus the matcher serves. */
 type AnnotationFocus = Extract<GatheredContext['focus'], { kind: 'annotation' }>;
@@ -130,7 +131,12 @@ export class Matcher {
     const views = deriveViews(context.graph, mainResourceId);
     const connections = views.connections;
 
-    // 1. Multi-source candidate retrieval (parallel)
+    // 1. Multi-source candidate retrieval (parallel).
+    // The set-shaped sources (name search, entity-type listing) are
+    // eventually consistent BY DESIGN (graph-read-after-write-coverage.md,
+    // mechanism (d)): there is no key to await for "all resources matching
+    // this search", and multi-source retrieval absorbs a just-created
+    // resource missing from one source for the Weaver's ~tens-of-ms lag.
     const [nameMatches, entityTypeMatches, semanticMatches] = await Promise.all([
       this.kb.graph.searchResources(searchTerm),
       annotationEntityTypes.length > 0
@@ -141,12 +147,18 @@ export class Matcher {
       this.searchVectors(searchTerm),
     ]);
 
-    // 3. Graph neighborhood candidates — fetch full resources for connection IDs
-    const neighborResources = await Promise.all(
-      connections.map(conn =>
-        this.kb.graph.getResource(resourceId(conn.resourceId)).catch(() => null)
-      ),
+    // 3. Graph neighborhood candidates — id-keyed hydration: graph-first
+    // with view fallback (mechanism (b′)). A just-created endpoint must not
+    // be dropped while the Weaver lags; retrying here would multiply across
+    // the candidate loop, and the view already holds the descriptor.
+    const neighborResolved = await Promise.all(
+      connections.map(conn => resourceWithViewGrace(this.kb, resourceId(conn.resourceId))),
     );
+    const laggedNeighbors = neighborResolved.filter(r => r.laggedBehindView).length;
+    if (laggedNeighbors > 0) {
+      this.logger.info('[graph lag] neighborhood candidates hydrated from view', { count: laggedNeighbors });
+    }
+    const neighborResources = neighborResolved.map(r => r.resource);
 
     // Union and deduplicate by resource ID
     const candidateMap = new Map<string, {
@@ -171,12 +183,19 @@ export class Matcher {
       if (r) addCandidate(r, 'neighborhood');
     }
 
-    // Semantic matches need to be resolved to full resources from the graph
+    // Semantic matches resolve to full resources — same id-keyed hydration
+    // with view fallback (mechanism (b′)): a vector hit can precede the
+    // Weaver's apply, and dropping it would silently shrink recall.
     const semanticScores = new Map<string, number>();
+    let laggedSemantic = 0;
     for (const sm of semanticMatches) {
       semanticScores.set(sm.resourceId, sm.score);
-      const resource = await this.kb.graph.getResource(resourceId(sm.resourceId)).catch(() => null);
+      const { resource, laggedBehindView } = await resourceWithViewGrace(this.kb, resourceId(sm.resourceId));
+      if (laggedBehindView) laggedSemantic++;
       if (resource) addCandidate(resource, 'semantic');
+    }
+    if (laggedSemantic > 0) {
+      this.logger.info('[graph lag] semantic candidates hydrated from view', { count: laggedSemantic });
     }
 
     this.logger.debug('Candidate retrieval', {

--- a/packages/make-meaning/src/resource-context.ts
+++ b/packages/make-meaning/src/resource-context.ts
@@ -41,6 +41,10 @@ export class ResourceContext {
    */
   static async listResources(filters: ListResourcesFilters | undefined, kb: KnowledgeBase): Promise<ResourceDescriptor[]> {
     if (filters?.search) {
+      // Set-shaped graph read — eventually consistent BY DESIGN
+      // (graph-read-after-write-coverage.md, mechanism (d)): no key to
+      // await, human-timescale browse; a just-created resource appears in
+      // search after the Weaver's ~tens-of-ms apply.
       const matches = await kb.graph.searchResources(filters.search);
       const filtered = filters.archived !== undefined
         ? matches.filter((doc) => doc.archived === filters.archived)


### PR DESCRIPTION
# Pull Request

## Description

The **graph read-after-write sweep**: after GRAPH-PROJECTION-SYNC fixed the
diagnosed gather race and built the `whenApplied` barrier, the barrier had
exactly one consumer — every other `kb.graph.*` reader still read the
projection ungated and could race the Weaver the same way gather did. This PR
audits the whole class and gives **every graph reader an assigned, implemented
read-after-write posture** (spec/ledger: `.plans/bugs/graph-read-after-write-coverage.md`,
untracked per house convention; the per-reader posture table now lives in
`.plans/GRAPH-PROJECTION-SYNC.md`).

### What the audit found (P0 — it overturned the filed guesses)

- **The filed HIGH risk (backlinks) downgraded, on evidence.** The inbound
  edge query is *keyless* — the racing write lives in the CITING resource's
  stream, so neither `whenApplied` nor a view cross-check has anything to wait
  on. And no consumer anywhere does mint-then-read-backlinks: the SDK's
  `referencedBy` cache invalidates only on `bus:resume-gap` (never on
  annotation create), and a direct search of every named candidate — the full
  semiont-*-kb skill fleet and my-chat — found **zero `referencedBy` consumers
  at all**. Accepted as eventually consistent, documented in place.
- **The real live defect was hiding in the same handler:** the per-citer
  `getResource` hydration races today — a woven edge with an unwoven endpoint
  renders **"Untitled Resource"**. User-visible, id-keyed, fixable.

### The mechanism: view-fallback, not retry

New shared helper `graph-read-grace.ts` (`resourceWithViewGrace`): graph-first,
**view-fallback** — for id-keyed descriptor reads, the view is the *fresher*
projection and already holds the full descriptor these sites need. No waiting,
no dropped candidates, and no 375 ms backoffs multiplying inside candidate
loops (which ruled out the P1-style retry here). This is the "third instance"
shared helper GRAPH-PROJECTION-SYNC anticipated. The barrier + bounded retry
stay exclusive to `buildKnowledgeGraph`, where traversal genuinely needs the
node in the graph.

Converted sites, each logging a `[graph lag]` breadcrumb (L4: degradation
observable, never silent — and the breadcrumbs are **asserted in specs**, not
decoration):

- `browser.ts` referenced-by **citer hydration** (kills the Untitled artifact)
- `matcher.ts` **neighborhood** and **semantic** candidate hydrations (a
  just-created endpoint / fresh vector hit is no longer silently dropped)

Accept-documented sites, each with a mechanism comment stating *why* eventual
consistency is the contract: the referenced-by edge query, matcher name-search
and entity-type listing (multi-source retrieval absorbs), resource search
(human-timescale), entity-type IDF stats (stale-tolerant corpus statistic).

### One deliberate contract change

A single citer's store hiccup no longer fails the entire references reply — the
helper absorbs the per-citer error and degrades that entry (view fallback, else
Untitled). An **edge-query** failure still fails the request (its spec is
unchanged). The old spec pinning whole-request failure was rewritten to the new
contract.

### Hardened by review

An "is this actually done?" pass closed three gaps before this PR: the
adjacency search was extended to the named external candidates (fleet +
my-chat — the decisive zero-consumers result above), breadcrumb assertions were
added to the lag specs, and the semantic loop got its own pin (full bus flow
with vectors/embedding mocks) instead of relying on call-shape similarity.

## Type of Change

- [x] Bug fix (the "Untitled Resource" artifact; silently dropped candidates)
- [x] Code refactoring

## Areas Changed

Only `packages/make-meaning` (browser, matcher, resource/annotation contexts,
the new helper, and their tests).

## Security Checklist

Not applicable — no authentication, authorization, or admin surface touched.

## Verification

- RED-first: helper unit specs + both call-site specs observed failing pre-fix
  (candidate dropped; Untitled rendered); all pre-existing specs green
  throughout.
- Final: build + full workspace `tsc --noEmit` clean; make-meaning 38 files /
  460 passed + 3 expected-fail (the weaver-axioms trackers, unrelated);
  touched suites 58/58 after the review-round additions (node:24 container).

## Out of scope, with named owners

W1-strict (rebuild racing live traffic — pinned `it.fails` in the weaver
axioms ledger, tracked via #845), split-topology e2e (Local Testing), and the
vector-projection sibling (prospective SMELTER-INDEX-SYNC).
