### PR TITLE
Bounded startup retry for worker, smelter, and weaver connections to the backend

### DIFF
--- a/packages/core/src/__tests__/retry.test.ts
+++ b/packages/core/src/__tests__/retry.test.ts
@@ -1,0 +1,120 @@
+/**
+ * retryWithBackoff exists so a long-running peer whose first fetch to the
+ * KS fails (backend restart, container-network warm-up) waits out the
+ * blip instead of dying — orchestration runs these processes with `--rm`
+ * and no restart policy, so exit-on-first-failure is permanent death.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY, type RetryAttemptInfo } from '../retry';
+
+const FAST = { attempts: 4, initialDelayMs: 1, maxDelayMs: 4 };
+
+function fetchFailed(): TypeError {
+  return Object.assign(new TypeError('fetch failed'), {
+    cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:4000'), { code: 'ECONNREFUSED' }),
+  });
+}
+
+describe('retryWithBackoff', () => {
+  it('returns the first success after transient failures', async () => {
+    let calls = 0;
+    const result = await retryWithBackoff(
+      async () => {
+        calls++;
+        if (calls < 3) throw fetchFailed();
+        return 'up';
+      },
+      isTransientFetchError,
+      FAST,
+    );
+    expect(result).toBe('up');
+    expect(calls).toBe(3);
+  });
+
+  it('rethrows a non-retryable error immediately, without consuming the budget', async () => {
+    let calls = 0;
+    await expect(
+      retryWithBackoff(
+        async () => {
+          calls++;
+          throw new Error('Authentication failed: 401 Unauthorized');
+        },
+        isTransientFetchError,
+        FAST,
+      ),
+    ).rejects.toThrow(/401/);
+    expect(calls).toBe(1);
+  });
+
+  it('exhausts the budget and rethrows the last error', async () => {
+    let calls = 0;
+    await expect(
+      retryWithBackoff(
+        async () => {
+          calls++;
+          throw fetchFailed();
+        },
+        isTransientFetchError,
+        FAST,
+      ),
+    ).rejects.toThrow('fetch failed');
+    expect(calls).toBe(FAST.attempts);
+  });
+
+  it('doubles the delay each retry and caps at maxDelayMs, reporting via onRetry', async () => {
+    const seen: RetryAttemptInfo[] = [];
+    await expect(
+      retryWithBackoff(
+        async () => { throw fetchFailed(); },
+        isTransientFetchError,
+        { attempts: 5, initialDelayMs: 1, maxDelayMs: 4 },
+        (info) => seen.push(info),
+      ),
+    ).rejects.toThrow();
+    expect(seen.map((s) => s.delayMs)).toEqual([1, 2, 4, 4]);
+    expect(seen.map((s) => s.attempt)).toEqual([1, 2, 3, 4]);
+    expect(seen.every((s) => s.attempts === 5)).toBe(true);
+  });
+
+  it('does not call setTimeout on the success path', async () => {
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+    try {
+      await retryWithBackoff(async () => 'ok', isTransientFetchError, FAST);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('isTransientFetchError', () => {
+  it("accepts undici's TypeError('fetch failed')", () => {
+    expect(isTransientFetchError(fetchFailed())).toBe(true);
+  });
+
+  it('accepts a TypeError carrying a socket error code in cause', () => {
+    const err = Object.assign(new TypeError('terminated'), {
+      cause: Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+    });
+    expect(isTransientFetchError(err)).toBe(true);
+  });
+
+  it('rejects HTTP-level and programming errors', () => {
+    expect(isTransientFetchError(new Error('Authentication failed: 503'))).toBe(false);
+    expect(isTransientFetchError(new TypeError("Cannot read properties of undefined (reading 'x')"))).toBe(false);
+    expect(isTransientFetchError('fetch failed')).toBe(false);
+  });
+});
+
+describe('STARTUP_FETCH_RETRY', () => {
+  it('waits ~39s worst case — inside the 30–60s startup window', () => {
+    let delay = STARTUP_FETCH_RETRY.initialDelayMs;
+    let total = 0;
+    for (let i = 1; i < STARTUP_FETCH_RETRY.attempts; i++) {
+      total += delay;
+      delay = Math.min(delay * 2, STARTUP_FETCH_RETRY.maxDelayMs);
+    }
+    expect(total).toBeGreaterThanOrEqual(30_000);
+    expect(total).toBeLessThanOrEqual(60_000);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -386,3 +386,8 @@ export type {
 // shared by @semiont/make-meaning (matcher) and @semiont/jobs (generation).
 export { deriveViews } from './knowledge-graph-views';
 export type { GraphViews } from './knowledge-graph-views';
+
+// Bounded retry with backoff — startup connections from long-running peers
+// (worker, smelter, weaver) to the KS.
+export { retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY } from './retry';
+export type { RetryPolicy, RetryAttemptInfo } from './retry';

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -1,0 +1,79 @@
+/**
+ * Bounded retry with exponential backoff.
+ *
+ * Exists for startup-critical network calls in long-running peers (worker,
+ * smelter, weaver): each authenticates against the KS the moment its
+ * container starts, and the backend may not be reachable for a few seconds
+ * (backend restart, container-network warm-up). Orchestration runs these
+ * processes with `--rm` and no restart policy, so a process that dies on
+ * the first `TypeError: fetch failed` is dead for good — the retry window
+ * here is the only recovery it gets.
+ */
+
+export interface RetryPolicy {
+  /** Total attempts, including the first one. */
+  attempts: number;
+  /** Delay before the second attempt; doubles each retry. */
+  initialDelayMs: number;
+  /** Ceiling for the doubled delay. */
+  maxDelayMs: number;
+}
+
+export interface RetryAttemptInfo {
+  /** 1-based number of the attempt that just failed. */
+  attempt: number;
+  /** Total attempt budget from the policy. */
+  attempts: number;
+  /** How long we wait before the next attempt. */
+  delayMs: number;
+  error: unknown;
+}
+
+/**
+ * Default policy for startup connections to the backend: 8 attempts with
+ * delays 1s, 2s, 4s, then capped at 8s — ~39s of patience before giving up.
+ */
+export const STARTUP_FETCH_RETRY: RetryPolicy = {
+  attempts: 8,
+  initialDelayMs: 1_000,
+  maxDelayMs: 8_000,
+};
+
+/**
+ * True for the errors `fetch` throws when the connection itself fails —
+ * undici's `TypeError: fetch failed` (ECONNREFUSED, ENOTFOUND, reset,
+ * timeout — the socket error rides in `cause`). Deliberately false for
+ * HTTP-level failures (a 401 means the backend is UP and rejected us;
+ * retrying won't change its mind) and for programming errors.
+ */
+export function isTransientFetchError(error: unknown): boolean {
+  if (!(error instanceof TypeError)) return false;
+  if (error.message === 'fetch failed') return true;
+  const code = (error.cause as { code?: string } | undefined)?.code;
+  return typeof code === 'string' && code.length > 0;
+}
+
+/**
+ * Run `fn`, retrying on errors `isRetryable` accepts, with exponential
+ * backoff per `policy`. `onRetry` fires before each wait — the caller's
+ * hook for logging the attempt. The final error (retryable budget
+ * exhausted, or the first non-retryable one) is rethrown verbatim.
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  isRetryable: (error: unknown) => boolean,
+  policy: RetryPolicy,
+  onRetry?: (info: RetryAttemptInfo) => void,
+): Promise<T> {
+  let delayMs = policy.initialDelayMs;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= policy.attempts || !isRetryable(error)) throw error;
+      onRetry?.({ attempt, attempts: policy.attempts, delayMs, error });
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * 2, policy.maxDelayMs);
+    }
+  }
+}

--- a/packages/jobs/src/__tests__/worker-runtime.test.ts
+++ b/packages/jobs/src/__tests__/worker-runtime.test.ts
@@ -13,6 +13,9 @@ import type { Logger } from '@semiont/core';
 import { startAgentWorker, authenticateAgent, parseBackendUrl, type AgentGroup } from '../worker-runtime';
 import { startWorkerProcess } from '../worker-process';
 import type { InferenceClient } from '@semiont/inference';
+import { createServer, type Server } from 'http';
+import { once } from 'events';
+import type { AddressInfo } from 'net';
 
 vi.mock('../worker-process', () => ({
   startWorkerProcess: vi.fn(() => ({ dispose: vi.fn() })),
@@ -136,6 +139,90 @@ describe('worker-runtime — identity is minted by the exchange, carried verbati
     await expect(
       authenticateAgent({ backendBaseUrl: DIAL_URL, workerSecret: '', provider: 'anthropic', model: 'm1' }),
     ).rejects.toThrow(/SEMIONT_WORKER_SECRET/);
+  });
+
+  // The blip that used to be fatal: any momentary backend unreachability
+  // at the instant the worker starts (backend restart, container-network
+  // warm-up) threw `TypeError: fetch failed` straight out of main() and
+  // killed the process — with `--rm` and no restart policy, permanently.
+  it('retries startup auth while the backend is unreachable and succeeds once it comes up', async () => {
+    // Reserve a port, then free it — the first attempts dial a closed port
+    // and fail at the connection level, exactly like a backend mid-restart.
+    const probe = createServer();
+    probe.listen(0, '127.0.0.1');
+    await once(probe, 'listening');
+    const port = (probe.address() as AddressInfo).port;
+    probe.close();
+    await once(probe, 'close');
+
+    let backend: Server | undefined;
+    const bringUp = setTimeout(() => {
+      backend = createServer((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ token: fakeJwt(), did: CANONICAL_DID }));
+      });
+      backend.listen(port, '127.0.0.1');
+    }, 150);
+
+    const warn = vi.fn();
+    try {
+      const result = await authenticateAgent({
+        backendBaseUrl: `http://127.0.0.1:${port}`,
+        workerSecret: 'test-secret',
+        provider: 'anthropic',
+        model: 'claude-haiku-4-5',
+        logger: { ...noopLogger, warn } as unknown as Logger,
+        retry: { attempts: 20, initialDelayMs: 50, maxDelayMs: 100 },
+      });
+      expect(result.did).toBe(CANONICAL_DID);
+      expect(warn).toHaveBeenCalledWith(
+        'Backend unreachable, retrying agent authentication',
+        expect.objectContaining({ agent: 'anthropic:claude-haiku-4-5', attempt: expect.any(Number) }),
+      );
+    } finally {
+      clearTimeout(bringUp);
+      if (backend) {
+        backend.close();
+        await once(backend, 'close');
+      }
+    }
+  }, 15_000);
+
+  it('gives up after the retry budget when the backend never comes up', async () => {
+    const calls = { count: 0 };
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      calls.count++;
+      throw Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      });
+    }));
+
+    await expect(
+      authenticateAgent({
+        backendBaseUrl: DIAL_URL,
+        workerSecret: 'test-secret',
+        provider: 'anthropic',
+        model: 'm1',
+        retry: { attempts: 3, initialDelayMs: 1, maxDelayMs: 2 },
+      }),
+    ).rejects.toThrow('fetch failed');
+    expect(calls.count).toBe(3);
+  });
+
+  it('does NOT retry an HTTP-level rejection — the backend is up and said no', async () => {
+    const fetchMock = vi.fn(async () => new Response('nope', { status: 401, statusText: 'Unauthorized' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      authenticateAgent({
+        backendBaseUrl: DIAL_URL,
+        workerSecret: 'bad',
+        provider: 'anthropic',
+        model: 'm1',
+        retry: { attempts: 5, initialDelayMs: 1, maxDelayMs: 2 },
+      }),
+    ).rejects.toThrow(/401/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('parseBackendUrl keeps its connection role: host/port/protocol from the dial string', () => {

--- a/packages/jobs/src/worker-runtime.ts
+++ b/packages/jobs/src/worker-runtime.ts
@@ -16,7 +16,17 @@
 import { startWorkerProcess } from './worker-process';
 import type { InferenceClient } from '@semiont/inference';
 import { hostname } from 'os';
-import { didToAgent, baseUrl, type components, type Logger, type AccessToken } from '@semiont/core';
+import {
+  didToAgent,
+  baseUrl,
+  retryWithBackoff,
+  isTransientFetchError,
+  STARTUP_FETCH_RETRY,
+  type RetryPolicy,
+  type components,
+  type Logger,
+  type AccessToken,
+} from '@semiont/core';
 import {
   InMemorySessionStorage,
   SemiontClient,
@@ -70,29 +80,53 @@ export function parseBackendUrl(url: string): { protocol: 'http' | 'https'; host
  * Exchange the worker secret for this agent's JWT and its canonical DID.
  * The DID is minted by the backend (from its `site.domain`) — the caller
  * carries it verbatim.
+ *
+ * Connection-level failures (`TypeError: fetch failed`) are retried with
+ * exponential backoff: the backend may be mid-restart or the container
+ * network still warming up when this process starts, and orchestration
+ * runs workers with `--rm` and no restart policy — exiting on the first
+ * failed fetch is permanent death. HTTP-level rejections (401 on a bad
+ * secret) are NOT retried; the backend is up and said no.
  */
 export async function authenticateAgent(opts: {
   backendBaseUrl: string;
   workerSecret: string;
   provider: string;
   model: string;
+  logger?: Logger;
+  retry?: RetryPolicy;
 }): Promise<{ token: string; did: string }> {
-  const { backendBaseUrl, workerSecret, provider, model } = opts;
+  const { backendBaseUrl, workerSecret, provider, model, logger, retry = STARTUP_FETCH_RETRY } = opts;
   if (!workerSecret) {
     throw new Error('SEMIONT_WORKER_SECRET is required to authenticate worker agents');
   }
 
-  const response = await fetch(`${backendBaseUrl}/api/tokens/agent`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ secret: workerSecret, provider, model }),
-  });
+  return retryWithBackoff(
+    async () => {
+      const response = await fetch(`${backendBaseUrl}/api/tokens/agent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ secret: workerSecret, provider, model }),
+      });
 
-  if (!response.ok) {
-    throw new Error(`Agent authentication failed for ${provider}:${model}: ${response.status} ${response.statusText}`);
-  }
+      if (!response.ok) {
+        throw new Error(`Agent authentication failed for ${provider}:${model}: ${response.status} ${response.statusText}`);
+      }
 
-  return await response.json() as { token: string; did: string };
+      return await response.json() as { token: string; did: string };
+    },
+    isTransientFetchError,
+    retry,
+    ({ attempt, attempts, delayMs, error }) => {
+      logger?.warn('Backend unreachable, retrying agent authentication', {
+        agent: `${provider}:${model}`,
+        attempt,
+        attempts,
+        retryInMs: delayMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
 }
 
 export async function startAgentWorker(
@@ -107,6 +141,7 @@ export async function startAgentWorker(
     workerSecret,
     provider: inference.type,
     model: inference.model,
+    logger,
   });
 
   // The exchange minted this worker's canonical DID (from the backend's
@@ -148,6 +183,7 @@ export async function startAgentWorker(
           workerSecret,
           provider: inference.type,
           model: inference.model,
+          logger,
         });
         return token;
       } catch (err) {

--- a/packages/make-meaning/src/smelter-main.ts
+++ b/packages/make-meaning/src/smelter-main.ts
@@ -21,7 +21,7 @@ import { BehaviorSubject } from 'rxjs';
 import { createSmelterActorStateUnit, type SmelterActorStateUnit } from './smelter-actor-state-unit';
 import { Smelter } from './smelter';
 import { HttpTransport, HttpContentTransport } from '@semiont/http-transport';
-import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader } from '@semiont/core';
+import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader, retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY } from '@semiont/core';
 import type { AccessToken } from '@semiont/core';
 import { createVectorStore, createEmbeddingProvider } from '@semiont/vectors';
 import type { ChunkingConfig } from '@semiont/vectors';
@@ -92,22 +92,42 @@ async function authenticate(): Promise<string> {
   // agent DID onto every event it emits. Identity granularity follows
   // the embedding config; two smelters with different embedding
   // providers run as different agents.
-  const response = await fetch(`${baseUrl}/api/tokens/agent`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      secret: workerSecret,
-      provider: embeddingType,
-      model: embeddingModel,
-    }),
-  });
+  //
+  // Connection-level failures are retried with backoff: the backend may be
+  // mid-restart or the container network still warming up when this process
+  // starts, and orchestration runs it with `--rm` and no restart policy —
+  // exiting on the first failed fetch is permanent death. HTTP-level
+  // rejections (bad secret) are NOT retried; the backend is up and said no.
+  return retryWithBackoff(
+    async () => {
+      const response = await fetch(`${baseUrl}/api/tokens/agent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          secret: workerSecret,
+          provider: embeddingType,
+          model: embeddingModel,
+        }),
+      });
 
