### PR TITLE
anchor rect rides browse:click and panel:open (runtime-only)

### DIFF
--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -58,6 +58,24 @@ type BindUpdateBodyCommand =
  * - Commands/reads/results/UI: OpenAPI schema refs — plain strings
  * - void: UI-only signals with no payload
  */
+
+/**
+ * Viewport-space rectangle of a clicked annotation element — runtime-only
+ * view geometry riding UI events (never wire vocabulary; deliberately not in
+ * the OpenAPI schemas). Structurally satisfied by a DOM `DOMRect`, spelled
+ * out here because this package compiles without the DOM lib.
+ */
+export interface AnchorRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
 export type EventMap = {
 
   // ========================================================================
@@ -300,7 +318,7 @@ export type EventMap = {
   'browse:directory-failed': { correlationId: string; path: string } & components['schemas']['CommandError'];
 
   // UI events (session-scoped — fire on the client bus, tied to a KB)
-  'browse:click': components['schemas']['BrowseClickEvent'];
+  'browse:click': components['schemas']['BrowseClickEvent'] & { anchorRect?: AnchorRect };
   'browse:reference-navigate': components['schemas']['BrowseReferenceNavigateEvent'];
   'browse:entity-type-clicked': components['schemas']['BrowseEntityTypeClickedEvent'];
 
@@ -311,7 +329,7 @@ export type EventMap = {
   // ========================================================================
 
   'panel:toggle': components['schemas']['BrowsePanelToggleEvent'];
-  'panel:open': components['schemas']['BrowsePanelOpenEvent'];
+  'panel:open': components['schemas']['BrowsePanelOpenEvent'] & { anchorRect?: AnchorRect };
   'panel:close': void;
   'shell:sidebar-toggle': void;
   'tabs:close': components['schemas']['BrowseResourceCloseEvent'];
@@ -628,13 +646,13 @@ export const CHANNEL_SCHEMAS = {
   'browse:directory-requested':       'BrowseDirectoryRequest',
   'browse:directory-result':          'BrowseDirectoryResult',
   'browse:directory-failed':          null, // { correlationId; path } & CommandError
-  'browse:click':                     'BrowseClickEvent',
+  'browse:click':                     null, // includes runtime `anchorRect?: AnchorRect`
   'browse:reference-navigate':        'BrowseReferenceNavigateEvent',
   'browse:entity-type-clicked':       'BrowseEntityTypeClickedEvent',
 
   // ── SHELL (app-scoped UI events, fire on SemiontBrowser bus) ────
   'panel:toggle':                     'BrowsePanelToggleEvent',
-  'panel:open':                       'BrowsePanelOpenEvent',
+  'panel:open':                       null, // includes runtime `anchorRect?: AnchorRect`
   'panel:close':                      null, // void
   'shell:sidebar-toggle':             null, // void
   'tabs:close':                       'BrowseResourceCloseEvent',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,7 @@ export type {
   EventName,
   EmittableChannel,
   ResourceBroadcastType,
+  AnchorRect,
 } from './bus-protocol';
 export { RESOURCE_BROADCAST_TYPES, CHANNEL_SCHEMAS } from './bus-protocol';
 

--- a/packages/react-ui/src/components/image-annotation/AnnotationOverlay.tsx
+++ b/packages/react-ui/src/components/image-annotation/AnnotationOverlay.tsx
@@ -128,7 +128,7 @@ export function AnnotationOverlay({
                   className="semiont-annotation-overlay__shape"
                   data-hovered={isHovered ? 'true' : 'false'}
                   data-selected={isSelected ? 'true' : 'false'}
-                  onClick={() => session?.client.browse.click(annotation.id, annotation.motivation)}
+                  onClick={(e) => session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect())}
                   onMouseEnter={() => handleMouseEnter(annotation.id)}
                   onMouseLeave={handleMouseLeave}
                 />
@@ -141,7 +141,7 @@ export function AnnotationOverlay({
                     style={{ userSelect: 'none' }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      session?.client.browse.click(annotation.id, annotation.motivation);
+                      session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect());
                     }}
                     onMouseEnter={() => handleMouseEnter(annotation.id)}
                     onMouseLeave={handleMouseLeave}
@@ -175,7 +175,7 @@ export function AnnotationOverlay({
                   className="semiont-annotation-overlay__shape"
                   data-hovered={isHovered ? 'true' : 'false'}
                   data-selected={isSelected ? 'true' : 'false'}
-                  onClick={() => session?.client.browse.click(annotation.id, annotation.motivation)}
+                  onClick={(e) => session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect())}
                   onMouseEnter={() => handleMouseEnter(annotation.id)}
                   onMouseLeave={handleMouseLeave}
                 />
@@ -188,7 +188,7 @@ export function AnnotationOverlay({
                     style={{ userSelect: 'none' }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      session?.client.browse.click(annotation.id, annotation.motivation);
+                      session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect());
                     }}
                     onMouseEnter={() => handleMouseEnter(annotation.id)}
                     onMouseLeave={handleMouseLeave}
@@ -235,7 +235,7 @@ export function AnnotationOverlay({
                   className="semiont-annotation-overlay__shape"
                   data-hovered={isHovered ? 'true' : 'false'}
                   data-selected={isSelected ? 'true' : 'false'}
-                  onClick={() => session?.client.browse.click(annotation.id, annotation.motivation)}
+                  onClick={(e) => session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect())}
                   onMouseEnter={() => handleMouseEnter(annotation.id)}
                   onMouseLeave={handleMouseLeave}
                 />
@@ -248,7 +248,7 @@ export function AnnotationOverlay({
                     style={{ userSelect: 'none' }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      session?.client.browse.click(annotation.id, annotation.motivation);
+                      session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect());
                     }}
                     onMouseEnter={() => handleMouseEnter(annotation.id)}
                     onMouseLeave={handleMouseLeave}

--- a/packages/react-ui/src/components/image-annotation/SvgDrawingCanvas.tsx
+++ b/packages/react-ui/src/components/image-annotation/SvgDrawingCanvas.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import type { Annotation } from '@semiont/core';
+import type { Annotation, AnchorRect } from '@semiont/core';
 import { createRectangleSvg, createCircleSvg, createPolygonSvg, scaleSvgToNative, parseSvgSelector, Point, resourceId as toResourceId } from '@semiont/core';
+import { toViewportAnchorRect } from '../../lib/anchor-rect';
 import { AnnotationOverlay } from './AnnotationOverlay';
 import type { SelectionMotivation } from '../annotation/AnnotateToolbar';
 import type { SemiontSession } from '@semiont/sdk';
@@ -175,7 +176,10 @@ export function SvgDrawingCanvas({
       // This was a click, not a drag - check if we clicked an existing annotation
       if (existingAnnotations.length > 0) {
         // Find annotation at click point
-        // Note: We're checking in display coordinates
+        // Note: We're checking in display coordinates. The hit-test owns the
+        // coordinate transform — capture the hit annotation's viewport rect
+        // for the emission below (A1 anchor).
+        let hitRect: AnchorRect | undefined;
         const clickedAnnotation = existingAnnotations.find(ann => {
           if (typeof ann.target === 'string') return false;
 
@@ -201,19 +205,23 @@ export function SvgDrawingCanvas({
             const displayWidth = width * scaleX;
             const displayHeight = height * scaleY;
 
-            return (
+            const hit = (
               endPoint.x >= displayX &&
               endPoint.x <= displayX + displayWidth &&
               endPoint.y >= displayY &&
               endPoint.y <= displayY + displayHeight
             );
+            if (hit && imageRef.current) {
+              hitRect = toViewportAnchorRect(imageRef.current.getBoundingClientRect(), displayX, displayY, displayWidth, displayHeight);
+            }
+            return hit;
           }
 
           return false;
         });
 
         if (clickedAnnotation) {
-          session?.client.browse.click(clickedAnnotation.id, clickedAnnotation.motivation);
+          session?.client.browse.click(clickedAnnotation.id, clickedAnnotation.motivation, hitRect);
           setIsDrawing(false);
           setStartPoint(null);
           setCurrentPoint(null);

--- a/packages/react-ui/src/components/image-annotation/__tests__/AnnotationOverlay.click.test.tsx
+++ b/packages/react-ui/src/components/image-annotation/__tests__/AnnotationOverlay.click.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * A1 anchor thread (HEADLESS-ANNOTATION-PANELS Phase 3) — image overlay pin.
+ *
+ * The overlay's shape elements own their on-screen geometry: a click passes
+ * the element's viewport rect as browse.click's third argument so hosts can
+ * anchor popovers. Runtime-only view geometry; no schema involvement.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { Annotation, AnnotationId } from '@semiont/core';
+import { AnnotationOverlay } from '../AnnotationOverlay';
+
+const rectAnnotation: Annotation = {
+  '@context': 'http://www.w3.org/ns/anno.jsonld',
+  id: 'img-ann-1' as AnnotationId,
+  type: 'Annotation',
+  motivation: 'highlighting',
+  created: '2024-01-01T10:00:00Z',
+  target: {
+    source: 'resource-1',
+    selector: {
+      type: 'SvgSelector',
+      value: '<svg><rect x="10" y="10" width="20" height="20"/></svg>',
+    },
+  },
+};
+
+function sessionDouble() {
+  const click = vi.fn();
+  const session = {
+    client: {
+      browse: { click },
+      beckon: { hover: vi.fn() },
+    },
+  } as unknown as SemiontSession;
+  return { session, click };
+}
+
+describe('AnnotationOverlay — anchorRect on click', () => {
+  it('passes the shape element rect as browse.click third argument', () => {
+    const { session, click } = sessionDouble();
+
+    const { container } = render(
+      <AnnotationOverlay
+        annotations={[rectAnnotation]}
+        imageWidth={100}
+        imageHeight={100}
+        displayWidth={200}
+        displayHeight={200}
+        session={session}
+        hoverDelayMs={0}
+      />,
+    );
+
+    const shape = container.querySelector('.semiont-annotation-overlay__shape');
+    expect(shape).toBeInTheDocument();
+
+    fireEvent.click(shape!);
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.calls[0]?.[0]).toBe('img-ann-1');
+    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
+    const anchorRect = click.mock.calls[0]?.[2];
+    expect(anchorRect).toBeDefined();
+    expect(typeof anchorRect.width).toBe('number');
+    expect(typeof anchorRect.left).toBe('number');
+  });
+});

--- a/packages/react-ui/src/components/image-annotation/__tests__/AnnotationOverlay.click.test.tsx
+++ b/packages/react-ui/src/components/image-annotation/__tests__/AnnotationOverlay.click.test.tsx
@@ -12,20 +12,24 @@ import type { SemiontSession } from '@semiont/sdk';
 import type { Annotation, AnnotationId } from '@semiont/core';
 import { AnnotationOverlay } from '../AnnotationOverlay';
 
-const rectAnnotation: Annotation = {
-  '@context': 'http://www.w3.org/ns/anno.jsonld',
-  id: 'img-ann-1' as AnnotationId,
-  type: 'Annotation',
-  motivation: 'highlighting',
-  created: '2024-01-01T10:00:00Z',
-  target: {
-    source: 'resource-1',
-    selector: {
-      type: 'SvgSelector',
-      value: '<svg><rect x="10" y="10" width="20" height="20"/></svg>',
+function svgAnnotation(id: string, motivation: Annotation['motivation'], svgValue: string): Annotation {
+  return {
+    '@context': 'http://www.w3.org/ns/anno.jsonld',
+    id: id as AnnotationId,
+    type: 'Annotation',
+    motivation,
+    created: '2024-01-01T10:00:00Z',
+    target: {
+      source: 'resource-1',
+      selector: {
+        type: 'SvgSelector',
+        value: svgValue,
+      },
     },
-  },
-};
+  };
+}
+
+const rectAnnotation = svgAnnotation('img-ann-1', 'highlighting', '<svg><rect x="10" y="10" width="20" height="20"/></svg>');
 
 function sessionDouble() {
   const click = vi.fn();
@@ -66,5 +70,68 @@ describe('AnnotationOverlay — anchorRect on click', () => {
     expect(anchorRect).toBeDefined();
     expect(typeof anchorRect.width).toBe('number');
     expect(typeof anchorRect.left).toBe('number');
+  });
+
+  // The other shape kinds render distinct SVG elements with their own
+  // handlers — each instance of the pattern gets its own pin.
+  it.each([
+    ['circle', svgAnnotation('img-circle-1', 'commenting', '<svg><circle cx="30" cy="30" r="10"/></svg>')],
+    ['polygon', svgAnnotation('img-polygon-1', 'assessing', '<svg><polygon points="10,10 30,10 20,30"/></svg>')],
+  ] as const)('passes the %s element rect as browse.click third argument', (_kind, annotation) => {
+    const { session, click } = sessionDouble();
+
+    const { container } = render(
+      <AnnotationOverlay
+        annotations={[annotation]}
+        imageWidth={100}
+        imageHeight={100}
+        displayWidth={200}
+        displayHeight={200}
+        session={session}
+        hoverDelayMs={0}
+      />,
+    );
+
+    const shape = container.querySelector('.semiont-annotation-overlay__shape');
+    expect(shape).toBeInTheDocument();
+
+    fireEvent.click(shape!);
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.calls[0]?.[0]).toBe(annotation.id);
+    const anchorRect = click.mock.calls[0]?.[2];
+    expect(anchorRect).toBeDefined();
+    expect(typeof anchorRect.width).toBe('number');
+  });
+
+  it('passes the status-indicator element rect as browse.click third argument', () => {
+    // Only references render a status indicator (🔗/❓).
+    const reference = svgAnnotation('img-ref-1', 'linking', '<svg><rect x="10" y="10" width="20" height="20"/></svg>');
+    const { session, click } = sessionDouble();
+
+    const { container } = render(
+      <AnnotationOverlay
+        annotations={[reference]}
+        imageWidth={100}
+        imageHeight={100}
+        displayWidth={200}
+        displayHeight={200}
+        session={session}
+        hoverDelayMs={0}
+      />,
+    );
+
+    const indicator = container.querySelector('.semiont-annotation-overlay__status-indicator');
+    expect(indicator).toBeInTheDocument();
+
+    fireEvent.click(indicator!);
+
+    // stopPropagation: the indicator's own handler emits, exactly once.
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.calls[0]?.[0]).toBe('img-ref-1');
+    expect(click.mock.calls[0]?.[1]).toBe('linking');
+    const anchorRect = click.mock.calls[0]?.[2];
+    expect(anchorRect).toBeDefined();
+    expect(typeof anchorRect.width).toBe('number');
   });
 });

--- a/packages/react-ui/src/components/image-annotation/__tests__/SvgDrawingCanvas.click.test.tsx
+++ b/packages/react-ui/src/components/image-annotation/__tests__/SvgDrawingCanvas.click.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * A1 anchor thread — image canvas drawing-path hit-test pin.
+ *
+ * In drawing mode, a sub-10px "click" on an existing annotation goes through
+ * the mouse-up hit-test (not the overlay's element handlers): the hit-test
+ * owns the display-coordinate transform and must emit browse.click with the
+ * annotation's viewport rect (display rect offset by the image's position —
+ * zeros in jsdom, so viewport == display coordinates here).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SemiontSession } from '@semiont/sdk';
+import type { Annotation, AnnotationId } from '@semiont/core';
+import { SvgDrawingCanvas } from '../SvgDrawingCanvas';
+
+// jsdom's Image never fires onload; the canvas loads natural dimensions via a
+// detached `new Image()`. Stub it to report 100×100 synchronously-ish.
+class FakeImage {
+  onload: (() => void) | null = null;
+  naturalWidth = 100;
+  naturalHeight = 100;
+  set src(_value: string) {
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+const rectAnnotation: Annotation = {
+  '@context': 'http://www.w3.org/ns/anno.jsonld',
+  id: 'canvas-ann-1' as AnnotationId,
+  type: 'Annotation',
+  motivation: 'highlighting',
+  created: '2024-01-01T10:00:00Z',
+  target: {
+    source: 'resource-1',
+    selector: {
+      type: 'SvgSelector',
+      value: '<svg><rect x="10" y="10" width="20" height="20"/></svg>',
+    },
+  },
+};
+
+function sessionDouble() {
+  const click = vi.fn();
+  const session = {
+    client: {
+      browse: { click },
+      beckon: { hover: vi.fn() },
+    },
+  } as unknown as SemiontSession;
+  return { session, click };
+}
+
+describe('SvgDrawingCanvas — drawing-path hit-test anchorRect', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Image', FakeImage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('emits browse.click with the hit annotation viewport rect on a sub-10px click', async () => {
+    const { session, click } = sessionDouble();
+
+    const { container } = render(
+      <SvgDrawingCanvas
+        imageUrl="http://test/image.png"
+        resourceUri="resource-1"
+        existingAnnotations={[rectAnnotation]}
+        drawingMode="rectangle"
+        selectedMotivation="highlighting"
+        session={session}
+      />,
+    );
+
+    // Wait for the stubbed Image load to land imageDimensions (overlay mounts).
+    await waitFor(() => {
+      expect(container.querySelector('.semiont-svg-drawing-canvas__overlay-container')).toBeInTheDocument();
+    });
+
+    // jsdom has no layout: give the rendered <img> display dimensions and let
+    // the resize listener re-read them (display 200×200 over natural 100×100
+    // → scale 2, so the 10,10,20,20 annotation displays at 20,20,40,40).
+    const img = container.querySelector('.semiont-svg-drawing-canvas__image') as HTMLImageElement;
+    Object.defineProperty(img, 'clientWidth', { value: 200, configurable: true });
+    Object.defineProperty(img, 'clientHeight', { value: 200, configurable: true });
+    fireEvent(window, new Event('resize'));
+
+    await waitFor(() => {
+      const overlay = container.querySelector('.semiont-svg-drawing-canvas__overlay') as HTMLElement;
+      expect(overlay?.style.width).toBe('200px');
+    });
+
+    // Sub-10px gesture inside the displayed annotation (image rect is zeros
+    // in jsdom, so client coordinates are display coordinates).
+    const canvas = container.querySelector('.semiont-svg-drawing-canvas')!;
+    fireEvent.mouseDown(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.mouseUp(canvas, { clientX: 30, clientY: 30 });
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.calls[0]?.[0]).toBe('canvas-ann-1');
+    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
+    expect(click.mock.calls[0]?.[2]).toEqual({
+      x: 20, y: 20, left: 20, top: 20, width: 40, height: 40, right: 60, bottom: 60,
+    });
+  });
+});

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useRef, useState, useCallback, useEffect, useMemo } from 'react';
-import type { Annotation } from '@semiont/core';
+import type { Annotation, AnchorRect } from '@semiont/core';
 import { resourceId as toResourceId } from '@semiont/core';
+import { toViewportAnchorRect } from '../../lib/anchor-rect';
 import {
   getTargetSelector,
   createFragmentSelector,
@@ -256,6 +257,9 @@ export function PdfAnnotationCanvas({
     if (dragDistance < MIN_DRAG_DISTANCE) {
       // This was a click, not a drag - check if we clicked an existing annotation
       if (existingAnnotations.length > 0) {
+        // The hit-test owns the coordinate transform — capture the hit
+        // annotation's viewport rect for the emission below (A1 anchor).
+        let hitRect: AnchorRect | undefined;
         const clickedAnnotation = pageAnnotations.find(ann => {
           const fragmentSel = getFragmentSelector(ann.target);
           if (!fragmentSel) return false;
@@ -274,16 +278,20 @@ export function PdfAnnotationCanvas({
           const displayWidth = rect.width * scaleX;
           const displayHeight = rect.height * scaleY;
 
-          return (
+          const hit = (
             selection.endX >= displayX &&
             selection.endX <= displayX + displayWidth &&
             selection.endY >= displayY &&
             selection.endY <= displayY + displayHeight
           );
+          if (hit && imageRef.current) {
+            hitRect = toViewportAnchorRect(imageRef.current.getBoundingClientRect(), displayX, displayY, displayWidth, displayHeight);
+          }
+          return hit;
         });
 
         if (clickedAnnotation) {
-          session?.client.browse.click(clickedAnnotation.id, clickedAnnotation.motivation);
+          session?.client.browse.click(clickedAnnotation.id, clickedAnnotation.motivation, hitRect);
           setIsDrawing(false);
           setSelection(null);
           return;
@@ -461,7 +469,7 @@ export function PdfAnnotationCanvas({
                         cursor: 'pointer',
                         opacity: isSelected ? 1 : isHovered ? 0.9 : 0.7
                       }}
-                      onClick={() => session?.client.browse.click(ann.id, ann.motivation)}
+                      onClick={(e) => session?.client.browse.click(ann.id, ann.motivation, e.currentTarget.getBoundingClientRect())}
                       onMouseEnter={() => handleMouseEnter(ann.id)}
                       onMouseLeave={handleMouseLeave}
                     />

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -11,7 +11,8 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PdfAnnotationCanvas } from '../PdfAnnotationCanvas';
-import { resourceId, annotationId } from '@semiont/core';
+import { resourceId, annotationId, parseFragmentSelector } from '@semiont/core';
+import { pdfToCanvasCoordinates } from '../../../lib/pdf-coordinates';
 
 import type { Annotation } from '@semiont/core';
 
@@ -234,6 +235,82 @@ describe('PdfAnnotationCanvas', () => {
     const anchorRect = click.mock.calls[0]?.[2];
     expect(anchorRect).toBeDefined();
     expect(typeof anchorRect.width).toBe('number');
+  });
+
+  test('drawing-path hit-test emits browse.click with the annotation viewport rect', async () => {
+    // A1 anchor: in drawing mode, a sub-10px click on an existing annotation
+    // goes through the mouse-up hit-test, which owns the PDF→display
+    // coordinate transform. Expected rect computed with the same lib
+    // functions the component uses (scale is 1: display 612×792 == page).
+    const click = vi.fn();
+    const session = {
+      client: { browse: { click }, beckon: { hover: vi.fn() } },
+    } as unknown as import('@semiont/sdk').SemiontSession;
+
+    const fragmentValue = 'page=1&viewrect=100,200,150,100';
+    const mockAnnotations: Annotation[] = [
+      {
+        '@context': 'http://www.w3.org/ns/anno.jsonld',
+        type: 'Annotation',
+        id: annotationId('ann-hit-1'),
+        target: {
+          source: mockResourceId,
+          selector: {
+            type: 'FragmentSelector',
+            value: fragmentValue,
+            conformsTo: 'http://tools.ietf.org/rfc/rfc3778'
+          }
+        },
+        motivation: 'highlighting',
+        created: new Date().toISOString()
+      }
+    ];
+
+    render(
+      <PdfAnnotationCanvas resourceUri="res-1"
+        pdfUrl={mockPdfUrl}
+        existingAnnotations={mockAnnotations}
+        drawingMode="rectangle"
+        selectedMotivation="highlighting"
+        session={session}
+      />
+    );
+
+    await waitFor(() => {
+      const img = document.querySelector('.semiont-pdf-annotation-canvas__image') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+    });
+
+    const img = document.querySelector('.semiont-pdf-annotation-canvas__image') as HTMLImageElement;
+    Object.defineProperty(img, 'clientWidth', { value: 612, configurable: true });
+    Object.defineProperty(img, 'clientHeight', { value: 792, configurable: true });
+    fireEvent.load(img);
+
+    await waitFor(() => {
+      const rects = document.querySelector('.semiont-pdf-annotation-canvas__svg')?.querySelectorAll('rect');
+      expect(rects?.length).toBeGreaterThan(0);
+    });
+
+    const pdfCoord = parseFragmentSelector(fragmentValue)!;
+    const displayRect = pdfToCanvasCoordinates(pdfCoord, 792, 1.0);
+
+    // Sub-10px gesture at the annotation's display-rect center (image rect is
+    // zeros in jsdom, so client coordinates are display coordinates).
+    const canvasContainer = document.querySelector('.semiont-pdf-annotation-canvas__container')!;
+    const clickX = displayRect.x + displayRect.width / 2;
+    const clickY = displayRect.y + displayRect.height / 2;
+    fireEvent.mouseDown(canvasContainer, { clientX: clickX, clientY: clickY });
+    fireEvent.mouseUp(canvasContainer, { clientX: clickX, clientY: clickY });
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.calls[0]?.[0]).toBe('ann-hit-1');
+    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
+    expect(click.mock.calls[0]?.[2]).toMatchObject({
+      left: displayRect.x,
+      top: displayRect.y,
+      width: displayRect.width,
+      height: displayRect.height,
+    });
   });
 
   test('accepts a drawing gesture without throwing when drawing mode is active', async () => {

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -177,6 +177,65 @@ describe('PdfAnnotationCanvas', () => {
     });
   });
 
+  test('passes the annotation rect as browse.click third argument (A1 anchor)', async () => {
+    const click = vi.fn();
+    const session = {
+      client: { browse: { click }, beckon: { hover: vi.fn() } },
+    } as unknown as import('@semiont/sdk').SemiontSession;
+
+    const mockAnnotations: Annotation[] = [
+      {
+        '@context': 'http://www.w3.org/ns/anno.jsonld',
+        type: 'Annotation',
+        id: annotationId('ann-1'),
+        target: {
+          source: mockResourceId,
+          selector: {
+            type: 'FragmentSelector',
+            value: 'page=1&viewrect=100,200,150,100',
+            conformsTo: 'http://tools.ietf.org/rfc/rfc3778'
+          }
+        },
+        motivation: 'highlighting',
+        created: new Date().toISOString()
+      }
+    ];
+
+    render(
+      <PdfAnnotationCanvas resourceUri="res-1"
+        pdfUrl={mockPdfUrl}
+        existingAnnotations={mockAnnotations}
+        drawingMode={null}
+        session={session}
+      />
+    );
+
+    await waitFor(() => {
+      const img = document.querySelector('.semiont-pdf-annotation-canvas__image') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+    });
+
+    const img = document.querySelector('.semiont-pdf-annotation-canvas__image') as HTMLImageElement;
+    Object.defineProperty(img, 'clientWidth', { value: 612, configurable: true });
+    Object.defineProperty(img, 'clientHeight', { value: 792, configurable: true });
+    fireEvent.load(img);
+
+    await waitFor(() => {
+      const rects = document.querySelector('.semiont-pdf-annotation-canvas__svg')?.querySelectorAll('rect');
+      expect(rects?.length).toBeGreaterThan(0);
+    });
+
+    const annotationRect = document.querySelector('.semiont-pdf-annotation-canvas__svg')!.querySelector('rect')!;
+    fireEvent.click(annotationRect);
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.calls[0]?.[0]).toBe('ann-1');
+    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
+    const anchorRect = click.mock.calls[0]?.[2];
+    expect(anchorRect).toBeDefined();
+    expect(typeof anchorRect.width).toBe('number');
+  });
+
   test('accepts a drawing gesture without throwing when drawing mode is active', async () => {
     render(
       <PdfAnnotationCanvas resourceUri="res-1"

--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -152,7 +152,9 @@ export const BrowseView = memo(function BrowseView({
       if (annotationId) {
         const annotation = allAnnotations.find(a => a.id === annotationId);
         if (annotation) {
-          session.client.browse.click(annotation.id, annotation.motivation);
+          // The emission site owns the geometry: the clicked span's viewport
+          // rect rides the event so hosts can anchor popovers (A1).
+          session.client.browse.click(annotation.id, annotation.motivation, annotationElement.getBoundingClientRect());
         }
       }
     };

--- a/packages/react-ui/src/components/resource/ResourceViewer.tsx
+++ b/packages/react-ui/src/components/resource/ResourceViewer.tsx
@@ -6,7 +6,7 @@ import { AnnotateView, type SelectionMotivation, type ClickAction, type ShapeTyp
 import { BrowseView, type ReferenceHover } from './BrowseView';
 import { PopupContainer } from '../annotation-popups/SharedPopupElements';
 import { JsonLdView } from '../annotation-popups/JsonLdView';
-import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, components, EventMap } from '@semiont/core';
+import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, components, EventMap, AnchorRect } from '@semiont/core';
 import { getExactText, getTargetSelector, isHighlight, isAssessment, isReference, isComment, isTag, getBodySource } from '@semiont/core';
 import type { SemiontSession } from '@semiont/sdk';
 import { useSessionEventSubscriptions } from '../../hooks/useSessionEventSubscriptions';
@@ -283,9 +283,10 @@ export function ResourceViewer({
   }, [annotateMode, selectedClick, focusAnnotation, onOpenResource]);
 
   // Annotation click coordinator - handles panel opening and scrolling
-  const handleAnnotationClickEvent = useCallback(({ annotationId, motivation }: {
+  const handleAnnotationClickEvent = useCallback(({ annotationId, motivation, anchorRect }: {
     annotationId: string;
     motivation: components['schemas']['Motivation'];
+    anchorRect?: AnchorRect;
   }) => {
     // Find the annotation metadata
     const metadata = Object.values(ANNOTATORS).find(a => a.matchesAnnotation({ motivation } as Annotation));
@@ -311,8 +312,9 @@ export function ResourceViewer({
     }
 
     // All annotations open the unified annotations panel — the host owns the panel.
-    // The panel internally switches tabs based on the motivation → tab mapping in UnifiedAnnotationsPanel
-    onOpenPanel?.({ panel: 'annotations', scrollToAnnotationId: annotationId, motivation });
+    // The panel internally switches tabs based on the motivation → tab mapping in UnifiedAnnotationsPanel.
+    // View geometry passes through untouched: the emitter owned it, the host anchors with it.
+    onOpenPanel?.({ panel: 'annotations', scrollToAnnotationId: annotationId, motivation, ...(anchorRect ? { anchorRect } : {}) });
   }, [highlights, references, assessments, comments, tags, handleAnnotationClick, selectedClick, onOpenPanel]);
 
   // Event subscriptions - Combined into single useEventSubscriptions call to prevent hook ordering issues

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
@@ -446,6 +446,46 @@ describe('BrowseView Component', () => {
       }
     });
 
+    it('should include the clicked span rect as anchorRect', async () => {
+      // A1 anchor thread (HEADLESS-ANNOTATION-PANELS Phase 3): the emission
+      // site owns the geometry — the clicked span's viewport rect rides the
+      // event so hosts can anchor popovers. Runtime-only; no schema pin.
+      const tracker = createEventTracker();
+      const annotations = {
+        ...defaultProps.annotations,
+        highlights: [createMockAnnotation('highlighting', 'highlight-1')],
+      };
+
+      const { container } = renderWithEventTracking(
+        <BrowseView {...defaultProps} annotations={annotations} />,
+        tracker
+      );
+
+      const el = document.createElement('span');
+      el.setAttribute('data-annotation-id', 'highlight-1');
+      el.setAttribute('data-annotation-type', 'highlight');
+      const RECT: DOMRect = {
+        x: 10, y: 20, width: 30, height: 40,
+        top: 20, right: 40, bottom: 60, left: 10,
+        toJSON: () => ({}),
+      };
+      el.getBoundingClientRect = () => RECT;
+      const mockTarget = { closest: vi.fn(() => el) } as unknown as EventTarget;
+
+      const browseContainer = container.querySelector('.semiont-browse-view__content');
+      tracker.clear();
+      fireEvent.click(browseContainer!, { target: mockTarget });
+
+      await waitFor(() => {
+        expect(tracker.events.some(e =>
+          e.event === 'browse:click' &&
+          e.payload?.annotationId === 'highlight-1' &&
+          e.payload?.anchorRect?.left === 10 &&
+          e.payload?.anchorRect?.width === 30
+        )).toBe(true);
+      });
+    });
+
     it('should not emit browse:click when the click completes a text selection', async () => {
       // Browse mode is the reading surface: a drag-select that starts and ends
       // inside one annotated span fires click on it. The guard applies to

--- a/packages/react-ui/src/components/resource/__tests__/ResourceViewer.embeddable.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/ResourceViewer.embeddable.test.tsx
@@ -12,10 +12,11 @@
  * subtree is covered by AnnotateView.embeddable.test.tsx.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { SemiontSession } from '@semiont/sdk';
 import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { createTestSemiontWrapper } from '../../../test-utils';
 import { ResourceViewer } from '../ResourceViewer';
 
 // Minimal bring-your-own-session double: just the surface ResourceViewer + its
@@ -59,5 +60,43 @@ describe('ResourceViewer — embeddable (bring-your-own-session, no providers)',
       />,
     );
     expect(screen.getByText('Embeddable content.')).toBeInTheDocument();
+  });
+
+  // A1 anchor thread: the viewer is a pass-through for view geometry — an
+  // anchorRect arriving on browse:click reaches the host's onOpenPanel
+  // untouched (detail routing, the default click action).
+  it('forwards the browse:click anchorRect into onOpenPanel', async () => {
+    const { session, eventBus } = createTestSemiontWrapper();
+    const onOpenPanel = vi.fn();
+
+    render(
+      <ResourceViewer
+        session={session}
+        resource={resource}
+        annotations={annotations}
+        onOpenResource={vi.fn()}
+        onOpenPanel={onOpenPanel}
+      />,
+    );
+
+    const anchorRect = {
+      x: 5, y: 6, width: 7, height: 8,
+      top: 6, right: 12, bottom: 14, left: 5,
+    };
+    act(() => {
+      eventBus.get('browse:click').next({
+        annotationId: 'ann-1',
+        motivation: 'highlighting',
+        anchorRect,
+      });
+    });
+
+    await waitFor(() => {
+      expect(onOpenPanel).toHaveBeenCalledWith(expect.objectContaining({
+        panel: 'annotations',
+        scrollToAnnotationId: 'ann-1',
+        anchorRect: expect.objectContaining({ left: 5, width: 7 }),
+      }));
+    });
   });
 });

--- a/packages/react-ui/src/lib/__tests__/anchor-rect.test.ts
+++ b/packages/react-ui/src/lib/__tests__/anchor-rect.test.ts
@@ -1,0 +1,35 @@
+/**
+ * A1 anchor thread — the display→viewport conversion both canvas hit-tests
+ * share (image + PDF). Pure math: the origin is the canvas image's viewport
+ * position; x/y/width/height are the hit annotation's display-coordinate rect.
+ */
+import { describe, it, expect } from 'vitest';
+import { toViewportAnchorRect } from '../anchor-rect';
+
+describe('toViewportAnchorRect', () => {
+  it('offsets the display rect by the origin and derives all edges', () => {
+    const rect = toViewportAnchorRect({ left: 100, top: 50 }, 20, 30, 40, 60);
+
+    expect(rect).toEqual({
+      x: 120,
+      y: 80,
+      left: 120,
+      top: 80,
+      width: 40,
+      height: 60,
+      right: 160,
+      bottom: 140,
+    });
+  });
+
+  it('is the identity offset at a zero origin (jsdom canvases)', () => {
+    const rect = toViewportAnchorRect({ left: 0, top: 0 }, 10, 10, 20, 20);
+
+    expect(rect.left).toBe(10);
+    expect(rect.top).toBe(10);
+    expect(rect.right).toBe(30);
+    expect(rect.bottom).toBe(30);
+    expect(rect.x).toBe(rect.left);
+    expect(rect.y).toBe(rect.top);
+  });
+});

--- a/packages/react-ui/src/lib/anchor-rect.ts
+++ b/packages/react-ui/src/lib/anchor-rect.ts
@@ -1,0 +1,19 @@
+import type { AnchorRect } from '@semiont/core';
+
+/**
+ * Convert a rect in element-local display coordinates to a viewport-space
+ * AnchorRect, offset by the element's own viewport position. Used by the
+ * canvas hit-tests (image / PDF), whose annotation geometry lives in display
+ * coordinates rather than on a DOM element.
+ */
+export function toViewportAnchorRect(
+  origin: { left: number; top: number },
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): AnchorRect {
+  const left = origin.left + x;
+  const top = origin.top + y;
+  return { x: left, y: top, width, height, top, right: left + width, bottom: top + height, left };
+}

--- a/packages/sdk/src/__tests__/browse-click-anchor.test.ts
+++ b/packages/sdk/src/__tests__/browse-click-anchor.test.ts
@@ -1,0 +1,61 @@
+/**
+ * A1 anchor thread — the `browse.click` payload contract.
+ *
+ * The anchorRect is a runtime-only enrichment: present exactly when the
+ * emitter passed geometry, and never present as an `undefined`-valued key
+ * (equality matchers ignore those, so this pins the key itself).
+ */
+import { describe, it, expect } from 'vitest';
+import { Subject } from 'rxjs';
+import { EventBus, annotationId } from '@semiont/core';
+import type { AnchorRect, IContentTransport, ITransport } from '@semiont/core';
+import { BrowseNamespace } from '../namespaces/browse';
+
+function inertTransport(): ITransport {
+  return {
+    baseUrl: 'http://test',
+    emit: async () => {},
+    stream: () => new Subject().asObservable(),
+    subscribeToResource: () => () => {},
+    bridgeInto: () => {},
+    state$: new Subject(),
+    errors$: new Subject(),
+    dispose: () => {},
+  } as unknown as ITransport;
+}
+
+describe('browse.click anchorRect payload contract', () => {
+  it('omits the anchorRect key entirely when no geometry is passed', () => {
+    const bus = new EventBus();
+    const browse = new BrowseNamespace(inertTransport(), bus, {} as unknown as IContentTransport);
+
+    const payloads: object[] = [];
+    bus.get('browse:click').subscribe((p) => payloads.push(p));
+
+    browse.click(annotationId('a1'), 'linking');
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toEqual({ annotationId: 'a1', motivation: 'linking' });
+    expect('anchorRect' in payloads[0]!).toBe(false);
+  });
+
+  it('carries the anchorRect verbatim when geometry is passed', () => {
+    const bus = new EventBus();
+    const browse = new BrowseNamespace(inertTransport(), bus, {} as unknown as IContentTransport);
+
+    const payloads: object[] = [];
+    bus.get('browse:click').subscribe((p) => payloads.push(p));
+
+    const anchorRect: AnchorRect = {
+      x: 1, y: 2, width: 3, height: 4, top: 2, right: 4, bottom: 6, left: 1,
+    };
+    browse.click(annotationId('a1'), 'highlighting', anchorRect);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toEqual({
+      annotationId: 'a1',
+      motivation: 'highlighting',
+      anchorRect,
+    });
+  });
+});

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -7,6 +7,7 @@ import type {
   EventMap,
   ResourceDescriptor,
   ResourceId,
+  AnchorRect,
   AnnotationId,
   GraphConnection,
   Motivation,
@@ -430,8 +431,8 @@ export class BrowseNamespace implements IBrowseNamespace {
 
   // ── UI signals (local bus fan-out) ────────────────────────────────────
 
-  click(annotationId: AnnotationId, motivation: Motivation): void {
-    this.bus.get('browse:click').next({ annotationId, motivation });
+  click(annotationId: AnnotationId, motivation: Motivation, anchorRect?: AnchorRect): void {
+    this.bus.get('browse:click').next({ annotationId, motivation, ...(anchorRect ? { anchorRect } : {}) });
   }
 
   navigateReference(resourceId: ResourceId): void {


### PR DESCRIPTION
Phase 3 (the "A1 anchor thread") of `.plans/HEADLESS-ANNOTATION-PANELS.md`: annotation clicks now carry the clicked element's viewport rectangle, so a host rendering annotation detail off `onOpenPanel` can anchor a popover or card at the click instead of opening a detached panel. Builds on #1015 — same click handler; the selection guard runs first, anchor capture rides the emission branch.

## Motivation

`browse:click` tells subscribers *which* annotation was clicked but not *where on screen*. The where is only knowable at the emission site, and it evaporates immediately: a text span's rect comes from the live DOM element, while the image and PDF canvases have **no per-annotation DOM element at all** — their geometry exists only inside the hit-test math. No subscriber can reconstruct it after the fact, and a host querying the viewer's DOM would both fail on canvases and re-couple hosts to viewer markup the embeddable arc removed. A click has a location; the location must be part of the event.

## What changed

**core** — exports a structural `AnchorRect` (the eight numeric rect fields; a real `DOMRect` satisfies it, so `getBoundingClientRect()` results flow in unchanged). `EventMap['browse:click']` and `EventMap['panel:open']` gain `& { anchorRect?: AnchorRect }` as **runtime-only** intersections, with both `CHANNEL_SCHEMAS` entries nulled — the `nav:external`/`cancelFallback` precedent. Deliberately not in the OpenAPI schemas: viewport pixels at one instant are view geometry, not wire vocabulary. Spelled `AnchorRect` rather than `DOMRect` because core and sdk compile with `lib: ["ES2022"]` (Node-safe isomorphic packages, no DOM ambient).

**sdk** — `browse.click(annotationId, motivation, anchorRect?)`, additive; the field is spread-omitted when absent. The typed verb is the only sanctioned emit path, so the signature is the only door into the payload.

**react-ui emitters** — every surface that owns geometry populates it:
- `BrowseView`: the clicked span's element rect.
- `AnnotationOverlay` (×6 handlers: rect/circle/polygon shapes + status indicators): `e.currentTarget.getBoundingClientRect()`.
- PDF overlay rects: same element-level capture.
- Both canvas drawing-path hit-tests (image + PDF): the hit annotation's display-coordinate rect is captured inside the hit-test and converted to viewport space via a shared `toViewportAnchorRect` helper (both canvases anchor display coords off their `imageRef`).
- Panel entries and codemirror handlers pass nothing — a list-row click shouldn't anchor to itself; the param is optional.

**ResourceViewer** — forwards `anchorRect` from `browse:click` into `onOpenPanel` untouched (detail routing); the stock page's re-emit onto app-scoped `panel:open` carries it for free.

## Verification (TDD)

- RED observed first: four pins failed pre-implementation exactly as written — the BrowseView span rect in the `browse:click` payload, the ResourceViewer forward into `onOpenPanel` (mounted provider-free with a real bus), the image overlay shape click's third argument, and the PDF overlay rect click's third argument. All 24 neighboring tests stayed green through RED.
- GREEN: the four touched suites pass 28/28 (BrowseView, ResourceViewer.embeddable, AnnotationOverlay.click, PdfAnnotationCanvas).
- `tsc --noEmit`: 0 errors in core, sdk, and react-ui (node:24-alpine); core + sdk dists rebuilt.
- No schema pin, deliberately — there is no wire contract to pin.
