### PR TITLE
cgroup-aware backend heap, job-worker liveness, :local image fan-out, container docs

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -74,7 +74,11 @@ RUN chown semiont:nodejs /kb
 USER semiont
 
 ENV NODE_ENV=production
-ENV NODE_OPTIONS=--max-old-space-size=6144
+# Deliberately NO explicit --max-old-space-size: node:24 is cgroup-aware and
+# sizes the heap to ~half the container memory limit, making --memory /
+# mem_limit the single memory knob. A baked heap override defeats that — it
+# licensed the heap past small container limits (OOM-kill instead of GC
+# pressure) and was an unmeasured 2026-04 artifact, not a profiled need.
 EXPOSE 4000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \

--- a/docs/development/RELEASE.md
+++ b/docs/development/RELEASE.md
@@ -291,8 +291,10 @@ gh workflow run release.yml
 gh run list --workflow=release.yml --limit=1
 gh run watch <run-id> --exit-status
 
-# 5. After the npm packages are live, publish the frontend container image
+# 5. After the npm packages are live, publish the container images
+#    (frontend + the four service images; the two workflows can run in parallel)
 gh workflow run publish-frontend.yml --field version=<version> --field tag_latest=true
+gh workflow run publish-service-images.yml --field version=<version> --field tag_latest=true
 
 # 6. Bump version for next development cycle
 ./scripts/release/version-bump.sh patch
@@ -336,12 +338,18 @@ npm install @semiont/frontend@dev
 ### Container Images
 
 The frontend container image is published to GHCR by