-  if (!response.ok) {
-    throw new Error(`Authentication failed: ${response.status} ${response.statusText}`);
-  }
+      if (!response.ok) {
+        throw new Error(`Authentication failed: ${response.status} ${response.statusText}`);
+      }
 
-  const { token } = await response.json() as { token: string; did: string };
-  return token;
+      const { token } = await response.json() as { token: string; did: string };
+      return token;
+    },
+    isTransientFetchError,
+    STARTUP_FETCH_RETRY,
+    ({ attempt, attempts, delayMs, error }) => {
+      logger.warn('Backend unreachable, retrying authentication', {
+        attempt,
+        attempts,
+        retryInMs: delayMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
 }
 
 // ── Main ─────────────────────────────────────────────────────────────

--- a/packages/make-meaning/src/weaver-main.ts
+++ b/packages/make-meaning/src/weaver-main.ts
@@ -23,7 +23,7 @@ import { createWeaverActorStateUnit, type WeaverActorStateUnit } from './weaver-
 import { Weaver, type WeaverTiming } from './weaver';
 import { FileWeaverCheckpoint } from './weaver-checkpoint';
 import { HttpTransport } from '@semiont/http-transport';
-import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader } from '@semiont/core';
+import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader, retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY } from '@semiont/core';
 import type { AccessToken } from '@semiont/core';
 import { getGraphDatabase } from '@semiont/graph';
 import { createServer } from 'http';
