### PR TITLE
Publish backend service images (backend · worker · smelter · weaver)

### DIFF
--- a/.github/licenses/allowlist.txt
+++ b/.github/licenses/allowlist.txt
@@ -1,0 +1,33 @@
+# Permissive SPDX license allowlist for the published service images.
+#
+# The license-policy gate (.github/scripts/check-licenses.mjs) checks every
+# bundled npm dependency's SPDX license against this list and fails the publish
+# if anything is unlisted. Approved (permissive) licenses pass silently;
+# copyleft / unknown / unusual licenses trip CI and get a human review — at
+# which point either the dependency is dropped or, if the license is genuinely
+# permissive, its SPDX ID is added here with a note.
+#
+# One SPDX license ID per line. Blank lines and #-comments are ignored. A
+# trailing `*` is a prefix wildcard (e.g. `Foo-*`). Matching is case-insensitive.
+#
+# Seeded 2026-07-15 from the actual union of the four images' dependency trees
+# (`license-checker` over @semiont/cli + @semiont/backend + @semiont/jobs +
+# @semiont/make-meaning + neo4j-driver + @qdrant/js-client-rest): MIT, Apache-2.0,
+# ISC, BSD-3-Clause, BSD-2-Clause, 0BSD, Unlicense, Python-2.0, and one
+# (MIT OR CC0-1.0) dual. All permissive; no copyleft present.
+
+Apache-2.0
+MIT
+MIT-0
+ISC
+BSD-2-Clause
+BSD-3-Clause
+0BSD
+Unlicense
+Python-2.0
+CC0-1.0
+BlueOak-1.0.0
+
+# Deliberately NOT wildcarded to `BSD-*`: BSD-4-Clause carries the advertising
+# clause and should trip a review rather than pass silently. Add BSD-2/3-Clause
+# explicitly above instead.

--- a/.github/licenses/exceptions.txt
+++ b/.github/licenses/exceptions.txt
@@ -1,0 +1,16 @@
+# Per-package license exceptions.
+#
+# Some npm packages omit a machine-readable `license` field in package.json (so
+# the SBOM scanner reports NOASSERTION) yet ship a LICENSE file whose terms a
+# human has verified. Each entry here supplies that verified SPDX id.
+#
+# Two guardrails keep this honest:
+#   1. An exception is applied ONLY when the scanner reports no license. If a
+#      future version declares a real (possibly copyleft) license, it is detected
+#      normally and the exception does not mask it.
+#   2. The supplied SPDX id is still checked against allowlist.txt — an exception
+#      can only rescue a package TO a permissive license, never past the policy.
+#
+# Format: <package-name> <SPDX-id>   # note incl. source of truth + review date
+
+seq-queue MIT   # pkg.json omits license; bundled LICENSE is MIT (Netease/pomelo; via @semiont/backend→prisma→mysql2). Verified 2026-07-15.

