### PR TITLE
smelter index sync: smelt:settled signal + gather read-your-writes barrier (S14)

### DIFF
--- a/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
+++ b/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
@@ -26,6 +26,7 @@ export function stubKnowledgeBase(overrides: Partial<KnowledgeBase> = {}): Knowl
     content:        { store: vi.fn(), retrieve: vi.fn() } as unknown as KnowledgeBase['content'],
     graph:          {} as KnowledgeBase['graph'],
     weaveProgress: { dispose: vi.fn() } as unknown as KnowledgeBase['weaveProgress'],
+    smeltProgress: { settledAt: vi.fn(), whenSettled: vi.fn(async () => 'inert' as const), dispose: vi.fn() } as unknown as KnowledgeBase['smeltProgress'],
     projectionsDir: '',
     ...overrides,
   };

--- a/apps/backend/src/__tests__/integration/annotation-crud.test.ts
+++ b/apps/backend/src/__tests__/integration/annotation-crud.test.ts
@@ -35,7 +35,7 @@ describe('Annotation CRUD Integration Tests - W3C multi-body annotation', () => 
 
     // Create KnowledgeBase for AnnotationContext calls
     const viewStorage = new FilesystemViewStorage(project);
-    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaveProgress: {} as any };
+    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, projectionsDir: '', weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
 
     // Create test resources in event store
     const eventStore = createEventStore(project, new EventBus(), mockLogger);

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -376,6 +376,16 @@ export type EventMap = {
    */
   'weave:applied': { resourceId: string; sequenceNumber: number };
 
+  // Signal — the vector projection's per-resource decision report: emitted
+  // by the Smelter after indexing a resource's content ('indexed') or after
+  // deciding not to ('skipped': media gate, empty text). Keyed by the
+  // checksum of the bytes inspected — "settled at C" is read-your-writes for
+  // exactly that content. NEVER emitted on transient failures: an error is not
+  // a decision (SMELTER-INDEX-SYNC A2). Consumed by the backend-local
+  // `SmeltProgress` fold behind the gather-side barrier. This is the
+  // Smelter's single outbound signal (SMELTER-AXIOMS D3, as amended).
+  'smelt:settled': { resourceId: string; contentChecksum: string; outcome: 'indexed' | 'skipped' };
+
   // Command — rebuild the graph projection from the event log (full when
   // resourceId is absent, one resource when present). Served by the Weaver;
   // replaces direct `rebuildAll()`/`rebuildResource()` access, which does
@@ -669,6 +679,7 @@ export const CHANNEL_SCHEMAS = {
 
   // ── WEAVE FLOW ──────────────────────────────────────────────────
   'weave:applied':                    null, // { resourceId; sequenceNumber }
+  'smelt:settled':                    null, // { resourceId; contentChecksum; outcome }
   'weave:rebuild':                    'WeaveRebuildCommand',
   'weave:rebuild-ok':                 null, // { correlationId }
   'weave:rebuild-failed':             null, // { correlationId; message }

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -78,7 +78,7 @@ describe('AnnotationContext', () => {
       content: new WorkingTreeStore(project, mockLogger),
       graph: mockGraphDb,
       projectionsDir: project.projectionsDir,
-      weaveProgress: {} as any,
+      weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
     };
   });
 

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -95,7 +95,7 @@ describe('AnnotationOperations', () => {
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     const { WorkingTreeStore } = await import('@semiont/content');
     const repStore = new WorkingTreeStore(project, mockLogger);
-    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any };
+    kb = { eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/gatherer.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer.test.ts
@@ -49,7 +49,7 @@ function createMockKb(): KnowledgeBase {
     content: {} as any,
     graph: {} as any,
     projectionsDir: '',
-      weaveProgress: {} as any,
+      weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
   };
 }
 
@@ -167,6 +167,7 @@ describe('Gatherer', () => {
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
         mockInferenceClient,
+        expect.anything(), // the gatherer's logger — breadcrumb sink for the P2 barrier
       );
     });
 

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -30,7 +30,7 @@ describe('GraphContext', () => {
     content: {} as any,
     graph: mockGraphDb as any,
     projectionsDir: '',
-    weaveProgress: mockWeaveProgress as any,
+    weaveProgress: mockWeaveProgress as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
   };
 
   it('should get backlinks for a resource', async () => {

--- a/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
+++ b/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
@@ -145,11 +145,14 @@ export function createMockContentTransport(
 /**
  * BusRequestPrimitive serving the browse RPC channels from a fake catalog,
  * with the same correlationId request/reply protocol the Browser actor uses.
+ * Every emit is also recorded in `emitted` (browse requests included —
+ * filter by channel in assertions), so tests can observe the Smelter's
+ * outbound signals (`smelt:settled`).
  */
 export function createFakeKsBus(
   resources: ResourceDescriptor[],
   annotationsByResource: Map<string, Annotation[]> = new Map(),
-): BusRequestPrimitive {
+): BusRequestPrimitive & { emitted: Array<{ channel: string; payload: Record<string, unknown> }> } {
   const channels = new Map<string, Subject<Record<string, unknown>>>();
   const channel = (name: string): Subject<Record<string, unknown>> => {
     let subject = channels.get(name);
@@ -159,10 +162,13 @@ export function createFakeKsBus(
     }
     return subject;
   };
+  const emitted: Array<{ channel: string; payload: Record<string, unknown> }> = [];
 
   return {
+    emitted,
     async emit<K extends keyof EventMap>(name: K, payload: EventMap[K]): Promise<void> {
       const request = payload as Record<string, unknown>;
+      emitted.push({ channel: name as string, payload: request });
       if (name === 'browse:resources-requested') {
         const offset = (request.offset as number | undefined) ?? 0;
         const limit = (request.limit as number | undefined) ?? 50;

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -15,14 +15,15 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { LLMContext } from '../llm-context';
+import { LLMContext, SMELT_SETTLE_TIMEOUT_MS } from '../llm-context';
 import { ResourceOperations } from '../resource-operations';
 import { AnnotationOperations } from '../annotation-operations';
 import { resourceId, annotationId, userId, EventBus, type Logger, type SupportedMediaType } from '@semiont/core';
 import type { GraphServiceConfig, GatheredContext } from '@semiont/core';
 import { createEventStore, type EventStore } from '@semiont/event-sourcing';
-import { WorkingTreeStore, deriveStorageUri } from '@semiont/content';
+import { WorkingTreeStore, deriveStorageUri, calculateChecksum } from '@semiont/content';
 import type { KnowledgeBase } from '../knowledge-base';
+import { createSmeltProgress } from '../smelt-progress';
 import { Stower } from '../stower';
 import { createTestProject } from './helpers/test-project';
 
@@ -95,7 +96,7 @@ describe('LLM Context', () => {
     // Create KnowledgeBase - share event store's view storage to avoid separate instances
     const { getGraphDatabase } = await import('@semiont/graph');
     const graphDb = await getGraphDatabase(graphConfig);
-    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any };
+    kb = { eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
 
     // Start Stower
     stower = new Stower(kb, eventBus, project, mockLogger);
@@ -138,7 +139,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).resource).toBeDefined();
@@ -151,7 +153,8 @@ describe('LLM Context', () => {
           resourceId('non-existent-resource'),
           { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
           kb,
-          mockClient
+          mockClient,
+          mockLogger
         )
       ).rejects.toThrow('Resource not found');
     });
@@ -161,7 +164,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       const related = result.graph.nodes.filter((n) => n.type === 'resource' && n.id !== testResourceId);
@@ -213,7 +217,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       const annotationNodes = result.graph.nodes.filter((n) => n.type === 'annotation');
@@ -227,7 +232,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(result.graph).toBeDefined();
@@ -242,7 +248,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       const mainResourceNode = result.graph.nodes.find(n => n.id === testResourceId);
@@ -256,7 +263,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).content?.main).toBeDefined();
@@ -268,7 +276,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).content?.main).toBeUndefined();
@@ -279,7 +288,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).content?.related).toBeDefined();
@@ -291,7 +301,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).content?.related).toBeUndefined();
@@ -306,7 +317,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: true },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).summary).toBeDefined();
@@ -318,7 +330,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).summary).toBeUndefined();
@@ -329,7 +342,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: true },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).summary).toBeUndefined();
@@ -347,7 +361,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).suggestedReferences).toBeDefined();
@@ -359,7 +374,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).suggestedReferences).toBeUndefined();
@@ -372,7 +388,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 5, includeContent: true, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       // The graph is the full neighborhood; maxResources caps the related-resource *content*
@@ -386,7 +403,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 1, includeContent: false, includeSummary: false },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).resource).toBeDefined();
@@ -404,7 +422,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 2, maxResources: 50, includeContent: true, includeSummary: true },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       expect(resFocus(result).resource).toBeDefined();
@@ -428,7 +447,8 @@ describe('LLM Context', () => {
         resourceId(testResourceId),
         { depth: 1, maxResources: 20, includeContent: true, includeSummary: true },
         kb,
-        mockClient
+        mockClient,
+        mockLogger
       );
 
       // Verify all major components are present
@@ -471,7 +491,7 @@ describe('LLM Context', () => {
     }
 
     it('populates semanticContext from searchByResource', async () => {
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient, mockLogger);
       expect(ctx.semanticContext?.similar.map((s) => s.resourceId).sort()).toEqual(['r-answer', 'r-question']);
     });
 
@@ -482,6 +502,7 @@ describe('LLM Context', () => {
         { ...baseOpts, excludeEntityTypes: ['Question'] },
         kbWithVectors((o) => { seen = o; }),
         mockClient,
+        mockLogger,
       );
       expect(seen.filter.excludeEntityTypes).toEqual(['Question']);             // filter forwarded
       expect(ctx.semanticContext?.similar.map((s) => s.resourceId)).toEqual(['r-answer']); // Question omitted
@@ -489,13 +510,105 @@ describe('LLM Context', () => {
     });
 
     it('records no excludedEntityTypes when no exclusion is applied', async () => {
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient, mockLogger);
       expect(ctx.semanticContext?.excludedEntityTypes).toBeUndefined();
     });
 
     it('leaves semanticContext absent when no vector store is configured', async () => {
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kb, mockClient);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kb, mockClient, mockLogger);
       expect(ctx.semanticContext).toBeUndefined();
+    });
+  });
+
+  describe('semanticContext read-your-writes barrier (SMELTER-INDEX-SYNC P2)', () => {
+    const baseOpts = { depth: 1, maxResources: 5, includeContent: false, includeSummary: false };
+    const hit = [{ id: 'r-sim#0', score: 0.9, resourceId: 'r-sim', text: 'similar text', entityTypes: [] }];
+    // The focal resource's content generation — what the barrier waits on (D2).
+    const TEST_CHECKSUM = calculateChecksum('This is test content for LLM context building.');
+
+    // A vector store that has no focal vectors until the "Smelter" applies,
+    // plus a real SmeltProgress fold on a test-driven bus: the delayed-Smelter
+    // harness ("projection-lag grace" pattern).
+    function lagKb(progressBus: EventBus, state: { indexed: boolean }): { lagged: KnowledgeBase; searches: () => number } {
+      const searchByResource = vi.fn(async () => (state.indexed ? hit : []));
+      const lagged: KnowledgeBase = {
+        ...kb,
+        smeltProgress: createSmeltProgress(progressBus),
+        vectors: { searchByResource } as unknown as KnowledgeBase['vectors'],
+      };
+      return { lagged, searches: () => searchByResource.mock.calls.length };
+    }
+
+    it('populates semanticContext once the Smelter settles — event-driven, within the barrier', async () => {
+      const progressBus = new EventBus();
+      const state = { indexed: false };
+      const { lagged } = lagKb(progressBus, state);
+
+      const pending = LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, mockLogger);
+      setTimeout(() => {
+        state.indexed = true;
+        progressBus.get('smelt:settled').next({ resourceId: testResourceId, contentChecksum: TEST_CHECKSUM, outcome: 'indexed' });
+      }, 50);
+
+      const ctx = await pending;
+      expect(ctx.semanticContext?.similar.map((s) => s.resourceId)).toEqual(['r-sim']);
+    });
+
+    it('resolves immediately for skipped resources — no timeout tax, no re-search', async () => {
+      const progressBus = new EventBus();
+      const state = { indexed: false };
+      const { lagged, searches } = lagKb(progressBus, state);
+      progressBus.get('smelt:settled').next({ resourceId: testResourceId, contentChecksum: TEST_CHECKSUM, outcome: 'skipped' });
+
+      const started = Date.now();
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, mockLogger);
+      expect(ctx.semanticContext).toBeUndefined();
+      expect(Date.now() - started).toBeLessThan(2000);
+      expect(searches()).toBe(1);
+    });
+
+    it('degrades on timeout: semanticContext absent + exactly one breadcrumb', async () => {
+      const progressBus = new EventBus(); // never settles
+      const state = { indexed: false };
+      const { lagged, searches } = lagKb(progressBus, state);
+      const degradeLogger: Logger = {
+        debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => degradeLogger),
+      };
+
+      // Fake only setTimeout: the barrier's timer must be advanceable while
+      // real I/O (view + graph reads in the gather prelude) still progresses.
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        const pending = LLMContext.getResourceContext(
+          resourceId(testResourceId), baseOpts, lagged, mockClient, degradeLogger,
+        );
+        // The barrier's timer is scheduled only after the I/O prelude
+        // completes, so advance in slices with a REAL macrotask yield between
+        // them (setImmediate is unfaked) — pure microtask loops starve I/O.
+        for (let elapsed = 0; elapsed < SMELT_SETTLE_TIMEOUT_MS + 5000; elapsed += 1000) {
+          await new Promise((resolve) => setImmediate(resolve));
+          await vi.advanceTimersByTimeAsync(1000);
+        }
+        const ctx = await pending;
+
+        expect(ctx.semanticContext).toBeUndefined();
+        const breadcrumbs = (degradeLogger.warn as ReturnType<typeof vi.fn>).mock.calls
+          .filter(([message]) => String(message).includes('[gather DEGRADED]'));
+        expect(breadcrumbs).toHaveLength(1);
+        expect(searches()).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('probes before waiting — already-indexed resources never touch the barrier', async () => {
+      const progressBus = new EventBus(); // never signaled: a cold fold
+      const state = { indexed: true };
+      const { lagged, searches } = lagKb(progressBus, state);
+
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, mockLogger);
+      expect(ctx.semanticContext?.similar.map((s) => s.resourceId)).toEqual(['r-sim']);
+      expect(searches()).toBe(1);
     });
   });
 });

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -133,7 +133,7 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
     views: { get: overrides.viewsGet ?? vi.fn().mockResolvedValue(null) } as any,
     content: {} as any,
     projectionsDir: '',
