### PR TITLE
react-ui: annotation panels take session as a prop (headless phase 1)

### DIFF
--- a/packages/react-ui/docs/ANNOTATIONS.md
+++ b/packages/react-ui/docs/ANNOTATIONS.md
@@ -161,6 +161,12 @@ import { ResourceViewer } from '@semiont/react-ui';
 - **TaggingPanel** - Tag management
 - **JsonLdPanel** - JSON-LD representation
 
+The panels and their per-annotation entry rows (`HighlightEntry`, `ReferenceEntry`,
+`CommentEntry`, `AssessmentEntry`, `TagEntry`) are **bring-your-own-session**: each takes a
+`session: SemiontSession | null` prop and needs no `SemiontProvider` (`JsonLdPanel` is the
+one exception). See [COMPONENTS.md](COMPONENTS.md#annotation-panels) for the headless usage
+and the entries' interaction contract.
+
 ---
 
 ## Annotation Registry
@@ -239,7 +245,7 @@ const annotators = withHandlers({
   }
 });
 
-<UnifiedAnnotationsPanel annotators={annotators} />
+<UnifiedAnnotationsPanel session={session} annotations={annotations} annotators={annotators} /* …state props */ />
 ```
 
 ---

--- a/packages/react-ui/docs/COMPONENTS.md
+++ b/packages/react-ui/docs/COMPONENTS.md
@@ -291,9 +291,10 @@ See [ANNOTATIONS.md](ANNOTATIONS.md) for detailed annotation documentation.
 
 ### AnnotateToolbar
 
-The tool bar `ResourceViewer` composes in annotate mode — selection / click / shape tool state,
-driven over the session bus. Composed for you by `ResourceViewer`; use it directly only for a
-custom annotate surface.
+The tool bar `ResourceViewer` composes in annotate mode. **Purely presentational**: each
+control reports its chosen value via a callback and the owner (viewer instance or host)
+applies it — the bar holds no pref state, emits no bus events, and touches no storage.
+Composed for you by `ResourceViewer`; use it directly only for a custom annotate surface.
 
 ```tsx
 import { AnnotateToolbar } from '@semiont/react-ui';
@@ -303,29 +304,67 @@ import { AnnotateToolbar } from '@semiont/react-ui';
   selectedClick={selectedClick}             // 'detail' | 'follow' | 'jsonld' | 'deleting'
   annotateMode
   annotators={annotators}
-  session={session}
+  onSelectionChange={setSelectedMotivation}
+  onClickActionChange={setSelectedClick}
+  onModeChange={setAnnotateMode}
 />
 ```
 
-Optional: `showSelectionGroup`, `showDeleteButton`, `showShapeGroup`, `selectedShape`, `mediaType`. See the `AnnotateToolbarProps` interface for the rest.
+Optional: `parts` (which of the four control groups to render — `'clickAction' | 'mode' | 'selection' | 'shape'`), `compact` (icon-only inline form), `selectedShape` + `onShapeChange`, `mediaType` (gates the shape group), `showDeleteButton`. See the `AnnotateToolbarProps` interface for the rest.
 
 ### Annotation Panels
 
-The side-panel renderers for each annotation motivation. They take the **grouped annotation
-arrays + UI state** (from `useResourceLoader` / the page state unit) — not a `resourceId`; they
-render what you pass and emit edits on the session bus.
+The side-panel renderers for each annotation motivation. **Bring-your-own-session**, like
+`ResourceViewer`: every panel takes a `session: SemiontSession | null` prop directly — no
+`SemiontProvider` required — plus the **grouped annotation arrays + UI state** (from
+`useResourceLoader` / the page state unit). They render what you pass, send interactions
+through the session's client, and follow `browse:click` on its bus for entry focus.
+`session={null}` renders inert (display-only).
 
 ```tsx
-import { HighlightPanel, UnifiedAnnotationsPanel } from '@semiont/react-ui';
+import { HighlightPanel } from '@semiont/react-ui';
 
