### PR TITLE
react-ui: browse-mode text clicks emit browse:click for every motivation

### DIFF
--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -134,16 +134,22 @@ export const BrowseView = memo(function BrowseView({
 
     const container = containerRef.current;
 
-    // Single click handler for the container
+    // Single click handler for the container — emits browse:click for whatever
+    // annotation the click resolves, any motivation (parity with the image/PDF
+    // and annotate-mode emitters; ResourceViewer routes by click action).
     const handleClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
       const annotationElement = target.closest('[data-annotation-id]');
       if (!annotationElement) return;
 
-      const annotationId = annotationElement.getAttribute('data-annotation-id');
-      const annotationType = annotationElement.getAttribute('data-annotation-type');
+      // Browse mode is the reading surface: a drag-select that starts and ends
+      // inside one annotated span fires click on it — suppress emission so
+      // copying text never opens or navigates.
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) return;
 
-      if (annotationId && annotationType === 'reference') {
+      const annotationId = annotationElement.getAttribute('data-annotation-id');
+      if (annotationId) {
         const annotation = allAnnotations.find(a => a.id === annotationId);
         if (annotation) {
           session.client.browse.click(annotation.id, annotation.motivation);

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
@@ -402,12 +402,16 @@ describe('BrowseView Component', () => {
       });
     });
 
-    it('should emit browse:click only for reference annotations', async () => {
+    it('should emit browse:click for every motivation', async () => {
+      // browse:click is the platform's one "user clicked an annotation" signal;
+      // text browse mode must emit it for whatever the click resolves, matching
+      // the image/PDF/annotate emitters (BROWSE-CLICK-ALL-MOTIVATIONS.md).
       const tracker = createEventTracker();
       const annotations = {
         ...defaultProps.annotations,
         references: [createMockAnnotation('linking', 'ref-1')],
         highlights: [createMockAnnotation('highlighting', 'highlight-1')],
+        comments: [createMockAnnotation('commenting', 'comment-1')],
       };
 
       const { container } = renderWithEventTracking(
@@ -415,36 +419,61 @@ describe('BrowseView Component', () => {
         tracker
       );
 
-      const mockReferenceElement = document.createElement('span');
-      mockReferenceElement.setAttribute('data-annotation-id', 'ref-1');
-      mockReferenceElement.setAttribute('data-annotation-type', 'reference');
-
-      const mockHighlightElement = document.createElement('span');
-      mockHighlightElement.setAttribute('data-annotation-id', 'highlight-1');
-      mockHighlightElement.setAttribute('data-annotation-type', 'highlight');
-
-      const mockRefTarget = { closest: vi.fn(() => mockReferenceElement) } as any;
-      const mockHighlightTarget = { closest: vi.fn(() => mockHighlightElement) } as any;
-
       const browseContainer = container.querySelector('.semiont-browse-view__content');
 
+      const clickCases = [
+        { id: 'ref-1', type: 'reference', motivation: 'linking' },
+        { id: 'highlight-1', type: 'highlight', motivation: 'highlighting' },
+        { id: 'comment-1', type: 'comment', motivation: 'commenting' },
+      ] as const;
+
+      for (const { id, type, motivation } of clickCases) {
+        const el = document.createElement('span');
+        el.setAttribute('data-annotation-id', id);
+        el.setAttribute('data-annotation-type', type);
+        const mockTarget = { closest: vi.fn(() => el) } as unknown as EventTarget;
+
+        tracker.clear();
+        fireEvent.click(browseContainer!, { target: mockTarget });
+
+        await waitFor(() => {
+          expect(tracker.events.some(e =>
+            e.event === 'browse:click' &&
+            e.payload?.annotationId === id &&
+            e.payload?.motivation === motivation
+          )).toBe(true);
+        });
+      }
+    });
+
+    it('should not emit browse:click when the click completes a text selection', async () => {
+      // Browse mode is the reading surface: a drag-select that starts and ends
+      // inside one annotated span fires click on it. The guard applies to
+      // references too — a copy-drag inside a reference span must not emit
+      // (deliberate behavior change; previously it navigated under `follow`).
+      const tracker = createEventTracker();
+      const annotations = {
+        ...defaultProps.annotations,
+        references: [createMockAnnotation('linking', 'ref-1')],
+      };
+
+      const { container } = renderWithEventTracking(
+        <BrowseView {...defaultProps} annotations={annotations} />,
+        tracker
+      );
+
+      const el = document.createElement('span');
+      el.setAttribute('data-annotation-id', 'ref-1');
+      el.setAttribute('data-annotation-type', 'reference');
+      const mockTarget = { closest: vi.fn(() => el) } as unknown as EventTarget;
+
+      vi.spyOn(window, 'getSelection').mockReturnValue({
+        isCollapsed: false,
+      } as Selection);
+
+      const browseContainer = container.querySelector('.semiont-browse-view__content');
       tracker.clear();
-
-      // Click reference - should emit
-      fireEvent.click(browseContainer!, { target: mockRefTarget });
-
-      await waitFor(() => {
-        expect(tracker.events.some(e =>
-          e.event === 'browse:click' &&
-          e.payload?.annotationId === 'ref-1' &&
-          e.payload?.motivation === 'linking'
-        )).toBe(true);
-      });
-
-      tracker.clear();
-
-      // Click highlight - should not emit
-      fireEvent.click(browseContainer!, { target: mockHighlightTarget });
+      fireEvent.click(browseContainer!, { target: mockTarget });
 
       await new Promise(resolve => setTimeout(resolve, 50));
       expect(tracker.events.filter(e => e.event === 'browse:click').length).toBe(0);
@@ -550,13 +579,13 @@ describe('BrowseView Component', () => {
         expect(eventTracker.some(e => e.event === 'browse:click' && e.annotationId === 'ref-1')).toBe(true);
       });
 
-      // Verify highlight doesn't trigger click events
+      // Highlights emit through the same delegated handler (all motivations)
       eventTracker.length = 0; // Clear tracker
       fireEvent.click(browseContainer!, { target: mockHighlightTarget });
 
-      // Should not have any click events for highlights
-      await new Promise(resolve => setTimeout(resolve, 50));
-      expect(eventTracker.some(e => e.event === 'browse:click')).toBe(false);
+      await waitFor(() => {
+        expect(eventTracker.some(e => e.event === 'browse:click' && e.annotationId === 'highlight-1')).toBe(true);
+      });
 
       // The key insight: With event delegation, we can handle 100 annotations
       // with only container-level listeners, not 100+ individual listeners


### PR DESCRIPTION
Executes `.plans/BROWSE-CLICK-ALL-MOTIVATIONS.md`: text browse mode now emits `browse:click` for every annotation motivation, closing a silent dead zone, and gains a selection guard so drag-to-copy never triggers annotation actions.

## Motivation

`browse:click` is the platform's one "user clicked an annotation" signal, and `ResourceViewer` routes it motivation-agnostically by click action (`detail` → `onOpenPanel`, `jsonld` → built-in modal, `follow` → `onOpenResource`). But the emitters disagreed about who gets to emit: image overlays, PDF canvases, annotate-mode text, and the panel entries all emit for every motivation — text **browse** mode emitted only for reference spans (`annotationType === 'reference'` gate in `BrowseView`'s delegated click handler).

Net effect: detail-clicking a highlight circle on an image opened its detail; detail-clicking the same highlight's span in prose did nothing, silently, unless annotate mode was on. The `jsonld` click action had the same text-browse dead zone. Any host surface that renders annotation detail off `onOpenPanel` — including the Browser's own sidebar — was reachable from every surface except the one where most reading happens.

## What changed

**Gate dropped.** `BrowseView`'s `handleClick` already resolves the clicked element via `[data-annotation-id]` and looks up the annotation for its motivation — it now emits for whatever it finds. No new props, no schema change, no routing change (`ResourceViewer`'s handling was already motivation-agnostic). The now-unused `data-annotation-type` read is deleted with the gate.

**Selection guard added.** Browse mode is the reading surface: a drag-select that starts and ends inside one annotated span fires `click` on it. With emission widened to all motivations — and highlighted text being exactly what users select — the handler now suppresses emission when the click completes a non-collapsed selection (`window.getSelection()` check before resolution). The guard deliberately applies to references too: previously a copy-drag inside a reference span under the `follow` click action navigated away; now it emits nothing. That behavior change is pinned by its own spec.

**Out of scope, untouched:** annotate mode, the image/PDF emitters, `ResourceViewer` routing, and the panels — all already motivation-complete.

## Verification (TDD)

- RED observed first: `should emit browse:click for every motivation` (highlight + comment spans silent pre-fix) and `should not emit browse:click when the click completes a text selection` (reference emitted through a non-collapsed selection pre-fix) both failed before the source change, then passed after.
- Two existing pins of the old gate were flipped to the new truth rather than deleted: the event-handling spec (now asserts emission for reference + highlight + comment) and the event-delegation performance spec (its "highlight click emits nothing" tail now asserts emission). Their `as any` mock targets became typed casts.
- Gates: BrowseView suite 17/17 passing; `tsc --noEmit` 0 errors (node:24-alpine).