-      weaveProgress: {} as any,
+      weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
     graph: {
       searchResources: overrides.searchResources ?? vi.fn().mockResolvedValue([]),
       getResourceReferencedBy: overrides.getResourceReferencedBy ?? vi.fn().mockResolvedValue([]),

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -48,7 +48,7 @@ describe('ResourceContext', () => {
       content: mockRepStore,
       graph: mockGraph,
       projectionsDir: '',
-      weaveProgress: {} as any,
+      weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
     };
   });
 

--- a/packages/make-meaning/src/__tests__/smelt-progress.test.ts
+++ b/packages/make-meaning/src/__tests__/smelt-progress.test.ts
@@ -1,0 +1,101 @@
+/**
+ * SmeltProgress Tests (SMELTER-INDEX-SYNC P1, D1 = push barrier)
+ *
+ * The backend-local fold of `smelt:settled` signals. `whenSettled` is the
+ * read-your-writes barrier: it resolves with the Smelter's decision
+ * (`indexed` | `skipped`) the moment the vector projection settles the
+ * exact content generation the caller holds — event-driven, no polling
+ * quantum — and rejects with a distinct error on the bounded timeout so
+ * callers degrade observably (one L4 breadcrumb).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@semiont/core';
+import { assertStateUnitAxioms } from '@semiont/core/testing';
+import { createSmeltProgress, SmeltProgressTimeout } from '../smelt-progress';
+
+describe('SmeltProgress', () => {
+  it('resolves immediately when the fold already holds the settlement', async () => {
+    const bus = new EventBus();
+    const progress = createSmeltProgress(bus);
+    bus.get('smelt:settled').next({ resourceId: 'res-1', contentChecksum: 'cs-a', outcome: 'indexed' });
+
+    await expect(progress.whenSettled('res-1', 'cs-a', 1000)).resolves.toBe('indexed');
+    expect(progress.settledAt('res-1')).toEqual({ contentChecksum: 'cs-a', outcome: 'indexed' });
+
+    progress.dispose();
+  });
+
+  it('resolves when the signal arrives while waiting — event-driven, not polled', async () => {
+    const bus = new EventBus();
+    const progress = createSmeltProgress(bus);
+
+    const wait = progress.whenSettled('res-1', 'cs-a', 1000);
+    bus.get('smelt:settled').next({ resourceId: 'res-1', contentChecksum: 'cs-a', outcome: 'indexed' });
+
+    await expect(wait).resolves.toBe('indexed');
+    progress.dispose();
+  });
+
+  it('resolves skipped decisions — never-embeddable resources do not eat the timeout', async () => {
+    const bus = new EventBus();
+    const progress = createSmeltProgress(bus);
+
+    const wait = progress.whenSettled('res-pdf', 'cs-pdf', 1000);
+    bus.get('smelt:settled').next({ resourceId: 'res-pdf', contentChecksum: 'cs-pdf', outcome: 'skipped' });
+
+    await expect(wait).resolves.toBe('skipped');
+    progress.dispose();
+  });
+
+  it('a settlement at a different checksum does not resolve the waiter; the matching one does', async () => {
+    const bus = new EventBus();
+    const progress = createSmeltProgress(bus);
+
+    const wait = progress.whenSettled('res-1', 'cs-new', 1000);
+    bus.get('smelt:settled').next({ resourceId: 'res-1', contentChecksum: 'cs-old', outcome: 'indexed' });
+    bus.get('smelt:settled').next({ resourceId: 'res-other', contentChecksum: 'cs-new', outcome: 'indexed' });
+    bus.get('smelt:settled').next({ resourceId: 'res-1', contentChecksum: 'cs-new', outcome: 'indexed' });
+
+    await expect(wait).resolves.toBe('indexed');
+    progress.dispose();
+  });
+
+  it('the latest settlement wins — a new content generation replaces the fold entry', async () => {
+    const bus = new EventBus();
+    const progress = createSmeltProgress(bus);
+
+    bus.get('smelt:settled').next({ resourceId: 'res-1', contentChecksum: 'cs-v1', outcome: 'indexed' });
+    bus.get('smelt:settled').next({ resourceId: 'res-1', contentChecksum: 'cs-v2', outcome: 'skipped' });
+
+    expect(progress.settledAt('res-1')).toEqual({ contentChecksum: 'cs-v2', outcome: 'skipped' });
+    progress.dispose();
+  });
+
+  it('rejects with the distinct timeout error when no matching settlement comes', async () => {
+    const bus = new EventBus();
+    const progress = createSmeltProgress(bus);
+
+    await expect(progress.whenSettled('res-ghost', 'cs-x', 20)).rejects.toBeInstanceOf(SmeltProgressTimeout);
+    progress.dispose();
+  });
+
+  it('dispose resolves pending waiters inert — shutdown never throws through a gather', async () => {
+    const bus = new EventBus();
+    const progress = createSmeltProgress(bus);
+
+    const wait = progress.whenSettled('res-1', 'cs-a', 60_000);
+    progress.dispose();
+
+    await expect(wait).resolves.toBe('inert');
+  });
+
+  describe('StateUnit axioms', () => {
+    it('satisfies the StateUnit axioms', () => {
+      assertStateUnitAxioms({
+        setup: () => createSmeltProgress(new EventBus()),
+        invocations: (u) => [() => u.settledAt('res-1')],
+      });
+    });
+  });
+});

--- a/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
@@ -266,6 +266,8 @@ interface Harness {
   upsertCounts: Map<string, number>;
   setText: (rid: string, text: string) => void;
   ids: () => Promise<ModelIds>;
+  /** Latest `smelt:settled` signal per resource, as emitted on the bus (S14). */
+  settledSignals: () => Map<string, { contentChecksum: string; outcome: string }>;
   settle: () => Promise<void>;
   stop: () => void;
 }