-// One motivation:
-<HighlightPanel annotations={highlights} pendingAnnotation={pending} annotateMode />
-
-// All motivations in one panel:
-<UnifiedAnnotationsPanel annotations={annotations} annotators={annotators} pendingAnnotation={pending} annotateMode />
+// One motivation — no providers, just the session:
+<HighlightPanel
+  session={session}
+  resourceId={rId}
+  annotations={highlights}
+  pendingAnnotation={pending}
+  annotateMode
+/>
 ```
 
-Also exported: `CommentsPanel`, `TaggingPanel`, `ReferencesPanel`, `AssessmentPanel`, `JsonLdPanel`. Each panel's `Props` interface lists its state inputs.
+Also exported: `CommentsPanel`, `TaggingPanel`, `ReferencesPanel`, `AssessmentPanel`,
+`ResourceInfoPanel`, and `UnifiedAnnotationsPanel` (all motivations in one tabbed panel —
+additionally takes `annotators`, `Link` + `routes` for its reference-tab links, and
+`onOpenResource?` for host-owned navigation when a resolved reference is followed).
+Each panel's `Props` interface lists its state inputs. `JsonLdPanel` is the one exception
+that still reads `SemiontProvider`.
+
+### Panel Entries
+
+The per-annotation row each panel composes — exported for hosts that build their own list
+chrome around the same interaction contract: `HighlightEntry`, `ReferenceEntry`,
+`CommentEntry`, `AssessmentEntry`, `TagEntry`. Same bring-your-own-session shape.
+
+```tsx
+import { CommentEntry, ReferenceEntry } from '@semiont/react-ui';
+
+<CommentEntry session={session} comment={annotation} isFocused={false} />
+
+<ReferenceEntry
+  session={session}
+  reference={annotation}
+  isFocused={false}
+  onOpenResource={(id) => navigate(id)}  // 🔗 opens the resolved resource (host nav)
+/>
+```
+
+**The shared contract:**
+- `session`, the annotation (prop named by motivation: `highlight` / `reference` / `comment` / `assessment` / `tag`), and `isFocused` are required; `isHovered?` pulses the row, `ref?` reaches the row element.
+- Click emits `browse:click` via `session.client.browse.click(id, motivation)` — the same event the stock Browser routes to panel focus, so a host-composed list and any Semiont surface on the same session stay in sync for free.
+- Hover (debounced) emits the beckon hover signal that highlights the annotation in an open viewer on the same session.
+- `ReferenceEntry` extras: `onOpenResource?` (host navigation when the resolved reference is followed), `annotateMode?` (resolve / unlink affordances), `isGenerating?`.
 
 ---
 

--- a/packages/react-ui/src/components/resource/panels/AssessmentEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssessmentEntry.tsx
@@ -3,8 +3,7 @@
 import type { Ref } from 'react';
 import type { Annotation } from '@semiont/core';
 import { getAnnotationExactText } from '@semiont/core';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import { useHoverEmitter } from '../../../hooks/useHoverEmitter';
 import { renderAgentLabel } from './agent-label';
 
@@ -17,6 +16,8 @@ interface TextualBody {
 }
 
 interface AssessmentEntryProps {
+  /** Session for interaction routing (browse.click etc.); the panel threads it. */
+  session: SemiontSession | null;
   assessment: Annotation;
   isFocused: boolean;
   isHovered?: boolean;
@@ -69,13 +70,13 @@ function getAssessmentText(annotation: Annotation): string | null {
 }
 
 export function AssessmentEntry({
+  session,
   assessment,
   isFocused,
   isHovered = false,
   ref,
 }: AssessmentEntryProps) {
-  const session = useObservable(useSemiont().activeSession$);
-  const hoverProps = useHoverEmitter(assessment.id);
+  const hoverProps = useHoverEmitter(session, assessment.id);
 
   const selectedText = getAnnotationExactText(assessment);
   const assessmentText = getAssessmentText(assessment);

--- a/packages/react-ui/src/components/resource/panels/AssessmentPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssessmentPanel.tsx
@@ -2,9 +2,8 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useTranslations } from '../../../contexts/TranslationContext';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
-import { useEventSubscriptions } from '../../../contexts/useEventSubscription';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../../hooks/useSessionEventSubscriptions';
 import type { components, Selector } from '@semiont/core';
 import { getTextPositionSelector, getTargetSelector } from '@semiont/core';
 import { AssessmentEntry } from './AssessmentEntry';
@@ -40,6 +39,8 @@ function getSelectorDisplayText(selector: Selector | Selector[]): string | null 
 }
 
 interface AssessmentPanelProps {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
   /** The '@id' of the panel's resource — stamped as `source` on mark:submit (multi-viewer routing). */
   resourceId: string;
   annotations: Annotation[];
@@ -63,6 +64,7 @@ interface AssessmentPanelProps {
  * @subscribes browse:click - Annotation clicked. Payload: { annotationId: string }
  */
 export function AssessmentPanel({
+  session,
   resourceId,
   annotations,
   pendingAnnotation,
@@ -76,7 +78,6 @@ export function AssessmentPanel({
   hoveredAnnotationId,
 }: AssessmentPanelProps) {
   const t = useTranslations('AssessmentPanel');
-  const session = useObservable(useSemiont().activeSession$);
   const [newAssessmentText, setNewAssessmentText] = useState('');
   const [focusedAnnotationId, setFocusedAnnotationId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -185,7 +186,7 @@ export function AssessmentPanel({
   }, []);
 
   // Subscribe to click events - update focused state
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     'browse:click': handleAnnotationClick,
   });
 
@@ -247,6 +248,7 @@ export function AssessmentPanel({
         {/* Assist Section - only in Annotate mode and for text resources */}
         {annotateMode && (
           <AssistSection
+            session={session}
             annotationType="assessment"
             isAssisting={isAssisting}
             locale={locale}
@@ -264,6 +266,7 @@ export function AssessmentPanel({
           ) : (
             sortedAnnotations.map((assessment) => (
               <AssessmentEntry
+                session={session}
                 key={assessment.id}
                 assessment={assessment}
                 isFocused={assessment.id === focusedAnnotationId}

--- a/packages/react-ui/src/components/resource/panels/AssistSection.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssistSection.tsx
@@ -2,14 +2,15 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from '../../../contexts/TranslationContext';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import type { Motivation, components } from '@semiont/core';
 import './AssistSection.css';
 
 type JobProgress = components['schemas']['JobProgress'];
 
 interface AssistSectionProps {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
   annotationType: 'highlight' | 'assessment' | 'comment';
   isAssisting: boolean;
   /** User UI locale — written into the annotation body's `language` field for comment/assessment. */
@@ -34,6 +35,7 @@ interface AssistSectionProps {
  * @emits mark:progress-dismiss - Dismiss the annotation progress display
  */
 export function AssistSection({
+  session,
   annotationType,
   isAssisting,
   locale,
@@ -45,7 +47,6 @@ export function AssistSection({
                      annotationType === 'assessment' ? 'AssessmentPanel' :
                      'CommentsPanel';
   const t = useTranslations(panelName);
-  const session = useObservable(useSemiont().activeSession$);
   const [instructions, setInstructions] = useState('');
   type ToneValue = 'scholarly' | 'explanatory' | 'conversational' | 'technical' | 'analytical' | 'critical' | 'balanced' | 'constructive' | '';
   const [tone, setTone] = useState<ToneValue>('');

--- a/packages/react-ui/src/components/resource/panels/CommentEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/CommentEntry.tsx
@@ -4,12 +4,13 @@ import { useState, useEffect, useRef, useImperativeHandle, type Ref } from 'reac
 import { useTranslations } from '../../../contexts/TranslationContext';
 import type { Annotation } from '@semiont/core';
 import { getAnnotationExactText, getCommentText } from '@semiont/core';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import { useHoverEmitter } from '../../../hooks/useHoverEmitter';
 import { renderAgentLabel } from './agent-label';
 
 interface CommentEntryProps {
+  /** Session for interaction routing (browse.click etc.); the panel threads it. */
+  session: SemiontSession | null;
   comment: Annotation;
   isFocused: boolean;
   isHovered?: boolean;
@@ -35,6 +36,7 @@ function formatRelativeTime(isoString: string): string {
 }
 
 export function CommentEntry({
+  session,
   comment,
   isFocused,
   isHovered = false,
@@ -42,8 +44,7 @@ export function CommentEntry({
   ref,
 }: CommentEntryProps) {
   const t = useTranslations('CommentsPanel');
-  const session = useObservable(useSemiont().activeSession$);
-  const hoverProps = useHoverEmitter(comment.id);
+  const hoverProps = useHoverEmitter(session, comment.id);
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState('');
   const internalRef = useRef<HTMLDivElement>(null);

--- a/packages/react-ui/src/components/resource/panels/CommentsPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/CommentsPanel.tsx
@@ -2,9 +2,8 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useTranslations } from '../../../contexts/TranslationContext';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
-import { useEventSubscriptions } from '../../../contexts/useEventSubscription';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../../hooks/useSessionEventSubscriptions';
 import type { components, Selector } from '@semiont/core';
 import { getTextPositionSelector, getTargetSelector } from '@semiont/core';
 import { CommentEntry } from './CommentEntry';
@@ -40,6 +39,8 @@ function getSelectorDisplayText(selector: Selector | Selector[]): string | null 
 }
 
 interface CommentsPanelProps {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
   /** The '@id' of the panel's resource — stamped as `source` on mark:submit (multi-viewer routing). */
   resourceId: string;
   annotations: Annotation[];
@@ -63,6 +64,7 @@ interface CommentsPanelProps {
  * @subscribes browse:click - Annotation clicked. Payload: { annotationId: string }
  */
 export function CommentsPanel({
+  session,
   resourceId,
   annotations,
   pendingAnnotation,
@@ -76,7 +78,6 @@ export function CommentsPanel({
   hoveredAnnotationId,
 }: CommentsPanelProps) {
   const t = useTranslations('CommentsPanel');
-  const session = useObservable(useSemiont().activeSession$);
   const [newCommentText, setNewCommentText] = useState('');
   const [focusedAnnotationId, setFocusedAnnotationId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -167,7 +168,7 @@ export function CommentsPanel({
     setTimeout(() => setFocusedAnnotationId(null), 3000);
   }, []);
 
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     'browse:click': handleAnnotationClick,
   });
 
@@ -257,6 +258,7 @@ export function CommentsPanel({
         {/* Assist Section - only in Annotate mode and for text resources */}
         {annotateMode && (
           <AssistSection
+            session={session}
             annotationType="comment"
             isAssisting={isAssisting}
             locale={locale}
@@ -274,6 +276,7 @@ export function CommentsPanel({
           ) : (
             sortedAnnotations.map((comment) => (
               <CommentEntry
+                session={session}
                 key={comment.id}
                 comment={comment}
                 isFocused={comment.id === focusedAnnotationId}

--- a/packages/react-ui/src/components/resource/panels/HighlightEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/HighlightEntry.tsx
@@ -3,12 +3,13 @@
 import type { Ref } from 'react';
 import type { Annotation } from '@semiont/core';
 import { getAnnotationExactText } from '@semiont/core';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import { useHoverEmitter } from '../../../hooks/useHoverEmitter';
 import { renderAgentLabel } from './agent-label';
 
 interface HighlightEntryProps {
+  /** Session for interaction routing (browse.click etc.); the panel threads it. */
+  session: SemiontSession | null;
   highlight: Annotation;
   isFocused: boolean;
   isHovered?: boolean;
@@ -33,13 +34,13 @@ function formatRelativeTime(isoString: string): string {
 }
 
 export function HighlightEntry({
+  session,
   highlight,
   isFocused,
   isHovered = false,
   ref,
 }: HighlightEntryProps) {
-  const session = useObservable(useSemiont().activeSession$);
-  const hoverProps = useHoverEmitter(highlight.id);
+  const hoverProps = useHoverEmitter(session, highlight.id);
 
   const selectedText = getAnnotationExactText(highlight);
 

--- a/packages/react-ui/src/components/resource/panels/HighlightPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/HighlightPanel.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { useTranslations } from '../../../contexts/TranslationContext';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
-import { useEventSubscriptions } from '../../../contexts/useEventSubscription';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../../hooks/useSessionEventSubscriptions';
 import type { components, Selector } from '@semiont/core';
 import { getTextPositionSelector, getTargetSelector } from '@semiont/core';
 import { HighlightEntry } from './HighlightEntry';
@@ -23,6 +22,8 @@ interface PendingAnnotation {
 }
 
 interface HighlightPanelProps {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
   /** The '@id' of the panel's resource — stamped as `source` on mark:submit (multi-viewer routing). */
   resourceId: string;
   annotations: Annotation[];
@@ -44,6 +45,7 @@ interface HighlightPanelProps {
  * @subscribes browse:click - Annotation clicked. Payload: { annotationId: string }
  */
 export function HighlightPanel({
+  session,
   resourceId,
   annotations,
   pendingAnnotation,
@@ -57,7 +59,6 @@ export function HighlightPanel({
 }: HighlightPanelProps) {
 
   const t = useTranslations('HighlightPanel');
-  const session = useObservable(useSemiont().activeSession$);
   const [focusedAnnotationId, setFocusedAnnotationId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -128,7 +129,7 @@ export function HighlightPanel({
     setTimeout(() => setFocusedAnnotationId(null), 3000);
   }, []);
 
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     'browse:click': handleAnnotationClick,
   });
 
@@ -155,6 +156,7 @@ export function HighlightPanel({
         {/* Assist Section - only in Annotate mode and for text resources */}
         {annotateMode && (
           <AssistSection
+            session={session}
             annotationType="highlight"
             isAssisting={isAssisting}
             progress={progress}
@@ -171,6 +173,7 @@ export function HighlightPanel({
           ) : (
             sortedAnnotations.map((highlight) => (
               <HighlightEntry
+                session={session}
                 key={highlight.id}
                 highlight={highlight}
                 isFocused={highlight.id === focusedAnnotationId}

--- a/packages/react-ui/src/components/resource/panels/ReferenceEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/ReferenceEntry.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import type { Ref } from 'react';
-import type { RouteBuilder } from '../../../contexts/RoutingContext';
 import { useTranslations } from '../../../contexts/TranslationContext';
 import type { Annotation } from '@semiont/core';
 import { resourceId } from '@semiont/core';
 import { getAnnotationExactText, isBodyResolved, getBodySource, getFragmentSelector, getSvgSelector, getTargetSelector } from '@semiont/core';
 import { getEntityTypes } from '@semiont/ontology';
 import { getResourceIcon } from '../../../lib/resource-utils';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import { renderAgentLabel } from './agent-label';
-import { useObservableExternalNavigation } from '../../../hooks/useObservableBrowse';
 import { useHoverEmitter } from '../../../hooks/useHoverEmitter';
 
 // Extended annotation type with runtime properties added by backend enrichment
@@ -21,29 +18,31 @@ interface EnrichedAnnotation extends Annotation {
 }
 
 interface ReferenceEntryProps {
+  /** Session for interaction routing (browse.click etc.); the panel threads it. */
+  session: SemiontSession | null;
   reference: Annotation;
   isFocused: boolean;
   isHovered?: boolean;
-  routes: RouteBuilder;
+  /** Host-owned navigation: called with the resolved resource id when the entry's link opens. */
+  onOpenResource?: (resourceId: string) => void;
   annotateMode?: boolean;
   isGenerating?: boolean;
   ref?: Ref<HTMLDivElement>;
 }
 
 export function ReferenceEntry({
+  session,
   reference,
   isFocused,
   isHovered = false,
-  routes,
+  onOpenResource,
   annotateMode = true,
   isGenerating = false,
   ref,
 }: ReferenceEntryProps) {
   const t = useTranslations('ReferencesPanel');
-  const session = useObservable(useSemiont().activeSession$);
   const semiont = session?.client;
-  const navigate = useObservableExternalNavigation();
-  const hoverProps = useHoverEmitter(reference.id);
+  const hoverProps = useHoverEmitter(session, reference.id);
 
   const selectedText = getAnnotationExactText(reference) || '';
   const isResolved = isBodyResolved(reference.body);
@@ -65,7 +64,7 @@ export function ReferenceEntry({
   const handleOpen = () => {
     if (resolvedResourceUri) {
       // resolvedResourceUri is already a bare resource ID
-      navigate(routes.resourceDetail(resolvedResourceUri), { resourceId: resolvedResourceUri });
+      onOpenResource?.(resolvedResourceUri);
     }
   };
 

--- a/packages/react-ui/src/components/resource/panels/ReferencesPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/ReferencesPanel.tsx
@@ -2,9 +2,8 @@
 
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useTranslations } from '../../../contexts/TranslationContext';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
-import { useEventSubscriptions } from '../../../contexts/useEventSubscription';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../../hooks/useSessionEventSubscriptions';
 import type { RouteBuilder, LinkComponentProps } from '../../../contexts/RoutingContext';
 import { AnnotateReferencesProgressWidget } from '../../AnnotateReferencesProgressWidget';
 import { ReferenceEntry } from './ReferenceEntry';
@@ -43,6 +42,10 @@ function getSelectorDisplayText(selector: Selector | Selector[]): string | null 
 }
 
 interface Props {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
+  /** Host-owned navigation: called with the resolved resource id when a reference entry opens. */
+  onOpenResource?: (resourceId: string) => void;
   /** The '@id' of the panel's resource — stamped as `source` on mark:submit (multi-viewer routing). */
   resourceId: string;
   // Generic panel props
@@ -78,6 +81,8 @@ interface Props {
  * @subscribes browse:click - Annotation clicked. Payload: { annotationId: string }
  */
 export function ReferencesPanel({
+  session,
+  onOpenResource,
   resourceId,
   annotations = [],
   isAssisting,
@@ -97,7 +102,6 @@ export function ReferencesPanel({
   sourceLanguage,
 }: Props) {
   const t = useTranslations('ReferencesPanel');
-  const session = useObservable(useSemiont().activeSession$);
   const [selectedEntityTypes, setSelectedEntityTypes] = useState<string[]>([]);
   const [lastAnnotationLog, setLastDetectionLog] = useState<Array<{ entityType: string; foundCount: number }> | null>(null);
   const [pendingEntityTypes, setPendingEntityTypes] = useState<string[]>([]);
@@ -206,7 +210,7 @@ export function ReferencesPanel({
     setTimeout(() => setFocusedAnnotationId(null), 3000);
   }, []);
 
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     'browse:click': handleAnnotationClick,
   });
 
@@ -492,11 +496,12 @@ export function ReferencesPanel({
             ) : (
               sortedAnnotations.map((reference) => (
                 <ReferenceEntry
+                  session={session}
                   key={reference.id}
                   reference={reference}
                   isFocused={reference.id === focusedAnnotationId}
                   isHovered={reference.id === hoveredAnnotationId}
-                  routes={routes}
+                  onOpenResource={onOpenResource}
                   annotateMode={annotateMode}
                   isGenerating={reference.id === generatingReferenceId}
                   ref={(el) => setEntryRef(reference.id, el)}

--- a/packages/react-ui/src/components/resource/panels/ResourceInfoPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/ResourceInfoPanel.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useTranslations } from '../../../contexts/TranslationContext';
-import { useSemiont } from '../../../session/SemiontProvider';
-import { useObservable } from '../../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import { formatLocaleDisplay } from '@semiont/core';
 import { resourceId as makeResourceId, type components } from '@semiont/core';
 import { renderAgentLabel } from './agent-label';
@@ -11,6 +10,8 @@ import './ResourceInfoPanel.css';
 type Agent = components['schemas']['Agent'];
 
 interface Props {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
   resourceId: string;
   documentEntityTypes: string[];
   documentLocale?: string | undefined;
@@ -39,6 +40,7 @@ interface Props {
  * @emits mark:archive - Archive this resource
  */
 export function ResourceInfoPanel({
+  session,
   resourceId,
   documentEntityTypes,
   documentLocale,
@@ -54,7 +56,6 @@ export function ResourceInfoPanel({
   onGenerate,
 }: Props) {
   const t = useTranslations('ResourceInfoPanel');
-  const session = useObservable(useSemiont().activeSession$);
 
   // Single attribution surface. `wasAttributedTo` is the canonical list
   // of responsible parties; if a producer set only `generator` we

--- a/packages/react-ui/src/components/resource/panels/TagEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/TagEntry.tsx
@@ -5,12 +5,14 @@ import type { Ref } from 'react';
 import type { Annotation } from '@semiont/core';
 import { getAnnotationExactText } from '@semiont/core';
 import { getTagCategory, getTagSchemaId } from '@semiont/ontology';
-import { useSemiont } from '../../../session/SemiontProvider';
 import { useObservable } from '../../../hooks/useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 import { useHoverEmitter } from '../../../hooks/useHoverEmitter';
 import { renderAgentLabel } from './agent-label';
 
 interface TagEntryProps {
+  /** Session for interaction routing (browse.click, tag schemas); the panel threads it. */
+  session: SemiontSession | null;
   tag: Annotation;
   isFocused: boolean;
   isHovered?: boolean;
@@ -18,13 +20,13 @@ interface TagEntryProps {
 }
 
 export function TagEntry({
+  session,
   tag,
   isFocused,
   isHovered = false,
   ref,
 }: TagEntryProps) {
-  const session = useObservable(useSemiont().activeSession$);
-  const hoverProps = useHoverEmitter(tag.id);
+  const hoverProps = useHoverEmitter(session, tag.id);
 
   const selectedText = getAnnotationExactText(tag);
   const category = getTagCategory(tag);

--- a/packages/react-ui/src/components/resource/panels/TaggingPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/TaggingPanel.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useTranslations } from '../../../contexts/TranslationContext';
-import { useSemiont } from '../../../session/SemiontProvider';
 import { useObservable } from '../../../hooks/useObservable';
-import { useEventSubscriptions } from '../../../contexts/useEventSubscription';
+import type { SemiontSession } from '@semiont/sdk';
+import { useSessionEventSubscriptions } from '../../../hooks/useSessionEventSubscriptions';
 import type { components, Selector } from '@semiont/core';
 import { getTextPositionSelector, getTargetSelector } from '@semiont/core';
 import { TagEntry } from './TagEntry';
@@ -39,6 +39,8 @@ function getSelectorDisplayText(selector: Selector | Selector[]): string | null 
 }
 
 interface TaggingPanelProps {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
   /** The '@id' of the panel's resource — stamped as `source` on mark:submit (multi-viewer routing). */
   resourceId: string;
   annotations: Annotation[];
@@ -64,6 +66,7 @@ interface TaggingPanelProps {
  * @subscribes browse:click - Annotation clicked. Payload: { annotationId: string }
  */
 export function TaggingPanel({
+  session,
   resourceId,
   annotations,
   annotateMode = true,
@@ -77,7 +80,6 @@ export function TaggingPanel({
   sourceLanguage,
 }: TaggingPanelProps) {
   const t = useTranslations('TaggingPanel');
-  const session = useObservable(useSemiont().activeSession$);
 
   // Subscribe to the per-KB tag-schema registry. Schemas are runtime-
   // registered by the KB at session start (see frame.addTagSchema).
@@ -129,7 +131,7 @@ export function TaggingPanel({
     setTimeout(() => setFocusedAnnotationId(null), 3000);
   }, []);
 
-  useEventSubscriptions({
+  useSessionEventSubscriptions(session, {
     'browse:click': handleAnnotationClick,
   });
 
@@ -528,6 +530,7 @@ export function TaggingPanel({
           ) : (
             sortedAnnotations.map((tag) => (
               <TagEntry
+                session={session}
                 key={tag.id}
                 tag={tag}
                 isFocused={tag.id === focusedAnnotationId}

--- a/packages/react-ui/src/components/resource/panels/UnifiedAnnotationsPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/UnifiedAnnotationsPanel.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from '../../../contexts/TranslationContext';
 import type { components, Selector } from '@semiont/core';
 type JobProgress = components['schemas']['JobProgress'];
 import type { RouteBuilder, LinkComponentProps } from '../../../contexts/RoutingContext';
+import type { SemiontSession } from '@semiont/sdk';
 import type { Annotator } from '../../../lib/annotation-registry';
 import { StatisticsPanel } from './StatisticsPanel';
 import { HighlightPanel } from './HighlightPanel';
@@ -37,6 +38,12 @@ const TAB_ORDER: TabKey[] = ['statistics', 'reference', 'highlight', 'assessment
  * - All operations managed via event bus (no callback props)
  */
 interface UnifiedAnnotationsPanelProps {
+  /** Session carrying the client and event bus; null renders inert. */
+  session: SemiontSession | null;
+
+  /** Host-owned navigation: called with the resolved resource id when a reference entry opens. */
+  onOpenResource?: (resourceId: string) => void;
+
   // All annotations (grouped internally by motivation)
   annotations: Annotation[];
 
@@ -245,6 +252,7 @@ export function UnifiedAnnotationsPanel(props: UnifiedAnnotationsPanelProps) {
 
           // Common props for all annotation panels
           const commonProps = {
+            session: props.session,
             resourceId: props.resourceId,
             annotations,
             pendingAnnotation: props.pendingAnnotation,
@@ -270,6 +278,8 @@ export function UnifiedAnnotationsPanel(props: UnifiedAnnotationsPanelProps) {
           if (activeTab === 'reference') {
             return (
               <ReferencesPanel
+                session={commonProps.session}
+                onOpenResource={props.onOpenResource}
                 resourceId={commonProps.resourceId}
                 annotations={commonProps.annotations}
                 pendingAnnotation={commonProps.pendingAnnotation}

--- a/packages/react-ui/src/components/resource/panels/__tests__/AssessmentEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/AssessmentEntry.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { renderWithProviders } from '../../../../test-utils';
+import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
 import userEvent from '@testing-library/user-event';
 
-import type { Annotation, AnnotationId } from '@semiont/core';
+import type { Annotation, AnnotationId, EventBus } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
 
 // Mock @semiont/http-transport
 vi.mock('@semiont/core', async () => {
@@ -53,20 +54,28 @@ describe('AssessmentEntry', () => {
     isFocused: false,
   };
 
+  // Per-test session/bus — created in beforeEach (a module-scope factory
+  // call would hand tests a client that test-utils disposes after the
+  // first test). The `session` prop and the `eventBus` the interaction
+  // test subscribes come from the SAME factory call.
+  let session: SemiontSession;
+  let eventBus: EventBus;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    ({ session, eventBus } = createTestSemiontWrapper());
     mockGetAnnotationExactText.mockReturnValue('Selected passage text');
   });
 
   describe('Rendering', () => {
     it('should render the selected text in quotes', () => {
-      renderWithProviders(<AssessmentEntry {...defaultProps} />);
+      renderWithProviders(<AssessmentEntry {...defaultProps} session={session} />);
 
       expect(screen.getByText(/Selected passage text/)).toBeInTheDocument();
     });
 
     it('should render the assessment body text', () => {
-      renderWithProviders(<AssessmentEntry {...defaultProps} />);
+      renderWithProviders(<AssessmentEntry {...defaultProps} session={session} />);
 
       expect(screen.getByText('This passage needs clarification')).toBeInTheDocument();
     });
@@ -80,7 +89,7 @@ describe('AssessmentEntry', () => {
       });
 
       renderWithProviders(
-        <AssessmentEntry assessment={assessment} isFocused={false} />
+        <AssessmentEntry assessment={assessment} isFocused={false} session={session} />
       );
 
       expect(screen.getByText('Direct body assessment')).toBeInTheDocument();
@@ -95,7 +104,7 @@ describe('AssessmentEntry', () => {
       });
 
       renderWithProviders(
-        <AssessmentEntry assessment={assessment} isFocused={false} />
+        <AssessmentEntry assessment={assessment} isFocused={false} session={session} />
       );
 
       expect(screen.getByText('Array body assessment')).toBeInTheDocument();
@@ -105,14 +114,14 @@ describe('AssessmentEntry', () => {
       const longText = 'X'.repeat(150);
       mockGetAnnotationExactText.mockReturnValue(longText);
 
-      renderWithProviders(<AssessmentEntry {...defaultProps} />);
+      renderWithProviders(<AssessmentEntry {...defaultProps} session={session} />);
 
       expect(screen.getByText(new RegExp(`"${'X'.repeat(100)}`))).toBeInTheDocument();
       expect(screen.getByText(/\.\.\./)).toBeInTheDocument();
     });
 
     it('should show creator name', () => {
-      renderWithProviders(<AssessmentEntry {...defaultProps} />);
+      renderWithProviders(<AssessmentEntry {...defaultProps} session={session} />);
 
       expect(screen.getByText(/reviewer@example.com/)).toBeInTheDocument();
     });