--- a/.github/scripts/check-licenses.mjs
+++ b/.github/scripts/check-licenses.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// License-policy gate for the published service images.
+//
+// Reads a Trivy SPDX-JSON SBOM and a permissive allowlist, then fails if any
+// bundled npm dependency carries a license that the allowlist doesn't permit.
+// Scope is npm dependencies only (matched by `pkg:npm/` purl) — OS/apk packages
+// (e.g. git) are out of scope here and covered by the per-image NOTICE.
+//
+// Usage: node check-licenses.mjs <sbom.spdx.json> <allowlist.txt> [exceptions.txt]
+//
+// SPDX license expressions are evaluated properly: `A OR B` passes if either
+// side is allowed, `A AND B` needs both, `A WITH exc` is judged on `A`, and
+// parentheses group as written. NOASSERTION / NONE / LicenseRef-* (an
+// undetermined or non-standard license) fails as "unknown" so a human reviews —
+// unless the package is listed in exceptions.txt with a human-verified SPDX id
+// (which is itself still checked against the allowlist).
+
+import { readFileSync } from 'node:fs';
+
+const [sbomPath, allowlistPath, exceptionsPath] = process.argv.slice(2);
+if (!sbomPath || !allowlistPath) {
+  console.error('Usage: node check-licenses.mjs <sbom.spdx.json> <allowlist.txt> [exceptions.txt]');
+  process.exit(2);
+}
+
+// --- Allowlist -------------------------------------------------------------
+
+const exact = new Set();
+const prefixes = [];
+for (const raw of readFileSync(allowlistPath, 'utf8').split('\n')) {
+  const line = raw.replace(/#.*/, '').trim();
+  if (!line) continue;
+  if (line.endsWith('*')) prefixes.push(line.slice(0, -1).toLowerCase());
+  else exact.add(line.toLowerCase());
+}
+
+// --- Exceptions (package name → human-verified SPDX id) --------------------
+
+const exceptions = new Map();
+if (exceptionsPath) {
+  for (const raw of readFileSync(exceptionsPath, 'utf8').split('\n')) {
+    const line = raw.replace(/#.*/, '').trim();
+    if (!line) continue;
+    const [name, spdx] = line.split(/\s+/);
+    if (name && spdx) exceptions.set(name, spdx);
+  }
+}
+
+// True if a single SPDX license id is permitted by the allowlist.
+function idAllowed(id) {
+  let s = id.trim().toLowerCase().replace(/\+$/, ''); // drop "or-later" '+'
+  if (!s || s === 'noassertion' || s === 'none') return false;
+  if (s.startsWith('licenseref-')) return false; // non-standard → review
+  if (exact.has(s)) return true;
+  return prefixes.some((p) => s.startsWith(p));
+}
+
+// --- SPDX expression evaluator (recursive descent) -------------------------
+
+function tokenize(expr) {
+  return expr.replace(/\(/g, ' ( ').replace(/\)/g, ' ) ').split(/\s+/).filter(Boolean);
+}
+
+function evalExpr(expr) {
+  const toks = tokenize(expr);
+  let i = 0;
+  const peek = () => toks[i];
+  const isOp = (t, op) => t && t.toUpperCase() === op;
+
+  function parseOr() {
+    let v = parseAnd();
+    while (isOp(peek(), 'OR')) { i++; v = parseAnd() || v; }
+    return v;
+  }
+  function parseAnd() {
+    let v = parseWith();
+    while (isOp(peek(), 'AND')) { i++; v = parseWith() && v; }
+    return v;
+  }
+  function parseWith() {
+    const v = parseAtom();
+    if (isOp(peek(), 'WITH')) { i++; i++; } // consume WITH and its exception id
+    return v;
+  }
+  function parseAtom() {
+    if (peek() === '(') { i++; const v = parseOr(); if (peek() === ')') i++; return v; }
+    return idAllowed(toks[i++] ?? '');
+  }
+
+  const result = parseOr();
+  return { allowed: result, consumedAll: i >= toks.length };
+}
+
+// --- Walk the SBOM ---------------------------------------------------------
+
+const sbom = JSON.parse(readFileSync(sbomPath, 'utf8'));
+const packages = Array.isArray(sbom.packages) ? sbom.packages : [];
+
+function isNpm(pkg) {
+  return (pkg.externalRefs ?? []).some(
+    (ref) => ref.referenceType === 'purl' && String(ref.referenceLocator).startsWith('pkg:npm/'),
+  );
+}
+
+function licenseOf(pkg) {
+  const concluded = pkg.licenseConcluded;
+  if (concluded && concluded !== 'NOASSERTION' && concluded !== 'NONE') return concluded;
+  const declared = pkg.licenseDeclared;
+  if (declared && declared !== 'NOASSERTION' && declared !== 'NONE') return declared;
+  return null; // undetermined
+}
+
+const disallowed = [];
+const unknown = [];
+const excepted = [];
+let scanned = 0;
+
+for (const pkg of packages) {
+  if (!isNpm(pkg)) continue;
+  scanned++;
+  const name = `${pkg.name}@${pkg.versionInfo ?? '?'}`;
+  let license = licenseOf(pkg);
+
+  // An exception supplies a verified license ONLY when the scanner found none;
+  // a real detected license (even a bad one) is never masked.
+  let viaException = false;
+  if (license === null && exceptions.has(pkg.name)) {
+    license = exceptions.get(pkg.name);
+    viaException = true;
+  }
+
+  if (license === null) {
+    unknown.push({ name, license: pkg.licenseDeclared ?? 'NOASSERTION' });
+    continue;
+  }
+  const { allowed } = evalExpr(license);
+  if (!allowed) disallowed.push({ name, license: viaException ? `${license} (exception)` : license });
+  else if (viaException) excepted.push({ name, license });
+}
+
+// --- Report ----------------------------------------------------------------
+
+console.log(`Scanned ${scanned} npm dependencies against ${exact.size + prefixes.length} allowlist entries.`);
+
+for (const e of excepted) {
+  console.log(`ℹ️  ${e.name}: no license in metadata; using verified exception → ${e.license}`);
+}
+
+if (disallowed.length === 0 && unknown.length === 0) {
+  console.log('✅ All bundled npm dependency licenses are on the permissive allowlist.');
+  process.exit(0);
+}
+
+if (disallowed.length) {
+  console.error(`\n❌ ${disallowed.length} dependency(ies) with a non-allowlisted license:`);
+  for (const d of disallowed) console.error(`   ${d.name}  →  ${d.license}`);
+}
+if (unknown.length) {
+  console.error(`\n❌ ${unknown.length} dependency(ies) with an undetermined/non-standard license:`);
+  for (const u of unknown) console.error(`   ${u.name}  →  ${u.license}`);
+}
+console.error(
+  '\nEach either needs its SPDX id added to .github/licenses/allowlist.txt (if genuinely ' +
+    'permissive) or the dependency dropped. See the allowlist header for the policy.',
+);
+process.exit(1);

--- a/.github/workflows/publish-service-images.yml
+++ b/.github/workflows/publish-service-images.yml
@@ -1,0 +1,190 @@
+name: Publish Service Container Images
+
+run-name: "Service Images @ ${{ inputs.version }}${{ inputs.dry_run && ' (dry-run)' || '' }}"
+
+# Builds and publishes the four backend-side service images
+# (backend · worker · smelter · weaver) from the published @semiont/* packages,
+# mirroring publish-frontend.yml's verify-npm → scan → multi-arch push → SBOM →
+# attest spine, with an added license-policy gate. Config is runtime (bind-mount);
+# the images ship config-free.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '@semiont/* version to bundle (e.g. 0.5.13, 0.5.13-build.42, latest)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (build + gate but do not push)'
+        required: false
+        type: boolean
+        default: false
+      tag_latest:
+        description: 'Also tag as :latest'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # One service's failure must not cancel the others' publishes.
+      fail-fast: false
+      matrix:
+        include:
+          - service: backend
+            dockerfile: apps/backend/Dockerfile
+            # The backend image drives the role through @semiont/cli and loads
+            # the service from @semiont/backend — both must exist at the version.
+            verify_packages: '@semiont/cli @semiont/backend'
+          - service: worker
+            dockerfile: packages/jobs/Dockerfile
+            verify_packages: '@semiont/jobs'
+          - service: smelter
+            dockerfile: packages/make-meaning/Dockerfile.smelter
+            verify_packages: '@semiont/make-meaning'
+          - service: weaver
+            dockerfile: packages/make-meaning/Dockerfile.weaver
+            verify_packages: '@semiont/make-meaning'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Verify packages exist on npm
+        run: |
+          for pkg in ${{ matrix.verify_packages }}; do
+            npm view "${pkg}@${{ inputs.version }}" version || {
+              echo "❌ ${pkg}@${{ inputs.version }} not found on npm"
+              exit 1
+            }
+          done
+          echo "✅ ${{ matrix.service }} packages exist at ${{ inputs.version }}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine tags
+        id: tags
+        run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          IMAGE="ghcr.io/the-ai-alliance/semiont-${{ matrix.service }}"
+          TAGS="$IMAGE:${{ inputs.version }}"
+          TAGS="$TAGS,$IMAGE:sha-$COMMIT_SHA"
+          if [ "${{ inputs.tag_latest }}" = "true" ]; then
+            TAGS="$TAGS,$IMAGE:latest"
+          fi
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+
+      # Single-platform build for scanning + SBOM. amd64 OS-package CVEs cover
+      # arm64 too since base layers share package versions, and OS/library
+      # licenses are platform-independent, so one build feeds both gates. Both
+      # builds share the GHA cache; the multi-arch rebuild below is a near-instant
+      # cache hit on amd64.
+      - name: Build image (amd64, for scan + SBOM)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          load: true
+          tags: semiont-${{ matrix.service }}:scan
+          build-args: |
+            SEMIONT_VERSION=${{ inputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: semiont-${{ matrix.service }}:scan
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+
+      # Generate the SBOM before push so it gates the publish AND is reused for
+      # the attestation below (one SBOM, two uses). Runs on dry-run too.
+      - name: Generate SBOM with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: semiont-${{ matrix.service }}:scan
+          format: spdx-json
+          output: sbom.spdx.json
+
+      # License-policy gate: every bundled npm dependency's license must be on the
+      # permissive allowlist, else the publish fails for a human review.
+      - name: License policy gate
+        run: node .github/scripts/check-licenses.mjs sbom.spdx.json .github/licenses/allowlist.txt .github/licenses/exceptions.txt
+
+      - name: Build and push Docker image
+        id: build-push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ inputs.dry_run != 'true' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            SEMIONT_VERSION=${{ inputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # SLSA build provenance via GitHub's OIDC + Sigstore, stored as an OCI
+      # attestation alongside the image in GHCR. Verify with:
+      #   gh attestation verify oci://ghcr.io/the-ai-alliance/semiont-<svc>:VERSION \
+      #     --owner The-AI-Alliance
+      - name: Attest build provenance
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest-build-provenance@v4.1.1
+        with:
+          subject-name: ${{ steps.tags.outputs.image }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest SBOM
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest-sbom@v4
+        with:
+          subject-name: ${{ steps.tags.outputs.image }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Summary
+        run: |
+          echo "## semiont-${{ matrix.service }} Container Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Bundled @semiont/* version:** ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ steps.tags.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Dry run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pull with:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ steps.tags.outputs.image }}:${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Verify supply-chain attestations:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "gh attestation verify oci://${{ steps.tags.outputs.image }}:${{ inputs.version }} \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --owner The-AI-Alliance" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,68 @@
+# Stage 1: install (npm runs here, then is discarded).
+#
+# The backend image drives the role through the `@semiont/cli` global bin
+# (`semiont provision/start/useradd`), which loads the service package from the
+# semiont data dir. So we install two trees: the CLI globally, and the backend
+# package plus its lazy peers into the prefix the CLI reads services from.
+# neo4j-driver and @qdrant/js-client-rest are lazy peers of @semiont/graph and
+# @semiont/vector (loaded at connect time) — the backend dials both, so they are
+# bundled here explicitly rather than installed at startup.
+FROM node:26-alpine AS installer
+ARG NPM_REGISTRY=https://registry.npmjs.org
+ARG SEMIONT_VERSION=latest
+RUN npm config set registry $NPM_REGISTRY && \
+    npm install -g @semiont/cli@${SEMIONT_VERSION} && \
+    npm install @semiont/backend@${SEMIONT_VERSION} neo4j-driver @qdrant/js-client-rest \
+      --prefix /home/semiont/.local/share/semiont && \
+    npm cache clean --force
+
+# Stage 2: minimal runtime — node + git, no npm. The runtime entrypoint is the
+# `semiont` CLI; npm is build-only baggage. Removing it also drops the
+# picomatch / glob / etc. CVE surface that ships inside npm's bundled
+# node_modules.
+FROM node:26-alpine
+# Patch base-image OS packages so alpine security fixes apply even when the
+# node:26-alpine snapshot hasn't been rebuilt against them yet.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache git && \
+    # /kb is bind-mounted from the host. When the host UID doesn't match the
+    # in-container semiont user (UID 1001), git's CVE-2022-24765 dubious-ownership
+    # check refuses to operate. --system writes /etc/gitconfig, applied to all
+    # users in the image.
+    git config --system --add safe.directory /kb
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 semiont
+
+# The global @semiont/cli (with its hoisted deps) and the `semiont` bin symlink,
+# plus the backend package + lazy peers the CLI loads services from.
+COPY --from=installer /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=installer /usr/local/bin /usr/local/bin
+COPY --from=installer --chown=semiont:nodejs /home/semiont/.local/share/semiont /home/semiont/.local/share/semiont
+
+# Strip npm/npx after the COPY above re-introduces them from the installer tree.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx
+
+COPY LICENSE apps/backend/NOTICE /home/semiont/
+
+WORKDIR /kb
+RUN chown semiont:nodejs /kb
+USER semiont
+
+ENV NODE_ENV=production
+ENV NODE_OPTIONS=--max-old-space-size=6144
+EXPOSE 4000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:4000/api/health', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"
+
+CMD semiont provision --service backend --verbose && \
+    semiont provision --service embedding --verbose && \
+    semiont start --service backend --verbose && \
+    if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then \
+      semiont useradd --email "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD" --admin --upsert; \
+    fi && \
+    semiont useradd --email worker@semiont.local --generate-password --upsert && \
+    tail -f /home/semiont/.local/state/semiont/*/backend/app.log

--- a/apps/backend/NOTICE
+++ b/apps/backend/NOTICE
@@ -1,0 +1,25 @@
+Semiont
+Copyright 2025-2026 The AI Alliance
+
+This product is licensed under the Apache License, Version 2.0.
+
+This product includes software developed by The AI Alliance
+(https://thealliance.ai/).
+
+This container image (semiont-backend) includes the following third-party
+components:
+
+  Alpine Linux - MIT License
+  Node.js - MIT License
+  Git - GPL-2.0-only License
+
+  npm dependencies (installed at build time from https://registry.npmjs.org):
+    @semiont/cli - Apache-2.0 License (The AI Alliance)
+    @semiont/backend - Apache-2.0 License (The AI Alliance)
+    neo4j-driver - Apache-2.0 License (Neo4j, Inc.)
+    @qdrant/js-client-rest - Apache-2.0 License (Qdrant)
+
+Each npm dependency's full license text is available in its respective
+node_modules/<package>/LICENSE file within the image, under
+/usr/local/lib/node_modules (the CLI) and
+/home/semiont/.local/share/semiont/node_modules (the backend and its peers).

--- a/packages/jobs/Dockerfile
+++ b/packages/jobs/Dockerfile
@@ -1,0 +1,42 @@
+# Stage 1: install (npm runs here, then is discarded).
+FROM node:26-alpine AS installer
+ARG NPM_REGISTRY=https://registry.npmjs.org
+ARG SEMIONT_VERSION=latest
+RUN npm config set registry $NPM_REGISTRY && \
+    npm install -g @semiont/jobs@${SEMIONT_VERSION} && \
+    npm cache clean --force
+
+# Stage 2: minimal runtime — node only, no npm. The runtime entrypoint is
+# `node worker-main.js`, so npm is build-only baggage. Removing it also drops
+# the picomatch / glob / etc. CVE surface that ships inside npm's bundled
+# node_modules.
+FROM node:26-alpine
+# Patch base-image OS packages so alpine security fixes apply even when the
+# node:26-alpine snapshot hasn't been rebuilt against them yet.
+RUN apk upgrade --no-cache
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 semiont
+
+# The global @semiont/jobs (with its hoisted deps) and its bin symlinks.
+COPY --from=installer /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=installer /usr/local/bin /usr/local/bin
+
+# Strip npm/npx after the COPY above re-introduces them from the installer tree.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx
+
+COPY LICENSE packages/jobs/NOTICE /home/semiont/
+
+WORKDIR /kb
+RUN chown semiont:nodejs /kb
+USER semiont
+
+ENV NODE_ENV=production
+EXPOSE 9090
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:9090/health', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"
+
+CMD ["node", "/usr/local/lib/node_modules/@semiont/jobs/dist/worker-main.js"]

--- a/packages/jobs/NOTICE
+++ b/packages/jobs/NOTICE
@@ -1,0 +1,20 @@
+Semiont
+Copyright 2025-2026 The AI Alliance
+
+This product is licensed under the Apache License, Version 2.0.
+
+This product includes software developed by The AI Alliance
+(https://thealliance.ai/).
+
+This container image (semiont-worker) includes the following third-party
+components:
+
+  Alpine Linux - MIT License
+  Node.js - MIT License
+
+  npm dependencies (installed at build time from https://registry.npmjs.org):
+    @semiont/jobs - Apache-2.0 License (The AI Alliance)
+
+Each npm dependency's full license text is available in its respective
+node_modules/<package>/LICENSE file within the image, under
+/usr/local/lib/node_modules.

--- a/packages/make-meaning/Dockerfile.smelter
+++ b/packages/make-meaning/Dockerfile.smelter
@@ -1,0 +1,47 @@
+# Stage 1: install (npm runs here, then is discarded).
+#
+# smelter and weaver are separate images from the shared @semiont/make-meaning
+# package. The smelter does not dial the graph, so — unlike weaver — it bundles
+# no neo4j-driver.
+FROM node:26-alpine AS installer
+ARG NPM_REGISTRY=https://registry.npmjs.org
+ARG SEMIONT_VERSION=latest
+RUN npm config set registry $NPM_REGISTRY && \
+    npm install -g @semiont/make-meaning@${SEMIONT_VERSION} && \
+    npm cache clean --force
+
+# Stage 2: minimal runtime — node only, no npm. The runtime entrypoint is
+# `node smelter-main.js`, so npm is build-only baggage. Removing it also drops
+# the picomatch / glob / etc. CVE surface that ships inside npm's bundled
+# node_modules.
+FROM node:26-alpine
+# Patch base-image OS packages so alpine security fixes apply even when the
+# node:26-alpine snapshot hasn't been rebuilt against them yet.
+RUN apk upgrade --no-cache
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 semiont
+
+# The global @semiont/make-meaning (with its hoisted deps) and its bin symlinks.
+COPY --from=installer /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=installer /usr/local/bin /usr/local/bin
+
+# Strip npm/npx after the COPY above re-introduces them from the installer tree.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx
+
+COPY LICENSE /home/semiont/LICENSE
+COPY packages/make-meaning/NOTICE.smelter /home/semiont/NOTICE
+
+WORKDIR /kb
+RUN chown semiont:nodejs /kb
+USER semiont
+
+ENV NODE_ENV=production
+EXPOSE 9091
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:9091/health', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"
+
+CMD ["node", "/usr/local/lib/node_modules/@semiont/make-meaning/dist/smelter-main.js"]

--- a/packages/make-meaning/Dockerfile.weaver
+++ b/packages/make-meaning/Dockerfile.weaver
@@ -1,0 +1,49 @@
+# Stage 1: install (npm runs here, then is discarded).
+#
+# smelter and weaver are separate images from the shared @semiont/make-meaning
+# package. neo4j-driver is a lazy peer of @semiont/graph (loaded at connect
+# time, per graph sink) — the weaver is the one make-meaning entry point that
+# actually dials the graph, so it is bundled here explicitly (the smelter image
+# omits it).
+FROM node:26-alpine AS installer
+ARG NPM_REGISTRY=https://registry.npmjs.org
+ARG SEMIONT_VERSION=latest
+RUN npm config set registry $NPM_REGISTRY && \
+    npm install -g @semiont/make-meaning@${SEMIONT_VERSION} neo4j-driver && \
+    npm cache clean --force
+
+# Stage 2: minimal runtime — node only, no npm. The runtime entrypoint is
+# `node weaver-main.js`, so npm is build-only baggage. Removing it also drops
+# the picomatch / glob / etc. CVE surface that ships inside npm's bundled
+# node_modules.
+FROM node:26-alpine
+# Patch base-image OS packages so alpine security fixes apply even when the
+# node:26-alpine snapshot hasn't been rebuilt against them yet.
+RUN apk upgrade --no-cache
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 semiont
+
+# The global @semiont/make-meaning + neo4j-driver (with hoisted deps) and bins.
+COPY --from=installer /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=installer /usr/local/bin /usr/local/bin
+
+# Strip npm/npx after the COPY above re-introduces them from the installer tree.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx
+
+COPY LICENSE /home/semiont/LICENSE
+COPY packages/make-meaning/NOTICE.weaver /home/semiont/NOTICE
+
+WORKDIR /kb
+RUN chown semiont:nodejs /kb
+USER semiont
+
+ENV NODE_ENV=production
+EXPOSE 9092
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:9092/health', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"
+
+CMD ["node", "/usr/local/lib/node_modules/@semiont/make-meaning/dist/weaver-main.js"]

--- a/packages/make-meaning/NOTICE.smelter
+++ b/packages/make-meaning/NOTICE.smelter
@@ -1,0 +1,20 @@
+Semiont
+Copyright 2025-2026 The AI Alliance
+
+This product is licensed under the Apache License, Version 2.0.
+
+This product includes software developed by The AI Alliance
+(https://thealliance.ai/).
+
+This container image (semiont-smelter) includes the following third-party
+components:
+
+  Alpine Linux - MIT License
+  Node.js - MIT License
+
+  npm dependencies (installed at build time from https://registry.npmjs.org):
+    @semiont/make-meaning - Apache-2.0 License (The AI Alliance)
+
+Each npm dependency's full license text is available in its respective
+node_modules/<package>/LICENSE file within the image, under
+/usr/local/lib/node_modules.

--- a/packages/make-meaning/NOTICE.weaver
+++ b/packages/make-meaning/NOTICE.weaver
@@ -1,0 +1,21 @@
+Semiont
+Copyright 2025-2026 The AI Alliance
+
+This product is licensed under the Apache License, Version 2.0.
+
+This product includes software developed by The AI Alliance
+(https://thealliance.ai/).
+
+This container image (semiont-weaver) includes the following third-party
+components:
+
+  Alpine Linux - MIT License
+  Node.js - MIT License
+
+  npm dependencies (installed at build time from https://registry.npmjs.org):
+    @semiont/make-meaning - Apache-2.0 License (The AI Alliance)
+    neo4j-driver - Apache-2.0 License (Neo4j, Inc.)
+
+Each npm dependency's full license text is available in its respective
+node_modules/<package>/LICENSE file within the image, under
+/usr/local/lib/node_modules.


### PR DESCRIPTION
## What

Adds the build + publish pipeline for the four backend-side service images —
**backend · worker · smelter · weaver** — modeled on the existing
`apps/frontend/Dockerfile` + `.github/workflows/publish-frontend.yml`. The goal
is to stop every KB from building four `npm install`-based images on each clone
and instead have it pull versioned, attested, config-free images.

This is **Phase A** of `.plans/PUBLISH-SERVICE-IMAGES.md` (build + publish, in
this monorepo). The KB-fleet consumer flip (Phase B) and local dev loop (Phase C)
are **not** in this PR.

### New Dockerfiles

All two-stage `node:26-alpine`, `apk upgrade`, `npm`/`npx` stripped from the
runtime, non-root `semiont` (uid 1001), `node -e` healthcheck, **config-free**
(config becomes a runtime bind-mount), single `SEMIONT_VERSION` build-arg.

| Image | Dockerfile | Bundles (published `@semiont/*` + lazy peers) | Launch |
|---|---|---|---|
| `semiont-backend` | `apps/backend/Dockerfile` | `@semiont/cli` + `@semiont/backend` + `neo4j-driver` + `@qdrant/js-client-rest` | `semiont provision --service backend …` (verbatim compound CMD) |
| `semiont-worker` | `packages/jobs/Dockerfile` | `@semiont/jobs` | `worker-main.js` |
| `semiont-smelter` | `packages/make-meaning/Dockerfile.smelter` | `@semiont/make-meaning` | `smelter-main.js` |
| `semiont-weaver` | `packages/make-meaning/Dockerfile.weaver` | `@semiont/make-meaning` + `neo4j-driver` | `weaver-main.js` |

Backend keeps `git` + `safe.directory /kb` (it's the only image that bind-mounts
`/kb`). Each image ships a per-image `NOTICE`.

### New workflow — `.github/workflows/publish-service-images.yml`

`workflow_dispatch(version, dry_run, tag_latest)` with a `fail-fast: false`
matrix over the four services. Each row clones the frontend spine:

verify npm version(s) → buildx → GHCR login → tags (`:<version>`, `:sha-<short>`,
optional `:latest`) → **Trivy vuln gate** (HIGH/CRITICAL, `ignore-unfixed`) →
**Trivy SPDX SBOM** → **license gate** → multi-arch build+push (amd64+arm64) →
**SLSA provenance + SBOM attestations** to GHCR → summary.

One change vs. frontend: the SBOM is generated *before* push so it feeds the
license gate **and** is reused for the attestation (one SBOM, two uses); the
scan/SBOM/license gates run on `dry_run` too.

### License-policy gate

- `.github/scripts/check-licenses.mjs` — dependency-free node gate. Filters the
  SBOM to `pkg:npm/` components, evaluates each SPDX expression with a real
  recursive-descent parser (`OR`=any, `AND`=all, `WITH`=base license, parens),
  and matches against a permissive allowlist. `NOASSERTION`/`NONE`/`LicenseRef-*`
  → "unknown" fail. Scope is npm deps only (OS/apk packages like `git` stay out,
  documented in the per-image NOTICE).
- `.github/licenses/allowlist.txt` — seeded from the **actual** union of all four
  dep trees (MIT, Apache-2.0, ISC, BSD-2/3-Clause, 0BSD, Unlicense, Python-2.0,
  CC0-1.0, + MIT-0, BlueOak-1.0.0). Zero copyleft present.
- `.github/licenses/exceptions.txt` — per-package escape hatch for metadata gaps,
  applied only when the scanner finds no license and still checked against the
  allowlist. Seeded with `seq-queue` (MIT, verified from its bundled LICENSE).

## How to run (after merge to `main`)

`workflow_dispatch` requires the workflow on the default branch, so it becomes
runnable once this merges.

1. **Smoke test:** `dry_run = true`, `version = 0.5.12` (latest published; 0.5.13
   isn't on npm yet). Runs the full pipeline with **no GHCR push**.
2. **Publish:** `dry_run = false`, `version = 0.5.12`, `tag_latest = true`.

## Verification

- **Images build** locally (`container build`, `SEMIONT_VERSION=latest` → 0.5.12):
  backend `semiont --version` runs non-root with npm stripped; `argon2` loads;
  worker `worker-main.js` resolves as uid 1001. `node:24 → 26` confirmed **not a
  regression** (identical install artifact state on both bases).
- **License gate** validated against a real Trivy SPDX SBOM of the backend tree
  (410 npm pkgs): passes with `seq-queue` rescued via exception; a negative test
  confirms `GPL-3.0-only` fails while `(GPL-2.0-only OR MIT)` passes.
- **`actionlint`** on the workflow: no Actions-level errors (only the same
  info-level shellcheck notes the frontend workflow already carries).

## Not in this PR

- **Phase B** — KB fleet stops building and pulls these images (bind-mount config
  at runtime); delete the KB Dockerfiles; drop the hadolint/docker-build CI.
- **Phase C** — local dev loop building `:local` images via verdaccio.

Both are in `.plans/PUBLISH-SERVICE-IMAGES.md` and depend on these images existing
first.