@@ -86,22 +86,42 @@ async function authenticate(): Promise<string> {
   // inference (provider, model), so it authenticates under the stable
   // identity (semiont, weaver) — DID did:web:<host>:agents:semiont:weaver —
   // and the bus stamps that onto every signal it emits.
-  const response = await fetch(`${baseUrl}/api/tokens/agent`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      secret: workerSecret,
-      provider: 'semiont',
-      model: 'weaver',
-    }),
-  });
+  //
+  // Connection-level failures are retried with backoff: the backend may be
+  // mid-restart or the container network still warming up when this process
+  // starts, and orchestration runs it with `--rm` and no restart policy —
+  // exiting on the first failed fetch is permanent death. HTTP-level
+  // rejections (bad secret) are NOT retried; the backend is up and said no.
+  return retryWithBackoff(
+    async () => {
+      const response = await fetch(`${baseUrl}/api/tokens/agent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          secret: workerSecret,
+          provider: 'semiont',
+          model: 'weaver',
+        }),
+      });
 
-  if (!response.ok) {
-    throw new Error(`Authentication failed: ${response.status} ${response.statusText}`);
-  }
+      if (!response.ok) {
+        throw new Error(`Authentication failed: ${response.status} ${response.statusText}`);
+      }
 
-  const { token } = await response.json() as { token: string; did: string };
-  return token;
+      const { token } = await response.json() as { token: string; did: string };
+      return token;
+    },
+    isTransientFetchError,
+    STARTUP_FETCH_RETRY,
+    ({ attempt, attempts, delayMs, error }) => {
+      logger.warn('Backend unreachable, retrying authentication', {
+        attempt,
+        attempts,
+        retryInMs: delayMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
 }
 
 // ── Main ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
# Pull Request

## Description

The `@semiont/jobs` worker, smelter, and weaver all exited fatally on their FIRST failed fetch to the backend:

```
{"component":"worker","error":"fetch failed","level":"error","message":"Fatal","stack":"TypeError: fetch failed"}
```

Any momentary backend unreachability at the instant one of these processes starts — a backend restart, container-network warm-up, or the backend dying for unrelated reasons — killed the process permanently. KB orchestration runs these containers with `--rm` and no restart policy, so nothing ever revived them.

This PR adds bounded retry with exponential backoff to the startup connection (the `/api/tokens/agent` exchange) in all three entry points:

- **New shared helper in `@semiont/core`** (`packages/core/src/retry.ts`):
  - `retryWithBackoff` — bounded retry with exponential backoff and an `onRetry` hook for logging
  - `isTransientFetchError` — true for undici's connection-level `TypeError: fetch failed` (ECONNREFUSED, reset, timeout — socket error in `cause`); deliberately false for HTTP-level rejections and programming errors
  - `STARTUP_FETCH_RETRY` — the default policy: 8 attempts with delays 1s, 2s, 4s, then capped at 8s (~39s of patience before giving up)
- **Worker** (`packages/jobs/src/worker-runtime.ts`): `authenticateAgent` retries connection-level failures, logging each attempt at `warn`. Both the startup call and the token-refresh path get the retry, so a long-lived worker also survives a backend restart at refresh time. A 401 (bad secret) is NOT retried — the backend is up and said no.
- **Smelter and weaver** (`packages/make-meaning/src/{smelter,weaver}-main.ts`): the identical fatal-on-first-fetch pattern in their `authenticate()` gets the same retry and logging.

Note: the retry is bounded, so a backend that stays down past the ~39s window still ends the process. Outages longer than that need a restart policy in orchestration.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Areas Changed

- [x] Core (`packages/core`)
- [x] Jobs (`packages/jobs`)
- [x] Make Meaning (`packages/make-meaning`)

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass

New tests:

- `packages/core/src/__tests__/retry.test.ts` — success after transient failures, immediate rethrow of non-retryable errors, budget exhaustion, delay doubling/capping via `onRetry`, transient-error classification, and a pin that the default policy's worst-case wait stays in the 30–60s startup window.
- `packages/jobs/src/__tests__/worker-runtime.test.ts` — simulates an initially-unreachable backend that becomes reachable within the retry window: reserves a real port, leaves it closed so the first attempts fail with genuine `ECONNREFUSED`, brings up a real HTTP server on that port 150 ms later, and asserts `authenticateAgent` recovers and logged the retries. Plus budget exhaustion when the backend never appears, and no-retry-on-401.

Full suites: `@semiont/core` 480 tests, `@semiont/jobs` 294, `@semiont/make-meaning` 480 — all green.

## Security Checklist

Not applicable — no authentication, authorization, or admin functionality modified. The retry wraps the existing agent-token exchange without changing its semantics; HTTP-level auth rejections still fail immediately.

## Performance Impact

- [x] No significant performance degradation

Retry only engages when the connection itself fails; the success path adds no delay.

## Breaking Changes

None.