@@ -322,6 +324,17 @@ async function makeHarness(opts: {
       resources: [...(await inner.listResourceStamps()).keys()].sort(),
       annotations: [...(await inner.listAnnotationIds())].sort(),
     }),
+    settledSignals: () => {
+      const latest = new Map<string, { contentChecksum: string; outcome: string }>();
+      for (const e of bus.emitted) {
+        if (e.channel !== 'smelt:settled') continue;
+        latest.set(String(e.payload.resourceId), {
+          contentChecksum: String(e.payload.contentChecksum),
+          outcome: String(e.payload.outcome),
+        });
+      }
+      return latest;
+    },
     settle: async (quietMs = 30, maxMs = 5000) => {
       const t0 = Date.now();
       for (;;) {
@@ -739,6 +752,45 @@ describe('Smelter axioms', () => {
         },
       ),
       { numRuns: 20 },
+    );
+  }, 30_000);
+
+  // S14 (FOPL): ∀ K, ∀ reachable r ∈ K delivered a create:
+  //   ∃! latest settled(r, checksum(r,K), outcome) ∧
+  //   outcome = indexed ⇔ gate(media(r)) ∧ text(r) non-empty, else skipped;
+  //   ∀ unreachable r (transient read failure): ∄ settled(r, ·) — an error
+  //   is not a decision (SMELTER-INDEX-SYNC A2). The projection always
+  //   states its decision; absence means only "not yet" or "failed".
+  it('S14: every decision is announced — settled(indexed|skipped) per (rid, checksum); never on failures', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        catalogArb.filter((c) => c.length > 0).chain((catalog) =>
+          fc.tuple(fc.constant(catalog), fc.subarray(catalog.map((e) => e.rid))),
+        ),
+        async ([catalog, failed]) => {
+          const failRids = new Set(failed);
+          const h = await makeHarness({ catalog, failRids });
+          try {
+            for (const e of catalog) h.events$.next({ type: 'yield:created', resourceId: e.rid, payload: {} });
+            await h.settle();
+
+            const signals = h.settledSignals();
+            for (const e of catalog) {
+              if (failRids.has(e.rid)) {
+                expect(signals.has(e.rid)).toBe(false);
+                continue;
+              }
+              expect(signals.get(e.rid)).toEqual({
+                contentChecksum: calculateChecksum(e.text),
+                outcome: embeds(e.mediaType) ? 'indexed' : 'skipped',
+              });
+            }
+          } finally {
+            h.stop();
+          }
+        },
+      ),
+      { numRuns: 25 },
     );
   }, 30_000);
 });