-[Step 1b](#step-1b-publish-the-frontend-container-image):
+[Step 1b](#step-1b-publish-the-frontend-container-image), and the four
+service images by `publish-service-images.yml`:
 
 ```bash
-docker pull ghcr.io/the-ai-alliance/semiont-frontend:0.5.6
 docker pull ghcr.io/the-ai-alliance/semiont-frontend:latest
+docker pull ghcr.io/the-ai-alliance/semiont-backend:latest
+docker pull ghcr.io/the-ai-alliance/semiont-worker:latest
+docker pull ghcr.io/the-ai-alliance/semiont-smelter:latest
+docker pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 ```
+
+All five also carry `:<version>` (e.g. `:0.5.12`) and `:sha-<commit>` tags.
 
 
 ## Version Bump Guidelines
@@ -411,6 +419,7 @@ After releasing:
 - [ ] Verify npm packages published (including `@semiont/backend` and `@semiont/frontend`)
 - [ ] If desktop was checked, verify the desktop artifacts on the GitHub Release
 - [ ] Publish the frontend container image ([Step 1b](#step-1b-publish-the-frontend-container-image)) and confirm the `:<version>` and `:latest` tags on GHCR
+- [ ] Publish the four service images (`publish-service-images.yml`) and confirm `semiont-backend`, `semiont-worker`, `semiont-smelter`, and `semiont-weaver` carry `:<version>` and `:latest` on GHCR
 - [ ] Test installation: `npm install -g @semiont/cli@latest && semiont init && semiont provision`
 - [ ] Bump version for next cycle: `./scripts/release/version-bump.sh`
 

--- a/docs/system/CONTAINER-TOPOLOGY.md
+++ b/docs/system/CONTAINER-TOPOLOGY.md
@@ -6,7 +6,7 @@ How a Semiont deployment splits into containers, how those containers communicat
 >
 > See [PACKAGE-ARCHITECTURE.md](PACKAGE-ARCHITECTURE.md) for the package layering that defines what each container actually contains.
 
-For the actor responsibilities running inside the backend / worker / smelter containers, see [KNOWLEDGE-SYSTEM.md](KNOWLEDGE-SYSTEM.md). For the SPA running in the frontend container, see [HUMAN-UI.md](HUMAN-UI.md).
+For the actor responsibilities running inside the backend / worker / smelter / weaver containers, see [KNOWLEDGE-SYSTEM.md](KNOWLEDGE-SYSTEM.md). For the Semiont Browser SPA (served by the frontend container, executed in the user's web browser), see [HUMAN-UI.md](HUMAN-UI.md).
 
 ## Multi-container layout
 
@@ -23,7 +23,7 @@ graph TB
     subgraph backend_c ["semiont-backend"]
         BUS["Event Bus"]
         STOWER["Stower"]
-        BROWSER["Browser"]
+        BROWSER["Browser<br/>(browse.* reads)"]
         GATHERER["Gatherer"]
         MATCHER["Matcher"]
         VIEWS[("Materialized Views")]
@@ -126,7 +126,7 @@ Services run on different platforms, configured in `~/.semiontconfig` per enviro
 
 The currently supported platforms:
 
-- **POSIX** — Local processes (monorepo development). Each Semiont service is a Node process started directly on the host. See [platforms/POSIX.md](platforms/POSIX.md).
+- **POSIX** — Local processes (monorepo development). Each Semiont service is a Node process started directly on the host. See [platforms/POSIX.md](platforms/POSIX.md) and [LOCAL-SEMIONT.md](LOCAL-SEMIONT.md) for running Semiont locally.
 - **Container** — Docker / Podman / Apple containers. Each service is a containerized Node process; the diagram above shows this layout. This is what KB stacks use — locally via `.semiont/scripts/start.sh` (any of the three runtimes) and in **GitHub Codespaces** via `docker compose` in the devcontainer. See [platforms/Container.md](platforms/Container.md).
 - **AWS** — ECS Fargate tasks, RDS, S3, Neptune. The same containers, scheduled by ECS. See [platforms/AWS.md](platforms/AWS.md).
 

--- a/docs/system/CONTAINER-TOPOLOGY.md
+++ b/docs/system/CONTAINER-TOPOLOGY.md
@@ -10,12 +10,14 @@ For the actor responsibilities running inside the backend / worker / smelter con
 
 ## Multi-container layout
 
-A local deployment runs four containers of Semiont code, five if you include the frontend, or nine if you also count the infrastructure dependencies. All five Semiont containers are **published, attested images** (`ghcr.io/the-ai-alliance/semiont-*`) that knowledge-base stacks pull — selecting the version via `SEMIONT_VERSION` — and configure by bind-mounting per-KB TOML at runtime; KBs do not build images (see [Container Images](administration/IMAGES.md)):
+A local deployment runs four containers of Semiont code, five with the frontend, nine with the infrastructure dependencies — and ten with the Jaeger observability sidecar, which local KB stacks run **by default** (`--no-observe` skips it): the backend, worker, smelter, and weaver all export OTLP traces + metrics to it. All five Semiont containers are **published, attested images** (`ghcr.io/the-ai-alliance/semiont-*`) that knowledge-base stacks pull — selecting the version via `SEMIONT_VERSION` — and configure by bind-mounting per-KB TOML at runtime; KBs do not build images (see [Container Images](administration/IMAGES.md)):
 
 ```mermaid
 graph TB
+    UB["User's Web Browser<br/>(runs the SPA)"]
+
     subgraph frontend_c ["semiont-frontend"]
-        SPA["Semiont Browser SPA<br/>(Vite + React)"]
+        SPA["Static SPA server<br/>(serves the Semiont Browser)"]
     end
 
     subgraph backend_c ["semiont-backend"]
@@ -27,7 +29,7 @@ graph TB
         VIEWS[("Materialized Views")]
     end
 
-    GIT[("KB Git Repo")]
+    GIT[("KB Git Repo<br/>(event log + content)")]
 
     subgraph worker_c ["semiont-worker"]
         WORKERS["Worker Pool"]
@@ -54,10 +56,15 @@ graph TB
     end
 
     subgraph ol_c ["semiont-ollama"]
-        OL["Ollama"]
+        OL["Ollama<br/>(embeddings + local inference)"]
     end
 
-    SPA --- BUS
+    subgraph jag_c ["semiont-jaeger (observability)"]
+        JAG["Jaeger<br/>(OTLP traces + metrics)"]
+    end
+
+    UB --- SPA
+    UB --- BUS
     WORKERS --- BUS
     SMELTER --- BUS
     WEAVER --- BUS
@@ -65,9 +72,16 @@ graph TB
     STOWER --- GIT
     STOWER --- VIEWS
     VIEWS --- GIT
+    BROWSER --- VIEWS
+    GATHERER --- VIEWS
+    GATHERER --- GIT
     WEAVER --- NEO
     SMELTER --- QD
-    BUS --- PG
+    backend_c ---|"users / auth"| PG
+    backend_c -.- JAG
+    WORKERS -.- JAG
+    SMELTER -.- JAG
+    WEAVER -.- JAG
     WORKERS --- OL
     SMELTER --- OL
     GATHERER --- NEO
@@ -86,19 +100,21 @@ graph TB
     class BUS bus
     class STOWER,BROWSER,GATHERER,MATCHER,WEAVER,WORKERS,SMELTER actor
     class GIT,VIEWS,PG,NEO,QD store
-    class SPA spa
-    class OL service
+    class SPA,UB spa
+    class OL,JAG service
 ```
 
-The four Semiont-code backend containers communicate exclusively through the unified bus exposed by `semiont-backend` (`/bus/emit`, `/bus/subscribe`). Workers, the smelter, and the weaver authenticate via `POST /api/tokens/agent`, which exchanges a shared secret (`SEMIONT_WORKER_SECRET`) plus a `(provider, model)` identity for a JWT carrying a typed Software-agent DID (the smelter presents its embedding config; the weaver presents `(semiont, weaver)`); the existing auth middleware validates that JWT exactly as it would a user's. This split isolates long-running LLM, embedding, and graph-projection work from the request-serving event loop — the backend stays responsive to human users while workers, the smelter, and the weaver run in separate V8 isolates.
+Two reading notes on the diagram. First, the SPA *executes in the user's web browser* — `semiont-frontend` only serves its static assets; the browser then talks to the backend directly (`localhost:4000`), which is why the frontend container needs no config and no backend connection of its own. Second, the Ollama edges show the fully-local default: with the anthropic config, LLM inference for the workers, Gatherer, and Matcher goes to the Anthropic API instead, while embeddings stay on Ollama either way.
+
+The worker, smelter, and weaver communicate with the backend exclusively through the unified bus it exposes (`/bus/emit`, `/bus/subscribe`). Workers, the smelter, and the weaver authenticate via `POST /api/tokens/agent`, which exchanges a shared secret (`SEMIONT_WORKER_SECRET`) plus a `(provider, model)` identity for a JWT carrying a typed Software-agent DID (the smelter presents its embedding config; the weaver presents `(semiont, weaver)`); the existing auth middleware validates that JWT exactly as it would a user's. This split isolates long-running LLM, embedding, and graph-projection work from the request-serving event loop — the backend stays responsive to human users while workers, the smelter, and the weaver run in separate V8 isolates.
 
 ## Unified bus and SemiontSession
 
-Every actor that runs Semiont code — the Semiont Browser SPA, CLI, MCP, worker pool, and smelter — is a bus participant using the same primitives in `@semiont/sdk`. The backend exposes exactly two runtime endpoints that carry domain traffic: `POST /bus/emit` and `GET /bus/subscribe` (an SSE stream with dynamic channel subscriptions and Last-Event-ID replay on reconnect). Every other HTTP route exists for auth, admin, exchange, binary content, or infrastructure — not for domain commands. Commands and domain events flow through the bus.
+Every actor that runs Semiont code — the Semiont Browser SPA, CLI, MCP, worker pool, smelter, and weaver — is a bus participant using the same primitives in `@semiont/sdk`. The backend exposes exactly two runtime endpoints that carry domain traffic: `POST /bus/emit` and `GET /bus/subscribe` (an SSE stream with dynamic channel subscriptions and Last-Event-ID replay on reconnect). Every other HTTP route exists for auth, admin, exchange, binary content, or infrastructure — not for domain commands. Commands and domain events flow through the bus.
 
 The common abstraction for "I am a Semiont actor" is `SemiontSession`, which lives in `@semiont/sdk` and carries per-KB authentication, token refresh, bus access, and cross-process state synchronization. A session is constructed against a storage adapter (`SessionStorage`): `WebBrowserStorage` in the browser, filesystem storage for CLI and MCP, in-memory storage in workers and tests. `SemiontClient` exposes namespace methods (e.g. `client.browse.resource(...)`, `client.mark.annotation(...)`) over the bus; raw `emit`/`on`/`stream` are internal to the SDK and not part of the consumer surface.
 
-A new kind of actor slots in the same way in every environment: construct a session with the right storage adapter, authenticate, subscribe to the channels it cares about, emit the commands it produces. The worker and smelter containers are the clearest demonstration — same session, same bus primitives, same authentication pattern as the frontend; just different storage and different channels.
+A new kind of actor slots in the same way in every environment: construct a session with the right storage adapter, authenticate, subscribe to the channels it cares about, emit the commands it produces. The worker, smelter, and weaver containers are the clearest demonstration — same session, same bus primitives, same authentication pattern as the frontend; just different storage and different channels. (The weaver is also the proof by induction: it was added as a standalone actor after the pattern existed, and slotted in without any new plumbing.)
 
 For the wire-level event protocol, see **[../protocol/EVENT-BUS.md](../protocol/EVENT-BUS.md)**.
 
@@ -110,8 +126,8 @@ Services run on different platforms, configured in `~/.semiontconfig` per enviro
 
 The currently supported platforms:
 
-- **POSIX** — Local processes (development, Codespaces). Each Semiont service is a Node process started directly on the host. See [platforms/POSIX.md](platforms/POSIX.md).
-- **Container** — Docker / Podman / Apple containers. Each service is a containerized Node process; the diagram above shows this layout. See [platforms/Container.md](platforms/Container.md).
+- **POSIX** — Local processes (monorepo development). Each Semiont service is a Node process started directly on the host. See [platforms/POSIX.md](platforms/POSIX.md).
+- **Container** — Docker / Podman / Apple containers. Each service is a containerized Node process; the diagram above shows this layout. This is what KB stacks use — locally via `.semiont/scripts/start.sh` (any of the three runtimes) and in **GitHub Codespaces** via `docker compose` in the devcontainer. See [platforms/Container.md](platforms/Container.md).
 - **AWS** — ECS Fargate tasks, RDS, S3, Neptune. The same containers, scheduled by ECS. See [platforms/AWS.md](platforms/AWS.md).
 
 These three are what the Semiont CLI knows how to provision and manage today. They share the same containers because they share the same npm packages — the difference is where the Node processes run, not what they run.
@@ -128,17 +144,19 @@ The constraint is the **port contracts** — the bus (`/bus/emit`, `/bus/subscri
 
 | Environment | Compute | Storage | Graph | Users DB |
 |-------------|---------|---------|-------|----------|
-| **Local** | Local processes | Filesystem | In-memory | PostgreSQL |
+| **Local (KB stack)** | Containers (Apple `container` / Docker / Podman) | Filesystem (KB git repo, bind-mounted) | Neo4j (container) | PostgreSQL (container) |
 | **Production (AWS)** | ECS Fargate | S3/EFS | Neptune | RDS PostgreSQL |
 
 ### Service management
 
-All services are managed through the Semiont CLI:
+Two layers, easy to conflate:
+
+- **Operator entry points.** A KB stack is driven by its repo's scripts — `.semiont/scripts/start.sh` / `logs.sh` / `stop.sh` (runtime-portable, `--runtime` to force one) — or by `docker compose` against `.semiont/compose/backend.yml` (Codespaces uses this). Operators do not invoke the Semiont CLI directly.
+- **The CLI inside the containers.** Each published image's entrypoint uses the Semiont CLI to provision and start its own service (e.g. the backend runs `semiont provision --service backend && semiont start --service backend`). Monorepo developers on the POSIX platform can drive the same CLI directly:
 
 ```bash
 semiont start --environment local
 semiont check --service all
-semiont stop --environment production
 ```
 
 See **[CLI Documentation](../../apps/cli/README.md)** and **[administration/CONFIGURATION.md](administration/CONFIGURATION.md)** for full configuration details.

--- a/docs/system/LOCAL-SEMIONT.md
+++ b/docs/system/LOCAL-SEMIONT.md
@@ -64,8 +64,9 @@ Want to verify image provenance before running? See [Supply-chain verification](
 **Running from source instead of published images:** build all five images
 from a monorepo working tree with
 [`scripts/ci/local-build.sh`](../../scripts/ci/local-build.sh) (they get the
-local-only `:local` tag, never pushed), then start the KB stack with
-`SEMIONT_VERSION=local .semiont/scripts/start.sh …` — the `local` version
+local-only `:local` tag, never pushed, and are loaded into every container
+engine on the machine — any `--runtime` can run them), then start the KB stack
+with `SEMIONT_VERSION=local .semiont/scripts/start.sh …` — the `local` version
 skips the registry pull.
 
 Open **http://localhost:3000** and enter **http://localhost:4000** as the knowledge base URL.

--- a/docs/system/administration/IMAGES.md
+++ b/docs/system/administration/IMAGES.md
@@ -85,8 +85,9 @@ carry no Dockerfiles and no image builds of their own.
 **Local dev loop:** [scripts/ci/local-build.sh](../../../scripts/ci/local-build.sh)
 builds all five images from the working tree as
 `ghcr.io/the-ai-alliance/semiont-<svc>:local` (via a throwaway local
-verdaccio; never pushed). A KB stack consumes them with
-`SEMIONT_VERSION=local`, which also skips the pull.
+verdaccio; never pushed), fanning each built image out to every other
+container engine on the machine so any `--runtime` finds them. A KB stack
+consumes them with `SEMIONT_VERSION=local`, which also skips the pull.
 
 ---
 

--- a/packages/jobs/src/__tests__/job-claim-adapter.test.ts
+++ b/packages/jobs/src/__tests__/job-claim-adapter.test.ts
@@ -169,4 +169,105 @@ describe('createJobClaimAdapter', () => {
     adapter.dispose();
     expect(flags).toEqual({ active: true, proc: true, done: true, errs: true });
   });
+
+  // ── Vitals (WORKER-LIVENESS.md P1) ─────────────────────────────────
+  // The adapter is the only component that sees every announcement,
+  // claim, and finish — its snapshot is what /health and the stall
+  // watchdog read.
+
+  describe('vitals', () => {
+    it('starts empty', () => {
+      const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+
+      expect(adapter.vitals()).toEqual({
+        lastQueuedEventAt: null,
+        lastClaimAt: null,
+        lastFinishedAt: null,
+        lastActivityAt: null,
+        activeJob: null,
+        jobsCompleted: 0,
+      });
+
+      adapter.dispose();
+    });
+
+    it('records the claim → activity → completion cycle', async () => {
+      const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+      adapter.start();
+
+      h.pushEvent('job:queued', { jobId: 'jv1', jobType: 'generation', resourceId: 'r1' });
+      await new Promise((r) => setTimeout(r, 0));
+      h.pushEvent('job:claimed', {
+        correlationId: h.emits[0]!.payload.correlationId,
+        response: { params: {}, metadata: { userId: 'u' } },
+      });
+      await firstValueFrom(adapter.activeJob$.pipe(skip(1), take(1)));
+
+      const claimed = adapter.vitals();
+      expect(claimed.lastQueuedEventAt).not.toBeNull();
+      expect(claimed.lastClaimAt).not.toBeNull();
+      expect(claimed.lastActivityAt).not.toBeNull();
+      expect(claimed.activeJob).toMatchObject({ jobId: 'jv1', type: 'generation' });
+      expect(typeof claimed.activeJob!.since).toBe('string');
+      expect(claimed.lastFinishedAt).toBeNull();
+
+      adapter.completeJob();
+
+      const done = adapter.vitals();
+      expect(done.activeJob).toBeNull();
+      expect(done.jobsCompleted).toBe(1);
+      expect(done.lastFinishedAt).not.toBeNull();
+
+      adapter.dispose();
+    });
+
+    it('bumps lastQueuedEventAt even for announcements it ignores (transport liveness)', async () => {
+      const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: ['generation'] });
+      adapter.start();
+
+      h.pushEvent('job:queued', { jobId: 'jx', jobType: 'other-type', resourceId: 'r1' });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(adapter.vitals().lastQueuedEventAt).not.toBeNull();
+      expect(h.emits).toEqual([]); // still filtered — no claim attempted
+
+      adapter.dispose();
+    });
+
+    it('touchActivity() stamps lastActivityAt without touching the rest', () => {
+      const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+
+      adapter.touchActivity();
+
+      const v = adapter.vitals();
+      expect(v.lastActivityAt).not.toBeNull();
+      expect(v.lastClaimAt).toBeNull();
+      expect(v.activeJob).toBeNull();
+
+      adapter.dispose();
+    });
+
+    it('failJob stamps lastFinishedAt and clears activeJob without counting a completion', async () => {
+      const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+      adapter.start();
+
+      h.pushEvent('job:queued', { jobId: 'jv2', jobType: 'generation', resourceId: 'r1' });
+      await new Promise((r) => setTimeout(r, 0));
+      h.pushEvent('job:claimed', {
+        correlationId: h.emits[0]!.payload.correlationId,
+        response: { params: {}, metadata: { userId: 'u' } },
+      });
+      await firstValueFrom(adapter.activeJob$.pipe(skip(1), take(1)));
+      adapter.errors$.subscribe(() => {});
+
+      adapter.failJob('jv2', 'kaboom');
+
+      const v = adapter.vitals();
+      expect(v.activeJob).toBeNull();
+      expect(v.lastFinishedAt).not.toBeNull();
+      expect(v.jobsCompleted).toBe(0);
+
+      adapter.dispose();
+    });
+  });
 });

--- a/packages/jobs/src/__tests__/worker-runtime.test.ts
+++ b/packages/jobs/src/__tests__/worker-runtime.test.ts
@@ -10,15 +10,29 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Logger } from '@semiont/core';
-import { startAgentWorker, authenticateAgent, parseBackendUrl, type AgentGroup } from '../worker-runtime';
+import { startAgentWorker, authenticateAgent, parseBackendUrl, buildHealthPayload, startStallWatchdog, STALL_THRESHOLD_MS, STALL_CHECK_INTERVAL_MS, type AgentGroup, type AgentVitals } from '../worker-runtime';
 import { startWorkerProcess } from '../worker-process';
 import type { InferenceClient } from '@semiont/inference';
 import { createServer, type Server } from 'http';
 import { once } from 'events';
 import type { AddressInfo } from 'net';
 
+const { FAKE_ADAPTER_VITALS } = vi.hoisted(() => ({
+  FAKE_ADAPTER_VITALS: {
+    lastQueuedEventAt: '2026-07-17T00:00:00.000Z',
+    lastClaimAt: null,
+    lastFinishedAt: null,
+    lastActivityAt: '2026-07-17T00:00:00.000Z',
+    activeJob: null,
+    jobsCompleted: 3,
+  },
+}));
+
 vi.mock('../worker-process', () => ({
-  startWorkerProcess: vi.fn(() => ({ dispose: vi.fn() })),
+  startWorkerProcess: vi.fn(() => ({
+    dispose: vi.fn(),
+    vitals: vi.fn(() => FAKE_ADAPTER_VITALS),
+  })),
 }));
 
 // The skew fixture: the worker DIALS a gateway IP…
@@ -228,5 +242,171 @@ describe('worker-runtime — identity is minted by the exchange, carried verbati
   it('parseBackendUrl keeps its connection role: host/port/protocol from the dial string', () => {
     expect(parseBackendUrl('http://192.168.64.1:4000')).toEqual({ protocol: 'http', host: '192.168.64.1', port: 4000 });
     expect(parseBackendUrl('https://kb.example')).toEqual({ protocol: 'https', host: 'kb.example', port: 443 });
+  });
+});
+
+describe('worker-runtime — health vitals (WORKER-LIVENESS.md P1)', () => {
+  beforeEach(() => {
+    vi.mocked(startWorkerProcess).mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('startAgentWorker exposes vitals composing agent identity with the adapter snapshot', async () => {
+    installFetchStub();
+
+    const worker = await startAgentWorker({
+      group: makeGroup(),
+      backendBaseUrl: DIAL_URL,
+      workerSecret: 'test-secret',
+      logger: noopLogger,
+    });
+
+    expect(worker.vitals()).toEqual({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      did: CANONICAL_DID,
+      jobTypes: ['reference-annotation', 'generation'],
+      ...FAKE_ADAPTER_VITALS,
+    });
+
+    await worker.dispose();
+  });
+
+  it('buildHealthPayload stays additive and reflects vitals advancing across cycles', () => {
+    let stamp = '2026-07-17T00:00:00.000Z';
+    const fakeWorker = {
+      vitals: (): AgentVitals => ({
+        provider: 'ollama',
+        model: 'm',
+        did: 'did:web:kb.example:agents:ollama:m',
+        jobTypes: ['generation'],
+        lastQueuedEventAt: stamp,
+        lastClaimAt: null,
+        lastFinishedAt: null,
+        lastActivityAt: stamp,
+        activeJob: null,
+        jobsCompleted: 0,
+      }),
+    };
+
+    const first = buildHealthPayload([fakeWorker]);
+    // Additive: existing consumers keep reading status/agents.
+    expect(first).toMatchObject({ status: 'ok', agents: 1 });
+    expect(first.workers[0]!.lastQueuedEventAt).toBe('2026-07-17T00:00:00.000Z');
+
+    stamp = '2026-07-17T00:00:30.000Z';
+    const second = buildHealthPayload([fakeWorker]);
+    expect(second.workers[0]!.lastQueuedEventAt).toBe('2026-07-17T00:00:30.000Z');
+  });
+});
+
+describe('worker-runtime — stall watchdog (WORKER-LIVENESS.md P3)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const vitalsWith = (over: Partial<AgentVitals>): AgentVitals => ({
+    provider: 'ollama',
+    model: 'm',
+    did: 'did:web:kb.example:agents:ollama:m',
+    jobTypes: ['generation'],
+    lastQueuedEventAt: null,
+    lastClaimAt: null,
+    lastFinishedAt: null,
+    lastActivityAt: null,
+    activeJob: null,
+    jobsCompleted: 0,
+    ...over,
+  });
+
+  it('exits loudly when a processing agent shows no activity past the threshold', () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    const error = vi.fn();
+    const logger = { ...noopLogger, error } as unknown as Logger;
+    const stale = new Date(Date.now() - STALL_THRESHOLD_MS - 60_000).toISOString();
+    const worker = {
+      vitals: () => vitalsWith({
+        activeJob: { jobId: 'j-wedged', type: 'generation', since: stale },
+        lastActivityAt: stale,
+      }),
+    };
+
+    const watchdog = startStallWatchdog({ workers: [worker], logger, exit });
+    vi.advanceTimersByTime(STALL_CHECK_INTERVAL_MS + 1);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(error).toHaveBeenCalledWith(
+      'Worker stalled — exiting for restart',
+      expect.objectContaining({ jobId: 'j-wedged', jobType: 'generation' }),
+    );
+    watchdog.dispose();
+  });
+
+  it('never fires for an idle agent, however old its timestamps', () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    const ancient = new Date(Date.now() - 60 * 60_000).toISOString();
+    const worker = {
+      vitals: () => vitalsWith({ lastActivityAt: ancient, lastFinishedAt: ancient }),
+    };
+
+    const watchdog = startStallWatchdog({ workers: [worker], logger: noopLogger, exit });
+    vi.advanceTimersByTime(STALL_CHECK_INTERVAL_MS * 3);
+
+    expect(exit).not.toHaveBeenCalled();
+    watchdog.dispose();
+  });
+
+  it('never fires while progress keeps activity fresh — long jobs are not duration-limited', () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    // Job claimed an hour ago, but activity stays one minute old at
+    // every check: a long multi-call job proving liveness between
+    // inference calls via onProgress → touchActivity.
+    const worker = {
+      vitals: () => vitalsWith({
+        activeJob: {
+          jobId: 'j-long',
+          type: 'reference-annotation',
+          since: new Date(Date.now() - 60 * 60_000).toISOString(),
+        },
+        lastActivityAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    };
+
+    const watchdog = startStallWatchdog({ workers: [worker], logger: noopLogger, exit });
+    vi.advanceTimersByTime(STALL_CHECK_INTERVAL_MS * 5);
+
+    expect(exit).not.toHaveBeenCalled();
+    watchdog.dispose();
+  });
+
+  it('the teeth: a wedge that develops after start is caught on a later tick', () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    let vital = vitalsWith({}); // idle and healthy at start
+    const worker = { vitals: () => vital };
+
+    const watchdog = startStallWatchdog({ workers: [worker], logger: noopLogger, exit });
+
+    vi.advanceTimersByTime(STALL_CHECK_INTERVAL_MS);
+    expect(exit).not.toHaveBeenCalled();
+
+    // Wedge: a job is claimed, then total silence — the timestamps
+    // freeze while the clock advances past the threshold.
+    const claimedAt = new Date(Date.now()).toISOString();
+    vital = vitalsWith({
+      activeJob: { jobId: 'j-frozen', type: 'generation', since: claimedAt },
+      lastActivityAt: claimedAt,
+    });
+    vi.advanceTimersByTime(STALL_THRESHOLD_MS + STALL_CHECK_INTERVAL_MS);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(exit).toHaveBeenCalledTimes(1); // interval cleared on breach — no refire
+    watchdog.dispose();
   });
 });

--- a/packages/jobs/src/__tests__/workers/inference-call.test.ts
+++ b/packages/jobs/src/__tests__/workers/inference-call.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Bounded inference calls (WORKER-LIVENESS.md P2).
+ *
+ * The claim loop's only unbounded await was the model call: one HTTP
+ * request that never settles used to wedge the worker forever (the
+ * adapter ignores announcements while isProcessing). These tests pin
+ * the bound: a never-resolving call becomes an ordinary job failure,
+ * a fast call passes through untouched, and real model errors are not
+ * masked as timeouts.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { InferenceClient } from '@semiont/inference';
+import {
+  boundedGenerate,
+  boundedGenerateWithMetadata,
+  INFERENCE_TIMEOUT_MS,
+} from '../../workers/inference-call';
+import { AnnotationDetection } from '../../workers/annotation-detection';
+
+const never = () => new Promise<never>(() => {});
+
+function clientWith(overrides: Partial<InferenceClient>): InferenceClient {
+  return {
+    type: 'test',
+    modelId: 'test-model',
+    generateText: vi.fn(async () => 'text'),
+    generateTextWithMetadata: vi.fn(async () => ({ text: '[]', stopReason: 'end_turn' })),
+    ...overrides,
+  } as InferenceClient;
+}
+
+describe('bounded inference calls', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('passes results and arguments through when the model answers in time', async () => {
+    const client = clientWith({});
+
+    await expect(boundedGenerate(client, 'p', 100, 0.1)).resolves.toBe('text');
+    await expect(
+      boundedGenerateWithMetadata(client, 'p', 100, 0.1, { format: 'json' }),
+    ).resolves.toEqual({ text: '[]', stopReason: 'end_turn' });
+
+    expect(client.generateText).toHaveBeenCalledWith('p', 100, 0.1, undefined);
+    expect(client.generateTextWithMetadata).toHaveBeenCalledWith('p', 100, 0.1, { format: 'json' });
+  });
+
+  it('rejects with a timeout error when the model call never resolves', async () => {
+    vi.useFakeTimers();
+    const client = clientWith({ generateTextWithMetadata: vi.fn(never) });
+
+    const pending = boundedGenerateWithMetadata(client, 'p', 100, 0.1);
+    const assertion = expect(pending).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+    await assertion;
+  });
+
+  it('rejects the simple-interface variant on timeout too', async () => {
+    vi.useFakeTimers();
+    const client = clientWith({ generateText: vi.fn(never) });
+
+    const pending = boundedGenerate(client, 'p', 100, 0.1);
+    const assertion = expect(pending).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+    await assertion;
+  });
+
+  it('propagates model errors unchanged — no timeout masking', async () => {
+    const client = clientWith({
+      generateText: vi.fn(async () => {
+        throw new Error('model exploded');
+      }),
+    });
+
+    await expect(boundedGenerate(client, 'p', 100, 0.1)).rejects.toThrow('model exploded');
+  });
+
+  it('detection call sites route through the bound (never-resolving model → timeout, not a wedged worker)', async () => {
+    vi.useFakeTimers();
+    const client = clientWith({ generateTextWithMetadata: vi.fn(never) });
+
+    const pending = AnnotationDetection.detectHighlights('some content', client);
+    const assertion = expect(pending).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+    await assertion;
+  });
+});

--- a/packages/jobs/src/job-claim-adapter.ts
+++ b/packages/jobs/src/job-claim-adapter.ts
@@ -64,6 +64,28 @@ export interface JobClaimAdapterOptions {
   jobTypes: string[];
 }
 
+/**
+ * Point-in-time liveness snapshot (WORKER-LIVENESS.md P1). The adapter
+ * is the only component that sees every announcement, claim, and finish,
+ * so its snapshot is what `/health` reports and the stall watchdog reads.
+ *
+ * There is no poll loop in this architecture — the honest signals are:
+ * `lastQueuedEventAt` (any `job:queued` received, matching or not —
+ * transport liveness; the backend re-announces pending jobs every 30s,
+ * so this advances whenever the queue is non-empty), and
+ * `lastActivityAt` (claim, progress emission, or finish — processing
+ * liveness; a job stuck mid-inference stops advancing it).
+ */
+export interface WorkerVitals {
+  lastQueuedEventAt: string | null;
+  lastClaimAt: string | null;
+  /** Last completion or failure — a failing-but-moving worker is alive. */
+  lastFinishedAt: string | null;
+  lastActivityAt: string | null;
+  activeJob: { jobId: string; type: string; since: string } | null;
+  jobsCompleted: number;
+}
+
 export interface JobClaimAdapter {
   /** Currently-claimed job, or null when idle. */
   readonly activeJob$: Observable<ActiveJob | null>;
@@ -90,6 +112,16 @@ export interface JobClaimAdapter {
   /** Signal failure of `activeJob$`. Emits on `errors$`. */
   failJob(jobId: string, error: string): void;
 
+  /** Liveness snapshot for `/health` and the stall watchdog. */
+  vitals(): WorkerVitals;
+
+  /**
+   * Record processing activity. The worker process calls this on every
+   * progress emission so a long multi-call job keeps proving liveness
+   * between inference calls.
+   */
+  touchActivity(): void;
+
   /** Release observables. Does not dispose the shared bus. */
   dispose(): void;
 }
@@ -108,6 +140,14 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
 
   let jobSubscription: { unsubscribe(): void } | null = null;
   let started = false;
+
+  // Vitals clock (epoch ms internally; rendered as ISO in snapshots).
+  let lastQueuedEventAt: number | null = null;
+  let lastClaimAt: number | null = null;
+  let lastFinishedAt: number | null = null;
+  let lastActivityAt: number | null = null;
+  let activeSince: number | null = null;
+  const iso = (t: number | null): string | null => (t === null ? null : new Date(t).toISOString());
 
   const claimJob = async (assignment: JobAssignment): Promise<ActiveJob | null> => {
     try {
@@ -154,6 +194,10 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
       jobSubscription = bus
         .on$<{ jobId: string; jobType: string; resourceId: string }>('job:queued')
         .subscribe((event) => {
+          // Every announcement received — matching or not — proves the
+          // transport is alive; stamp before any filtering.
+          lastQueuedEventAt = Date.now();
+
           const jobType = event.jobType;
           if (jobTypes.length > 0 && !jobTypes.includes(jobType)) return;
           if (isProcessing$.getValue()) return;
@@ -162,6 +206,10 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
           claimJob({ jobId: event.jobId, type: jobType, resourceId: event.resourceId })
             .then((job) => {
               if (job) {
+                const now = Date.now();
+                lastClaimAt = now;
+                lastActivityAt = now;
+                activeSince = now;
                 activeJob$.next(job);
               } else {
                 isProcessing$.next(false);
@@ -180,15 +228,41 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
     },
 
     completeJob: () => {
+      const now = Date.now();
+      lastFinishedAt = now;
+      lastActivityAt = now;
+      activeSince = null;
       activeJob$.next(null);
       isProcessing$.next(false);
       jobsCompleted$.next(jobsCompleted$.getValue() + 1);
     },
 
     failJob: (jid: string, error: string) => {
+      const now = Date.now();
+      lastFinishedAt = now;
+      lastActivityAt = now;
+      activeSince = null;
       activeJob$.next(null);
       isProcessing$.next(false);
       errors$.next({ jobId: jid, error });
+    },
+
+    vitals: () => {
+      const active = activeJob$.getValue();
+      return {
+        lastQueuedEventAt: iso(lastQueuedEventAt),
+        lastClaimAt: iso(lastClaimAt),
+        lastFinishedAt: iso(lastFinishedAt),
+        lastActivityAt: iso(lastActivityAt),
+        activeJob: active && activeSince !== null
+          ? { jobId: active.jobId, type: active.type, since: iso(activeSince)! }
+          : null,
+        jobsCompleted: jobsCompleted$.getValue(),
+      };
+    },
+
+    touchActivity: () => {
+      lastActivityAt = Date.now();
     },
 
     dispose: () => {

--- a/packages/jobs/src/worker-main.ts
+++ b/packages/jobs/src/worker-main.ts
@@ -26,6 +26,8 @@
 
 import {
   startAgentWorker,
+  buildHealthPayload,
+  startStallWatchdog,
   type AgentGroup,
   type ResolvedInference,
 } from './worker-runtime';
@@ -149,7 +151,7 @@ async function main() {
   const health = createServer((req, res) => {
     if (req.url === '/health') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok', agents: workers.length }));
+      res.end(JSON.stringify(buildHealthPayload(workers)));
     } else {
       res.writeHead(404);
       res.end();
@@ -159,8 +161,13 @@ async function main() {
     logger.info('Health endpoint ready', { port: healthPort });
   });
 
+  // Fail fast on a wedged claim loop: a crashed container is visible,
+  // diagnosable, and restartable; a silent zombie is none of those.
+  const watchdog = startStallWatchdog({ workers, logger });
+
   const shutdown = async () => {
     logger.info('Shutting down');
+    watchdog.dispose();
     await Promise.all(workers.map((w) => w.dispose()));
     health.close();
     process.exit(0);

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -195,6 +195,10 @@ async function handleJobInner(
   }
 
   const onProgress: OnProgress = (percentage, message, stage, extra) => {
+    // Progress doubles as the worker's liveness heartbeat: it feeds the
+    // stall watchdog here and refreshes the backend janitor's mtime
+    // heartbeat via the job:report-progress mirror.
+    adapter.touchActivity();
     emitEvent(session, 'job:report-progress', {
       ...lifecycleBase,
       percentage,

--- a/packages/jobs/src/worker-runtime.ts
+++ b/packages/jobs/src/worker-runtime.ts
@@ -14,6 +14,7 @@
  */
 
 import { startWorkerProcess } from './worker-process';
+import type { WorkerVitals } from './job-claim-adapter';
 import type { InferenceClient } from '@semiont/inference';
 import { hostname } from 'os';
 import {
@@ -64,6 +65,98 @@ export interface WorkerRuntimeOptions {
   /** Shared secret for `/api/tokens/agent`. */
   workerSecret: string;
   logger: Logger;
+}
+
+/** Per-agent liveness: the adapter's snapshot plus this agent's identity. */
+export interface AgentVitals extends WorkerVitals {
+  provider: string;
+  model: string;
+  did: string;
+  jobTypes: string[];
+}
+
+export interface AgentWorkerHandle {
+  session: SemiontSession;
+  vitals(): AgentVitals;
+  dispose(): Promise<void>;
+}
+
+export interface WorkerHealthPayload {
+  status: 'ok';
+  agents: number;
+  workers: AgentVitals[];
+}
+
+/**
+ * The `/health` body (WORKER-LIVENESS.md P1). Additive: existing
+ * consumers (image HEALTHCHECK, compose `service_healthy`, start.sh)
+ * keep reading `status`/`agents`; the per-agent vitals expose
+ * claim-loop progress so a stalled worker is *visible*, not just alive.
+ */
+export function buildHealthPayload(workers: ReadonlyArray<{ vitals(): AgentVitals }>): WorkerHealthPayload {
+  return {
+    status: 'ok',
+    agents: workers.length,
+    workers: workers.map((w) => w.vitals()),
+  };
+}
+
+/**
+ * Stall watchdog (WORKER-LIVENESS.md P3) — the fail-fast line behind the
+ * inference timeout. There is no poll loop to heartbeat; the honest
+ * stall signal in this push-driven architecture is *processing without
+ * activity*: an agent holding a claimed job whose `lastActivityAt`
+ * (claim / progress / finish) has stopped advancing is wedged — the
+ * adapter ignores every announcement while `isProcessing`, so a wedged
+ * agent never recovers on its own. Silent hang → loud crash → whatever
+ * restart policy the deployment chose.
+ *
+ * Thresholds are fixed by design (no env knobs) and deliberately
+ * layered: inference timeout (10 min, P2) fires first; this watchdog
+ * (15 min) catches the failure modes nobody predicted; the backend's
+ * dead-worker janitor (30 min) re-queues the job regardless.
+ */
+export const STALL_THRESHOLD_MS = 15 * 60_000;
+export const STALL_CHECK_INTERVAL_MS = 60_000;
+
+export interface StallWatchdogOptions {
+  workers: ReadonlyArray<{ vitals(): AgentVitals }>;
+  logger: Logger;
+  /** Test seam; defaults to process.exit. */
+  exit?: (code: number) => void;
+}
+
+export function startStallWatchdog(opts: StallWatchdogOptions): { dispose(): void } {
+  const { workers, logger, exit = (code: number) => process.exit(code) } = opts;
+
+  const timer = setInterval(() => {
+    const now = Date.now();
+    for (const worker of workers) {
+      const v = worker.vitals();
+      if (!v.activeJob || !v.lastActivityAt) continue;
+
+      const silentForMs = now - Date.parse(v.lastActivityAt);
+      if (silentForMs <= STALL_THRESHOLD_MS) continue;
+
+      logger.error('Worker stalled — exiting for restart', {
+        provider: v.provider,
+        model: v.model,
+        did: v.did,
+        jobId: v.activeJob.jobId,
+        jobType: v.activeJob.type,
+        processingSince: v.activeJob.since,
+        lastActivityAt: v.lastActivityAt,
+        silentForMs,
+        thresholdMs: STALL_THRESHOLD_MS,
+      });
+      clearInterval(timer);
+      exit(1);
+      return;
+    }
+  }, STALL_CHECK_INTERVAL_MS);
+  timer.unref?.();
+
+  return { dispose: () => clearInterval(timer) };
 }
 
 export function parseBackendUrl(url: string): { protocol: 'http' | 'https'; host: string; port: number } {
@@ -131,7 +224,7 @@ export async function authenticateAgent(opts: {
 
 export async function startAgentWorker(
   opts: WorkerRuntimeOptions,
-): Promise<{ session: SemiontSession; dispose: () => Promise<void> }> {
+): Promise<AgentWorkerHandle> {
   const { group, backendBaseUrl, workerSecret, logger } = opts;
   const { inference } = group;
 
@@ -217,6 +310,13 @@ export async function startAgentWorker(
 
   return {
     session,
+    vitals: () => ({
+      provider: inference.type,
+      model: inference.model,
+      did,
+      jobTypes: group.jobTypes,
+      ...adapter.vitals(),
+    }),
     dispose: async () => {
       adapter.dispose();
       await session.dispose();

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -11,6 +11,7 @@
  */
 
 import type { InferenceClient, InferenceResponse } from '@semiont/inference';
+import { boundedGenerateWithMetadata } from './inference-call';
 import { MotivationPrompts } from './detection/motivation-prompts';
 import {
   MotivationParsers,
@@ -54,7 +55,7 @@ export class AnnotationDetection {
     sourceLanguage?: string
   ): Promise<CommentMatch[]> {
     const prompt = MotivationPrompts.buildCommentPrompt(content, instructions, tone, density, language, sourceLanguage);
-    const response = await client.generateTextWithMetadata(prompt, 3000, 0.4, { format: 'json' });
+    const response = await boundedGenerateWithMetadata(client, prompt, 3000, 0.4, { format: 'json' });
     assertNotTruncated(response, 'comment');
     return MotivationParsers.parseComments(response.text, content);
   }
@@ -74,7 +75,7 @@ export class AnnotationDetection {
     sourceLanguage?: string
   ): Promise<HighlightMatch[]> {
     const prompt = MotivationPrompts.buildHighlightPrompt(content, instructions, density, sourceLanguage);
-    const response = await client.generateTextWithMetadata(prompt, 2000, 0.3, { format: 'json' });
+    const response = await boundedGenerateWithMetadata(client, prompt, 2000, 0.3, { format: 'json' });
     assertNotTruncated(response, 'highlight');
     return MotivationParsers.parseHighlights(response.text, content);
   }
@@ -96,7 +97,7 @@ export class AnnotationDetection {
     sourceLanguage?: string
   ): Promise<AssessmentMatch[]> {
     const prompt = MotivationPrompts.buildAssessmentPrompt(content, instructions, tone, density, language, sourceLanguage);
-    const response = await client.generateTextWithMetadata(prompt, 3000, 0.3, { format: 'json' });
+    const response = await boundedGenerateWithMetadata(client, prompt, 3000, 0.3, { format: 'json' });
     assertNotTruncated(response, 'assessment');
     return MotivationParsers.parseAssessments(response.text, content);
   }
@@ -136,7 +137,7 @@ export class AnnotationDetection {
       sourceLanguage
     );
 
-    const response = await client.generateTextWithMetadata(prompt, 4000, 0.2, { format: 'json' });
+    const response = await boundedGenerateWithMetadata(client, prompt, 4000, 0.2, { format: 'json' });
     assertNotTruncated(response, 'tag');
     const parsedTags = MotivationParsers.parseTags(response.text);
     return MotivationParsers.validateTagOffsets(parsedTags, content, category);

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -1,5 +1,6 @@
 import type { InferenceClient } from '@semiont/inference';
 import { getLocaleEnglishName, isArray, isObject, isString, type Logger } from '@semiont/core';
+import { boundedGenerateWithMetadata } from '../inference-call';
 
 /**
  * Entity reference extracted from text — pre-reconciliation.
@@ -109,7 +110,8 @@ Example output:
 [{"exact":"Alice","entityType":"Person","prefix":"","suffix":" went to"},{"exact":"Paris","entityType":"Location","prefix":"went to ","suffix":" yesterday"}]`;
 
   logger.debug('Sending entity extraction request', { entityTypes: entityTypesDescription });
-  const response = await client.generateTextWithMetadata(
+  const response = await boundedGenerateWithMetadata(
+    client,
     prompt,
     4000, // Increased to handle many entities without truncation
     0.3,  // Lower temperature for more consistent extraction

--- a/packages/jobs/src/workers/generation/resource-generation.ts
+++ b/packages/jobs/src/workers/generation/resource-generation.ts
@@ -7,6 +7,7 @@
 import { getLocaleEnglishName, deriveViews } from '@semiont/core';
 import type { GatheredContext, Logger, SupportedMediaType } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
+import { boundedGenerate } from '../inference-call';
 
 
 function getLanguageName(locale: string): string {
@@ -300,7 +301,7 @@ ${formatRequirements}`;
     temperature: finalTemperature,
     maxTokens: finalMaxTokens
   });
-  const response = await client.generateText(prompt, finalMaxTokens, finalTemperature);
+  const response = await boundedGenerate(client, prompt, finalMaxTokens, finalTemperature);
   logger.debug('Got response from inference', { responseLength: response.length });
 
   const result = parseResponse(response);

--- a/packages/jobs/src/workers/inference-call.ts
+++ b/packages/jobs/src/workers/inference-call.ts
@@ -1,0 +1,80 @@
+/**
+ * Bounded inference calls — WORKER-LIVENESS.md P2 (G1: prevention).
+ *
+ * The claim loop's only unbounded await is the model call: bus
+ * operations gained transport timeouts in 0.5.6, the inference HTTP
+ * request did not. One request that never settles used to wedge the
+ * worker forever — the adapter ignores announcements while
+ * `isProcessing`, so a single stuck call silenced the whole agent.
+ * Bounding the call converts that silent hang into an ordinary job
+ * failure that flows through the existing `job:fail` path (and the
+ * backend's retry budget — a timeout is transient-shaped, so retrying
+ * is correct) and frees the claim loop.
+ *
+ * This is a timeout, not a cancellation: `InferenceOptions` has no
+ * AbortSignal support, so on timeout the underlying HTTP request is
+ * abandoned, not aborted — it settles (or dies at the socket level)
+ * in the background, with its eventual rejection swallowed. Adding
+ * `signal` to `@semiont/inference` would upgrade this to a true
+ * abort; the timeout stays either way as the last line.
+ */
+
+import type { InferenceClient, InferenceOptions, InferenceResponse } from '@semiont/inference';
+
+/**
+ * Generous single-call bound. Slow local models on large prompts run
+ * minutes, not tens of minutes; the stall watchdog (P3) sits above
+ * this at 15 minutes, and the backend's dead-worker janitor above
+ * that at 30. Fixed by design — no env knob.
+ */
+export const INFERENCE_TIMEOUT_MS = 10 * 60_000;
+
+async function withTimeout<T>(work: Promise<T>, label: string): Promise<T> {
+  let timer!: ReturnType<typeof setTimeout>;
+  const timedOut = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(
+        `Inference call timed out after ${INFERENCE_TIMEOUT_MS / 60_000} minutes (${label}) — failing the job to keep the claim loop live`,
+      ));
+    }, INFERENCE_TIMEOUT_MS);
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([work, timedOut]);
+  } catch (err) {
+    // If the timeout won, the abandoned call may still settle later —
+    // swallow its eventual rejection so it can't surface as an
+    // unhandled one and kill the process.
+    work.catch(() => {});
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function boundedGenerate(
+  client: InferenceClient,
+  prompt: string,
+  maxTokens: number,
+  temperature: number,
+  options?: InferenceOptions,
+): Promise<string> {
+  return withTimeout(
+    client.generateText(prompt, maxTokens, temperature, options),
+    `${client.type}:${client.modelId}`,
+  );
+}
+
+export function boundedGenerateWithMetadata(
+  client: InferenceClient,
+  prompt: string,
+  maxTokens: number,
+  temperature: number,
+  options?: InferenceOptions,
+): Promise<InferenceResponse> {
+  return withTimeout(
+    client.generateTextWithMetadata(prompt, maxTokens, temperature, options),
+    `${client.type}:${client.modelId}`,
+  );
+}

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -10,7 +10,7 @@ No npm is required on the host for local builds.
 | `build.sh` | Install deps + build packages and apps |
 | `publish.sh` | Version stamp + stage + publish to a registry |
 | `publish-npm-apps.mjs` | Stage backend/frontend into `.npm-stage/` for publishing |
-| `local-build.sh` | Host-side wrapper: start Verdaccio + build + publish in a container + build the `:local` service/frontend images |
+| `local-build.sh` | Host-side wrapper: start Verdaccio + build + publish in a container + build the `:local` service/frontend images, fanned out to every container engine on the machine |
 | `verdaccio.yaml` | Verdaccio config for local registry (proxies non-@semiont packages to npmjs.com) |
 
 ## GitHub Actions
@@ -27,7 +27,10 @@ The `publish-npm-packages.yml` workflow calls `build.sh` and `publish.sh`:
 Build and publish to a local Verdaccio registry, build the container images
 against it, then run them from a KB. KBs don't build anything — they consume
 images (the same production Dockerfiles the publish workflows use), tagged
-`ghcr.io/the-ai-alliance/semiont-<svc>:local` (local-only, never pushed):
+`ghcr.io/the-ai-alliance/semiont-<svc>:local` (local-only, never pushed).
+Built images are loaded into every responsive container engine on the machine
+(container/docker/podman), so the KB's `--runtime` choice is independent of
+who built — `CONTAINER_RUNTIME` picks the *build* engine only:
 
 ```bash
 # 1. Build all packages, publish to local Verdaccio, build all five images

--- a/scripts/ci/local-build.sh
+++ b/scripts/ci/local-build.sh
@@ -109,6 +109,11 @@ while [[ $# -gt 0 ]]; do
       echo "ghcr.io/the-ai-alliance/semiont-<svc>:local (local-only, never pushed)."
       echo "No npm required on the host — everything runs inside containers."
       echo ""
+      echo "Built images are also loaded into every other responsive container"
+      echo "engine on the machine (container/docker/podman), so any KB --runtime"
+      echo "can run them. CONTAINER_RUNTIME chooses which engine BUILDS, not"
+      echo "which engines can run the result."
+      echo ""
       echo "Options:"
       echo "  --package <list>   Comma-separated packages to build (default: all)"
       echo "  --start-from <pkg> Skip packages before this one in the build order"
@@ -307,6 +312,46 @@ BUILD_REGISTRY="http://$HOST_ADDR:4873"
 
 banner "CONTAINER IMAGES"
 
+# --- Image fan-out targets (see .plans/LOCAL-BUILD-IMAGE-FANOUT.md) ---
+#
+# The :local images land in $RT's image store, invisible to every other
+# engine — a KB started with a different --runtime then fails with
+# "semiont-<svc>:local: not found". Build once under $RT, then load each
+# built image into every OTHER responsive runtime. A fan-out failure is a
+# warning, not a build failure (the primary store is intact).
+#
+# File-based transfer only: P0 measured that `container image save` cannot
+# stream (`-o -` writes a literal file named "-"; /dev/stdout truncates the
+# archive), so pipe-less save→load via a temp file is the portable shape.
+# An installed-but-unresponsive engine (e.g. Docker Desktop not running)
+# warns once here and is skipped; an absent engine is silently ignored.
+FANOUT_RTS=""
+for rt in container docker podman; do
+  [[ "$rt" == "$RT" ]] && continue
+  command -v "$rt" >/dev/null 2>&1 || continue
+  if "$rt" image list >/dev/null 2>&1; then
+    FANOUT_RTS="$FANOUT_RTS $rt"
+  else
+    warn "$rt is installed but not responding — :local images will NOT be visible to it (start it and re-load manually: $RT image save <tag> -o /tmp/img.tar && $rt image load -i /tmp/img.tar)"
+  fi
+done
+FANOUT_FAILURES=""
+[[ -n "$FANOUT_RTS" ]] && step "Fan-out: images will also be loaded into${BOLD}$FANOUT_RTS${RESET}"
+
+fanout_image() {
+  local tag="$1" rt tmp
+  for rt in $FANOUT_RTS; do
+    tmp=$(mktemp "${TMPDIR:-/tmp}/semiont-fanout.XXXXXX")
+    if $RT image save "$tag" -o "$tmp" && "$rt" image load -i "$tmp" >/dev/null 2>&1; then
+      ok "$tag → $rt image store"
+    else
+      warn "Fan-out of $tag to $rt failed (build unaffected; manual: $RT image save $tag -o /tmp/img.tar && $rt image load -i /tmp/img.tar)"
+      FANOUT_FAILURES="$FANOUT_FAILURES $rt:$tag"
+    fi
+    rm -f "$tmp"
+  done
+}
+
 for img in $IMAGES; do
   DF=$(image_dockerfile "$img")
   TAG="ghcr.io/the-ai-alliance/semiont-${img}:local"
@@ -316,9 +361,21 @@ for img in $IMAGES; do
     --file "$REPO_ROOT/$DF" \
     "$REPO_ROOT"
   ok "$TAG built"
+  fanout_image "$TAG"
 done
 
 banner "DONE ✓"
+
+if [[ -n "$FANOUT_FAILURES" ]]; then
+  echo -e "${BOLD}Images tagged :local are in the ${RT} image store${RESET} (fan-out partially failed:${FANOUT_FAILURES// / })"
+  echo ""
+elif [[ -n "$FANOUT_RTS" ]]; then
+  echo -e "${BOLD}Images tagged :local are in every local image store:${RESET} $RT${FANOUT_RTS}"
+  echo ""
+else
+  echo -e "${BOLD}Images tagged :local are in the ${RT} image store${RESET} (no other engines detected)"
+  echo ""
+fi
 
 echo -e "${BOLD}Run the full stack from your KB against these images:${RESET}"
 echo ""


### PR DESCRIPTION
# Pull Request

## Description

Five related container/infra improvements from the 2026-07-17 work:

- **Backend heap sizing is now cgroup-aware** (`apps/backend/Dockerfile`): the baked
  `NODE_OPTIONS` heap override is removed; Node ≥ 24 sizes its heap from the
  container's cgroup memory limit, so the same image respects whatever
  `--memory` each deployment sets instead of a hardcoded ceiling.
- **Job-worker liveness** (`packages/jobs`): inference calls are wrapped in a
  dedicated `inference-call` module with liveness reporting through the worker
  runtime, so a worker stuck on a hung inference call is observable (and the
  job-queue's stale-running recovery can act) instead of silently wedged.
  Includes worker-runtime/claim-adapter/inference-call test coverage.
- **`local-build.sh` fans `:local` images out to every container engine**
  (`scripts/ci/local-build.sh`): images used to land in exactly one runtime's
  store ($RT from `detect_runtime`), so a KB started with a different
  `--runtime` failed with `semiont-<svc>:local: not found`. After each build the
  image is loaded into every other responsive engine; absent engines are
  skipped, failures warn (with the manual `save | load` one-liner) and never
  fail the build. `CONTAINER_RUNTIME` now only chooses who *builds*, not who
  can *run*.
- **RELEASE.md reconciled with service-image publishing**
  (`docs/development/RELEASE.md`): the Complete Release Example, the
  Container Images channel list, and the post-release checklist now cover
  `publish-service-images.yml` and all five GHCR images, not just the frontend.
- **Container topology doc + diagram updated** (`docs/system/CONTAINER-TOPOLOGY.md`,
  `docs/system/LOCAL-SEMIONT.md`, `docs/system/administration/IMAGES.md`,
  `scripts/ci/README.md`) to match the above.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Infrastructure/DevOps changes

## Areas Changed

- [x] Backend (`apps/backend`) — Dockerfile only
- [x] Jobs (`packages/jobs`)
- [x] Documentation (`docs/`)
- [x] Scripts (`scripts/`)

## Breaking Changes

None. The backend image's default heap behavior changes from a fixed override
to cgroup-derived sizing — deployments that relied on the baked value should
set `--memory` (they already do in the KB compose files).

## Testing

- [x] Added tests for new functionality (worker-runtime, job-claim-adapter,
      inference-call)
- [x] All existing tests pass (CI)