@@ -122,7 +131,7 @@ describe('AssessmentEntry', () => {
       delete (assessment as Record<string, unknown>).creator;
 
       renderWithProviders(
-        <AssessmentEntry assessment={assessment} isFocused={false} />
+        <AssessmentEntry assessment={assessment} isFocused={false} session={session} />
       );
 
       expect(screen.getByText(/Unknown/)).toBeInTheDocument();
@@ -133,7 +142,7 @@ describe('AssessmentEntry', () => {
       delete (assessment as Record<string, unknown>).body;
 
       const { container } = renderWithProviders(
-        <AssessmentEntry assessment={assessment} isFocused={false} />
+        <AssessmentEntry assessment={assessment} isFocused={false} session={session} />
       );
 
       // Body section should not render
@@ -143,7 +152,7 @@ describe('AssessmentEntry', () => {
     it('should not render quote section when selectedText is empty', () => {
       mockGetAnnotationExactText.mockReturnValue('');
 
-      const { container } = renderWithProviders(<AssessmentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<AssessmentEntry {...defaultProps} session={session} />);
 
       expect(container.querySelector('.semiont-annotation-entry__quote')).not.toBeInTheDocument();
     });
@@ -154,7 +163,7 @@ describe('AssessmentEntry', () => {
       });
 
       renderWithProviders(
-        <AssessmentEntry assessment={recentAssessment} isFocused={false} />
+        <AssessmentEntry assessment={recentAssessment} isFocused={false} session={session} />
       );
 
       expect(screen.getByText(/just now/)).toBeInTheDocument();
@@ -165,12 +174,11 @@ describe('AssessmentEntry', () => {
     it('should emit browse:click on click', async () => {
       const clickHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <AssessmentEntry {...defaultProps} />,
-        { returnEventBus: true }
+      const { container } = renderWithProviders(
+        <AssessmentEntry {...defaultProps} session={session} />
       );
 
-      const subscription = eventBus!.get('browse:click').subscribe(clickHandler);
+      const subscription = eventBus.get('browse:click').subscribe(clickHandler);
 
       const entry = container.firstChild as HTMLElement;
       await userEvent.click(entry);
@@ -187,7 +195,7 @@ describe('AssessmentEntry', () => {
   describe('Hover state', () => {
     it('should apply pulse class when isHovered is true', () => {
       const { container } = renderWithProviders(
-        <AssessmentEntry {...defaultProps} isHovered={true} />
+        <AssessmentEntry {...defaultProps} session={session} isHovered={true} />
       );
 
       const entry = container.firstChild as HTMLElement;
@@ -196,7 +204,7 @@ describe('AssessmentEntry', () => {
 
     it('should not apply pulse class when isHovered is false', () => {
       const { container } = renderWithProviders(
-        <AssessmentEntry {...defaultProps} isHovered={false} />
+        <AssessmentEntry {...defaultProps} session={session} isHovered={false} />
       );
 
       const entry = container.firstChild as HTMLElement;
@@ -207,7 +215,7 @@ describe('AssessmentEntry', () => {
   describe('Focus state', () => {
     it('should set data-focused to true when focused', () => {
       const { container } = renderWithProviders(
-        <AssessmentEntry {...defaultProps} isFocused={true} />
+        <AssessmentEntry {...defaultProps} session={session} isFocused={true} />
       );
 
       const entry = container.firstChild as HTMLElement;
@@ -215,7 +223,7 @@ describe('AssessmentEntry', () => {
     });
 
     it('should set data-type to assessment', () => {
-      const { container } = renderWithProviders(<AssessmentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<AssessmentEntry {...defaultProps} session={session} />);
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).toHaveAttribute('data-type', 'assessment');

--- a/packages/react-ui/src/components/resource/panels/__tests__/AssessmentPanel.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/AssessmentPanel.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { AssessmentPanel } from '../AssessmentPanel';
 import type { EventBus } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
 import { createTestSemiontWrapper } from '../../../../test-utils';
 
 import type { Annotation, AnnotationId } from '@semiont/core';
@@ -32,8 +33,15 @@ function createEventTracker() {
   };
 }
 
+// Per-test session/bus/wrapper — created in beforeEach (a module-scope
+// factory call would hand tests a client that test-utils disposes after
+// the first test). The `session` passed as a prop below and the `eventBus`
+// the tracker subscribes come from the SAME factory call.
+let session: SemiontSession;
+let eventBus: EventBus;
+let SemiontWrapper: React.ComponentType<{ children: React.ReactNode }>;
+
 const renderWithEventBus = (component: React.ReactElement, tracker?: ReturnType<typeof createEventTracker>) => {
-  const { SemiontWrapper, eventBus } = createTestSemiontWrapper();
   if (tracker) tracker._attach(eventBus);
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
@@ -148,6 +156,8 @@ describe('AssessmentPanel Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    ({ session, eventBus, SemiontWrapper } = createTestSemiontWrapper());
+
     // Mock scrollIntoView for jsdom
     Element.prototype.scrollIntoView = vi.fn();
 
@@ -167,20 +177,20 @@ describe('AssessmentPanel Component', () => {
 
   describe('Rendering', () => {
     it('should render panel header with title and count', () => {
-      renderWithEventBus(<AssessmentPanel {...defaultProps} annotations={mockAssessments.multiple} />);
+      renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} annotations={mockAssessments.multiple} />);
 
       expect(screen.getByText(/Assessments/)).toBeInTheDocument();
       expect(screen.getByText(/\(3\)/)).toBeInTheDocument();
     });
 
     it('should show empty state when no assessments', () => {
-      renderWithEventBus(<AssessmentPanel {...defaultProps} />);
+      renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} />);
 
       expect(screen.getByText(/No assessments yet/)).toBeInTheDocument();
     });
 
     it('should render all assessments', () => {
-      renderWithEventBus(<AssessmentPanel {...defaultProps} annotations={mockAssessments.multiple} />);
+      renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} annotations={mockAssessments.multiple} />);
 
       expect(screen.getByTestId('assessment-1')).toBeInTheDocument();
       expect(screen.getByTestId('assessment-2')).toBeInTheDocument();
@@ -188,7 +198,7 @@ describe('AssessmentPanel Component', () => {
     });
 
     it('should have proper panel structure', () => {
-      const { container } = renderWithEventBus(<AssessmentPanel {...defaultProps} />);
+      const { container } = renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} />);
 
       const panel = container.firstChild as HTMLElement;
       expect(panel).toHaveClass('semiont-panel');
@@ -197,7 +207,7 @@ describe('AssessmentPanel Component', () => {
 
   describe('Assessment Sorting', () => {
     it('should sort assessments by position in resource', () => {
-      renderWithEventBus(<AssessmentPanel {...defaultProps} annotations={mockAssessments.multiple} />);
+      renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} annotations={mockAssessments.multiple} />);
 
       const assessments = screen.getAllByTestId(/assessment-/);
 
@@ -211,14 +221,14 @@ describe('AssessmentPanel Component', () => {
       mockGetTextPositionSelector.mockReturnValue(null);
 
       expect(() => {
-        renderWithEventBus(<AssessmentPanel {...defaultProps} annotations={mockAssessments.multiple} />);
+        renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} annotations={mockAssessments.multiple} />);
       }).not.toThrow();
     });
   });
 
   describe('New Assessment Creation', () => {
     it('should not show new assessment input by default', () => {
-      renderWithEventBus(<AssessmentPanel {...defaultProps} />);
+      renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} />);
 
       expect(screen.queryByPlaceholderText(/Type your assessment here/)).not.toBeInTheDocument();
     });
@@ -228,7 +238,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -241,7 +251,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -255,7 +265,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -269,7 +279,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -285,7 +295,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -303,7 +313,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -317,7 +327,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -332,7 +342,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />,
         tracker
@@ -358,7 +368,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -376,7 +386,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />,
         tracker
@@ -399,7 +409,7 @@ describe('AssessmentPanel Component', () => {
 
       const { container } = renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -414,7 +424,7 @@ describe('AssessmentPanel Component', () => {
     it('should render assessment entries', () => {
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           annotations={mockAssessments.single}
         />
       );
@@ -429,7 +439,7 @@ describe('AssessmentPanel Component', () => {
       expect(() => {
         renderWithEventBus(
           <AssessmentPanel
-            {...defaultProps}
+            {...defaultProps} session={session}
             annotations={mockAssessments.single}
           />
         );
@@ -441,7 +451,7 @@ describe('AssessmentPanel Component', () => {
     it('should render AssistSection when annotateMode is true', () => {
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           annotateMode={true}
         />
       );
@@ -452,7 +462,7 @@ describe('AssessmentPanel Component', () => {
     it('should not render AssistSection when annotateMode is false', () => {
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           annotateMode={false}
         />
       );
@@ -463,7 +473,7 @@ describe('AssessmentPanel Component', () => {
     it('should render AssistSection with correct annotationType', () => {
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           annotateMode={true}
         />
       );
@@ -479,7 +489,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -492,7 +502,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );
@@ -509,7 +519,7 @@ describe('AssessmentPanel Component', () => {
 
   describe('Accessibility', () => {
     it('should have proper heading structure', () => {
-      renderWithEventBus(<AssessmentPanel {...defaultProps} />);
+      renderWithEventBus(<AssessmentPanel {...defaultProps} session={session} />);
 
       const heading = screen.getByText(/Assessments/);
       expect(heading).toHaveClass('semiont-panel-header__text');
@@ -520,7 +530,7 @@ describe('AssessmentPanel Component', () => {
 
       renderWithEventBus(
         <AssessmentPanel
-          {...defaultProps}
+          {...defaultProps} session={session}
           pendingAnnotation={pendingAnnotation}
         />
       );

--- a/packages/react-ui/src/components/resource/panels/__tests__/AssistSection.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/AssistSection.test.tsx
@@ -14,8 +14,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from '../../../../test-utils';
+import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
 import userEvent from '@testing-library/user-event';
+import type { EventBus } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
 import { AssistSection } from '../AssistSection';
 
 // Mock translations
@@ -52,8 +54,16 @@ vi.mock('../../../../contexts/TranslationContext', () => ({
 }));
 
 describe('AssistSection', () => {
+  // Per-test session/bus — created in beforeEach (a module-scope factory
+  // call would hand tests a client that test-utils disposes after the
+  // first test). The `session` prop and the `eventBus` the emission
+  // tests subscribe come from the SAME factory call.
+  let session: SemiontSession;
+  let eventBus: EventBus;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    ({ session, eventBus } = createTestSemiontWrapper());
     // Clear localStorage
     if (typeof window !== 'undefined') {
       localStorage.clear();
@@ -64,6 +74,7 @@ describe('AssistSection', () => {
     it('should render progress message when progress prop provided', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={true}
           progress={{
@@ -80,6 +91,7 @@ describe('AssistSection', () => {
     it('should render progress message with sparkle icon', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={true}
           progress={{
@@ -99,6 +111,7 @@ describe('AssistSection', () => {
     it('should render request parameters when provided', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={true}
           progress={{
@@ -123,6 +136,7 @@ describe('AssistSection', () => {
     it('should hide form when progress is present', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={true}
           progress={{
@@ -141,6 +155,7 @@ describe('AssistSection', () => {
     it('should show form when progress is null', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
@@ -155,6 +170,7 @@ describe('AssistSection', () => {
     it('should show form when progress is undefined', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={undefined}
@@ -169,6 +185,7 @@ describe('AssistSection', () => {
     it('should keep progress visible after detection completes (isAssisting=false but progress exists)', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={{
@@ -190,6 +207,7 @@ describe('AssistSection', () => {
     it('should render for highlight type', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
@@ -202,6 +220,7 @@ describe('AssistSection', () => {
     it('should render for assessment type', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="assessment"
           isAssisting={false}
           progress={null}
@@ -214,6 +233,7 @@ describe('AssistSection', () => {
     it('should render for comment type', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="comment"
           isAssisting={false}
           progress={null}
@@ -226,6 +246,7 @@ describe('AssistSection', () => {
     it('should show tone selector for comments', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="comment"
           isAssisting={false}
           progress={null}
@@ -239,6 +260,7 @@ describe('AssistSection', () => {
     it('should show tone selector for assessments', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="assessment"
           isAssisting={false}
           progress={null}
@@ -252,6 +274,7 @@ describe('AssistSection', () => {
     it('should not show tone selector for highlights', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
@@ -268,16 +291,16 @@ describe('AssistSection', () => {
       const user = userEvent.setup();
       const detectionHandler = vi.fn();
 
-      const { eventBus } = renderWithProviders(
+      renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
-        />,
-        { returnEventBus: true }
+        />
       );
 
-      const subscription = eventBus!.get('mark:assist-request').subscribe(detectionHandler);
+      const subscription = eventBus.get('mark:assist-request').subscribe(detectionHandler);
 
       const annotateButton = screen.getByRole('button', { name: /✨\s*Annotate/ });
       await user.click(annotateButton);
@@ -294,16 +317,16 @@ describe('AssistSection', () => {
       const user = userEvent.setup();
       const detectionHandler = vi.fn();
 
-      const { eventBus } = renderWithProviders(
+      renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="assessment"
           isAssisting={false}
           progress={null}
-        />,
-        { returnEventBus: true }
+        />
       );
 
-      const subscription = eventBus!.get('mark:assist-request').subscribe(detectionHandler);
+      const subscription = eventBus.get('mark:assist-request').subscribe(detectionHandler);
 
       const annotateButton = screen.getByRole('button', { name: /✨\s*Annotate/ });
       await user.click(annotateButton);
@@ -320,16 +343,16 @@ describe('AssistSection', () => {
       const user = userEvent.setup();
       const detectionHandler = vi.fn();
 
-      const { eventBus } = renderWithProviders(
+      renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="comment"
           isAssisting={false}
           progress={null}
-        />,
-        { returnEventBus: true }
+        />
       );
 
-      const subscription = eventBus!.get('mark:assist-request').subscribe(detectionHandler);
+      const subscription = eventBus.get('mark:assist-request').subscribe(detectionHandler);
 
       const annotateButton = screen.getByRole('button', { name: /✨\s*Annotate/ });
       await user.click(annotateButton);
@@ -346,16 +369,16 @@ describe('AssistSection', () => {
       const user = userEvent.setup();
       const detectionHandler = vi.fn();
 
-      const { eventBus } = renderWithProviders(
+      renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
-        />,
-        { returnEventBus: true }
+        />
       );
 
-      const subscription = eventBus!.get('mark:assist-request').subscribe(detectionHandler);
+      const subscription = eventBus.get('mark:assist-request').subscribe(detectionHandler);
 
       const textarea = screen.getByPlaceholderText('Enter custom instructions...');
       await user.type(textarea, 'Find key concepts');
@@ -379,6 +402,7 @@ describe('AssistSection', () => {
     it('should be expanded by default', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
@@ -395,6 +419,7 @@ describe('AssistSection', () => {
 
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
@@ -413,6 +438,7 @@ describe('AssistSection', () => {
 
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={false}
           progress={null}
@@ -432,6 +458,7 @@ describe('AssistSection', () => {
     it('should handle empty progress message', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={true}
           progress={{
@@ -450,6 +477,7 @@ describe('AssistSection', () => {
     it('should handle progress without percentage', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={true}
           progress={{
@@ -466,6 +494,7 @@ describe('AssistSection', () => {
     it('should handle progress with empty requestParams array', () => {
       renderWithProviders(
         <AssistSection
+          session={session}
           annotationType="highlight"
           isAssisting={true}
           progress={{

--- a/packages/react-ui/src/components/resource/panels/__tests__/CommentEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/CommentEntry.test.tsx
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import React from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { renderWithProviders } from '../../../../test-utils';
+import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { CommentEntry } from '../CommentEntry';
+import type { SemiontSession } from '@semiont/sdk';
 
-import type { Annotation, AnnotationId } from '@semiont/core';
+import type { Annotation, AnnotationId, EventBus } from '@semiont/core';
 
 // Mock TranslationContext
 vi.mock('../../../../contexts/TranslationContext', () => ({
@@ -99,8 +100,17 @@ describe('CommentEntry Component', () => {
     isFocused: false,
   };
 
+  // Per-test session/bus — created in beforeEach because test-utils disposes
+  // every created client after each test (a module-scope session would be
+  // disposed after the first test). The component is provider-free: the
+  // session prop is the only session it sees, so event assertions subscribe
+  // on the eventBus from the SAME factory call.
+  let session: SemiontSession;
+  let eventBus: EventBus;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    ({ session, eventBus } = createTestSemiontWrapper());
     mockGetCommentText.mockReturnValue('This is a test comment');
     mockGetAnnotationExactText.mockReturnValue('This is th');
 
@@ -114,14 +124,14 @@ describe('CommentEntry Component', () => {
 
   describe('Rendering', () => {
     it('should render comment with text and metadata', () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       expect(screen.getByText('This is a test comment')).toBeInTheDocument();
       expect(screen.getByText(/user@example.com/)).toBeInTheDocument();
     });
 
     it('should render selected text quote', () => {
-      const { container } = renderWithProviders(<CommentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const quote = container.querySelector('.semiont-annotation-entry__quote');
       expect(quote).toBeInTheDocument();
@@ -132,7 +142,7 @@ describe('CommentEntry Component', () => {
       const longText = 'A'.repeat(150);
       mockGetAnnotationExactText.mockReturnValue(longText);
 
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       expect(screen.getByText(new RegExp(`"${'A'.repeat(100)}`))).toBeInTheDocument();
       expect(screen.getByText(/\.\.\./)).toBeInTheDocument();
@@ -141,6 +151,7 @@ describe('CommentEntry Component', () => {
     it('should render creator name from creator object', () => {
       renderWithProviders(
         <CommentEntry
+          session={session}
           {...defaultProps}
           comment={mockCommentStates.withCreatorObject}
         />
@@ -150,7 +161,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should handle creator as object with name', () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       expect(screen.getByText(/user@example.com/)).toBeInTheDocument();
     });
@@ -161,6 +172,7 @@ describe('CommentEntry Component', () => {
 
       renderWithProviders(
         <CommentEntry
+          session={session}
           {...defaultProps}
           comment={commentWithoutCreator}
         />
@@ -172,6 +184,7 @@ describe('CommentEntry Component', () => {
     it('should format relative time correctly for recent comments', () => {
       renderWithProviders(
         <CommentEntry
+          session={session}
           {...defaultProps}
           comment={mockCommentStates.recentComment}
         />
@@ -183,6 +196,7 @@ describe('CommentEntry Component', () => {
     it('should format relative time correctly for old comments', () => {
       renderWithProviders(
         <CommentEntry
+          session={session}
           {...defaultProps}
           comment={mockCommentStates.oldComment}
         />
@@ -195,7 +209,7 @@ describe('CommentEntry Component', () => {
   describe('Focus State', () => {
     it('should apply focus styles when focused', () => {
       const { container } = renderWithProviders(
-        <CommentEntry {...defaultProps} isFocused={true} />
+        <CommentEntry session={session} {...defaultProps} isFocused={true} />
       );
 
       const commentDiv = container.querySelector('.semiont-annotation-entry');
@@ -205,7 +219,7 @@ describe('CommentEntry Component', () => {
 
     it('should not apply focus styles when not focused', () => {
       const { container } = renderWithProviders(
-        <CommentEntry {...defaultProps} isFocused={false} />
+        <CommentEntry session={session} {...defaultProps} isFocused={false} />
       );
 
       const commentDiv = container.querySelector('.semiont-skeleton-outline');
@@ -217,14 +231,14 @@ describe('CommentEntry Component', () => {
       Element.prototype.scrollIntoView = mockScrollIntoView;
 
       const { rerender } = renderWithProviders(
-        <CommentEntry {...defaultProps} isFocused={false} />
+        <CommentEntry session={session} {...defaultProps} isFocused={false} />
       );
 
       // Clear any initial calls
       mockScrollIntoView.mockClear();
 
       // Becomes focused
-      rerender(<CommentEntry {...defaultProps} isFocused={true} />);
+      rerender(<CommentEntry session={session} {...defaultProps} isFocused={true} />);
 
       await waitFor(() => {
         expect(mockScrollIntoView).toHaveBeenCalledWith({
@@ -239,13 +253,12 @@ describe('CommentEntry Component', () => {
     it('should emit browse:click event when comment is clicked', async () => {
       const clickHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <CommentEntry {...defaultProps} />,
-        { returnEventBus: true }
+      const { container } = renderWithProviders(
+        <CommentEntry session={session} {...defaultProps} />
       );
 
       // Subscribe to actual event on real event bus
-      const subscription = eventBus!.get('browse:click').subscribe(clickHandler);
+      const subscription = eventBus.get('browse:click').subscribe(clickHandler);
 
       const commentDiv = container.firstChild as HTMLElement;
       await userEvent.click(commentDiv);
@@ -260,7 +273,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should be clickable with cursor-pointer class', () => {
-      const { container } = renderWithProviders(<CommentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const commentDiv = container.firstChild as HTMLElement;
       expect(commentDiv).toHaveClass('semiont-annotation-entry');
@@ -272,13 +285,12 @@ describe('CommentEntry Component', () => {
       vi.useFakeTimers();
       const hoverHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <CommentEntry {...defaultProps} />,
-        { returnEventBus: true }
+      const { container } = renderWithProviders(
+        <CommentEntry session={session} {...defaultProps} />
       );
 
       // Subscribe to actual event
-      const subscription = eventBus!.get('beckon:hover').subscribe(hoverHandler);
+      const subscription = eventBus.get('beckon:hover').subscribe(hoverHandler);
 
       const commentDiv = container.firstChild as HTMLElement;
       fireEvent.mouseEnter(commentDiv);
@@ -300,13 +312,12 @@ describe('CommentEntry Component', () => {
       vi.useFakeTimers();
       const hoverHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <CommentEntry {...defaultProps} />,
-        { returnEventBus: true }
+      const { container } = renderWithProviders(
+        <CommentEntry session={session} {...defaultProps} />
       );
 
       // Subscribe to actual event
-      const subscription = eventBus!.get('beckon:hover').subscribe(hoverHandler);
+      const subscription = eventBus.get('beckon:hover').subscribe(hoverHandler);
 
       const commentDiv = container.firstChild as HTMLElement;
       fireEvent.mouseEnter(commentDiv);
@@ -326,12 +337,11 @@ describe('CommentEntry Component', () => {
       vi.useFakeTimers();
       const hoverHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <CommentEntry {...defaultProps} />,
-        { returnEventBus: true }
+      const { container } = renderWithProviders(
+        <CommentEntry session={session} {...defaultProps} />
       );
 
-      const subscription = eventBus!.get('beckon:hover').subscribe(hoverHandler);
+      const subscription = eventBus.get('beckon:hover').subscribe(hoverHandler);
 
       const commentDiv = container.firstChild as HTMLElement;
       fireEvent.mouseEnter(commentDiv);
@@ -348,7 +358,7 @@ describe('CommentEntry Component', () => {
 
     it('should handle hover events without errors', () => {
       const { container } = renderWithProviders(
-        <CommentEntry {...defaultProps} />
+        <CommentEntry session={session} {...defaultProps} />
       );
 
       const commentDiv = container.firstChild as HTMLElement;
@@ -362,13 +372,13 @@ describe('CommentEntry Component', () => {
 
   describe('Edit Functionality', () => {
     it('should show edit button', () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       expect(screen.getByText('Edit')).toBeInTheDocument();
     });
 
     it('should enter edit mode when edit button is clicked', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const editButton = screen.getByText('Edit');
       await userEvent.click(editButton);
@@ -381,7 +391,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should show save and cancel buttons in edit mode', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const editButton = screen.getByText('Edit');
       await userEvent.click(editButton);
@@ -393,12 +403,11 @@ describe('CommentEntry Component', () => {
 
     it('should stop event propagation when clicking textarea in edit mode', async () => {
       const clickHandler = vi.fn();
-      const { eventBus } = renderWithProviders(
-        <CommentEntry {...defaultProps} />,
-        { returnEventBus: true }
+      renderWithProviders(
+        <CommentEntry session={session} {...defaultProps} />
       );
 
-      const subscription = eventBus!.get('browse:click').subscribe(clickHandler);
+      const subscription = eventBus.get('browse:click').subscribe(clickHandler);
 
       await userEvent.click(screen.getByText('Edit'));
 
@@ -415,7 +424,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should update text in textarea', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
       const textarea = screen.getByRole('textbox');
@@ -427,7 +436,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should show character count in edit mode', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
 
@@ -435,7 +444,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should enforce max length of 2000 characters', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
       const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
@@ -444,7 +453,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should update textarea value and exit edit mode when save is clicked', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
       const textarea = screen.getByRole('textbox');
@@ -463,7 +472,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should exit edit mode after save', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
       await userEvent.click(screen.getByText('Save'));
@@ -473,7 +482,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should discard changes when cancel is clicked', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
       const textarea = screen.getByRole('textbox');
@@ -489,12 +498,11 @@ describe('CommentEntry Component', () => {
 
     it('should not emit any update when cancel is clicked', async () => {
       const clickHandler = vi.fn();
-      const { eventBus } = renderWithProviders(
-        <CommentEntry {...defaultProps} />,
-        { returnEventBus: true }
+      renderWithProviders(
+        <CommentEntry session={session} {...defaultProps} />
       );
 
-      const subscription = eventBus!.get('browse:click').subscribe(clickHandler);
+      const subscription = eventBus.get('browse:click').subscribe(clickHandler);
 
       await userEvent.click(screen.getByText('Edit'));
       clickHandler.mockClear();
@@ -512,14 +520,14 @@ describe('CommentEntry Component', () => {
 
   describe('Styling and Appearance', () => {
     it('should have proper border and padding styles', () => {
-      const { container } = renderWithProviders(<CommentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const commentDiv = container.firstChild as HTMLElement;
       expect(commentDiv).toHaveClass('semiont-annotation-entry');
     });
 
     it('should have hover styles when not focused', () => {
-      const { container } = renderWithProviders(<CommentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const commentDiv = container.firstChild as HTMLElement;
       expect(commentDiv).toHaveClass('semiont-annotation-entry');
@@ -527,7 +535,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should support dark mode classes', () => {
-      const { container } = renderWithProviders(<CommentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const commentDiv = container.firstChild as HTMLElement;
       expect(commentDiv).toHaveClass('semiont-annotation-entry');
@@ -535,7 +543,7 @@ describe('CommentEntry Component', () => {
 
     it('should render comment text with whitespace preserved', () => {
       mockGetCommentText.mockReturnValue('Line 1\nLine 2\nLine 3');
-      const { container } = renderWithProviders(<CommentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       // Look for the comment text in the annotation entry
       const commentContent = container.querySelector('.semiont-annotation-entry__body');
@@ -546,7 +554,7 @@ describe('CommentEntry Component', () => {
   describe('Edge Cases', () => {
     it('should handle empty comment text', () => {
       mockGetCommentText.mockReturnValue('');
-      const { container } = renderWithProviders(<CommentEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       // Check that the annotation entry exists even with empty text
       const commentDiv = container.querySelector('.semiont-annotation-entry');
@@ -557,7 +565,7 @@ describe('CommentEntry Component', () => {
       mockGetAnnotationExactText.mockReturnValue('');
 
       expect(() => {
-        renderWithProviders(<CommentEntry {...defaultProps} />);
+        renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
       }).not.toThrow();
     });
 
@@ -567,7 +575,7 @@ describe('CommentEntry Component', () => {
 
       expect(() => {
         renderWithProviders(
-          <CommentEntry {...defaultProps} comment={commentWithoutTimestamp} />
+          <CommentEntry session={session} {...defaultProps} comment={commentWithoutTimestamp} />
         );
       }).not.toThrow();
     });
@@ -577,7 +585,7 @@ describe('CommentEntry Component', () => {
       mockGetCommentText.mockReturnValue(longText);
 
       renderWithProviders(
-        <CommentEntry {...defaultProps} comment={mockCommentStates.withLongText} />
+        <CommentEntry session={session} {...defaultProps} comment={mockCommentStates.withLongText} />
       );
 
       // Use a more flexible matcher for long text
@@ -587,7 +595,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should handle rapid edit/cancel cycles', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       for (let i = 0; i < 3; i++) {
         await userEvent.click(screen.getByText('Edit'));
@@ -601,7 +609,7 @@ describe('CommentEntry Component', () => {
 
   describe('Accessibility', () => {
     it('should have proper ARIA attributes for textarea', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
       const textarea = screen.getByRole('textbox');
@@ -610,7 +618,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should be keyboard navigable', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       const editButton = screen.getByText('Edit');
       editButton.focus();
@@ -619,7 +627,7 @@ describe('CommentEntry Component', () => {
     });
 
     it('should support keyboard interaction for save/cancel', async () => {
-      renderWithProviders(<CommentEntry {...defaultProps} />);
+      renderWithProviders(<CommentEntry session={session} {...defaultProps} />);
 
       await userEvent.click(screen.getByText('Edit'));
 

--- a/packages/react-ui/src/components/resource/panels/__tests__/CommentsPanel.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/CommentsPanel.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { CommentsPanel } from '../CommentsPanel';
 import type { EventBus } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
 import { createTestSemiontWrapper } from '../../../../test-utils';
 
 import type { Annotation, AnnotationId } from '@semiont/core';
@@ -32,8 +33,18 @@ function createEventTracker() {
   };
 }
 
+// Per-test session/bus/wrapper — created in beforeEach because test-utils
+// disposes every created client after each test (a module-scope wrapper
+// would hand later tests a disposed client).
+let session: SemiontSession;
+let eventBus: EventBus;
+let SemiontWrapper: React.ComponentType<{ children: React.ReactNode }>;
+
+beforeEach(() => {
+  ({ session, eventBus, SemiontWrapper } = createTestSemiontWrapper());
+});
+
 const renderWithEventBus = (component: React.ReactElement, tracker?: ReturnType<typeof createEventTracker>) => {
-  const { SemiontWrapper, eventBus } = createTestSemiontWrapper();
   if (tracker) tracker._attach(eventBus);
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
@@ -168,7 +179,7 @@ describe('CommentsPanel Component', () => {
 
   describe('Rendering', () => {
     it('should render panel header with title and count', () => {
-      renderWithEventBus(<CommentsPanel {...defaultProps} annotations={mockComments.multiple} />);
+      renderWithEventBus(<CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />);
 
       const headings = screen.getAllByText(/Comments/);
       expect(headings.length).toBeGreaterThan(0);
@@ -176,13 +187,13 @@ describe('CommentsPanel Component', () => {
     });
 
     it('should show empty state when no comments', () => {
-      renderWithEventBus(<CommentsPanel {...defaultProps} />);
+      renderWithEventBus(<CommentsPanel session={session} {...defaultProps} />);
 
       expect(screen.getByText(/No comments yet/)).toBeInTheDocument();
     });
 
     it('should render all comments', () => {
-      renderWithEventBus(<CommentsPanel {...defaultProps} annotations={mockComments.multiple} />);
+      renderWithEventBus(<CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />);
 
       expect(screen.getByTestId('comment-1')).toBeInTheDocument();
       expect(screen.getByTestId('comment-2')).toBeInTheDocument();
@@ -190,7 +201,7 @@ describe('CommentsPanel Component', () => {
     });
 
     it('should have proper panel structure', () => {
-      const { container } = renderWithEventBus(<CommentsPanel {...defaultProps} />);
+      const { container } = renderWithEventBus(<CommentsPanel session={session} {...defaultProps} />);
 
       // Find the root panel div (first child of the container)
       const panel = container.firstChild as HTMLElement;
@@ -199,7 +210,7 @@ describe('CommentsPanel Component', () => {
 
     it('should have scrollable comments list', () => {
       const { container } = renderWithEventBus(
-        <CommentsPanel {...defaultProps} annotations={mockComments.many} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.many} />
       );
 
       const commentsList = container.querySelector('.semiont-panel__list');
@@ -209,7 +220,7 @@ describe('CommentsPanel Component', () => {
 
   describe('Comment Sorting', () => {
     it('should sort comments by position in resource', () => {
-      renderWithEventBus(<CommentsPanel {...defaultProps} annotations={mockComments.multiple} />);
+      renderWithEventBus(<CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />);
 
       const comments = screen.getAllByTestId(/comment-/);
 
@@ -223,13 +234,13 @@ describe('CommentsPanel Component', () => {
       mockGetTextPositionSelector.mockReturnValue(null);
 
       expect(() => {
-        renderWithEventBus(<CommentsPanel {...defaultProps} annotations={mockComments.multiple} />);
+        renderWithEventBus(<CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />);
       }).not.toThrow();
     });
 
     it('should maintain sort order when comments update', () => {
       const { rerender } = renderWithEventBus(
-        <CommentsPanel {...defaultProps} annotations={mockComments.multiple} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />
       );
 
       // Add a new comment at position 25
@@ -239,7 +250,7 @@ describe('CommentsPanel Component', () => {
       ];
 
       rerender(
-        <CommentsPanel {...defaultProps} annotations={updatedComments} />
+        <CommentsPanel session={session} {...defaultProps} annotations={updatedComments} />
       );
 
       const comments = screen.getAllByTestId(/comment-/);
@@ -254,7 +265,7 @@ describe('CommentsPanel Component', () => {
 
   describe('New Comment Creation', () => {
     it('should not show new comment input by default', () => {
-      renderWithEventBus(<CommentsPanel {...defaultProps} />);
+      renderWithEventBus(<CommentsPanel session={session} {...defaultProps} />);
 
       expect(screen.queryByPlaceholderText(/Add your comment/)).not.toBeInTheDocument();
     });
@@ -264,6 +275,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -277,6 +289,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -291,6 +304,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -305,6 +319,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -321,6 +336,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -339,6 +355,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -353,6 +370,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -368,6 +386,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />,
@@ -394,6 +413,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -411,6 +431,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -425,6 +446,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -442,6 +464,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -459,6 +482,7 @@ describe('CommentsPanel Component', () => {
 
       const { container } = renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -474,6 +498,7 @@ describe('CommentsPanel Component', () => {
     it('should render comment entries', () => {
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           annotations={mockComments.single}
         />
@@ -490,6 +515,7 @@ describe('CommentsPanel Component', () => {
       expect(() => {
         renderWithEventBus(
           <CommentsPanel
+            session={session}
             {...defaultProps}
             annotations={mockComments.single}
           />
@@ -502,6 +528,7 @@ describe('CommentsPanel Component', () => {
     it('should render comments', () => {
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           annotations={mockComments.multiple}
         />
@@ -515,7 +542,7 @@ describe('CommentsPanel Component', () => {
   describe('Panel Structure and Styling', () => {
     it('should have fixed header that does not scroll', () => {
       renderWithEventBus(
-        <CommentsPanel {...defaultProps} annotations={mockComments.many} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.many} />
       );
 
       const headers = screen.getAllByText(/Comments/);
@@ -524,7 +551,7 @@ describe('CommentsPanel Component', () => {
     });
 
     it('should support dark mode', () => {
-      const { container } = renderWithEventBus(<CommentsPanel {...defaultProps} />);
+      const { container } = renderWithEventBus(<CommentsPanel session={session} {...defaultProps} />);
 
       const panel = container.firstChild as HTMLElement;
       expect(panel).toHaveClass('semiont-panel');
@@ -532,7 +559,7 @@ describe('CommentsPanel Component', () => {
 
     it('should have proper spacing between comments', () => {
       const { container } = renderWithEventBus(
-        <CommentsPanel {...defaultProps} annotations={mockComments.multiple} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />
       );
 
       const commentsList = container.querySelector('.semiont-panel__list');
@@ -540,7 +567,7 @@ describe('CommentsPanel Component', () => {
     });
 
     it('should have proper border styling', () => {
-      renderWithEventBus(<CommentsPanel {...defaultProps} />);
+      renderWithEventBus(<CommentsPanel session={session} {...defaultProps} />);
 
       const headers = screen.getAllByText(/Comments/);
       const header = headers[0].closest('div');
@@ -551,7 +578,7 @@ describe('CommentsPanel Component', () => {
   describe('Edge Cases', () => {
     it('should handle empty comments array', () => {
       expect(() => {
-        renderWithEventBus(<CommentsPanel {...defaultProps} annotations={[]} />);
+        renderWithEventBus(<CommentsPanel session={session} {...defaultProps} annotations={[]} />);
       }).not.toThrow();
 
       expect(screen.getByText(/No comments yet/)).toBeInTheDocument();
@@ -559,7 +586,7 @@ describe('CommentsPanel Component', () => {
 
     it('should handle rapid comment additions', () => {
       const { rerender } = renderWithEventBus(
-        <CommentsPanel {...defaultProps} annotations={mockComments.empty} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.empty} />
       );
 
       for (let i = 1; i <= 5; i++) {
@@ -567,7 +594,7 @@ describe('CommentsPanel Component', () => {
           createMockComment(`${j + 1}`, j * 10, (j + 1) * 10)
         );
         rerender(
-          <CommentsPanel {...defaultProps} annotations={comments} />
+          <CommentsPanel session={session} {...defaultProps} annotations={comments} />
         );
       }
 
@@ -576,13 +603,13 @@ describe('CommentsPanel Component', () => {
 
     it('should handle comment removal', () => {
       const { rerender } = renderWithEventBus(
-        <CommentsPanel {...defaultProps} annotations={mockComments.multiple} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />
       );
 
       expect(screen.getAllByTestId(/comment-/)).toHaveLength(3);
 
       rerender(
-        <CommentsPanel {...defaultProps} annotations={mockComments.single} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.single} />
       );
 
       expect(screen.getAllByTestId(/comment-/)).toHaveLength(1);
@@ -593,6 +620,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -608,7 +636,7 @@ describe('CommentsPanel Component', () => {
       );
 
       expect(() => {
-        renderWithEventBus(<CommentsPanel {...defaultProps} annotations={manyComments} />);
+        renderWithEventBus(<CommentsPanel session={session} {...defaultProps} annotations={manyComments} />);
       }).not.toThrow();
 
       expect(screen.getAllByTestId(/comment-/)).toHaveLength(100);
@@ -622,7 +650,7 @@ describe('CommentsPanel Component', () => {
       ];
 
       expect(() => {
-        renderWithEventBus(<CommentsPanel {...defaultProps} annotations={commentsAtSamePosition} />);
+        renderWithEventBus(<CommentsPanel session={session} {...defaultProps} annotations={commentsAtSamePosition} />);
       }).not.toThrow();
 
       expect(screen.getAllByTestId(/comment-/)).toHaveLength(3);
@@ -631,7 +659,7 @@ describe('CommentsPanel Component', () => {
 
   describe('Accessibility', () => {
     it('should have proper heading structure', () => {
-      renderWithEventBus(<CommentsPanel {...defaultProps} />);
+      renderWithEventBus(<CommentsPanel session={session} {...defaultProps} />);
 
       const headings = screen.getAllByText(/Comments/);
       expect(headings[0]).toHaveClass('semiont-panel-header__text');
@@ -648,6 +676,7 @@ describe('CommentsPanel Component', () => {
 
       renderWithEventBus(
         <CommentsPanel
+          session={session}
           {...defaultProps}
           pendingAnnotation={pendingAnnotation}
         />
@@ -659,7 +688,7 @@ describe('CommentsPanel Component', () => {
 
     it('should have semantic HTML structure', () => {
       const { container } = renderWithEventBus(
-        <CommentsPanel {...defaultProps} annotations={mockComments.multiple} />
+        <CommentsPanel session={session} {...defaultProps} annotations={mockComments.multiple} />
       );
 
       // Panel should be a properly structured div hierarchy

--- a/packages/react-ui/src/components/resource/panels/__tests__/HighlightEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/HighlightEntry.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { renderWithProviders } from '../../../../test-utils';
+import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
 import userEvent from '@testing-library/user-event';
+import type { SemiontSession } from '@semiont/sdk';
 
-import type { Annotation, AnnotationId } from '@semiont/core';
+import type { Annotation, AnnotationId, EventBus } from '@semiont/core';
 
 // Mock @semiont/http-transport
 vi.mock('@semiont/core', async () => {
@@ -49,14 +50,21 @@ describe('HighlightEntry', () => {
     isFocused: false,
   };
 
+  // Created per-test: test-utils disposes every created client in a
+  // module-scope afterEach, so a module-scope session would be dead
+  // after the first test.
+  let session: SemiontSession;
+  let eventBus: EventBus;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAnnotationExactText.mockReturnValue('This is the highlighted text');
+    ({ session, eventBus } = createTestSemiontWrapper());
   });
 
   describe('Rendering', () => {
     it('should render the selected text in quotes', () => {
-      renderWithProviders(<HighlightEntry {...defaultProps} />);
+      renderWithProviders(<HighlightEntry {...defaultProps} session={session} />);
 
       expect(screen.getByText(/This is the highlighted text/)).toBeInTheDocument();
     });
@@ -65,7 +73,7 @@ describe('HighlightEntry', () => {
       const longText = 'A'.repeat(250);
       mockGetAnnotationExactText.mockReturnValue(longText);
 
-      renderWithProviders(<HighlightEntry {...defaultProps} />);
+      renderWithProviders(<HighlightEntry {...defaultProps} session={session} />);
 
       // Should show first 200 chars followed by ellipsis
       expect(screen.getByText(new RegExp(`"${'A'.repeat(200)}`))).toBeInTheDocument();
@@ -76,7 +84,7 @@ describe('HighlightEntry', () => {
       const exactText = 'B'.repeat(200);
       mockGetAnnotationExactText.mockReturnValue(exactText);
 
-      const { container } = renderWithProviders(<HighlightEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<HighlightEntry {...defaultProps} session={session} />);
 
       const quote = container.querySelector('.semiont-annotation-entry__quote');
       expect(quote).toBeInTheDocument();
@@ -84,7 +92,7 @@ describe('HighlightEntry', () => {
     });
 
     it('should show creator name', () => {
-      renderWithProviders(<HighlightEntry {...defaultProps} />);
+      renderWithProviders(<HighlightEntry {...defaultProps} session={session} />);
 
       expect(screen.getByText(/alice@example.com/)).toBeInTheDocument();
     });
@@ -94,7 +102,7 @@ describe('HighlightEntry', () => {
       delete (highlight as Record<string, unknown>).creator;
 
       renderWithProviders(
-        <HighlightEntry highlight={highlight} isFocused={false} />
+        <HighlightEntry highlight={highlight} isFocused={false} session={session} />
       );
 
       expect(screen.getByText(/Unknown/)).toBeInTheDocument();
@@ -106,7 +114,7 @@ describe('HighlightEntry', () => {
       });
 
       renderWithProviders(
-        <HighlightEntry highlight={recentHighlight} isFocused={false} />
+        <HighlightEntry highlight={recentHighlight} isFocused={false} session={session} />
       );
 
       expect(screen.getByText(/just now/)).toBeInTheDocument();
@@ -115,7 +123,7 @@ describe('HighlightEntry', () => {
     it('should not render quote section when selectedText is empty', () => {
       mockGetAnnotationExactText.mockReturnValue('');
 
-      const { container } = renderWithProviders(<HighlightEntry {...defaultProps} />);
+      const { container } = renderWithProviders(<HighlightEntry {...defaultProps} session={session} />);
 
       expect(container.querySelector('.semiont-annotation-entry__quote')).not.toBeInTheDocument();
     });
@@ -125,12 +133,14 @@ describe('HighlightEntry', () => {
     it('should emit browse:click on click', async () => {
       const clickHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <HighlightEntry {...defaultProps} />,
-        { returnEventBus: true }
+      // The component only sees the `session` prop now, so the assertion
+      // must subscribe on that same session's bus — not the bus of the
+      // wrapper renderWithProviders creates internally.
+      const { container } = renderWithProviders(
+        <HighlightEntry {...defaultProps} session={session} />
       );
 
-      const subscription = eventBus!.get('browse:click').subscribe(clickHandler);
+      const subscription = eventBus.get('browse:click').subscribe(clickHandler);
 
       const entry = container.firstChild as HTMLElement;
       await userEvent.click(entry);
@@ -147,7 +157,7 @@ describe('HighlightEntry', () => {
   describe('Hover state', () => {
     it('should apply pulse class when isHovered is true', () => {
       const { container } = renderWithProviders(
-        <HighlightEntry {...defaultProps} isHovered={true} />
+        <HighlightEntry {...defaultProps} isHovered={true} session={session} />
       );
 
       const entry = container.firstChild as HTMLElement;
@@ -156,7 +166,7 @@ describe('HighlightEntry', () => {
 
     it('should not apply pulse class when isHovered is false', () => {
       const { container } = renderWithProviders(
-        <HighlightEntry {...defaultProps} isHovered={false} />
+        <HighlightEntry {...defaultProps} isHovered={false} session={session} />
       );
 
       const entry = container.firstChild as HTMLElement;
@@ -167,7 +177,7 @@ describe('HighlightEntry', () => {
   describe('Focus state', () => {
     it('should set data-focused to true when focused', () => {
       const { container } = renderWithProviders(
-        <HighlightEntry {...defaultProps} isFocused={true} />
+        <HighlightEntry {...defaultProps} isFocused={true} session={session} />
       );
 
       const entry = container.firstChild as HTMLElement;
@@ -176,7 +186,7 @@ describe('HighlightEntry', () => {
 
     it('should set data-focused to false when not focused', () => {
       const { container } = renderWithProviders(
-        <HighlightEntry {...defaultProps} isFocused={false} />
+        <HighlightEntry {...defaultProps} isFocused={false} session={session} />
       );
 
       const entry = container.firstChild as HTMLElement;

--- a/packages/react-ui/src/components/resource/panels/__tests__/HighlightPanel.annotationProgress.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/HighlightPanel.annotationProgress.test.tsx
@@ -14,8 +14,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { renderWithProviders } from '../../../../test-utils';
+import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
 import { HighlightPanel } from '../HighlightPanel';
+import type { SemiontSession } from '@semiont/sdk';
 
 import type { Annotation, AnnotationId } from '@semiont/core';
 
@@ -48,9 +49,14 @@ vi.mock('../../../../contexts/useEventSubscription', () => ({
 
 describe('HighlightPanel + AssistSection Integration', () => {
   let mockAnnotations: Annotation[];
+  // Created per-test: test-utils disposes every created client in a
+  // module-scope afterEach, so a module-scope session would be dead
+  // after the first test.
+  let session: SemiontSession;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    ({ session } = createTestSemiontWrapper());
 
     mockAnnotations = [
       {
@@ -74,7 +80,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
   describe('Detection Progress Prop Passing', () => {
     it('should pass progress to AssistSection when provided', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -93,7 +99,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should pass null progress to AssistSection', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={false}
@@ -109,7 +115,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should pass undefined progress to AssistSection', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={false}
@@ -125,7 +131,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should keep progress visible after detection completes (isAssisting=false)', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={false}
@@ -146,7 +152,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should pass progress with request parameters to AssistSection', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -172,7 +178,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
   describe('Annotate Mode Toggling', () => {
     it('should render AssistSection when annotateMode is true', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={false}
@@ -186,7 +192,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should NOT render AssistSection when annotateMode is false', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={false}
@@ -200,7 +206,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should hide progress when switching to browse mode (annotateMode=false)', () => {
       const { rerender } = renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -217,7 +223,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
       // Switch to browse mode
       rerender(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -238,7 +244,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
   describe('State Combinations', () => {
     it('should handle isAssisting=true with no progress (starting state)', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -253,7 +259,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should handle isAssisting=false with progress (final state)', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={false}
@@ -274,7 +280,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should handle multiple progress updates', () => {
       const { rerender } = renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -291,7 +297,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
       // Update to analyzing
       rerender(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -309,7 +315,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
       // Update to complete
       rerender(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={false}
@@ -330,7 +336,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
   describe('Highlights List Rendering', () => {
     it('should render highlights list alongside detection progress', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={mockAnnotations}
           pendingAnnotation={null}
           isAssisting={true}
@@ -350,7 +356,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
 
     it('should show empty state when no highlights', () => {
       renderWithProviders(
-        <HighlightPanel resourceId="res-1"
+        <HighlightPanel session={session} resourceId="res-1"
           annotations={[]}
           pendingAnnotation={null}
           isAssisting={false}

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferenceEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferenceEntry.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { renderWithProviders } from '../../../../test-utils';
+import type { ComponentProps } from 'react';
+import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
 import userEvent from '@testing-library/user-event';
 import { BindNamespace } from '@semiont/sdk';
-import type { RouteBuilder } from '../../../../contexts/RoutingContext';
 
 import type { Annotation, AnnotationId } from '@semiont/core';
 
@@ -16,7 +16,6 @@ const mockGetFragmentSelector = vi.fn();
 const mockGetSvgSelector = vi.fn();
 const mockGetTargetSelector = vi.fn();
 const mockGetEntityTypes = vi.fn();
-const mockNavigate = vi.fn();
 const mockHoverProps = { onMouseEnter: vi.fn(), onMouseLeave: vi.fn() };
 
 vi.mock('@semiont/core', async () => {
@@ -38,10 +37,6 @@ vi.mock('@semiont/ontology', () => ({
 
 vi.mock('../../../../lib/resource-utils', () => ({
   getResourceIcon: vi.fn(() => '📄'),
-}));
-
-vi.mock('../../../../hooks/useObservableBrowse', () => ({
-  useObservableExternalNavigation: () => mockNavigate,
 }));
 
 vi.mock('../../../../hooks/useHoverEmitter', () => ({
@@ -71,22 +66,25 @@ const createMockReference = (overrides?: Partial<Annotation>): Annotation => ({
   ...overrides,
 });
 
-const mockRoutes: RouteBuilder = {
-  resourceDetail: vi.fn((id: string) => `/resources/${id}`),
-  userProfile: vi.fn((id: string) => `/users/${id}`),
-  search: vi.fn((query: string) => `/search?q=${query}`),
-  home: vi.fn(() => '/'),
-};
-
 describe('ReferenceEntry', () => {
-  const defaultProps = {
-    reference: createMockReference(),
-    isFocused: false,
-    routes: mockRoutes,
-  };
+  // Provider-free component: the session prop is the only session it sees.
+  // Created per-test — test-utils disposes registered clients in afterEach.
+  let session: ReturnType<typeof createTestSemiontWrapper>['session'];
+  let eventBus: ReturnType<typeof createTestSemiontWrapper>['eventBus'];
+
+  const renderEntry = (props: Partial<ComponentProps<typeof ReferenceEntry>> = {}) =>
+    renderWithProviders(
+      <ReferenceEntry
+        session={session}
+        reference={createMockReference()}
+        isFocused={false}
+        {...props}
+      />,
+    );
 
   beforeEach(() => {
     vi.clearAllMocks();
+    ({ session, eventBus } = createTestSemiontWrapper());
     mockGetAnnotationExactText.mockReturnValue('referenced text');
     mockIsBodyResolved.mockReturnValue(false);
     mockGetBodySource.mockReturnValue(null);
@@ -98,7 +96,7 @@ describe('ReferenceEntry', () => {
 
   describe('Rendering', () => {
     it('should render the selected text in quotes', () => {
-      renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      renderEntry();
 
       expect(screen.getByText(/referenced text/)).toBeInTheDocument();
     });
@@ -107,7 +105,7 @@ describe('ReferenceEntry', () => {
       const longText = 'A'.repeat(150);
       mockGetAnnotationExactText.mockReturnValue(longText);
 
-      renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      renderEntry();
 
       expect(screen.getByText(new RegExp(`"${'A'.repeat(100)}`))).toBeInTheDocument();
       expect(screen.getByText(/\.\.\./)).toBeInTheDocument();
@@ -116,7 +114,7 @@ describe('ReferenceEntry', () => {
     it('should show stub icon when reference is not resolved', () => {
       mockIsBodyResolved.mockReturnValue(false);
 
-      const { container } = renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      const { container } = renderEntry();
 
       const icon = container.querySelector('.semiont-reference-icon');
       expect(icon).toBeInTheDocument();
@@ -127,7 +125,7 @@ describe('ReferenceEntry', () => {
       mockIsBodyResolved.mockReturnValue(true);
       mockGetBodySource.mockReturnValue('linked-doc');
 
-      const { container } = renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      const { container } = renderEntry();
 
       const icon = container.querySelector('.semiont-reference-icon');
       expect(icon).toBeInTheDocument();
@@ -137,7 +135,7 @@ describe('ReferenceEntry', () => {
     it('should show annotation type when no selected text', () => {
       mockGetAnnotationExactText.mockReturnValue('');
 
-      renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      renderEntry();
 
       expect(screen.getByText('Annotation')).toBeInTheDocument();
     });
@@ -146,7 +144,7 @@ describe('ReferenceEntry', () => {
       mockGetAnnotationExactText.mockReturnValue('');
       mockGetFragmentSelector.mockReturnValue({ type: 'FragmentSelector', value: 'xywh=0,0,100,100' });
 
-      renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      renderEntry();
 
       expect(screen.getByText('Fragment annotation')).toBeInTheDocument();
     });
@@ -155,7 +153,7 @@ describe('ReferenceEntry', () => {
       mockGetAnnotationExactText.mockReturnValue('');
       mockGetSvgSelector.mockReturnValue({ type: 'SvgSelector', value: '<svg/>' });
 
-      renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      renderEntry();
 
       expect(screen.getByText('Image annotation')).toBeInTheDocument();
     });
@@ -170,7 +168,7 @@ describe('ReferenceEntry', () => {
         _resolvedDocumentMediaType: 'text/plain',
       };
 
-      renderWithProviders(<ReferenceEntry {...defaultProps} reference={enrichedRef as Annotation} />);
+      renderEntry({ reference: enrichedRef as Annotation });
 
       expect(screen.getByText(/My Linked Document/)).toBeInTheDocument();
     });
@@ -180,7 +178,7 @@ describe('ReferenceEntry', () => {
     it('should render entity type badges', () => {
       mockGetEntityTypes.mockReturnValue(['Person', 'Organization']);
 
-      renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      renderEntry();
 
       expect(screen.getByText('Person')).toBeInTheDocument();
       expect(screen.getByText('Organization')).toBeInTheDocument();
@@ -189,7 +187,7 @@ describe('ReferenceEntry', () => {
     it('should not render entity type section when empty', () => {
       mockGetEntityTypes.mockReturnValue([]);
 
-      const { container } = renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      const { container } = renderEntry();
 
       expect(container.querySelector('.semiont-annotation-entry__tags')).not.toBeInTheDocument();
     });
@@ -197,36 +195,28 @@ describe('ReferenceEntry', () => {
 
   describe('Focus and hover state', () => {
     it('should set data-focused to true when focused', () => {
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} isFocused={true} />
-      );
+      const { container } = renderEntry({ isFocused: true });
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).toHaveAttribute('data-focused', 'true');
     });
 
     it('should set data-focused to false when not focused', () => {
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} isFocused={false} />
-      );
+      const { container } = renderEntry({ isFocused: false });
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).toHaveAttribute('data-focused', 'false');
     });
 
     it('should apply pulse class when isHovered is true', () => {
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} isHovered={true} />
-      );
+      const { container } = renderEntry({ isHovered: true });
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).toHaveClass('semiont-annotation-pulse');
     });
 
     it('should not apply pulse class when isHovered is false', () => {
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} isHovered={false} />
-      );
+      const { container } = renderEntry({ isHovered: false });
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).not.toHaveClass('semiont-annotation-pulse');
@@ -237,12 +227,9 @@ describe('ReferenceEntry', () => {
     it('should emit browse:click on click', async () => {
       const clickHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} />,
-        { returnEventBus: true }
-      );
+      const { container } = renderEntry();
 
-      const subscription = eventBus!.get('browse:click').subscribe(clickHandler);
+      const subscription = eventBus.get('browse:click').subscribe(clickHandler);
 
       const entry = container.firstChild as HTMLElement;
       await userEvent.click(entry);
@@ -257,24 +244,24 @@ describe('ReferenceEntry', () => {
   });
 
   describe('Status icon — resolved reference', () => {
-    it('should navigate on 🔗 icon click', async () => {
+    it('should call onOpenResource on 🔗 icon click', async () => {
       mockIsBodyResolved.mockReturnValue(true);
       mockGetBodySource.mockReturnValue('linked-doc');
+      const onOpenResource = vi.fn();
 
-      const { container } = renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      const { container } = renderEntry({ onOpenResource });
 
       const icon = container.querySelector('.semiont-reference-icon')!;
       await userEvent.click(icon);
 
-      expect(mockRoutes.resourceDetail).toHaveBeenCalledWith('linked-doc');
-      expect(mockNavigate).toHaveBeenCalledWith('/resources/linked-doc', { resourceId: 'linked-doc' });
+      expect(onOpenResource).toHaveBeenCalledWith('linked-doc');
     });
 
     it('should have clickable class when resolved', () => {
       mockIsBodyResolved.mockReturnValue(true);
       mockGetBodySource.mockReturnValue('linked-doc');
 
-      const { container } = renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      const { container } = renderEntry();
 
       const icon = container.querySelector('.semiont-reference-icon');
       expect(icon).toHaveClass('semiont-reference-icon--clickable');
@@ -284,9 +271,7 @@ describe('ReferenceEntry', () => {
       mockIsBodyResolved.mockReturnValue(true);
       mockGetBodySource.mockReturnValue('linked-doc');
 
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} annotateMode={true} />
-      );
+      const { container } = renderEntry({ annotateMode: true });
 
       const unlinkButton = container.querySelector('.semiont-reference-unlink');
       expect(unlinkButton).toBeInTheDocument();
@@ -296,9 +281,7 @@ describe('ReferenceEntry', () => {
       mockIsBodyResolved.mockReturnValue(true);
       mockGetBodySource.mockReturnValue('linked-doc');
 
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} annotateMode={false} />
-      );
+      const { container } = renderEntry({ annotateMode: false });
 
       const unlinkButton = container.querySelector('.semiont-reference-unlink');
       expect(unlinkButton).not.toBeInTheDocument();
@@ -310,9 +293,7 @@ describe('ReferenceEntry', () => {
 
       const bindSpy = vi.spyOn(BindNamespace.prototype, 'body').mockResolvedValue(undefined);
 
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} annotateMode={true} />,
-      );
+      const { container } = renderEntry({ annotateMode: true });
 
       const unlinkButton = container.querySelector('.semiont-reference-unlink')!;
       await userEvent.click(unlinkButton);
@@ -333,12 +314,9 @@ describe('ReferenceEntry', () => {
       mockGetEntityTypes.mockReturnValue(['Person']);
       const initiateHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} annotateMode={true} />,
-        { returnEventBus: true }
-      );
+      const { container } = renderEntry({ annotateMode: true });
 
-      const subscription = eventBus!.get('bind:initiate').subscribe(initiateHandler);
+      const subscription = eventBus.get('bind:initiate').subscribe(initiateHandler);
 
       const icon = container.querySelector('.semiont-reference-icon')!;
       await userEvent.click(icon);
@@ -356,9 +334,7 @@ describe('ReferenceEntry', () => {
     it('should have clickable class in annotate mode', () => {
       mockIsBodyResolved.mockReturnValue(false);
 
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} annotateMode={true} />
-      );
+      const { container } = renderEntry({ annotateMode: true });
 
       const icon = container.querySelector('.semiont-reference-icon');
       expect(icon).toHaveClass('semiont-reference-icon--clickable');
@@ -367,9 +343,7 @@ describe('ReferenceEntry', () => {
     it('should not be clickable in browse mode', () => {
       mockIsBodyResolved.mockReturnValue(false);
 
-      const { container } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} annotateMode={false} />
-      );
+      const { container } = renderEntry({ annotateMode: false });
 
       const icon = container.querySelector('.semiont-reference-icon');
       expect(icon).not.toHaveClass('semiont-reference-icon--clickable');
@@ -379,12 +353,9 @@ describe('ReferenceEntry', () => {
       mockIsBodyResolved.mockReturnValue(false);
       const initiateHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <ReferenceEntry {...defaultProps} annotateMode={false} />,
-        { returnEventBus: true }
-      );
+      const { container } = renderEntry({ annotateMode: false });
 
-      const subscription = eventBus!.get('bind:initiate').subscribe(initiateHandler);
+      const subscription = eventBus.get('bind:initiate').subscribe(initiateHandler);
 
       const icon = container.querySelector('.semiont-reference-icon')!;
       await userEvent.click(icon);
@@ -397,7 +368,7 @@ describe('ReferenceEntry', () => {
 
   describe('data-type attribute', () => {
     it('should have data-type="reference"', () => {
-      const { container } = renderWithProviders(<ReferenceEntry {...defaultProps} />);
+      const { container } = renderEntry();
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).toHaveAttribute('data-type', 'reference');

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.headless.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.headless.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * HEADLESS-ANNOTATION-PANELS Phase 1 (B2) — keystone: the panel family mounts
+ * provider-free with a session PROP.
+ *
+ * ReferencesPanel rendered with a fake session prop and NO SemiontProvider /
+ * routing contexts (Link/routes are already props; translations fall back to
+ * bundled English): lists a reference annotation, and an entry click reaches
+ * session.client.browse.click — the same interaction the Browser gets, no
+ * provider anywhere.
+ *
+ * Started RED (the family reads useSemiont() — provider crash; no session
+ * prop) and GREEN once B2 lands.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { Annotation, AnnotationId } from '@semiont/core';
+import type { RouteBuilder, LinkComponentProps } from '../../../../contexts/RoutingContext';
+import { ReferencesPanel } from '../ReferencesPanel';
+
+function fakeSession() {
+  const client = {
+    browse: { click: vi.fn(), tagSchemas: () => ({ subscribe: () => ({ unsubscribe: () => {} }) }) },
+    beckon: { hover: vi.fn(), sparkle: vi.fn() },
+    mark: { requestAssist: vi.fn(), delete: vi.fn() },
+  };
+  const session = {
+    client,
+    subscribe: () => () => {},
+  } as unknown as SemiontSession;
+  return { session, client };
+}
+
+function referenceAnnotation(): Annotation {
+  return {
+    '@context': 'http://www.w3.org/ns/anno.jsonld',
+    id: 'ref-1' as AnnotationId,
+    type: 'Annotation',
+    motivation: 'linking',
+    creator: { '@type': 'Person', name: 'user@example.com' },
+    created: '2026-07-14T00:00:00Z',
+    target: {
+      source: 'res-1',
+      selector: [
+        { type: 'TextQuoteSelector', exact: 'linked text' },
+        { type: 'TextPositionSelector', start: 0, end: 11 },
+      ],
+    },
+  } as unknown as Annotation;
+}
+
+const TestLink = ({ href, children, ...rest }: LinkComponentProps) => (
+  <a href={href} {...rest}>{children}</a>
+);
+const testRoutes = {
+  resourceDetail: (id: string) => `/r/${id}`,
+  know: '/know',
+} as unknown as RouteBuilder;
+
+describe('ReferencesPanel — headless (session prop, no providers)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mounts provider-free, lists the reference, and routes an entry click through the session prop', () => {
+    const { session, client } = fakeSession();
+
+    render(
+      <ReferencesPanel
+        session={session}
+        resourceId="res-1"
+        annotations={[referenceAnnotation()]}
+        isAssisting={false}
+        progress={null}
+        pendingAnnotation={null}
+        allEntityTypes={[]}
+        Link={TestLink}
+        routes={testRoutes}
+      />,
+    );
+
+    const entryText = screen.getByText(/linked text/);
+    expect(entryText).toBeInTheDocument();
+
+    fireEvent.click(entryText);
+    expect(client.browse.click).toHaveBeenCalledWith('ref-1', 'linking');
+  });
+});

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.observable-flow.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.observable-flow.test.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BehaviorSubject } from 'rxjs';
+import type { SemiontSession } from '@semiont/sdk';
 import { ReferencesPanel } from '../ReferencesPanel';
 import { createTestSemiontWrapper } from '../../../../test-utils';
 import { useObservable } from '../../../../hooks/useObservable';
@@ -66,10 +67,11 @@ const mockRoutes = { resourceDetail: (id: string) => `/resource/${id}` } as any;
  * same hook ResourceViewerPage uses for vm.entityTypes$) and forwards
  * its value into ReferencesPanel as `allEntityTypes`.
  */
-function ObservableHarness({ source$ }: { source$: BehaviorSubject<string[]> }) {
+function ObservableHarness({ source$, session }: { source$: BehaviorSubject<string[]>; session: SemiontSession | null }) {
   const entityTypes = useObservable(source$) ?? [];
   return (
-    <ReferencesPanel resourceId="res-1"
+    <ReferencesPanel session={session}
+      resourceId="res-1"
       annotations={[]}
       isAssisting={false}
       progress={null}
@@ -85,15 +87,19 @@ function ObservableHarness({ source$ }: { source$: BehaviorSubject<string[]> }) 
   );
 }
 
-const renderWithBus = (ui: React.ReactElement) => {
-  const { SemiontWrapper } = createTestSemiontWrapper();
-  return render(<SemiontWrapper>{ui}</SemiontWrapper>);
+// Callback form so the UI is built AFTER the per-call factory runs: the
+// provider-free ReferencesPanel only sees the `session` prop, which must be
+// the fake session from this call (test-utils disposes each created client
+// in a module-scope afterEach, so no module-scope session either).
+const renderWithBus = (ui: (session: SemiontSession) => React.ReactElement) => {
+  const { SemiontWrapper, session } = createTestSemiontWrapper();
+  return render(<SemiontWrapper>{ui(session)}</SemiontWrapper>);
 };
 
 describe('Layer 5-6 — state-unit observable → useObservable → ReferencesPanel chips', () => {
   it('an observable seeded with [9 strings] renders 9 pending-reference chips', async () => {
     const source$ = new BehaviorSubject<string[]>(NINE_TYPES);
-    renderWithBus(<ObservableHarness source$={source$} />);
+    renderWithBus((session) => <ObservableHarness source$={source$} session={session} />);
 
     // Wait for useEffect in useObservable to run and commit the value.
     const chips = await screen.findAllByRole('button', { name: (_, el) =>
@@ -107,7 +113,7 @@ describe('Layer 5-6 — state-unit observable → useObservable → ReferencesPa
     // to []) first, then the 9-string array once fetch resolves. The
     // prop chain must survive this transition.
     const source$ = new BehaviorSubject<string[]>([]);
-    renderWithBus(<ObservableHarness source$={source$} />);
+    renderWithBus((session) => <ObservableHarness source$={source$} session={session} />);
 
     // Initially: no chips (the gate is allEntityTypes.length > 0).
     expect(document.querySelectorAll('.semiont-tag-selector__item').length).toBe(0);
@@ -126,7 +132,7 @@ describe('Layer 5-6 — state-unit observable → useObservable → ReferencesPa
     // to concurrent SSE streams. Same data, but multiple BehaviorSubject
     // writes. Must not clobber the render.
     const source$ = new BehaviorSubject<string[]>([]);
-    renderWithBus(<ObservableHarness source$={source$} />);
+    renderWithBus((session) => <ObservableHarness source$={source$} session={session} />);
 
     await act(async () => {
       source$.next(NINE_TYPES);
@@ -143,7 +149,7 @@ describe('Layer 5-6 — state-unit observable → useObservable → ReferencesPa
     // message the failing e2e saw. Guards against the test passing
     // trivially because of a selector bug.
     const source$ = new BehaviorSubject<string[]>([]);
-    renderWithBus(<ObservableHarness source$={source$} />);
+    renderWithBus((session) => <ObservableHarness source$={source$} session={session} />);
 
     // There are two such text nodes in the panel (pending prompt + assist
     // section), but both correspond to the same allEntityTypes=[] state.

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { ReferencesPanel } from '../ReferencesPanel';
 import type { EventBus } from '@semiont/core';
+import type { SemiontSession } from '@semiont/sdk';
 import { createTestSemiontWrapper } from '../../../../test-utils';
 
 // Composition-based event tracker
@@ -29,8 +30,20 @@ function createEventTracker() {
   };
 }
 
+// Per-test session/wrapper: created in beforeEach — test-utils disposes every
+// created client in a module-scope afterEach, so a module-scope factory call
+// would hand tests after the first a disposed client. The component is
+// provider-free: the `session` passed as a prop (same factory call as the
+// eventBus the tracker attaches to) is the only session it sees.
+let session: SemiontSession;
+let eventBus: EventBus;
+let SemiontWrapper: React.ComponentType<{ children: React.ReactNode }>;
+
+beforeEach(() => {
+  ({ session, eventBus, SemiontWrapper } = createTestSemiontWrapper());
+});
+
 const renderWithEventBus = (component: React.ReactElement, tracker?: ReturnType<typeof createEventTracker>) => {
-  const { SemiontWrapper, eventBus } = createTestSemiontWrapper();
   if (tracker) tracker._attach(eventBus);
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
@@ -96,6 +109,11 @@ describe('ReferencesPanel Component', () => {
     pendingAnnotation: null,
   };
 
+  // Per-test props: merges the beforeEach-created session at render time.
+  // (Module/describe-scope defaultProps must stay session-free — disposal
+  // hazard, see note above renderWithEventBus.)
+  const panelProps = () => ({ ...defaultProps, session });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -106,13 +124,13 @@ describe('ReferencesPanel Component', () => {
 
   describe('Rendering', () => {
     it('should render panel with title', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       expect(screen.getByText('Annotate References')).toBeInTheDocument();
     });
 
     it('should render all entity type buttons', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       expect(screen.getByText('Person')).toBeInTheDocument();
       expect(screen.getByText('Organization')).toBeInTheDocument();
@@ -121,13 +139,13 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should show message when no entity types available', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} allEntityTypes={[]} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} allEntityTypes={[]} />);
 
       expect(screen.getByText('No entity types available')).toBeInTheDocument();
     });
 
     it('should render start detection button', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       expect(screen.getByTitle('Annotate')).toBeInTheDocument();
     });
@@ -135,7 +153,7 @@ describe('ReferencesPanel Component', () => {
 
   describe('Entity Type Selection', () => {
     it('should toggle entity type selection on click', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -154,7 +172,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should allow multiple selections', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
       const orgButton = screen.getByText('Organization');
@@ -170,7 +188,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should deselect when clicking selected type', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -182,7 +200,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should show selected count', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
       const orgButton = screen.getByText('Organization');
@@ -199,7 +217,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should not show selected count when none selected', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       expect(screen.queryByText(/selected/i)).not.toBeInTheDocument();
     });
@@ -207,7 +225,7 @@ describe('ReferencesPanel Component', () => {
 
   describe('Button Styling', () => {
     it('should style selected buttons differently', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -222,7 +240,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should have proper ARIA attributes', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -231,7 +249,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should have focus styles', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -241,7 +259,7 @@ describe('ReferencesPanel Component', () => {
 
   describe('Start Annotate Button', () => {
     it('should be disabled when no types selected', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const startButton = screen.getByTitle('Annotate');
 
@@ -249,7 +267,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should be enabled when types are selected', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
       await userEvent.click(personButton);
@@ -261,7 +279,7 @@ describe('ReferencesPanel Component', () => {
 
     it('should emit annotate:detect-request event with selected types and includeDescriptiveReferences', async () => {
       const tracker = createEventTracker();
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />, tracker);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />, tracker);
 
       await userEvent.click(screen.getByText('Person'));
       await userEvent.click(screen.getByText('Organization'));
@@ -282,7 +300,7 @@ describe('ReferencesPanel Component', () => {
 
     it('should emit annotate:detect-request event with includeDescriptiveReferences when checkbox is checked', async () => {
       const tracker = createEventTracker();
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />, tracker);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />, tracker);
 
       await userEvent.click(screen.getByText('Person'));
 
@@ -305,7 +323,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should clear selected types after detection starts', async () => {
-      const { rerender } = renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      const { rerender } = renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       await userEvent.click(screen.getByText('Person'));
 
@@ -315,7 +333,7 @@ describe('ReferencesPanel Component', () => {
       // Simulate detection starting
       rerender(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={true}
           progress={{ stage: 'analyzing', percentage: 0, message: 'Detecting references...', completedEntityTypes: [] }}
         />
@@ -324,7 +342,7 @@ describe('ReferencesPanel Component', () => {
       // Simulate detection completing
       rerender(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -340,7 +358,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should have proper styling when disabled', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const startButton = screen.getByTitle('Annotate');
 
@@ -351,7 +369,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should have proper styling when enabled', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       await userEvent.click(screen.getByText('Person'));
 
@@ -368,7 +386,7 @@ describe('ReferencesPanel Component', () => {
     it('should show progress widget when detecting', () => {
       renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={true}
           progress={{ stage: 'analyzing', percentage: 0, message: 'Detecting references...', completedEntityTypes: [] }}
         />
@@ -390,7 +408,7 @@ describe('ReferencesPanel Component', () => {
 
       renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={true}
           progress={progress}
         />
@@ -404,7 +422,7 @@ describe('ReferencesPanel Component', () => {
     it('should hide entity type selection during detection', () => {
       renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={true}
           progress={{ stage: 'analyzing', percentage: 0, message: 'Detecting references...', completedEntityTypes: [] }}
         />
@@ -417,7 +435,7 @@ describe('ReferencesPanel Component', () => {
     it('should render cancel button when detecting', async () => {
       renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={true}
           progress={{ stage: 'analyzing', percentage: 0, message: 'Detecting references...', completedEntityTypes: [] }}
         />
@@ -432,7 +450,7 @@ describe('ReferencesPanel Component', () => {
     it('should show completed log after detection finishes', () => {
       const { rerender } = renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -449,7 +467,7 @@ describe('ReferencesPanel Component', () => {
       // Parent clears progress after completion
       rerender(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={null}
         />
@@ -462,7 +480,7 @@ describe('ReferencesPanel Component', () => {
     it('should show found counts in log', () => {
       const { rerender } = renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -474,7 +492,7 @@ describe('ReferencesPanel Component', () => {
       );
 
       rerender(
-        <ReferencesPanel {...defaultProps} isAssisting={false} progress={null} />
+        <ReferencesPanel {...panelProps()} isAssisting={false} progress={null} />
       );
       expect(screen.getByText(/Found.*5/i)).toBeInTheDocument();
     });
@@ -482,7 +500,7 @@ describe('ReferencesPanel Component', () => {
     it('should show checkmarks for completed types', () => {
       const { rerender } = renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -494,7 +512,7 @@ describe('ReferencesPanel Component', () => {
       );
 
       rerender(
-        <ReferencesPanel {...defaultProps} isAssisting={false} progress={null} />
+        <ReferencesPanel {...panelProps()} isAssisting={false} progress={null} />
       );
       expect(screen.getByText('✓')).toBeInTheDocument();
     });
@@ -502,7 +520,7 @@ describe('ReferencesPanel Component', () => {
     it('should show detection log and selection UI together after completion', () => {
       const { rerender } = renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -514,7 +532,7 @@ describe('ReferencesPanel Component', () => {
       );
 
       rerender(
-        <ReferencesPanel {...defaultProps} isAssisting={false} progress={null} />
+        <ReferencesPanel {...panelProps()} isAssisting={false} progress={null} />
       );
 
       // Should show both the completed log AND the selection UI
@@ -525,7 +543,7 @@ describe('ReferencesPanel Component', () => {
     it('should show selection UI immediately after detection completes', async () => {
       const { rerender } = renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -537,7 +555,7 @@ describe('ReferencesPanel Component', () => {
       );
 
       rerender(
-        <ReferencesPanel {...defaultProps} isAssisting={false} progress={null} />
+        <ReferencesPanel {...panelProps()} isAssisting={false} progress={null} />
       );
 
       // Selection UI should be immediately available (no button click needed)
@@ -548,7 +566,7 @@ describe('ReferencesPanel Component', () => {
     it('should not show log when empty', () => {
       renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -567,7 +585,7 @@ describe('ReferencesPanel Component', () => {
 
   describe('State Transitions', () => {
     it('should transition from idle to detecting', () => {
-      const { rerender } = renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      const { rerender } = renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       // Idle state
       expect(screen.getByText('Select entity types')).toBeInTheDocument();
@@ -575,7 +593,7 @@ describe('ReferencesPanel Component', () => {
       // Start detecting
       rerender(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={true}
           progress={{ stage: 'analyzing', percentage: 0, message: 'Detecting references...', completedEntityTypes: [] }}
         />
@@ -589,7 +607,7 @@ describe('ReferencesPanel Component', () => {
     it('should transition from detecting to complete', () => {
       const { rerender } = renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={true}
           progress={{ stage: 'analyzing', percentage: 0, message: 'Detecting references...', completedEntityTypes: [] }}
         />
@@ -601,7 +619,7 @@ describe('ReferencesPanel Component', () => {
       // Complete - first trigger useEffect to copy to lastDetectionLog
       rerender(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -614,7 +632,7 @@ describe('ReferencesPanel Component', () => {
 
       // Then clear progress to show the log
       rerender(
-        <ReferencesPanel {...defaultProps} isAssisting={false} progress={null} />
+        <ReferencesPanel {...panelProps()} isAssisting={false} progress={null} />
       );
 
       expect(screen.queryByTestId('annotation-progress-widget')).not.toBeInTheDocument();
@@ -626,7 +644,7 @@ describe('ReferencesPanel Component', () => {
     it('should show selection UI after detection completes', async () => {
       const { rerender } = renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -639,14 +657,14 @@ describe('ReferencesPanel Component', () => {
 
       // Clear progress to show the log
       rerender(
-        <ReferencesPanel {...defaultProps} isAssisting={false} progress={null} />
+        <ReferencesPanel {...panelProps()} isAssisting={false} progress={null} />
       );
 
       // Selection UI should be immediately available
       expect(screen.getByText('Select entity types')).toBeInTheDocument();
 
       rerender(
-        <ReferencesPanel {...defaultProps} />
+        <ReferencesPanel {...panelProps()} />
       );
 
       expect(screen.getByText('Select entity types')).toBeInTheDocument();
@@ -656,7 +674,7 @@ describe('ReferencesPanel Component', () => {
   describe('Edge Cases', () => {
     it('should handle empty entity types array', () => {
       expect(() => {
-        renderWithEventBus(<ReferencesPanel {...defaultProps} allEntityTypes={[]} />);
+        renderWithEventBus(<ReferencesPanel {...panelProps()} allEntityTypes={[]} />);
       }).not.toThrow();
     });
 
@@ -664,7 +682,7 @@ describe('ReferencesPanel Component', () => {
       const manyTypes = Array.from({ length: 50 }, (_, i) => `Type${i}`);
 
       expect(() => {
-        renderWithEventBus(<ReferencesPanel {...defaultProps} allEntityTypes={manyTypes} />);
+        renderWithEventBus(<ReferencesPanel {...panelProps()} allEntityTypes={manyTypes} />);
       }).not.toThrow();
 
       expect(screen.getByText('Type0')).toBeInTheDocument();
@@ -674,7 +692,7 @@ describe('ReferencesPanel Component', () => {
     it('should handle entity types with special characters', () => {
       const specialTypes = ['Type-A', 'Type_B', 'Type.C', 'Type/D'];
 
-      renderWithEventBus(<ReferencesPanel {...defaultProps} allEntityTypes={specialTypes} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} allEntityTypes={specialTypes} />);
 
       specialTypes.forEach(type => {
         expect(screen.getByText(type)).toBeInTheDocument();
@@ -682,7 +700,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should handle selecting and deselecting all types', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       // Select all
       for (const type of defaultProps.allEntityTypes) {
@@ -704,7 +722,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should handle rapid selection changes', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -720,7 +738,7 @@ describe('ReferencesPanel Component', () => {
     it('should handle zero found count in results', () => {
       renderWithEventBus(
         <ReferencesPanel
-          {...defaultProps}
+          {...panelProps()}
           isAssisting={false}
           progress={{
             stage: 'complete',
@@ -738,7 +756,7 @@ describe('ReferencesPanel Component', () => {
       expect(() => {
         renderWithEventBus(
           <ReferencesPanel
-            {...defaultProps}
+            {...panelProps()}
             isAssisting={false}
             progress={undefined as any}
           />
@@ -749,21 +767,21 @@ describe('ReferencesPanel Component', () => {
 
   describe('Styling and Appearance', () => {
     it('should have proper panel structure', () => {
-      const { container } = renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      const { container } = renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const panel = container.firstChild as HTMLElement;
       expect(panel).toHaveClass('semiont-panel');
     });
 
     it('should support dark mode', () => {
-      const { container } = renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      const { container } = renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const panel = container.firstChild as HTMLElement;
       expect(panel).toHaveClass('semiont-panel');
     });
 
     it('should have title without emoji', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       // The emoji is no longer in the title (it's only in the tab now)
       const title = screen.getByRole('heading', { level: 2 });
@@ -772,7 +790,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should have proper button layout', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const buttonContainer = screen.getByText('Person').parentElement;
       expect(buttonContainer).toHaveClass('semiont-assist-widget__chips');
@@ -781,7 +799,7 @@ describe('ReferencesPanel Component', () => {
 
   describe('Accessibility', () => {
     it('should have proper ARIA labels for selection', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -795,7 +813,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should have proper ARIA pressed states', async () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
 
@@ -807,7 +825,7 @@ describe('ReferencesPanel Component', () => {
     });
 
     it('should be keyboard navigable', () => {
-      renderWithEventBus(<ReferencesPanel {...defaultProps} />);
+      renderWithEventBus(<ReferencesPanel {...panelProps()} />);
 
       const personButton = screen.getByText('Person');
       personButton.focus();

--- a/packages/react-ui/src/components/resource/panels/__tests__/ResourceInfoPanel.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ResourceInfoPanel.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { EventBus } from '@semiont/core';
-import type { SemiontClient } from '@semiont/sdk';
+import type { SemiontClient, SemiontSession } from '@semiont/sdk';
 import { ResourceInfoPanel } from '../ResourceInfoPanel';
 import { createTestSemiontWrapper } from '../../../../test-utils';
 
@@ -87,13 +87,15 @@ function createEventTracker() {
   };
 }
 
-const renderWithEventBus = (component: React.ReactElement, tracker?: ReturnType<typeof createEventTracker>) => {
-  const { SemiontWrapper, eventBus, client } = createTestSemiontWrapper();
+const renderWithEventBus = (component: React.ReactElement<{ session: SemiontSession | null }>, tracker?: ReturnType<typeof createEventTracker>) => {
+  const { SemiontWrapper, eventBus, client, session } = createTestSemiontWrapper();
   if (tracker) tracker._attach(eventBus, client);
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
   );
-  return render(component, { wrapper: Wrapper });
+  // The component is provider-free: inject the factory session so it is the
+  // SAME session whose client the tracker spies on / whose bus it subscribes.
+  return render(React.cloneElement(component, { session }), { wrapper: Wrapper });
 };
 
 describe('ResourceInfoPanel Component', () => {
@@ -103,6 +105,11 @@ describe('ResourceInfoPanel Component', () => {
     documentLocale: undefined,
     primaryMediaType: undefined,
     primaryByteSize: undefined,
+    // Satisfies JSX at element construction only; renderWithEventBus always
+    // replaces it (via cloneElement) with the per-test factory session. Never
+    // put a live session here — module-scope clients get disposed after the
+    // first test.
+    session: null,
   };
 
   beforeEach(() => {

--- a/packages/react-ui/src/components/resource/panels/__tests__/TagEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/TagEntry.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { cloneElement, type ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { of } from 'rxjs';
-import { CacheObservable } from '@semiont/sdk';
+import { CacheObservable, type SemiontSession } from '@semiont/sdk';
 import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
 import userEvent from '@testing-library/user-event';
 import type { TagSchema } from '@semiont/core';
@@ -65,6 +66,17 @@ describe('TagEntry', () => {
   const defaultProps = {
     tag: createMockTag(),
     isFocused: false,
+    // Satisfies JSX at element construction only; render helpers/tests pass
+    // the real per-test factory session explicitly. Never put a live session
+    // here — module-scope clients get disposed after the first test.
+    session: null,
+  };
+
+  // The component is provider-free: hand it a fresh per-test fake session as
+  // the `session` prop. renderWithProviders still supplies translations/toasts.
+  const renderTagEntry = (element: ReactElement<{ session: SemiontSession | null }>) => {
+    const { session } = createTestSemiontWrapper();
+    return renderWithProviders(cloneElement(element, { session }));
   };
 
   beforeEach(() => {
@@ -76,13 +88,13 @@ describe('TagEntry', () => {
 
   describe('Rendering', () => {
     it('should render the category badge', () => {
-      renderWithProviders(<TagEntry {...defaultProps} />);
+      renderTagEntry(<TagEntry {...defaultProps} />);
 
       expect(screen.getByText('Entity')).toBeInTheDocument();
     });
 
     it('should render the selected text in quotes', () => {
-      renderWithProviders(<TagEntry {...defaultProps} />);
+      renderTagEntry(<TagEntry {...defaultProps} />);
 
       expect(screen.getByText(/Tagged text content/)).toBeInTheDocument();
     });
@@ -91,7 +103,7 @@ describe('TagEntry', () => {
       const longText = 'C'.repeat(200);
       mockGetAnnotationExactText.mockReturnValue(longText);
 
-      renderWithProviders(<TagEntry {...defaultProps} />);
+      renderTagEntry(<TagEntry {...defaultProps} />);
 
       expect(screen.getByText(new RegExp(`"${'C'.repeat(150)}`))).toBeInTheDocument();
       expect(screen.getByText(/\.\.\./)).toBeInTheDocument();
@@ -101,7 +113,7 @@ describe('TagEntry', () => {
       const exactText = 'D'.repeat(150);
       mockGetAnnotationExactText.mockReturnValue(exactText);
 
-      const { container } = renderWithProviders(<TagEntry {...defaultProps} />);
+      const { container } = renderTagEntry(<TagEntry {...defaultProps} />);
 
       const quote = container.querySelector('.semiont-annotation-entry__quote');
       expect(quote).toBeInTheDocument();
@@ -121,11 +133,11 @@ describe('TagEntry', () => {
       // Stub the cache to resolve immediately with the test schema —
       // exercises the rendering path without round-tripping through the
       // transport's HTTP plumbing.
-      const { SemiontWrapper, client } = createTestSemiontWrapper();
+      const { SemiontWrapper, client, session } = createTestSemiontWrapper();
       vi.spyOn(client.browse, 'tagSchemas').mockReturnValue(
         CacheObservable.from(of([NER_SCHEMA]))
       );
-      render(<TagEntry {...defaultProps} />, { wrapper: SemiontWrapper });
+      render(<TagEntry {...defaultProps} session={session} />, { wrapper: SemiontWrapper });
 
       expect(screen.getByText('Named Entity Recognition')).toBeInTheDocument();
     });
@@ -135,17 +147,17 @@ describe('TagEntry', () => {
 
       // Stub the cache to resolve to an empty list — the schema lookup
       // misses, the schema-name `<span>` is not rendered.
-      const { SemiontWrapper, client } = createTestSemiontWrapper();
+      const { SemiontWrapper, client, session } = createTestSemiontWrapper();
       vi.spyOn(client.browse, 'tagSchemas').mockReturnValue(
         CacheObservable.from(of([]))
       );
-      const { container } = render(<TagEntry {...defaultProps} />, { wrapper: SemiontWrapper });
+      const { container } = render(<TagEntry {...defaultProps} session={session} />, { wrapper: SemiontWrapper });
 
       expect(container.querySelector('.semiont-annotation-entry__meta')).not.toBeInTheDocument();
     });
 
     it('should render category badge with correct data-variant', () => {
-      const { container } = renderWithProviders(<TagEntry {...defaultProps} />);
+      const { container } = renderTagEntry(<TagEntry {...defaultProps} />);
 
       const badge = container.querySelector('.semiont-tag-badge');
       expect(badge).toBeInTheDocument();
@@ -157,12 +169,14 @@ describe('TagEntry', () => {
     it('should emit browse:click on click', async () => {
       const clickHandler = vi.fn();
 
-      const { container, eventBus } = renderWithProviders(
-        <TagEntry {...defaultProps} />,
-        { returnEventBus: true }
-      );
+      // The session prop is the only session the provider-free component
+      // sees — subscribe on the SAME factory's bus that backs it.
+      const { session, eventBus } = createTestSemiontWrapper();
+      const subscription = eventBus.get('browse:click').subscribe(clickHandler);
 
-      const subscription = eventBus!.get('browse:click').subscribe(clickHandler);
+      const { container } = renderWithProviders(
+        <TagEntry {...defaultProps} session={session} />
+      );
 
       const entry = container.firstChild as HTMLElement;
       await userEvent.click(entry);
@@ -178,7 +192,7 @@ describe('TagEntry', () => {
 
   describe('Hover state', () => {
     it('should apply pulse class when isHovered is true', () => {
-      const { container } = renderWithProviders(
+      const { container } = renderTagEntry(
         <TagEntry {...defaultProps} isHovered={true} />
       );
 
@@ -187,7 +201,7 @@ describe('TagEntry', () => {
     });
 
     it('should not apply pulse class when isHovered is false', () => {
-      const { container } = renderWithProviders(
+      const { container } = renderTagEntry(
         <TagEntry {...defaultProps} isHovered={false} />
       );
 
@@ -198,7 +212,7 @@ describe('TagEntry', () => {
 
   describe('Focus state', () => {
     it('should set data-focused to true when focused', () => {
-      const { container } = renderWithProviders(
+      const { container } = renderTagEntry(
         <TagEntry {...defaultProps} isFocused={true} />
       );
 
@@ -207,7 +221,7 @@ describe('TagEntry', () => {
     });
 
     it('should set data-type to tag', () => {
-      const { container } = renderWithProviders(<TagEntry {...defaultProps} />);
+      const { container } = renderTagEntry(<TagEntry {...defaultProps} />);
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).toHaveAttribute('data-type', 'tag');

--- a/packages/react-ui/src/components/resource/panels/__tests__/TaggingPanel.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/TaggingPanel.test.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { of } from 'rxjs';
-import { CacheObservable } from '@semiont/sdk';
+import { CacheObservable, type SemiontSession } from '@semiont/sdk';
 import { TaggingPanel } from '../TaggingPanel';
 import type { EventBus, TagSchema } from '@semiont/core';
 import { createTestSemiontWrapper } from '../../../../test-utils';
@@ -53,8 +53,8 @@ const TEST_TAG_SCHEMAS: TagSchema[] = [
   },
 ];
 
-const renderWithEventBus = (component: React.ReactElement, tracker?: ReturnType<typeof createEventTracker>) => {
-  const { SemiontWrapper, eventBus, client } = createTestSemiontWrapper();
+const renderWithEventBus = (component: React.ReactElement<{ session: SemiontSession | null }>, tracker?: ReturnType<typeof createEventTracker>) => {
+  const { SemiontWrapper, eventBus, client, session } = createTestSemiontWrapper();
   vi.spyOn(client.browse, 'tagSchemas').mockReturnValue(
     CacheObservable.from(of(TEST_TAG_SCHEMAS))
   );
@@ -62,21 +62,24 @@ const renderWithEventBus = (component: React.ReactElement, tracker?: ReturnType<
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
   );
-  return render(component, { wrapper: Wrapper });
+  // The component is provider-free: the `session` prop is the only session it
+  // sees. Inject the factory session here so it is the SAME session whose
+  // client backs `eventBus` (trackers subscribe there).
+  return render(React.cloneElement(component, { session }), { wrapper: Wrapper });
 };
 
 // Variant for the empty-registry case: the cache resolves to `[]`
 // (post-bootstrap, no schemas registered). Distinct from the still-
 // loading case where the observable yields `undefined`.
-const renderWithEmptyRegistry = (component: React.ReactElement) => {
-  const { SemiontWrapper, client } = createTestSemiontWrapper();
+const renderWithEmptyRegistry = (component: React.ReactElement<{ session: SemiontSession | null }>) => {
+  const { SemiontWrapper, client, session } = createTestSemiontWrapper();
   vi.spyOn(client.browse, 'tagSchemas').mockReturnValue(
     CacheObservable.from(of([]))
   );
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <SemiontWrapper>{children}</SemiontWrapper>
   );
-  return render(component, { wrapper: Wrapper });
+  return render(React.cloneElement(component, { session }), { wrapper: Wrapper });
 };
 
 // Mock TranslationContext. The component now uses `schema.name` /
@@ -188,6 +191,11 @@ describe('TaggingPanel Component', () => {
     resourceId: 'res-1',
     annotations: mockTags.empty,
     pendingAnnotation: null,
+    // Satisfies JSX at element construction only; the render helpers always
+    // replace it (via cloneElement) with the per-test factory session. Never
+    // put a live session here — module-scope clients get disposed after the
+    // first test.
+    session: null,
   };
 
   beforeEach(() => {

--- a/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
+++ b/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
@@ -574,6 +574,8 @@ export function ResourceViewerPage({
             {/* Unified Annotations Panel */}
             {activePanel === 'annotations' && !resource.archived && (
               <UnifiedAnnotationsPanel
+                session={session ?? null}
+                onOpenResource={handleViewerOpenResource}
                 annotations={annotations}
                 annotators={ANNOTATORS}
                 annotateMode={annotateMode}
@@ -612,6 +614,7 @@ export function ResourceViewerPage({
             {/* Document Info Panel */}
             {activePanel === 'info' && (
               <ResourceInfoPanel
+                session={session ?? null}
                 resourceId={rUri}
                 documentEntityTypes={documentEntityTypes}
                 documentLocale={getLanguage(resource)}

--- a/packages/react-ui/src/hooks/useHoverEmitter.ts
+++ b/packages/react-ui/src/hooks/useHoverEmitter.ts
@@ -3,8 +3,7 @@
 import { useRef, useCallback, useEffect } from 'react';
 import type { AnnotationId } from '@semiont/core';
 import { HOVER_DELAY_MS } from '@semiont/sdk';
-import { useSemiont } from '../session/SemiontProvider';
-import { useObservable } from './useObservable';
+import type { SemiontSession } from '@semiont/sdk';
 
 export { HOVER_DELAY_MS } from '@semiont/sdk';
 export interface HoverEmitterProps {
@@ -12,8 +11,7 @@ export interface HoverEmitterProps {
   onMouseLeave: () => void;
 }
 
-export function useHoverEmitter(annotationId: AnnotationId, hoverDelayMs: number = HOVER_DELAY_MS): HoverEmitterProps {
-  const session = useObservable(useSemiont().activeSession$);
+export function useHoverEmitter(session: SemiontSession | null, annotationId: AnnotationId, hoverDelayMs: number = HOVER_DELAY_MS): HoverEmitterProps {
   const currentHoverRef = useRef<AnnotationId | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/packages/react-ui/src/test-utils.tsx
+++ b/packages/react-ui/src/test-utils.tsx
@@ -9,7 +9,7 @@ import React, { ReactElement } from 'react';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';
 import { vi, afterEach } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
-import { SemiontClient, type SemiontBrowser } from '@semiont/sdk';
+import { SemiontClient, type SemiontBrowser, type SemiontSession } from '@semiont/sdk';
 import { HttpContentTransport, HttpTransport } from '@semiont/http-transport';
 import { baseUrl, EventBus } from '@semiont/core';
 import { TranslationProvider } from './contexts/TranslationContext';
@@ -175,6 +175,8 @@ export interface RenderWithProvidersResult extends RenderResult {
   eventBus?: EventBus;
   /** App-scoped bus (the fake browser's own bus). */
   shellBus?: EventBus;
+  /** The fake session — pass as the `session` prop to provider-free components. */
+  session: SemiontSession | null;
 }
 
 /** Read the app-scoped bus stashed on the fake browser by createFakeBrowserForTests. */
@@ -216,7 +218,7 @@ export function renderWithProviders(
   const extras: Partial<RenderWithProvidersResult> = {};
   if (returnEventBus && client) extras.eventBus = busOf(client);
   if (returnShellBus) extras.shellBus = shellBusOf(fakeBrowser);
-  return Object.keys(extras).length ? { ...result, ...extras } : result;
+  return { ...result, session: fakeSession as unknown as SemiontSession | null, ...extras };
 }
 
 /**
@@ -233,6 +235,8 @@ export function createTestSemiontWrapper(apiBaseUrl: string = 'http://localhost:
   shellBus: EventBus;
   /** The fake session's client — for tests that need to spy on namespace methods. */
   client: SemiontClient;
+  /** The fake session — pass as the `session` prop to provider-free components. */
+  session: SemiontSession;
 } {
   const fakeBrowser = createFakeBrowserForTests(apiBaseUrl);
   const fakeSession = (fakeBrowser as unknown as { activeSession$: { getValue(): { client: SemiontClient } | null } }).activeSession$.getValue();
@@ -245,6 +249,7 @@ export function createTestSemiontWrapper(apiBaseUrl: string = 'http://localhost:
     eventBus: busOf(client),
     shellBus: shellBusOf(fakeBrowser)!,
     client,
+    session: fakeSession as unknown as SemiontSession,
   };
 }
 


### PR DESCRIPTION
Phase 1 of `.plans/HEADLESS-ANNOTATION-PANELS.md`: the annotation panel/entry family becomes provider-free. Hosts can now mount any of these components with nothing but a `SemiontSession` — no `SemiontProvider`, no routing context.

## Motivation

The headless-react-ui direction treats the logic tier as the product: every interactive primitive should be usable by a host that composes its own chrome, with the stock Browser UI as just one consumer of the same seams. The viewer subtree already works this way (bring-your-own-session `ResourceViewer`, presentational toolbar, prop-driven prefs). The annotation panels were the last major family still hard-wired to the provider: each component read `useObservable(useSemiont().activeSession$)` internally, so none of them could render outside a full provider tree.

## What changed

**Session becomes a prop (12 components).** `ReferencesPanel`, `TaggingPanel`, `CommentsPanel`, `AssessmentPanel`, `HighlightPanel`, their five entry components, `AssistSection`, and `ResourceInfoPanel` each take a required `session: SemiontSession | null` prop. The internal provider reads are deleted with no fallback — `null` renders inert, exactly like the rest of the bring-your-own-session surface. The five panels' `browse:click` focus subscriptions move from the provider-bound `useEventSubscriptions` to `useSessionEventSubscriptions(session, …)`.

**Hidden provider reads flushed out.** The mount keystone stayed red after the component transform and exposed two hooks reading `useSemiont()` internally:
- `useHoverEmitter` is now session-first — `useHoverEmitter(session, annotationId, delay?)` — with all five call sites updated in the same change.
- `useObservableExternalNavigation` in `ReferenceEntry` was slated for deletion by Phase 2 anyway, so that slice landed now instead of rewriting a doomed hook: `ReferenceEntry` drops its `routes` prop and calls a new optional `onOpenResource(resourceId)` callback, threaded `ReferencesPanel` → `UnifiedAnnotationsPanel` → viewer page (which supplies its existing navigation handler). Phase 2 shrinks to the remaining `Link`/`routes` seams on the panels.

**Threading.** `UnifiedAnnotationsPanel` accepts `session` (+ `onOpenResource`) and fans them out to the five sub-panels; the stock viewer page supplies both, so its rendered behavior is unchanged.

**Test infrastructure.** `createTestSemiontWrapper()` and `renderWithProviders()` now expose the fake `session` alongside the `eventBus`/`client` it backs. All 13 panel test files pass it as a prop; tests asserting bus emissions subscribe on the bus from the same factory as the prop session — the provider-internal bus is now invisible to these components, which is itself evidence the decoupling took. No payload assertions weakened, no tests skipped.

## Verification (TDD)

- RED observed first: a new keystone spec (`ReferencesPanel.headless.test.tsx`) mounts the panel with a fake session prop and zero providers, and failed with the `useSemiont must be used within a <SemiontProvider>` crash before the transform. It now passes and stays as a regression pin: provider-free mount, entry list render, and an entry click reaching `session.client.browse.click`.
- Panels suite: 19 test files, 398 tests, all passing (node:24-alpine).
- `tsc --noEmit`: 0 errors package-wide.
- `useSemiont` grep over `panels/*.tsx`: only `JsonLdPanel` remains (outside this family; tracked as follow-up with the assist-progress widget).