--- a/packages/make-meaning/src/__tests__/smelter.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter.test.ts
@@ -259,6 +259,76 @@ describe('Smelter mark:unarchived', () => {
   });
 });
 
+describe('Smelter smelt:settled signal', () => {
+  // SMELTER-INDEX-SYNC P1 — the settled signal is a decision report at
+  // existing decision points: 'indexed' after upsert, 'skipped' at the media
+  // gate / empty text, and NOTHING on transient failures (an error is not a
+  // decision — A2). Keyed by the checksum of the bytes inspected (D2).
+  function settledSignals(bus: { emitted: Array<{ channel: string; payload: Record<string, unknown> }> }) {
+    return bus.emitted.filter((e) => e.channel === 'smelt:settled').map((e) => e.payload);
+  }
+
+  async function harness(content: Map<string, string>, contentType = 'text/plain') {
+    const events$ = new Subject<SmelterEvent>();
+    const vectorStore = new MemoryVectorStore();
+    await vectorStore.connect();
+    const embeddingProvider = createMockEmbeddingProvider();
+    const bus = createFakeKsBus([...content.keys()].map((rid) => resourceDescriptor(rid, contentType)));
+    const smelter = new Smelter(
+      events$,
+      vectorStore,
+      embeddingProvider,
+      createMockContentTransport(content, contentType),
+      bus,
+      { chunkSize: 512, overlap: 64 },
+      { burstWindowMs: 50, maxBatchSize: 100, idleTimeoutMs: 200 },
+      mockLogger,
+    );
+    smelter.initialize();
+    return { events$, smelter, bus, embeddingProvider };
+  }
+
+  it('emits indexed with the content checksum after embedding', async () => {
+    const text = 'Content whose settlement is announced.';
+    const h = await harness(new Map([['res-sig', text]]));
+    try {
+      h.events$.next({ type: 'yield:created', resourceId: 'res-sig', payload: {} });
+      await tick();
+      expect(settledSignals(h.bus)).toEqual([
+        { resourceId: 'res-sig', contentChecksum: calculateChecksum(text), outcome: 'indexed' },
+      ]);
+    } finally {
+      h.smelter.stop();
+    }
+  });
+
+  it('emits skipped (with checksum) at the media gate, without an embedding call', async () => {
+    const bytes = 'not really a zip, but gated by media type';
+    const h = await harness(new Map([['res-zip', bytes]]), 'application/zip');
+    try {
+      h.events$.next({ type: 'yield:created', resourceId: 'res-zip', payload: {} });
+      await tick();
+      expect(settledSignals(h.bus)).toEqual([
+        { resourceId: 'res-zip', contentChecksum: calculateChecksum(bytes), outcome: 'skipped' },
+      ]);
+      expect(h.embeddingProvider.embedBatch).not.toHaveBeenCalled();
+    } finally {
+      h.smelter.stop();
+    }
+  });
+
+  it('never settles on transient failures — an error is not a decision', async () => {
+    const h = await harness(new Map());
+    try {
+      h.events$.next({ type: 'yield:created', resourceId: 'res-unreachable', payload: {} });
+      await tick();
+      expect(settledSignals(h.bus)).toEqual([]);
+    } finally {
+      h.smelter.stop();
+    }
+  });
+});
+
 describe('Smelter entity-tag stamps', () => {
   // bugs/smelter-stale-entity-type-stamps.md — tag edits must reach the
   // vector stamps without re-embedding: the stamp is the discriminator

--- a/packages/make-meaning/src/gatherer.ts
+++ b/packages/make-meaning/src/gatherer.ts
@@ -134,6 +134,7 @@ export class Gatherer {
         event.options,
         this.kb,
         this.inferenceClient,
+        this.logger,
       );
 
       this.eventBus.get('gather:resource-complete').next({

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -10,6 +10,8 @@
  * - Graph (eventually consistent relationship projection) — via GraphDatabase
  * - WeaveProgress (weave:applied fold — the graph-projection barrier; the
  *   Weaver itself runs standalone via @semiont/make-meaning/weaver-main)
+ * - SmeltProgress (smelt:settled fold — the vector-projection barrier;
+ *   SMELTER-INDEX-SYNC, same standalone-actor arrangement as the Weaver)
  * - Vectors (semantic search) — via VectorStore (optional, read-only)
  *
  * The Smelter (event-to-vector projection) runs as an external actor
@@ -25,6 +27,7 @@ import type { VectorStore } from '@semiont/vectors';
 import type { SemiontProject } from '@semiont/core/node';
 import type { EventBus, Logger } from '@semiont/core';
 import { createWeaveProgress, type WeaveProgress } from './weave-progress.js';
+import { createSmeltProgress, type SmeltProgress } from './smelt-progress.js';
 
 export interface KnowledgeBase {
   eventStore:    EventStore;
@@ -32,6 +35,7 @@ export interface KnowledgeBase {
   content:       WorkingTreeStore;
   graph:         GraphDatabase;
   weaveProgress: WeaveProgress;
+  smeltProgress: SmeltProgress;
   vectors?:      VectorStore;
   projectionsDir: string;
 }
@@ -60,6 +64,10 @@ export async function createKnowledgeBase(
   // a standalone actor, and its signals arrive over the bus. This fold is
   // the backend-side half, wherever the Weaver runs.
   const weaveProgress = createWeaveProgress(eventBus);
+  // Its vector-projection sibling: fold of `smelt:settled` decision signals
+  // from the standalone Smelter, backing the gather-side read-your-writes
+  // barrier (SMELTER-INDEX-SYNC D1 = push).
+  const smeltProgress = createSmeltProgress(eventBus);
 
   if (!options?.skipRebuild) {
     // Rebuild materialized views from the event log first. The Browser actor
@@ -72,7 +80,7 @@ export async function createKnowledgeBase(
   }
 
   const kb: KnowledgeBase = {
-    eventStore, views, content, graph: graphDb, weaveProgress,
+    eventStore, views, content, graph: graphDb, weaveProgress, smeltProgress,
     projectionsDir: project.projectionsDir,
   };
 

--- a/packages/make-meaning/src/llm-context.ts
+++ b/packages/make-meaning/src/llm-context.ts
@@ -9,12 +9,23 @@ import { ResourceContext } from './resource-context';
 import { GraphContext } from './graph-context';
 import { generateResourceSummary, generateReferenceSuggestions } from './generation/resource-generation';
 import type { InferenceClient } from '@semiont/inference';
-import { getResourceEntityTypes, getResourceId } from '@semiont/core';
-import { resourceId as makeResourceId, type ResourceId } from '@semiont/core';
+import { getPrimaryRepresentation, getResourceEntityTypes, getResourceId } from '@semiont/core';
+import { resourceId as makeResourceId, type Logger, type ResourceId } from '@semiont/core';
 import type { GatheredContext } from '@semiont/core';
 import type { KnowledgeBase } from './knowledge-base';
+import { SmeltProgressTimeout } from './smelt-progress';
 
 import type { ResourceDescriptor } from '@semiont/core';
+
+/**
+ * Bound on the semanticContext read-your-writes barrier (SMELTER-INDEX-SYNC
+ * D3/A4): generous in embedding terms — an external model call plus queue
+ * depth behind other work items — while nesting well inside consumer budgets
+ * (my-chat's 90s generation stall watchdog). A named constant, not a caller
+ * option, until a consumer hits the wall (the CONTEXT-IDENTIFIERS D4
+ * discipline).
+ */
+export const SMELT_SETTLE_TIMEOUT_MS = 15_000;
 
 export interface LLMContextOptions {
   depth: number;
@@ -37,7 +48,8 @@ export class LLMContext {
     resourceId: ResourceId,
     options: LLMContextOptions,
     kb: KnowledgeBase,
-    inferenceClient: InferenceClient
+    inferenceClient: InferenceClient,
+    logger: Logger,
   ): Promise<GatheredContext> {
     // Get main resource from view storage
     const mainDoc = await ResourceContext.getResourceMetadata(resourceId, kb);
@@ -104,14 +116,45 @@ export class LLMContext {
     // Semantic recall over the resource's OWN already-indexed vectors (no
     // re-embedding), excluding caller-supplied entity types. The applied filter
     // is recorded on semanticContext as build provenance. EXCLUDE-VECTORS Phase 2b.
+    //
+    // Read-your-writes barrier (SMELTER-INDEX-SYNC P2): probe first (A3) —
+    // an empty result is ambiguous (pending? never-embeddable?) — then wait
+    // for the Smelter's settled decision at exactly this content generation
+    // (D2) before concluding. Scoped to this slice alone: nothing else in
+    // the gather ever waits (D3). Timeout degrades to absent plus exactly
+    // one L4 breadcrumb; a `skipped` decision resolves immediately (D4).
     let semanticContext: GatheredContext['semanticContext'];
-    if (kb.vectors) {
+    const vectors = kb.vectors;
+    if (vectors) {
       const excludeEntityTypes = options.excludeEntityTypes ?? [];
-      const matches = await kb.vectors.searchByResource(resourceId, {
-        limit: options.maxResources,
-        scoreThreshold: 0.5,
-        ...(excludeEntityTypes.length ? { filter: { excludeEntityTypes } } : {}),
-      });
+      const search = () =>
+        vectors.searchByResource(resourceId, {
+          limit: options.maxResources,
+          scoreThreshold: 0.5,
+          ...(excludeEntityTypes.length ? { filter: { excludeEntityTypes } } : {}),
+        });
+
+      let matches = await search();
+      if (matches.length === 0) {
+        const contentChecksum = getPrimaryRepresentation(mainDoc)?.checksum;
+        if (contentChecksum) {
+          try {
+            const outcome = await kb.smeltProgress.whenSettled(resourceIdStr, contentChecksum, SMELT_SETTLE_TIMEOUT_MS);
+            if (outcome === 'indexed') {
+              matches = await search();
+            }
+            // 'skipped' | 'inert': legitimately absent — no breadcrumb.
+          } catch (error) {
+            if (!(error instanceof SmeltProgressTimeout)) throw error;
+            logger.warn('[gather DEGRADED] semanticContext absent — the vector projection did not settle within the barrier', {
+              resourceId: resourceIdStr,
+              contentChecksum,
+              timeoutMs: SMELT_SETTLE_TIMEOUT_MS,
+            });
+          }
+        }
+      }
+
       if (matches.length > 0) {
         semanticContext = {
           similar: matches.map((m) => ({

--- a/packages/make-meaning/src/smelt-progress.ts
+++ b/packages/make-meaning/src/smelt-progress.ts
@@ -1,0 +1,138 @@
+/**
+ * SmeltProgress — backend-local fold of `smelt:settled` signals
+ * (SMELTER-INDEX-SYNC P1, D1 = push barrier).
+ *
+ * The Smelter emits `smelt:settled` after deciding a resource's content:
+ * `indexed` (embedded + upserted) or `skipped` (media gate, empty text) —
+ * keyed by the checksum of the bytes it inspected, and NEVER on transient
+ * failures (an error is not a decision; SMELTER-INDEX-SYNC A2). This unit
+ * folds those signals per resource and exposes `whenSettled` — the
+ * read-your-writes barrier: an event-driven await that resolves the moment
+ * the vector projection has settled the exact content generation the caller
+ * holds (the view's checksum), and rejects with `SmeltProgressTimeout` on
+ * the bounded timeout so callers degrade observably (L4 breadcrumb).
+ *
+ * Deliberately transport-blind: it subscribes to the channel, not to the
+ * Smelter. The signal arrives through the bus gateway from the standalone
+ * worker; an in-process Smelter would ride the core EventBus and this unit
+ * would not change (the WeaveProgress precedent).
+ *
+ * The fold is ephemeral by design — on backend restart it rebuilds lazily
+ * from live signals. Barrier callers probe the vector store first
+ * (SMELTER-INDEX-SYNC A3), so a cold fold only costs waits for resources
+ * whose settlement genuinely hasn't been observed yet.
+ */
+
+import type { EventBus, StateUnit } from '@semiont/core';
+
+/** Distinct rejection for a barrier that hit its bounded timeout. */
+export class SmeltProgressTimeout extends Error {
+  constructor(resourceId: string, contentChecksum: string, timeoutMs: number) {
+    super(`smelt:settled not observed for ${resourceId} (checksum ${contentChecksum.slice(0, 12)}…) within ${timeoutMs}ms`);
+    this.name = 'SmeltProgressTimeout';
+  }
+}
+
+export type SmeltOutcome = 'indexed' | 'skipped';
+
+export interface SmeltProgress extends StateUnit {
+  /** The latest settlement seen for a resource, if any signal arrived. */
+  settledAt(resourceId: string): { contentChecksum: string; outcome: SmeltOutcome } | undefined;
+  /**
+   * Resolve with the Smelter's decision once it has settled `resourceId` at
+   * exactly `contentChecksum` — immediately if the fold already holds it.
+   * Rejects with `SmeltProgressTimeout` after `timeoutMs`. After dispose it
+   * resolves `'inert'`: shutdown must not throw through a gather in flight,
+   * and callers treat inert as breadcrumb-less degrade.
+   */
+  whenSettled(resourceId: string, contentChecksum: string, timeoutMs: number): Promise<SmeltOutcome | 'inert'>;
+}
+
+/**
+ * Entries older than this are evicted (lazily, at most one sweep per
+ * SWEEP_INTERVAL_MS). Eviction is free correctness-wise: the barrier only
+ * engages when the probe found no vectors, which cannot happen for a
+ * settlement minutes old — and a missed immediate-resolve merely degrades
+ * to the caller's bounded timeout. Same rationale as WeaveProgress.
+ */
+const SETTLED_TTL_MS = 5 * 60_000;
+const SWEEP_INTERVAL_MS = 60_000;
+
+interface Waiter {
+  resourceId: string;
+  contentChecksum: string;
+  resolve: (outcome: SmeltOutcome | 'inert') => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export function createSmeltProgress(eventBus: EventBus): SmeltProgress {
+  const settled = new Map<string, { contentChecksum: string; outcome: SmeltOutcome; at: number }>();
+  const waiters = new Set<Waiter>();
+  let disposed = false;
+  let lastSweep = Date.now();
+
+  const subscription = eventBus.get('smelt:settled').subscribe(({ resourceId, contentChecksum, outcome }) => {
+    const now = Date.now();
+    if (now - lastSweep >= SWEEP_INTERVAL_MS) {
+      lastSweep = now;
+      for (const [rid, entry] of settled) {
+        if (now - entry.at >= SETTLED_TTL_MS) settled.delete(rid);
+      }
+    }
+
+    // Latest settlement wins: signals leave the Smelter in per-resource lane
+    // order, so the newest one reflects the current content generation.
+    settled.set(resourceId, { contentChecksum, outcome, at: now });
+
+    for (const waiter of waiters) {
+      if (waiter.resourceId === resourceId && waiter.contentChecksum === contentChecksum) {
+        clearTimeout(waiter.timer);
+        waiters.delete(waiter);
+        waiter.resolve(outcome);
+      }
+    }
+  });
+
+  return {
+    settledAt: (resourceId) => {
+      const entry = settled.get(resourceId);
+      return entry ? { contentChecksum: entry.contentChecksum, outcome: entry.outcome } : undefined;
+    },
+
+    whenSettled: (resourceId, contentChecksum, timeoutMs) => {
+      if (disposed) return Promise.resolve('inert');
+
+      const current = settled.get(resourceId);
+      if (current && current.contentChecksum === contentChecksum) {
+        return Promise.resolve(current.outcome);
+      }
+
+      return new Promise<SmeltOutcome | 'inert'>((resolve, reject) => {
+        const waiter: Waiter = {
+          resourceId,
+          contentChecksum,
+          resolve,
+          timer: setTimeout(() => {
+            waiters.delete(waiter);
+            reject(new SmeltProgressTimeout(resourceId, contentChecksum, timeoutMs));
+          }, timeoutMs),
+        };
+        waiters.add(waiter);
+      });
+    },
+
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      subscription.unsubscribe();
+      // Resolve pending waiters inert: shutdown must not throw through a
+      // gather in flight — callers degrade without a breadcrumb.
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timer);
+        waiter.resolve('inert');
+      }
+      waiters.clear();
+      settled.clear();
+    },
+  };
+}

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -104,9 +104,27 @@ function sameStringSet(a: string[], b: string[]): boolean {
 
 export type SmelterInput = SmelterEvent | SmelterWorkItem;
 
+const WORK_ITEM_TYPES: ReadonlySet<string> = new Set<SmelterWorkItem['type']>([
+  'smelt:embed', 'smelt:restamp', 'smelt:purge', 'smelt:embed-annotation', 'smelt:purge-annotation',
+]);
+
 function isWorkItem(input: SmelterInput): input is SmelterWorkItem {
-  return input.type.startsWith('smelt:');
+  // Literal set, not a prefix match: `smelt:settled` is the Smelter's
+  // OUTBOUND decision signal (never a mailbox input) and must not read as
+  // work (SMELTER-INDEX-SYNC A1).
+  return WORK_ITEM_TYPES.has(input.type);
 }
+
+/**
+ * Outcome of a content fetch on the embed path. `skipped` carries the
+ * checksum of the bytes inspected so the settled signal stays content-keyed
+ * (SMELTER-INDEX-SYNC D2); `unavailable` is a transient failure and MUST NOT
+ * settle — an error is not a decision (A2).
+ */
+type FetchedContent =
+  | { kind: 'text'; text: string; checksum: string }
+  | { kind: 'skipped'; checksum: string }
+  | { kind: 'unavailable' };
 
 export class Smelter {
   private static readonly RECONCILE_PAGE_SIZE = 200;
@@ -338,23 +356,39 @@ export class Smelter {
    * null (logged) when the resource doesn't decode as text, is unavailable,
    * or is empty — callers skip it.
    */
-  private async fetchEmbeddableText(resourceId: string): Promise<{ text: string; checksum: string } | null> {
+  private async fetchEmbeddableText(resourceId: string): Promise<FetchedContent> {
     try {
       // The stored representation's bytes, untouched — the content route is a
       // pure pipe now (no negotiation), so getBinary returns exactly the bytes
       // the catalog's checksum was computed from (S12; the route-side half is
-      // the backend's resource-raw-mode lemma test).
+      // the backend's resource-raw-mode lemma test). The checksum is computed
+      // before the media gate so `skipped` decisions stay content-keyed (D2).
       const { data, contentType } = await this.content.getBinary(makeResourceId(resourceId));
+      const bytes = Buffer.from(data);
+      const checksum = calculateChecksum(bytes);
       if (textExtractionOf(contentType) !== 'decode') {
         this.logger.debug('Skipping resource that does not decode as text', { resourceId, contentType });
-        return null;
+        return { kind: 'skipped', checksum };
       }
-      const bytes = Buffer.from(data);
       const text = decodeRepresentation(bytes, contentType);
-      return text.trim() ? { text, checksum: calculateChecksum(bytes) } : null;
+      return text.trim() ? { kind: 'text', text, checksum } : { kind: 'skipped', checksum };
     } catch (error) {
       this.logger.warn('Content unavailable for embedding', { resourceId, error: errField(error) });
-      return null;
+      return { kind: 'unavailable' };
+    }
+  }
+
+  /**
+   * The Smelter's single outbound signal (SMELTER-AXIOMS D3 as amended by
+   * SMELTER-INDEX-SYNC): a per-resource decision report for the barrier
+   * fold. Best-effort — waiters degrade to their bounded timeout; a signal
+   * failure must never fail the embed.
+   */
+  private async emitSettled(resourceId: string, contentChecksum: string, outcome: 'indexed' | 'skipped'): Promise<void> {
+    try {
+      await this.bus.emit('smelt:settled', { resourceId, contentChecksum, outcome });
+    } catch (error) {
+      this.logger.warn('Failed to emit smelt:settled', { resourceId, outcome, error: errField(error) });
     }
   }
 
@@ -381,10 +415,17 @@ export class Smelter {
     if (!rid) return;
 
     const fetched = await this.fetchEmbeddableText(rid);
-    if (!fetched) return;
+    if (fetched.kind === 'unavailable') return;
+    if (fetched.kind === 'skipped') {
+      await this.emitSettled(rid, fetched.checksum, 'skipped');
+      return;
+    }
 
     const chunks = chunkText(fetched.text, this.chunkingConfig);
-    if (chunks.length === 0) return;
+    if (chunks.length === 0) {
+      await this.emitSettled(rid, fetched.checksum, 'skipped');
+      return;
+    }
 
     const entityTypes = await this.resolveEntityTypes(rid);
     const embeddings = await this.embeddingProvider.embedBatch(chunks);
@@ -393,6 +434,7 @@ export class Smelter {
     }));
 
     await this.vectorStore.upsertResourceVectors(makeResourceId(rid), embeddingChunks, fetched.checksum, entityTypes);
+    await this.emitSettled(rid, fetched.checksum, 'indexed');
     this.logger.info(logMessage, { resourceId: rid, chunks: chunks.length });
   }
 
@@ -481,10 +523,17 @@ export class Smelter {
       if (!rid) continue;
 
       const fetched = await this.fetchEmbeddableText(rid);
-      if (!fetched) continue;
+      if (fetched.kind === 'unavailable') continue;
+      if (fetched.kind === 'skipped') {
+        await this.emitSettled(rid, fetched.checksum, 'skipped');
+        continue;
+      }
 
       const chunks = chunkText(fetched.text, this.chunkingConfig);
-      if (chunks.length === 0) continue;
+      if (chunks.length === 0) {
+        await this.emitSettled(rid, fetched.checksum, 'skipped');
+        continue;
+      }
 
       const entityTypes = await this.resolveEntityTypes(rid);
       resourceData.push({ rid: makeResourceId(rid), chunks, checksum: fetched.checksum, entityTypes });
@@ -501,6 +550,7 @@ export class Smelter {
         chunkIndex: i, text: t, embedding: allEmbeddings[offset + i],
       }));
       await this.vectorStore.upsertResourceVectors(rid, embeddingChunks, checksum, entityTypes);
+      await this.emitSettled(String(rid), checksum, 'indexed');
       this.logger.info('Batch-indexed resource', { resourceId: String(rid), chunks: chunks.length });
       offset += chunks.length;
     }


### PR DESCRIPTION
## Description

Implements `.plans/SMELTER-INDEX-SYNC.md` (P0 ratified → P1–P3 landed): the **read-your-writes guarantee over the vector projection**, closing the Q→A first-turn race. The flow `yield.resource(question)` → `gather.resource(questionId)` builds `semanticContext` from the focal resource's **own stored vectors** (`searchByResource`), but the Smelter is an asynchronous projection — a freshly-yielded Question races it, the search returns `[]`, and the Answer generates **silently ungrounded** (the L4 failure class: no error, just thin). This PR makes the ordering explicit: the Smelter announces its per-resource decisions, and the gather waits for exactly the decision it needs — event-driven, bounded, and loud when degraded.

Three pieces, TDD throughout (every phase RED-confirmed in the node:24 container before GREEN):

### 1. The settled signal (P1) — the Smelter states its decisions

New protocol signal `smelt:settled { resourceId, contentChecksum, outcome: indexed | skipped }` (`bus-protocol.ts`, the `weave:applied` shape). Emitted at the Smelter's **existing** decision points — after upsert (`indexed`), at the media gate / empty text (`skipped`) — batch paths included. Two carefully-pinned negatives:

- **Transient failures never settle** (ratified amendment A2): `fetchEmbeddableText` became three-outcome (`text | skipped | unavailable`), with the checksum computed *before* the media gate so `skipped` stays content-keyed. An error is not a decision — settling on one would make gathers degrade *with confidence*.
- **This formally amends SMELTER-AXIOMS D3 (silent sink)** — recorded in the doc, not silently contradicted. The signal is the "first real consumer" that decision anticipated; everything else about D3 stands (single outbound signal, no request/reply surface). `isWorkItem` tightened from prefix-match to the literal work-item set so the outbound channel can never read as mailbox work (A1).

### 2. The fold + barrier (P1/P2) — the gather waits for exactly its content generation

- `SmeltProgress` (`smelt-progress.ts`, mirroring `WeaveProgress`): backend-local fold of settled signals, latest-settlement-wins per resource, TTL-swept, `whenSettled(resourceId, contentChecksum, timeoutMs)` — resolves with the Smelter's decision, rejects `SmeltProgressTimeout` on the bound, resolves `'inert'` on dispose (shutdown never throws through a gather). Wired on `KnowledgeBase` beside `weaveProgress`.
- `llm-context.ts` — the barrier, scoped to the `semanticContext` slice **only** (nothing else in a gather ever waits): **probe → wait → re-probe**. Probe `searchByResource` first (A3 — non-empty means indexed, which also makes the barrier survive a backend restart's cold fold); on empty, await `whenSettled` at the view's primary-representation checksum (D2 — read-your-writes for exactly the bytes the caller yielded); re-search on `indexed`; proceed quietly on `skipped` (never-embeddable resources pay **zero** timeout tax — D4's whole point); on timeout, degrade to absent plus **exactly one** `[gather DEGRADED]` breadcrumb. `SMELT_SETTLE_TIMEOUT_MS = 15s` — generous for an external embedding call, nested well inside consumer budgets (my-chat's 90s stall watchdog).
- `getResourceContext` gained a `logger` param (the Gatherer passes its own) — the breadcrumb needs a sink.

### 3. Axiom S14 (P3) — decision announcement, property-graded

`SMELTER-AXIOMS.md` gains **S14**: ∀ catalogs × failure masks, every reachable resource announces exactly one latest `settled(rid, checksum, outcome)` with `indexed ⇔ embeddable`, and failed reads announce nothing. Fast-check property over generated catalogs; the barrier behaviors (delayed-Smelter populate, skipped-immediate, probe-first, timeout-breadcrumb) are example-pinned in `llm-context.test.ts`; the fold in `smelt-progress.test.ts`.

## Deployment notes

- The signal crosses the bus gateway from the standalone worker exactly as `weave:applied` does — same registration, same DID-stamped agent emit path.
- **Mixed-version window:** a new backend with an old (non-emitting) worker degrades fresh-yield gathers to the 15s timeout + breadcrumb until the worker updates (already-indexed resources are unaffected — the probe short-circuits). An updated worker against an old backend logs a warn on the unrecognized channel and continues; the signal is best-effort by design and never fails an embed. Ship both from the same build as usual; a brief restart skew self-corrects.

## Type of Change

- [x] Bug fix (the silent first-turn thin-context failure)
- [x] New feature (settled signal, SmeltProgress, gather barrier, axiom S14)

## Areas Changed

- [x] Core (`packages/core`) — `smelt:settled` protocol registration
- [x] Make-meaning (`packages/make-meaning`) — smelter emissions, SmeltProgress, KnowledgeBase wiring, llm-context barrier, gatherer logger threading
- [x] Backend (`apps/backend`) — test helpers only (KnowledgeBase literals gained `smeltProgress`)

## Testing

RED-first per phase: P1 confirmed 8 failures (2 emission, 6 fold) before implementation; P2 confirmed the delayed-Smelter populate RED with skipped-immediate and probe-first as pins, timeout-breadcrumb added at GREEN. Final targeted gates (node:24 container): 82/82 across smelter / smelt-progress / llm-context / gatherer suites, incl. the S14 property; make-meaning + backend typechecks clean. Full suites are CI's job.

Honest residue: no live `smelt:settled` has crossed the SSE/gateway wire end-to-end (the gateway emit path is assumed per the `weave:applied` precedent), and the live first-turn validation (the `my-chat` Q→A shape) is the doc's named Local Testing follow-up post-release. The Matcher's vector read remains the last unpostured reader of this projection — deliberately deferred (`SMELTER-INDEX-SYNC` out-of-scope; a #1011-style one-pager if agentic bind flows make its exposure real).
