### PR TITLE
Image annotations paint (and click) in browse mode — the default renderer dropped them

### DIFF
--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -314,7 +314,7 @@ export const BrowseView = memo(function BrowseView({
       />
       )}
       <div ref={containerRef} className="semiont-browse-view__content" onClick={handleContentClick}>
-        <Renderer content={content} mimeType={mimeType} resourceUri={resourceUri} annotations={allAnnotations} />
+        <Renderer content={content} mimeType={mimeType} resourceUri={resourceUri} annotations={allAnnotations} session={session} />
       </div>
     </div>
   );

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
@@ -70,12 +70,8 @@ vi.mock('../../../lib/annotation-registry', () => ({
   },
 }));
 
-// Mock ImageViewer
-vi.mock('../../viewers', () => ({
-  ImageViewer: ({ resourceUri }: { resourceUri: string }) => (
-    <img data-testid="image-viewer" src={resourceUri} alt="Resource content" />
-  ),
-}));
+// Image browse renders the read-only SvgDrawingCanvas (real component — jsdom
+// renders its container fine; shape painting is covered by the dispatch spec).
 
 // Mock AnnotateToolbar
 vi.mock('../../annotation/AnnotateToolbar', () => ({
@@ -224,10 +220,12 @@ describe('BrowseView Component', () => {
       expect(screen.getByTestId('annotate-toolbar')).toBeInTheDocument();
     });
 
-    it('should render image viewer for image mime types', () => {
-      renderWithProviders(<BrowseView {...defaultProps} mimeType="image/png" />);
+    it('should render the read-only annotation canvas for image mime types', () => {
+      // Was a bare ImageViewer, which silently dropped the annotations prop
+      // (bugs/image-browse-renderer-drops-annotations.md).
+      const { container } = renderWithProviders(<BrowseView {...defaultProps} mimeType="image/png" />);
 
-      expect(screen.getByTestId('image-viewer')).toBeInTheDocument();
+      expect(container.querySelector('.semiont-svg-drawing-canvas')).toBeInTheDocument();
     });
 
     it('should render unsupported message for unsupported mime types', () => {

--- a/packages/react-ui/src/components/resource/__tests__/browse-renderers.dispatch.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/browse-renderers.dispatch.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * BUG: image-browse-renderer-drops-annotations — the default renderers must
+ * forward what BrowseView hands them.
+ *
+ * ImageBrowseRenderer destructured only content/mimeType and mounted a bare
+ * ImageViewer: shape annotations invisible in browse mode (annotate mode
+ * proves the data). Fix: the read-only annotation canvas (drawingMode=null),
+ * WITH the session extension on MediaRendererProps — clicks/hover route in
+ * browse mode too, and the PDF renderer's pre-existing session-less click gap
+ * heals in the same motion (per the fork note in the bug doc).
+ *
+ * Prop-capturing canvas mocks pin the contract: mounted, given the
+ * annotations, read-only, session threaded. Started RED (image: no canvas at
+ * all; pdf: no session) → GREEN.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { Annotation, AnnotationId } from '@semiont/core';
+import { BrowseView } from '../BrowseView';
+
+const captured = vi.hoisted(() => ({
+  svg: [] as Record<string, unknown>[],
+  pdf: [] as Record<string, unknown>[],
+}));
+
+vi.mock('../../image-annotation/SvgDrawingCanvas', () => ({
+  SvgDrawingCanvas: (props: Record<string, unknown>) => {
+    captured.svg.push(props);
+    return <div className="semiont-svg-drawing-canvas">svg-canvas-mock</div>;
+  },
+}));
+vi.mock('../../pdf-annotation/PdfAnnotationCanvas.client', () => ({
+  PdfAnnotationCanvas: (props: Record<string, unknown>) => {
+    captured.pdf.push(props);
+    return <div>pdf-canvas-mock</div>;
+  },
+}));
+vi.mock('../../annotation/AnnotateToolbar', () => ({ AnnotateToolbar: () => null }));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => ({}) }));
+
+function fakeSession(): SemiontSession {
+  return {
+    client: { browse: { click: vi.fn() }, beckon: { hover: vi.fn() } },
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+}
+
+/** A shape annotation (SvgSelector region) — the image-annotation shape. */
+function shapeAnnotation(): Annotation {
+  return {
+    '@context': 'http://www.w3.org/ns/anno.jsonld',
+    id: 'shape-1' as AnnotationId,
+    type: 'Annotation',
+    motivation: 'highlighting',
+    creator: { '@type': 'Person', name: 'user@example.com' },
+    created: '2026-07-14T00:00:00Z',
+    target: {
+      source: 'res-1',
+      selector: { type: 'SvgSelector', value: '<svg><rect x="1" y="1" width="5" height="5"/></svg>' },
+    },
+  } as unknown as Annotation;
+}
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+
+const baseProps = {
+  resourceUri: 'res-1',
+  annotateMode: false,
+};
+
+describe('browse-renderers — annotation + session forwarding (dispatch contract)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.svg.length = 0;
+    captured.pdf.length = 0;
+  });
+
+  it('image browse mounts the read-only annotation canvas with the annotations and session', () => {
+    const session = fakeSession();
+    const annotations = { ...emptyAnnotations, highlights: [shapeAnnotation()] };
+    const { container } = render(
+      <BrowseView {...baseProps} content="blob:image-url" mimeType="image/png"
+        annotations={annotations} session={session} />,
+    );
+
+    expect(within(container).getByText('svg-canvas-mock')).toBeInTheDocument();
+    expect(captured.svg).toHaveLength(1);
+    const props = captured.svg[0]!;
+    expect(props.imageUrl).toBe('blob:image-url');
+    expect(props.existingAnnotations).toEqual([shapeAnnotation()]); // the dropped prop
+    expect(props.drawingMode).toBeNull();                           // read-only in browse
+    expect(props.session).toBe(session);                            // interaction parity
+  });
+
+  it('pdf browse keeps its annotations (pinned) and gains the session (the healed click gap)', async () => {
+    const session = fakeSession();
+    const annotations = { ...emptyAnnotations, highlights: [shapeAnnotation()] };
+    const { container } = render(
+      <BrowseView {...baseProps} content="blob:pdf-url" mimeType="application/pdf"
+        annotations={annotations} session={session} />,
+    );
+
+    await within(container).findByText('pdf-canvas-mock'); // flush the lazy canvas
+    expect(captured.pdf).toHaveLength(1);
+    const props = captured.pdf[0]!;
+    expect(props.existingAnnotations).toEqual([shapeAnnotation()]); // pinned — worked before
+    expect(props.drawingMode).toBeNull();
+    expect(props.session).toBe(session);                            // NEW — was a session-less no-op
+  });
+});

--- a/packages/react-ui/src/components/resource/browse-renderers.tsx
+++ b/packages/react-ui/src/components/resource/browse-renderers.tsx
@@ -4,7 +4,8 @@ import { lazy, Suspense, memo, type ComponentType } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { Annotation } from '@semiont/core';
-import { ImageViewer } from '../viewers';
+import type { SemiontSession } from '@semiont/sdk';
+import { SvgDrawingCanvas } from '../image-annotation/SvgDrawingCanvas';
 
 // Lazy-load the PDF component to avoid SSR issues with browser PDF.js loading.
 const PdfAnnotationCanvas = lazy(() => import('../pdf-annotation/PdfAnnotationCanvas.client').then(mod => ({ default: mod.PdfAnnotationCanvas })));
@@ -19,6 +20,13 @@ export interface MediaRendererProps {
   mimeType: string;
   resourceUri: string;
   annotations: Annotation[];
+  /**
+   * Session for interaction routing inside annotation-bearing renderers — the
+   * canvases emit clicks/hover via `session.client.browse/beckon`. Absent/null
+   * → the annotations still PAINT, but are inert (paint-only). Threaded by
+   * BrowseView's dispatch; custom renderers may ignore it.
+   */
+  session?: SemiontSession | null;
 }
 
 /** Read-only media dispatch, keyed by the registry render mode. */
@@ -33,11 +41,24 @@ export function TextBrowseRenderer({ content }: MediaRendererProps) {
   return <MemoizedMarkdown content={content} />;
 }
 
-export function ImageBrowseRenderer({ content, mimeType }: MediaRendererProps) {
-  return <ImageViewer imageUrl={content} mimeType={mimeType} alt="Resource content" />;
+export function ImageBrowseRenderer({ content, resourceUri, annotations, session }: MediaRendererProps) {
+  // The annotate-mode canvas, read-only (drawingMode=null): paints SvgSelector
+  // shapes over the image and routes click/hover via the session — the same
+  // shapes browse mode silently dropped when this was a bare ImageViewer
+  // (bugs/image-browse-renderer-drops-annotations.md).
+  return (
+    <SvgDrawingCanvas
+      imageUrl={content}
+      resourceUri={resourceUri}
+      existingAnnotations={annotations}
+      drawingMode={null}
+      selectedMotivation={null}
+      session={session}
+    />
+  );
 }
 
-export function PdfBrowseRenderer({ content, resourceUri, annotations }: MediaRendererProps) {
+export function PdfBrowseRenderer({ content, resourceUri, annotations, session }: MediaRendererProps) {
   return (
     <Suspense fallback={<div className="semiont-browse-view__loading">Loading PDF viewer...</div>}>
       <PdfAnnotationCanvas
@@ -46,6 +67,7 @@ export function PdfBrowseRenderer({ content, resourceUri, annotations }: MediaRe
         existingAnnotations={annotations}
         drawingMode={null}
         selectedMotivation={null}
+        session={session}
       />
     </Suspense>
   );


### PR DESCRIPTION
## Summary

Image resources with shape annotations (SvgSelector regions) rendered as **bare images in browse mode** — zero overlay shapes, no hover, no click — while annotate mode painted the same annotations fine. The data was never the problem; the default image renderer silently dropped it. Fixed with interaction parity, and the PDF renderer's own hidden interaction gap healed in the same motion.

## Root cause

`browse-renderers.tsx`, the two default media renderers side by side: `PdfBrowseRenderer` takes `annotations` + `resourceUri` and mounts the annotation canvas; `ImageBrowseRenderer` destructured only `content`/`mimeType` and mounted an overlay-less `ImageViewer`. `BrowseView` passes `annotations` to **every** renderer and `MediaRendererProps` declares the field — the image renderer just ignored it. Third instance of the declared-but-ignored-props pattern (after `ResourceTagsInline`'s dead editing props and the pre-#974 capability masks): the type system tells hosts the feature exists; the implementation drops it. Structural by construction — no race, no host involvement (annotate mode proves the data).

**The fork the "copy the PDF renderer" fix would have hidden:** the PDF precedent delivered *paint* parity, not *interaction* parity — `MediaRendererProps` carried no `session`, and the canvases route clicks internally via `session.client.browse.click(...)`, so browse-mode PDF annotations painted but their clicks were session-less no-ops. Recorded in the diagnosis doc as a decision, then fixed for both media types.

## The fix

- **`MediaRendererProps` gains `session?: SemiontSession | null`** (documented: absent → annotations still paint, but inert), threaded from `BrowseView`'s render dispatch. Additive — custom renderers registered via the `renderers` override compile unchanged and may ignore it.
- **`ImageBrowseRenderer`**: bare `ImageViewer` → the annotate-mode canvas **read-only** (`SvgDrawingCanvas` with `drawingMode={null}`), forwarding `annotations`, `session`, and `resourceUri`. Browse-mode shapes now paint and route click/hover exactly like the pdf/text paths.
- **`PdfBrowseRenderer`**: gains `session` — its pre-existing browse-mode click gap closes.
- `ImageViewer` stays exported for hosts; it just no longer masquerades as an annotation renderer.

## Testing (TDD-first, RED observed)

New `browse-renderers.dispatch.test.tsx`, driven through `BrowseView` with prop-capturing canvas mocks — pinning exactly the defect class (dropped props):

1. **image**: canvas mounted with the annotations, `drawingMode={null}`, and the session (identity-checked) — observed RED (no canvas at all).
2. **pdf**: annotations pinned (worked before), session asserted NEW — observed RED (no session).

GREEN 2/2, plus the viewer sweep (BrowseView suites incl. overlay-async, toolbar opt-out, embeddable): **28/28 across 7 files**. One deliberate test change: `BrowseView.test`'s "renders image viewer" pin asserted the buggy bare-image behavior — flipped to assert the canvas; the dead `ImageViewer` mock deleted. `tsc --noEmit` clean — and it caught a gap vitest ran past (`SvgDrawingCanvas.resourceUri` is required; the canvas stamps its source on `mark:requested`).

## Notes

- No spec/core/SDK/backend change — one default renderer + the registry props interface (additive).
- Deliberately **not** worked around host-side via the `renderers` override — that mechanism exists for swapping renderers, not for patching upstream defects.
- Embedding hosts validate live on the release carrying this (shape-annotated image, browse mode: shapes paint, clicks route).
- Diagnosis, the parity-fork decision, and execution log: `.plans/bugs/image-browse-renderer-drops-annotations.md`.
