### PR TITLE
gather read barriers: config-owned settle bound (D5), observable degrades; W5-frames/W9-deep GREEN, A4 enforced at load

### DIFF
--- a/apps/backend/src/utils/config.ts
+++ b/apps/backend/src/utils/config.ts
@@ -15,9 +15,19 @@ export function makeMeaningConfigFrom(config: EnvironmentConfig): MakeMeaningCon
   const meta = config._metadata as (EnvironmentConfig['_metadata'] & {
     actors?: MakeMeaningConfig['actors'];
     workers?: MakeMeaningConfig['workers'];
+    gather?: MakeMeaningConfig['gather'];
   }) | undefined;
 
+  // The TOML loader always sets _metadata.gather (it owns the one default —
+  // D5). A missing value means this config bypassed the loader: fail loudly
+  // rather than default here.
+  const gather = meta?.gather;
+  if (!gather) {
+    throw new Error('make-meaning gather config missing — load config via loadEnvironmentConfig (the TOML loader owns the settleTimeoutMs default)');
+  }
+
   return {
+    gather,
     services: {
       graph: config.services?.graph,
       vectors: config.services?.vectors,

--- a/docs/system/KNOWLEDGE-SYSTEM.md
+++ b/docs/system/KNOWLEDGE-SYSTEM.md
@@ -11,6 +11,13 @@ All seven subscribe to the bus via RxJS pipelines and expose no public business 
 
 The third derived read model — the materialized views — is deliberately **not** pipeline-maintained: the EventStore's `ViewManager` materializes views synchronously inside `appendEvent()`, before the event is published, so subscribers get a read-your-writes guarantee that a fire-and-forget pipeline cannot provide.
 
+**The seam rule (standing).** Any new read path that consumes an eventually-consistent projection (the graph, the vectors) for content that may have *just been written* MUST declare its ordering semantics at design time, in its plan — one of exactly two choices:
+
+1. **Eventual** — the read tolerates projection lag. Say so, and say why lag is acceptable for that consumer.
+2. **Read-your-writes** — via the projection's progress fold: `weaveProgress.whenApplied(...)` for the graph, `smeltProgress.whenSettled(...)` for the vectors — with a **bounded, observable degrade** when the barrier times out (a breadcrumb plus a counter, never a silent thin result and never an unbounded wait).
+
+"Undeclared" is not an option. Both existing seams paid for its absence: the graph race shipped as a product bug (`gather.resource` "Resource not found", fixed by the `whenApplied` barrier), and the vector race was caught only by review diligence (EXCLUDE-VECTORS → the `whenSettled` barrier and its config-owned settle bound). The per-unit axiom suites (W\*, S\*) cannot own this property — every unit-level axiom holds *while* the race happens; ordering across an actor boundary belongs to the seam, and this rule is where the seam's obligations live. Views are exempt (synchronous by construction); any future projection inherits this rule on day one.
+
 For the broader actor model that frames these seven, see [ACTOR-MODEL.md](ACTOR-MODEL.md). For the deployment layout (which actors live in which container), see [CONTAINER-TOPOLOGY.md](CONTAINER-TOPOLOGY.md).
 
 ## Topology

--- a/packages/core/src/__tests__/config/toml-loader.test.ts
+++ b/packages/core/src/__tests__/config/toml-loader.test.ts
@@ -92,6 +92,25 @@ describe('loadTomlConfig', () => {
     expect(workers?.generation?.maxTokens).toBe(16384);
   });
 
+  // The gather settle bound (SMELTER-INDEX-SYNC D5): the loader is the ONE
+  // home of the default — consuming code receives a required value and
+  // defaults nothing.
+  it('always sets _metadata.gather.settleTimeoutMs, defaulting to 15000 when absent', () => {
+    const config = loadTomlConfig('/project', 'local', '/home/user/.semiontconfig', makeReader(MINIMAL_TOML), {});
+
+    expect((config._metadata as any)?.gather).toEqual({ settleTimeoutMs: 15_000 });
+  });
+
+  it('honors an explicit make-meaning.gather.settleTimeoutMs', () => {
+    const toml = `${MINIMAL_TOML}
+[environments.local.make-meaning.gather]
+settleTimeoutMs = 45000
+`;
+    const config = loadTomlConfig('/project', 'local', '/home/user/.semiontconfig', makeReader(toml), {});
+
+    expect((config._metadata as any)?.gather).toEqual({ settleTimeoutMs: 45_000 });
+  });
+
   it('resolves ${VAR} env var references', () => {
     const config = loadTomlConfig('/project', 'local', '/home/user/.semiontconfig', makeReader(WITH_ENV_VAR_TOML), { MY_API_KEY: 'sk-secret' });
 

--- a/packages/core/src/config/toml-loader.ts
+++ b/packages/core/src/config/toml-loader.ts
@@ -195,6 +195,14 @@ interface EnvironmentSection {
       matcher?: { inference?: InferenceConfig };
     };
     default?: { inference?: InferenceConfig };
+    /**
+     * Resource-gather knobs. `settleTimeoutMs` bounds the semanticContext
+     * read-your-writes barrier (SMELTER-INDEX-SYNC D3/D5) — how long a gather
+     * waits for the vector projection to settle before degrading to an absent
+     * semanticContext. Must nest INSIDE downstream watchdogs (job-worker
+     * liveness, client stall watchdogs) — see SMELTER-INDEX-SYNC A4.
+     */
+    gather?: { settleTimeoutMs?: number };
   };
   workers?: Record<string, { inference?: InferenceConfig }>;
   actors?: Record<string, { inference?: InferenceConfig }>;
@@ -500,6 +508,10 @@ export function loadTomlConfig(
       projectVersion,
       ...(Object.keys(actors).length > 0 ? { actors } : {}),
       ...(Object.keys(workers).length > 0 ? { workers } : {}),
+      // Always set — the loader is the ONE home of this default (D5).
+      // Consuming code (make-meaning's gather path) receives a required
+      // value and defaults nothing.
+      gather: { settleTimeoutMs: makeMeaningSection?.gather?.settleTimeoutMs ?? 15_000 },
     },
   };
 

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -77,3 +77,9 @@ export { AnnotationDetection } from './workers/annotation-detection';
 
 // Generation utilities
 export { generateResourceFromTopic } from './workers/generation/resource-generation';
+
+// Worker liveness bounds (WORKER-LIVENESS P3). STALL_THRESHOLD_MS also
+// participates in the A4 nesting assertion at make-meaning's composition
+// root: gather read-barrier budgets must degrade before this watchdog
+// fails fast.
+export { STALL_THRESHOLD_MS } from './worker-runtime';

--- a/packages/make-meaning/docs/SCRIPTING.md
+++ b/packages/make-meaning/docs/SCRIPTING.md
@@ -25,6 +25,11 @@ async function main() {
 
   // Typically loaded from your project's environment JSON
   const config: MakeMeaningConfig = {
+    // The resource-gather settle bound (semanticContext read-your-writes
+    // barrier). TOML deployments set it at
+    // [environments.<env>.make-meaning.gather]; hand-built configs state
+    // their policy explicitly — there is no in-code default.
+    gather: { settleTimeoutMs: 15_000 },
     services: {
       graph: { platform: { type: 'posix' }, type: 'memory' },
     },

--- a/packages/make-meaning/src/__tests__/agent-roster.test.ts
+++ b/packages/make-meaning/src/__tests__/agent-roster.test.ts
@@ -23,6 +23,7 @@ describe('deriveAgentRoster — DID domain is site.domain (the mint), never topo
     // this pins the one remaining source.
     const config: MakeMeaningConfig = {
       services: {},
+      gather: { settleTimeoutMs: 15_000 },
       site: { domain: 'kb.example' }, // the KB's identity — the exchange's mint value
       workers: WORKERS,
     };
@@ -38,6 +39,7 @@ describe('deriveAgentRoster — DID domain is site.domain (the mint), never topo
   it('throws loudly without site.domain — no topology fallback', () => {
     const config: MakeMeaningConfig = {
       services: {},
+      gather: { settleTimeoutMs: 15_000 },
       workers: WORKERS,
     };
 
@@ -47,6 +49,7 @@ describe('deriveAgentRoster — DID domain is site.domain (the mint), never topo
   it('carries a ported site.domain verbatim — byte-equal with the exchange mint', () => {
     const config: MakeMeaningConfig = {
       services: {},
+      gather: { settleTimeoutMs: 15_000 },
       site: { domain: 'localhost:4000' },
       workers: WORKERS,
     };

--- a/packages/make-meaning/src/__tests__/browser.test.ts
+++ b/packages/make-meaning/src/__tests__/browser.test.ts
@@ -66,7 +66,7 @@ const defaultStat = { size: 1024, mtime: new Date('2026-01-01T00:00:00Z') };
 
 const mockKb = { graph: {}, views: {} } as any;
 
-const emptyConfig: MakeMeaningConfig = { services: {} };
+const emptyConfig: MakeMeaningConfig = { services: {}, gather: { settleTimeoutMs: 15_000 } };
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
@@ -519,6 +519,7 @@ describe('Browser actor', () => {
       await withBrowser(
         {
           services: {},
+          gather: { settleTimeoutMs: 15_000 },
           site: { domain: SITE_DOMAIN },
           workers: {
             default: { type: 'anthropic', model: 'claude-haiku-4-5', apiKey: 'secret-key-do-not-leak' },
@@ -568,6 +569,7 @@ describe('Browser actor', () => {
       await withBrowser(
         {
           services: {},
+          gather: { settleTimeoutMs: 15_000 },
           site: { domain: SITE_DOMAIN },
           actors: { gatherer: { type: 'ollama', model: 'llama3' } },
         },
@@ -583,7 +585,7 @@ describe('Browser actor', () => {
     });
 
     it('answers an empty roster when no workers or actors are declared', async () => {
-      await withBrowser({ services: {}, site: { domain: SITE_DOMAIN } }, async (bus) => {
+      await withBrowser({ services: {}, gather: { settleTimeoutMs: 15_000 }, site: { domain: SITE_DOMAIN } }, async (bus) => {
         const r = await requestAgents(bus);
         if (r.kind !== 'result') throw new Error(`expected result, got failed: ${r.e.message}`);
         expect(r.e.response.agents).toEqual([]);
@@ -591,7 +593,7 @@ describe('Browser actor', () => {
     });
 
     it('fails naming the missing config key when site.domain is absent', async () => {
-      await withBrowser({ services: {} }, async (bus) => {
+      await withBrowser({ services: {}, gather: { settleTimeoutMs: 15_000 } }, async (bus) => {
         const r = await requestAgents(bus);
         if (r.kind !== 'failed') throw new Error('expected failed');
         expect(r.e.correlationId).toBe('cid-agents');

--- a/packages/make-meaning/src/__tests__/clone-token-manager.test.ts
+++ b/packages/make-meaning/src/__tests__/clone-token-manager.test.ts
@@ -47,6 +47,7 @@ describe('CloneTokenManager format selection', () => {
     const project = new SemiontProject(testDir);
 
     const config: MakeMeaningConfig = {
+      gather: { settleTimeoutMs: 15_000 },
       services: {
         graph: { platform: { type: 'posix' }, type: 'memory' },
       },

--- a/packages/make-meaning/src/__tests__/gatherer.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer.test.ts
@@ -62,7 +62,7 @@ describe('Gatherer', () => {
     vi.clearAllMocks();
     eventBus = new EventBus();
     kb = createMockKb();
-    gatherer = new Gatherer(kb, eventBus, mockInferenceClient as any, mockLogger);
+    gatherer = new Gatherer(kb, eventBus, mockInferenceClient as any, 15_000, mockLogger);
     await gatherer.initialize();
   });
 
@@ -167,6 +167,7 @@ describe('Gatherer', () => {
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
         mockInferenceClient,
+        15_000, // the settle bound the harness constructed the Gatherer with (D5: threaded, not defaulted)
         expect.anything(), // the gatherer's logger — breadcrumb sink for the P2 barrier
       );
     });

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -7,8 +7,9 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { GraphContext } from '../graph-context';
-import { resourceId } from '@semiont/core';
+import { resourceId, type Logger } from '@semiont/core';
 import type { KnowledgeBase } from '../knowledge-base';
+import { WeaveProgressTimeout } from '../weave-progress';
 
 const mockGraphDb = {
   getResource: vi.fn(),
@@ -306,16 +307,37 @@ describe('GraphContext', () => {
       expect(mockGraphDb.getResource).toHaveBeenCalledTimes(1);
     });
 
-    it('gives up after the bounded backoff when the graph never catches up', async () => {
+    it('exhaustion with the view still vouching is PROJECTION LAG — honestly named, breadcrumbed, counted; never "Resource not found"', async () => {
+      // The view has the resource; the graph never catches up. Calling that
+      // "Resource not found" is a lie — it misdirects debugging at a 404 when
+      // the actual fault is a lagging/stalled Weaver. The degrade must be
+      // distinguishable (distinct error), loggable (one [gather DEGRADED]
+      // breadcrumb), and countable (recordGatherDegrade('graph')).
       mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc });
+      mockGraphDb.getResource.mockReset().mockResolvedValue(null);
+      const degradeLogger: Logger = {
+        debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => degradeLogger),
+      };
+
+      await expect(
+        GraphContext.buildKnowledgeGraph(resourceId('res-main'), mockKb, degradeLogger),
+      ).rejects.toThrow(/projection did not catch up/);
+      // Bounded: more than one attempt, but not unbounded polling.
+      expect(mockGraphDb.getResource.mock.calls.length).toBeGreaterThan(1);
+      expect(mockGraphDb.getResource.mock.calls.length).toBeLessThanOrEqual(6);
+      const breadcrumbs = (degradeLogger.warn as ReturnType<typeof vi.fn>).mock.calls
+        .filter(([message]) => String(message).includes('[gather DEGRADED]'));
+      expect(breadcrumbs).toHaveLength(1);
+    });
+
+    it('rethrows a non-timeout barrier failure — a broken progress fold must surface, not silently poll', async () => {
+      mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc, lastSequence: 7 });
+      mockWeaveProgress.whenApplied.mockReset().mockRejectedValue(new Error('progress fold wedged'));
       mockGraphDb.getResource.mockReset().mockResolvedValue(null);
 
       await expect(
         GraphContext.buildKnowledgeGraph(resourceId('res-main'), mockKb),
-      ).rejects.toThrow('Resource not found');
-      // Bounded: more than one attempt, but not unbounded polling.
-      expect(mockGraphDb.getResource.mock.calls.length).toBeGreaterThan(1);
-      expect(mockGraphDb.getResource.mock.calls.length).toBeLessThanOrEqual(6);
+      ).rejects.toThrow('progress fold wedged');
     });
   });
 
@@ -346,7 +368,10 @@ describe('GraphContext', () => {
 
     it('falls back to the bounded poll when the barrier times out', async () => {
       mockViews.get.mockReset().mockResolvedValue({ resource: mainDoc, lastSequence: 7 });
-      mockWeaveProgress.whenApplied.mockReset().mockRejectedValue(new Error('WeaveProgressTimeout'));
+      // A REAL WeaveProgressTimeout instance: the barrier discriminates by
+      // type — only its own timeout downgrades to polling (a lookalike
+      // message on a plain Error must rethrow, see the sibling test).
+      mockWeaveProgress.whenApplied.mockReset().mockRejectedValue(new WeaveProgressTimeout('res-main', 7, 500));
       mockGraphDb.getResource
         .mockReset()
         .mockResolvedValueOnce(null)

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -15,7 +15,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { LLMContext, SMELT_SETTLE_TIMEOUT_MS } from '../llm-context';
+import { LLMContext } from '../llm-context';
 import { ResourceOperations } from '../resource-operations';
 import { AnnotationOperations } from '../annotation-operations';
 import { resourceId, annotationId, userId, EventBus, type Logger, type SupportedMediaType } from '@semiont/core';
@@ -140,6 +140,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -154,6 +155,7 @@ describe('LLM Context', () => {
           { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
           kb,
           mockClient,
+          15_000,
           mockLogger
         )
       ).rejects.toThrow('Resource not found');
@@ -165,6 +167,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -218,6 +221,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -233,6 +237,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -249,6 +254,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -264,6 +270,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -277,6 +284,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -289,6 +297,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -302,6 +311,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -318,6 +328,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: true },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -331,6 +342,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -343,6 +355,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: true },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -362,6 +375,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: true, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -375,6 +389,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 10, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -389,6 +404,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 5, includeContent: true, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -404,6 +420,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 1, includeContent: false, includeSummary: false },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -423,6 +440,7 @@ describe('LLM Context', () => {
         { depth: 2, maxResources: 50, includeContent: true, includeSummary: true },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -448,6 +466,7 @@ describe('LLM Context', () => {
         { depth: 1, maxResources: 20, includeContent: true, includeSummary: true },
         kb,
         mockClient,
+        15_000,
         mockLogger
       );
 
@@ -491,7 +510,7 @@ describe('LLM Context', () => {
     }
 
     it('populates semanticContext from searchByResource', async () => {
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient, mockLogger);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient, 15_000, mockLogger);
       expect(ctx.semanticContext?.similar.map((s) => s.resourceId).sort()).toEqual(['r-answer', 'r-question']);
     });
 
@@ -502,6 +521,7 @@ describe('LLM Context', () => {
         { ...baseOpts, excludeEntityTypes: ['Question'] },
         kbWithVectors((o) => { seen = o; }),
         mockClient,
+        15_000,
         mockLogger,
       );
       expect(seen.filter.excludeEntityTypes).toEqual(['Question']);             // filter forwarded
@@ -510,18 +530,23 @@ describe('LLM Context', () => {
     });
 
     it('records no excludedEntityTypes when no exclusion is applied', async () => {
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient, mockLogger);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kbWithVectors(), mockClient, 15_000, mockLogger);
       expect(ctx.semanticContext?.excludedEntityTypes).toBeUndefined();
     });
 
     it('leaves semanticContext absent when no vector store is configured', async () => {
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kb, mockClient, mockLogger);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, kb, mockClient, 15_000, mockLogger);
       expect(ctx.semanticContext).toBeUndefined();
     });
   });
 
   describe('semanticContext read-your-writes barrier (SMELTER-INDEX-SYNC P2)', () => {
     const baseOpts = { depth: 1, maxResources: 5, includeContent: false, includeSummary: false };
+    // The settle bound is explicit test policy (D5: config-owned, threaded as
+    // a plain argument). Small and REAL — these paths never wait it out
+    // (event-driven settle / skip / probe), and a regression fails fast
+    // instead of hanging a production-scale bound.
+    const SETTLE_MS = 1_000;
     const hit = [{ id: 'r-sim#0', score: 0.9, resourceId: 'r-sim', text: 'similar text', entityTypes: [] }];
     // The focal resource's content generation — what the barrier waits on (D2).
     const TEST_CHECKSUM = calculateChecksum('This is test content for LLM context building.');
@@ -544,7 +569,7 @@ describe('LLM Context', () => {
       const state = { indexed: false };
       const { lagged } = lagKb(progressBus, state);
 
-      const pending = LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, mockLogger);
+      const pending = LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, SETTLE_MS, mockLogger);
       setTimeout(() => {
         state.indexed = true;
         progressBus.get('smelt:settled').next({ resourceId: testResourceId, contentChecksum: TEST_CHECKSUM, outcome: 'indexed' });
@@ -561,7 +586,7 @@ describe('LLM Context', () => {
       progressBus.get('smelt:settled').next({ resourceId: testResourceId, contentChecksum: TEST_CHECKSUM, outcome: 'skipped' });
 
       const started = Date.now();
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, mockLogger);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, SETTLE_MS, mockLogger);
       expect(ctx.semanticContext).toBeUndefined();
       expect(Date.now() - started).toBeLessThan(2000);
       expect(searches()).toBe(1);
@@ -575,30 +600,20 @@ describe('LLM Context', () => {
         debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => degradeLogger),
       };
 
-      // Fake only setTimeout: the barrier's timer must be advanceable while
-      // real I/O (view + graph reads in the gather prelude) still progresses.
-      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-      try {
-        const pending = LLMContext.getResourceContext(
-          resourceId(testResourceId), baseOpts, lagged, mockClient, degradeLogger,
-        );
-        // The barrier's timer is scheduled only after the I/O prelude
-        // completes, so advance in slices with a REAL macrotask yield between
-        // them (setImmediate is unfaked) — pure microtask loops starve I/O.
-        for (let elapsed = 0; elapsed < SMELT_SETTLE_TIMEOUT_MS + 5000; elapsed += 1000) {
-          await new Promise((resolve) => setImmediate(resolve));
-          await vi.advanceTimersByTimeAsync(1000);
-        }
-        const ctx = await pending;
+      // Real timers, tiny real bound: the settle timeout is explicit test
+      // policy now (D5 — config-owned, threaded as a plain argument), so no
+      // fake-clock choreography exists to fight scheduling weather. This
+      // retires the coverage-fragile advancement loop for good (main CI run
+      // 29622765997 — see the SMELTER-INDEX-SYNC log).
+      const ctx = await LLMContext.getResourceContext(
+        resourceId(testResourceId), baseOpts, lagged, mockClient, 250, degradeLogger,
+      );
 
-        expect(ctx.semanticContext).toBeUndefined();
-        const breadcrumbs = (degradeLogger.warn as ReturnType<typeof vi.fn>).mock.calls
-          .filter(([message]) => String(message).includes('[gather DEGRADED]'));
-        expect(breadcrumbs).toHaveLength(1);
-        expect(searches()).toBe(1);
-      } finally {
-        vi.useRealTimers();
-      }
+      expect(ctx.semanticContext).toBeUndefined();
+      const breadcrumbs = (degradeLogger.warn as ReturnType<typeof vi.fn>).mock.calls
+        .filter(([message]) => String(message).includes('[gather DEGRADED]'));
+      expect(breadcrumbs).toHaveLength(1);
+      expect(searches()).toBe(1);
     });
 
     it('probes before waiting — already-indexed resources never touch the barrier', async () => {
@@ -606,7 +621,7 @@ describe('LLM Context', () => {
       const state = { indexed: true };
       const { lagged, searches } = lagKb(progressBus, state);
 
-      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, mockLogger);
+      const ctx = await LLMContext.getResourceContext(resourceId(testResourceId), baseOpts, lagged, mockClient, SETTLE_MS, mockLogger);
       expect(ctx.semanticContext?.similar.map((s) => s.resourceId)).toEqual(['r-sim']);
       expect(searches()).toBe(1);
     });

--- a/packages/make-meaning/src/__tests__/local-transport.test.ts
+++ b/packages/make-meaning/src/__tests__/local-transport.test.ts
@@ -45,6 +45,7 @@ const silentLogger: Logger = {
 };
 
 const config: MakeMeaningConfig = {
+  gather: { settleTimeoutMs: 15_000 },
   services: {
     graph: { platform: { type: 'posix' }, type: 'memory' },
   },

--- a/packages/make-meaning/src/__tests__/scripting-examples/create-resource.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/create-resource.test.ts
@@ -61,6 +61,7 @@ describe('Scripting Example: Create Resource', () => {
     project = new SemiontProject(testDir);
 
     config = {
+      gather: { settleTimeoutMs: 15_000 },
       services: {
         graph: {
           platform: { type: 'posix' },

--- a/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
@@ -86,6 +86,7 @@ describe('Scripting Example: Query Graph Database', () => {
     project = new SemiontProject(testDir);
 
     config = {
+      gather: { settleTimeoutMs: 15_000 },
       services: {
         graph: {
           platform: { type: 'posix' },

--- a/packages/make-meaning/src/__tests__/service.test.ts
+++ b/packages/make-meaning/src/__tests__/service.test.ts
@@ -72,6 +72,26 @@ describe('Make-Meaning Service', () => {
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
+  describe('A4 nesting assertion (gather barrier budgets vs the worker stall watchdog)', () => {
+    it('rejects a settle bound that cannot degrade before the stall watchdog fails fast', async () => {
+      const { STALL_THRESHOLD_MS } = await import('@semiont/jobs');
+      const badConfig: MakeMeaningConfig = {
+        ...config,
+        gather: { settleTimeoutMs: STALL_THRESHOLD_MS }, // ≥ the watchdog: the worker dies before the gather degrades
+      };
+      await expect(startMakeMeaning(project, badConfig, eventBus, mockLogger)).rejects.toThrow(
+        /settleTimeoutMs.*stall watchdog/,
+      );
+    });
+
+    it('rejects a non-positive settle bound', async () => {
+      const badConfig: MakeMeaningConfig = { ...config, gather: { settleTimeoutMs: 0 } };
+      await expect(startMakeMeaning(project, badConfig, eventBus, mockLogger)).rejects.toThrow(
+        /settleTimeoutMs must be a positive/,
+      );
+    });
+  });
+
   describe('initialization', () => {
     it('should initialize job queue', async () => {
       service = await startMakeMeaning(project, config, eventBus, mockLogger);

--- a/packages/make-meaning/src/__tests__/service.test.ts
+++ b/packages/make-meaning/src/__tests__/service.test.ts
@@ -43,6 +43,7 @@ describe('Make-Meaning Service', () => {
     eventBus = new EventBus();
 
     config = {
+      gather: { settleTimeoutMs: 15_000 },
       services: {
         graph: {
           platform: { type: 'posix' },

--- a/packages/make-meaning/src/__tests__/weaver-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver-axioms.test.ts
@@ -218,15 +218,15 @@ describe('W5 — rebuild ≡ replay', () => {
     );
   });
 
-  // ∀ σ: RB(σ) ≡ fold(σ) INCLUDING the entity-type registry. KNOWN false
-  // (found by this axiom's first run, 2026-07-13): `frame:entity-type-added`
-  // is a system event — it lives in no resource stream, so rebuildAll never
-  // replays it, while clearDatabase wiped the registry back to the ontology
-  // baseline. Consequence: `weave:rebuild` DROPS custom entity types.
-  // No bus read serves system events today; flips when one exists (or when
-  // rebuild preserves/re-registers the registry). Ledgered in
-  // WEAVER-AXIOMS.md; tracked on #845.
-  it.fails('W5-frames: rebuild restores frame-added entity types', async () => {
+  // ∀ σ: RB(σ) ≡ fold(σ) INCLUDING the entity-type registry. Was RED
+  // 2026-07-13 → 2026-07-18: `frame:entity-type-added` is a system event —
+  // it lives in no resource stream, so the per-resource replay can never
+  // restore it, while clearDatabase wiped the registry back to the ontology
+  // baseline. GREEN via the preserve-and-re-register arm (the ledgered
+  // alternative): rebuildAll captures the live-folded registry before the
+  // wipe and re-registers it after — the live registry is itself log-derived,
+  // and no weaver-readable stream exists to rebuild frames from.
+  it('W5-frames: rebuild restores frame-added entity types', async () => {
     const rig = await buildWeaverRig();
     const history = [
       storedEvent('yield:created', 'res-f', {
@@ -519,10 +519,12 @@ describe('W9 — reconcile detects and heals out-of-band divergence', () => {
     );
   });
 
-  // KNOWN v1 boundary: annotation bodies are outside the detectable class —
-  // a corrupted-in-place body reconciles as clean. Flips when #845's
-  // deep-equality checkbox lands.
-  it.fails('W9-deep: reconcile detects in-place annotation body corruption', async () => {
+  // Was RED (v1 boundary) → GREEN 2026-07-18: reconcile's divergenceOf now
+  // compares annotation BODIES canonically (key-order-independent) against
+  // the view's truth, so a corrupted-in-place body reads as
+  // 'annotation-body-mismatch' and heals from the log — membership equality
+  // alone was blind to it (#845 deep-equality checkbox).
+  it('W9-deep: reconcile detects in-place annotation body corruption', async () => {
     const rig = await buildWeaverRig();
     const rid = 'res-deep';
     const history = [

--- a/packages/make-meaning/src/annotation-context.ts
+++ b/packages/make-meaning/src/annotation-context.ts
@@ -206,7 +206,7 @@ export class AnnotationContext {
 
     // Build the knowledge graph for the neighborhood (full — the cap is a view concern, Q2=C).
     logger?.debug('Building knowledge graph', { resourceId });
-    const graph = await GraphContext.buildKnowledgeGraph(resourceId, kb);
+    const graph = await GraphContext.buildKnowledgeGraph(resourceId, kb, logger);
 
     // Derive the flattened views (connections / citedBy / siblings) from the graph (Q1=A).
     const views = deriveViews(graph, String(resourceId), annotationId);

--- a/packages/make-meaning/src/config.ts
+++ b/packages/make-meaning/src/config.ts
@@ -37,6 +37,14 @@ export interface WorkerInferenceConfig {
 
 /** Narrow config type — only the fields make-meaning actually reads */
 export interface MakeMeaningConfig {
+  /**
+   * Resource-gather policy. `settleTimeoutMs` bounds the semanticContext
+   * read-your-writes barrier (SMELTER-INDEX-SYNC D3/D5) — REQUIRED: the TOML
+   * loader owns the one default (15s at `[environments.<env>.make-meaning.gather]`);
+   * hand-built configs (scripts, tests) state their policy explicitly. Must
+   * nest inside downstream watchdogs (A4).
+   */
+  gather: { settleTimeoutMs: number };
   services: {
     graph?: GraphServiceConfig;
     vectors?: VectorsServiceConfig;

--- a/packages/make-meaning/src/gatherer.ts
+++ b/packages/make-meaning/src/gatherer.ts
@@ -43,6 +43,8 @@ export class Gatherer {
     private kb: KnowledgeBase,
     private eventBus: EventBus,
     private inferenceClient: InferenceClient,
+    /** Settle bound for the resource-gather barrier — operator-owned config (D5), threaded from `MakeMeaningConfig.gather`. */
+    private settleTimeoutMs: number,
     logger: Logger,
     private embeddingProvider?: EmbeddingProvider,
   ) {
@@ -134,6 +136,7 @@ export class Gatherer {
         event.options,
         this.kb,
         this.inferenceClient,
+        this.settleTimeoutMs,
         this.logger,
       );
 

--- a/packages/make-meaning/src/graph-context.ts
+++ b/packages/make-meaning/src/graph-context.ts
@@ -26,22 +26,32 @@ import type { ResourceDescriptor } from '@semiont/core';
 // hand-written local twins were deleted — this is the one canonical type definition.
 type KnowledgeGraph = components['schemas']['KnowledgeGraph'];
 
-export class GraphContext {
-  /**
-   * Backoff schedule for the projection-lag grace in `buildKnowledgeGraph`
-   * (GRAPH-PROJECTION-SYNC P1). Total wait is bounded at 375 ms — the Weaver
-   * applies in tens of milliseconds when merely lagging; anything slower is
-   * treated as a real miss.
-   */
-  private static readonly PROJECTION_LAG_BACKOFF_MS = [25, 50, 100, 200];
+/**
+ * Backoff schedule for the projection-lag grace in `buildKnowledgeGraph`
+ * (GRAPH-PROJECTION-SYNC P1). Total wait is bounded at 375 ms — the Weaver
+ * applies in tens of milliseconds when merely lagging; anything slower is
+ * treated as a real miss.
+ */
+const PROJECTION_LAG_BACKOFF_MS = [25, 50, 100, 200];
 
-  /**
-   * Bounded wait for the applied-offset barrier (GRAPH-PROJECTION-SYNC P2).
-   * The Weaver applies in tens of milliseconds when merely lagging; a
-   * barrier that hasn't woken in 500 ms means signals have stalled and the
-   * poll floor above owns the remainder.
-   */
-  private static readonly PROJECTION_BARRIER_TIMEOUT_MS = 500;
+/**
+ * Bounded wait for the applied-offset barrier (GRAPH-PROJECTION-SYNC P2).
+ * The Weaver applies in tens of milliseconds when merely lagging; a
+ * barrier that hasn't woken in 500 ms means signals have stalled and the
+ * poll floor above owns the remainder.
+ */
+const PROJECTION_BARRIER_TIMEOUT_MS = 500;
+
+/**
+ * Worst-case graph-barrier spend inside one gather (applied barrier + full
+ * poll floor). Participates in the A4 nesting assertion at the composition
+ * root (`service.ts`): this budget plus the settle bound must degrade
+ * gracefully BEFORE the job-worker stall watchdog fails fast.
+ */
+export const GRAPH_BARRIER_BUDGET_MS =
+  PROJECTION_BARRIER_TIMEOUT_MS + PROJECTION_LAG_BACKOFF_MS.reduce((a, b) => a + b, 0);
+
+export class GraphContext {
 
   /**
    * Get all resources referencing this resource (backlinks)
@@ -119,7 +129,7 @@ export class GraphContext {
             await kb.weaveProgress.whenApplied(
               String(resourceId),
               view.lastSequence,
-              GraphContext.PROJECTION_BARRIER_TIMEOUT_MS,
+              PROJECTION_BARRIER_TIMEOUT_MS,
             );
             mainDoc = await kb.graph.getResource(resourceId);
           } catch (error) {
@@ -132,7 +142,7 @@ export class GraphContext {
         // Bounded-poll floor (P1): the fallback when the barrier cannot
         // engage or its signals stall.
         if (!mainDoc) {
-          for (const delayMs of GraphContext.PROJECTION_LAG_BACKOFF_MS) {
+          for (const delayMs of PROJECTION_LAG_BACKOFF_MS) {
             await new Promise((resolve) => setTimeout(resolve, delayMs));
             mainDoc = await kb.graph.getResource(resourceId);
             if (mainDoc) break;
@@ -148,7 +158,7 @@ export class GraphContext {
           logger?.warn('[gather DEGRADED] graph projection did not catch up — resource present in views, absent in graph', {
             resourceId: String(resourceId),
             lastSequence: view.lastSequence,
-            barrierTimeoutMs: GraphContext.PROJECTION_BARRIER_TIMEOUT_MS,
+            barrierTimeoutMs: PROJECTION_BARRIER_TIMEOUT_MS,
           });
           throw new Error(
             `Graph projection did not catch up for ${String(resourceId)} — present in views, absent in graph (Weaver lag, not a missing resource)`,

--- a/packages/make-meaning/src/graph-context.ts
+++ b/packages/make-meaning/src/graph-context.ts
@@ -12,8 +12,11 @@ import type {
   components,
 } from '@semiont/core';
 import { getResourceId, getResourceEntityTypes, getTargetSource, resourceId as createResourceId } from '@semiont/core';
+import type { Logger } from '@semiont/core';
 import { getEntityTypes } from '@semiont/ontology';
+import { recordGatherDegrade } from '@semiont/observability';
 import type { KnowledgeBase } from './knowledge-base';
+import { WeaveProgressTimeout } from './weave-progress';
 
 import type { Annotation } from '@semiont/core';
 import type { ResourceDescriptor } from '@semiont/core';
@@ -94,6 +97,8 @@ export class GraphContext {
   static async buildKnowledgeGraph(
     resourceId: ResourceId,
     kb: KnowledgeBase,
+    /** Breadcrumb sink for the projection-lag degrade path; the degrade counter fires regardless. */
+    logger?: Logger,
   ): Promise<KnowledgeGraph> {
     // Read-your-writes grace for the graph projection: the view materializer
     // applies on the append path, the Weaver lags behind it (see
@@ -117,8 +122,11 @@ export class GraphContext {
               GraphContext.PROJECTION_BARRIER_TIMEOUT_MS,
             );
             mainDoc = await kb.graph.getResource(resourceId);
-          } catch {
-            // Barrier timed out — signals stalled; the poll floor owns it.
+          } catch (error) {
+            // Only the barrier's own timeout downgrades to the poll floor —
+            // any other failure is a broken progress fold and must surface,
+            // not silently degrade into polling.
+            if (!(error instanceof WeaveProgressTimeout)) throw error;
           }
         }
         // Bounded-poll floor (P1): the fallback when the barrier cannot
@@ -129,6 +137,22 @@ export class GraphContext {
             mainDoc = await kb.graph.getResource(resourceId);
             if (mainDoc) break;
           }
+        }
+        if (!mainDoc) {
+          // Exhausted with the view still vouching for the resource: this is
+          // PROJECTION LAG, not absence — saying "Resource not found" here
+          // would misdirect debugging at a 404 when the fault is a lagging or
+          // stalled Weaver. Countable (fleet alerting) + loggable (incident
+          // detail) + honestly named (the error says which subsystem).
+          recordGatherDegrade('graph');
+          logger?.warn('[gather DEGRADED] graph projection did not catch up — resource present in views, absent in graph', {
+            resourceId: String(resourceId),
+            lastSequence: view.lastSequence,
+            barrierTimeoutMs: GraphContext.PROJECTION_BARRIER_TIMEOUT_MS,
+          });
+          throw new Error(
+            `Graph projection did not catch up for ${String(resourceId)} — present in views, absent in graph (Weaver lag, not a missing resource)`,
+          );
         }
       }
     }

--- a/packages/make-meaning/src/llm-context.ts
+++ b/packages/make-meaning/src/llm-context.ts
@@ -14,18 +14,9 @@ import { resourceId as makeResourceId, type Logger, type ResourceId } from '@sem
 import type { GatheredContext } from '@semiont/core';
 import type { KnowledgeBase } from './knowledge-base';
 import { SmeltProgressTimeout } from './smelt-progress';
+import { recordGatherDegrade } from '@semiont/observability';
 
 import type { ResourceDescriptor } from '@semiont/core';
-
-/**
- * Bound on the semanticContext read-your-writes barrier (SMELTER-INDEX-SYNC
- * D3/A4): generous in embedding terms — an external model call plus queue
- * depth behind other work items — while nesting well inside consumer budgets
- * (my-chat's 90s generation stall watchdog). A named constant, not a caller
- * option, until a consumer hits the wall (the CONTEXT-IDENTIFIERS D4
- * discipline).
- */
-export const SMELT_SETTLE_TIMEOUT_MS = 15_000;
 
 export interface LLMContextOptions {
   depth: number;
@@ -49,6 +40,15 @@ export class LLMContext {
     options: LLMContextOptions,
     kb: KnowledgeBase,
     inferenceClient: InferenceClient,
+    /**
+     * Bound on the semanticContext read-your-writes barrier
+     * (SMELTER-INDEX-SYNC D3/D5). Operator-owned deployment policy: born in
+     * `[environments.<env>.make-meaning.gather] settleTimeoutMs` (the TOML
+     * loader holds the ONE default, 15s), threaded here as a plain argument
+     * via `MakeMeaningConfig.gather` → Gatherer. Must nest inside downstream
+     * watchdogs (A4) — e.g. my-chat's 90s generation stall watchdog.
+     */
+    settleTimeoutMs: number,
     logger: Logger,
   ): Promise<GatheredContext> {
     // Get main resource from view storage
@@ -63,7 +63,7 @@ export class LLMContext {
       : undefined;
 
     // Knowledge graph (full neighborhood — resources AND annotations as nodes).
-    const graph = await GraphContext.buildKnowledgeGraph(resourceId, kb);
+    const graph = await GraphContext.buildKnowledgeGraph(resourceId, kb, logger);
 
     // Related resources for content. The cap is a view concern (Q2=C): take the first
     // (maxResources - 1) peer resource nodes, matching the previous display count.
@@ -139,17 +139,21 @@ export class LLMContext {
         const contentChecksum = getPrimaryRepresentation(mainDoc)?.checksum;
         if (contentChecksum) {
           try {
-            const outcome = await kb.smeltProgress.whenSettled(resourceIdStr, contentChecksum, SMELT_SETTLE_TIMEOUT_MS);
+            const outcome = await kb.smeltProgress.whenSettled(resourceIdStr, contentChecksum, settleTimeoutMs);
             if (outcome === 'indexed') {
               matches = await search();
             }
             // 'skipped' | 'inert': legitimately absent — no breadcrumb.
           } catch (error) {
             if (!(error instanceof SmeltProgressTimeout)) throw error;
+            // Countable AND loggable: the counter feeds fleet alerting
+            // (a rising degrade rate = the Smelter isn't keeping up); the
+            // breadcrumb carries the per-incident detail (L4).
+            recordGatherDegrade('vectors');
             logger.warn('[gather DEGRADED] semanticContext absent — the vector projection did not settle within the barrier', {
               resourceId: resourceIdStr,
               contentChecksum,
-              timeoutMs: SMELT_SETTLE_TIMEOUT_MS,
+              timeoutMs: settleTimeoutMs,
             });
           }
         }

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -5,7 +5,7 @@
  *   const makeMeaning = await startMakeMeaning(project, config, eventBus, logger);
  */
 
-import { FsJobQueue, type JobQueue } from '@semiont/jobs';
+import { FsJobQueue, STALL_THRESHOLD_MS, type JobQueue } from '@semiont/jobs';
 import { createEventStore as createEventStoreCore } from '@semiont/event-sourcing';
 import type { SemiontProject } from '@semiont/core/node';
 import { EventBus, type Logger, jobId } from '@semiont/core';
@@ -16,6 +16,7 @@ import { mergeMap } from 'rxjs/operators';
 import { createInferenceClient } from '@semiont/inference';
 import { getGraphDatabase } from '@semiont/graph';
 import { createKnowledgeBase } from './knowledge-base';
+import { GRAPH_BARRIER_BUDGET_MS } from './graph-context';
 import { Gatherer } from './gatherer';
 import { Matcher } from './matcher';
 import { Stower } from './stower';
@@ -180,6 +181,24 @@ export async function startMakeMeaning(
 ): Promise<MakeMeaningService> {
   if (!config.services?.graph) {
     throw new Error('services.graph is required for make-meaning service');
+  }
+
+  // A4 nesting (SMELTER-INDEX-SYNC): the gather's worst-case read-barrier
+  // spend — the settle bound plus the graph barrier budget — must degrade
+  // gracefully BEFORE the job-worker stall watchdog fails fast; a barrier
+  // that outlives the watchdog gets the worker killed instead of a thin
+  // context. Enforced here because both bounds are visible at this
+  // composition root; tighter EXTERNAL watchdogs (e.g. my-chat's 90s
+  // generation stall) are not importable and remain documented on the
+  // config field.
+  if (!Number.isFinite(config.gather.settleTimeoutMs) || config.gather.settleTimeoutMs <= 0) {
+    throw new Error(`gather.settleTimeoutMs must be a positive number of milliseconds, got ${config.gather.settleTimeoutMs}`);
+  }
+  if (config.gather.settleTimeoutMs + GRAPH_BARRIER_BUDGET_MS >= STALL_THRESHOLD_MS) {
+    throw new Error(
+      `gather.settleTimeoutMs (${config.gather.settleTimeoutMs}ms) plus the graph barrier budget (${GRAPH_BARRIER_BUDGET_MS}ms) ` +
+      `must nest inside the job-worker stall watchdog (${STALL_THRESHOLD_MS}ms) — lower settleTimeoutMs (A4)`,
+    );
   }
 
   const skipRebuild = options?.skipRebuild ?? (process.env.SEMIONT_SKIP_REBUILD === 'true');

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -145,6 +145,7 @@ async function createKnowledgeSystemFromConfig(
   const gatherer = new Gatherer(
     kb, eventBus,
     createInferenceClient(resolveActorInference(config, 'gatherer'), logger.child({ component: 'inference-client-gatherer' })),
+    config.gather.settleTimeoutMs,
     logger.child({ component: 'gatherer' }),
     embeddingProvider,
   );

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -458,6 +458,24 @@ export class Weaver {
     return summary;
   }
 
+  /**
+   * Key-order-independent serialization for deep equality (W9-deep): two
+   * structurally equal bodies must compare equal regardless of the property
+   * order their storage backend happens to preserve.
+   */
+  private static canonicalJson(value: unknown): string {
+    if (Array.isArray(value)) {
+      return `[${value.map((v) => Weaver.canonicalJson(v)).join(',')}]`;
+    }
+    if (value !== null && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+      return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${Weaver.canonicalJson(v)}`).join(',')}}`;
+    }
+    return JSON.stringify(value) ?? 'null';
+  }
+
   /** Compare one resource's graph state against its view; null = in sync. */
   private async divergenceOf(resource: ResourceDescriptor): Promise<string | null> {
     const graphDb = this.ensureInitialized();
@@ -480,6 +498,18 @@ export class Weaver {
     if (viewIds.size !== graphIds.size) return 'annotation-set-mismatch';
     for (const id of viewIds) {
       if (!graphIds.has(id)) return 'annotation-set-mismatch';
+    }
+
+    // Content depth (W9-deep): membership equality is blind to a body
+    // mutated in place — a corrupted graph doc with the right id reconciled
+    // as clean. Compare bodies canonically against the view's truth.
+    const viewById = new Map(annotations.map((a) => [String(a.id), a]));
+    for (const graphAnnotation of graphAnnotations) {
+      const viewAnnotation = viewById.get(String(graphAnnotation.id));
+      if (!viewAnnotation) continue; // set equality established above
+      if (Weaver.canonicalJson(graphAnnotation.body) !== Weaver.canonicalJson(viewAnnotation.body)) {
+        return 'annotation-body-mismatch';
+      }
     }
 
     return null;
@@ -918,7 +948,22 @@ export class Weaver {
     this.logger.info('Rebuilding entire GraphDB from events');
     this.logger.info('Using two-pass approach: nodes first, then edges');
 
+    // Frame vocabulary survives the wipe (W5-frames): frame:entity-type-added
+    // is a system event — it lives in no resource stream, so the per-resource
+    // replay below can never restore it, while clearDatabase resets the
+    // registry to the ontology baseline. Capture the live-folded registry and
+    // re-register it after the wipe. Preservation IS the honest semantics
+    // here: no weaver-readable stream exists to rebuild frames from, and the
+    // live registry is itself log-derived (folded from the bus as the events
+    // arrived).
+    const entityTypes = await graphDb.getEntityTypes();
+
     await graphDb.clearDatabase();
+
+    if (entityTypes.length > 0) {
+      await graphDb.addEntityTypes(entityTypes);
+      this.logger.info('Re-registered frame vocabulary across the wipe', { count: entityTypes.length });
+    }
 
     // Resources are archive-only (never deleted), so the catalog's resource
     // set matches the event log's — discovery over the bus is complete.

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -234,6 +234,7 @@ let _busEmitCounter: Counter | undefined;
 let _handlerDurationHistogram: Histogram | undefined;
 let _jobOutcomeCounter: Counter | undefined;
 let _jobDurationHistogram: Histogram | undefined;
+let _gatherDegradeCounter: Counter | undefined;
 let _inferenceCallsCounter: Counter | undefined;
 let _inferenceTokensCounter: Counter | undefined;
 let _inferenceDurationHistogram: Histogram | undefined;
@@ -347,6 +348,27 @@ export function recordHandlerDuration(actor: string, channel: string, durationMs
 export function recordJobOutcome(jobType: string, outcome: 'completed' | 'failed', durationMs: number): void {
   jobOutcomeCounter().add(1, { 'job.type': jobType, 'job.outcome': outcome });
   jobDurationHistogram().record(durationMs, { 'job.type': jobType, 'job.outcome': outcome });
+}
+
+function gatherDegradeCounter(): Counter {
+  if (!_gatherDegradeCounter) {
+    _gatherDegradeCounter = meter().createCounter('semiont.gather.degraded', {
+      description: 'Gathers that degraded because an eventually-consistent projection did not catch up within its read barrier (vectors: absent semanticContext; graph: projection-lag failure). Labeled by projection.',
+    });
+  }
+  return _gatherDegradeCounter;
+}
+
+/**
+ * Record a gather degraded by a projection read barrier: `'vectors'` — the
+ * Smelter settle barrier timed out (semanticContext shipped absent);
+ * `'graph'` — the Weaver applied barrier + poll floor exhausted (projection
+ * lag surfaced as a distinct failure). Fleet-alertable counterpart of the
+ * `[gather DEGRADED]` L4 breadcrumbs — a rising rate on either label means
+ * that pipeline is not keeping up.
+ */
+export function recordGatherDegrade(projection: 'graph' | 'vectors'): void {
+  gatherDegradeCounter().add(1, { projection });
 }
 
 /** Increment the SSE subscriber gauge — call on `/bus/subscribe` open. */


### PR DESCRIPTION
## Description

Two changesets on the gather read-barrier seam. The first makes the settle bound deployment config and makes both projection-barrier degrades honest and countable; the second promotes two Weaver axioms to GREEN and enforces the A4 nesting bound at service startup.

Triggered by the main CI coverage-mode flake (run 29622765997): the degrade-path test faked the clock around a hardcoded 15s barrier constant and lost to scheduling weather under `--coverage`. The durable fix is ownership, not choreography — the bound becomes config, and the fake-timer choreography is deleted outright.

### 1. Config-owned settle bound (SMELTER-INDEX-SYNC D5)

Threaded as plain function arguments end to end — explicitly **no DI machinery**: no container, no registry, no auto-wiring; every hop is greppable.

- New TOML knob `[environments.<env>.make-meaning.gather] settleTimeoutMs`; the loader owns the ONE default (15s) and always sets `_metadata.gather` (+2 loader tests pinning default and explicit values).
- `MakeMeaningConfig.gather` is **required**; `makeMeaningConfigFrom` passes it through and fails loudly naming the key if handed a config that bypassed the loader — no fallback anywhere in consuming code.
- `SMELT_SETTLE_TIMEOUT_MS` deleted; the value travels `service.ts` → `Gatherer` ctor → `getResourceContext(argument)`. Hand-built configs (tests, scripting examples, SCRIPTING.md) state their policy explicitly.
- The barrier tests now pass small REAL bounds; the fake-timer advancement loop is gone — the coverage-fragility class is closed at the root, not worked around.

### 2. Graph (Weaver) barrier — stop lying, start counting

- Barrier exhaustion while the VIEW still vouches for the resource now throws a distinct projection-lag error instead of `Resource not found`; the 404 wording is reserved for true unknowns.
- Degrade is observable: one `[gather DEGRADED]` breadcrumb + the new `semiont.gather.degraded` counter, labeled `projection=graph|vectors` (`recordGatherDegrade` in `@semiont/observability`; the vectors call site labels itself). `buildKnowledgeGraph` gains an optional logger as the breadcrumb sink, threaded from both callers.
- The barrier's bare catch now rethrows anything that is not a real `WeaveProgressTimeout` — a broken progress fold surfaces instead of silently downgrading to polls. The old test's lookalike mock (a plain `Error` named like the timeout) upgraded to a real instance.

### 3. Weaver axiom promotions — W5-frames and W9-deep GREEN

- **W5-frames** (rebuild preserves the entity-type frame): `rebuildAll` snapshots registered entity types before `clearDatabase` and re-registers them after — a rebuild no longer silently drops the vocabulary frame. Promoted `it.fails` → `it`, test body untouched.
- **W9-deep** (divergence detection sees body edits): `divergenceOf` gains a body-depth check — canonical-JSON comparison of each annotation body shared between graph and view, on top of the id-set check. A body edit the graph missed now reads as `annotation-body-mismatch` instead of "no divergence". Promoted `it.fails` → `it`, test body untouched.
- Ledger expected-fail count: 3 → 1. **W1-strict is now the sole designed-RED**, ranked first in the escalation note — the only ledger RED that can lose a write, and the "sound" half of the slow-but-sound assumption both read barriers rest on.

### 4. A4 nesting bound — enforced at load, not just documented

`startMakeMeaning` now asserts that `gather.settleTimeoutMs` is a positive finite number and that it plus the graph barrier budget nests inside the job-worker stall watchdog — a barrier that outlives the watchdog gets the worker killed instead of a thin context.

- `GRAPH_BARRIER_BUDGET_MS` exported from `graph-context.ts` (applied-barrier timeout + full poll floor).
- `STALL_THRESHOLD_MS` re-exported from `@semiont/jobs` (the WORKER-LIVENESS P3 watchdog).
- Tighter EXTERNAL watchdogs (e.g. my-chat's 90s generation stall) are not importable and remain documented on the config field.

### Docs + ledgers

- `docs/system/KNOWLEDGE-SYSTEM.md`: standing **seam rule** — any new read of an eventually-consistent projection on fresh content must declare eventual (with rationale) or read-your-writes via the progress folds, with bounded observable degrade. Undeclared is not an option.
- `.plans/SMELTER-INDEX-SYNC.md`: D5 decision + execution log; seam declarations (annotation-gather: eventual, by analysis; matcher: eventual for ranking, create-then-bind flow left OPEN as a product decision); A4-enforced entry.
- `.plans/WEAVER-AXIOMS.md`: W5/W9 flipped GREEN with dates; W1-strict escalation note.

### Verified

In node:24-alpine: core loader tests RED→GREEN + core build; jobs and observability rebuilt; make-meaning `tsc` 0 and 39/39 test files green in BOTH plain and `--coverage` (the mode that failed on main); backend + cli `tsc` 0.
