### PR TITLE
Launcher: adopt SEMIONT_ROOT, add roots.json registry and start --root

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -44,6 +44,19 @@ semiont stop
   semiont` on macOS, `$XDG_STATE_HOME/semiont` (default
   `~/.local/state/semiont`) on Linux. `semiont status` lists the dir under
   LOCAL HOST DIRECTORIES. Logging is best-effort — it never blocks a command.
+- KB-root discovery matches the npm CLI (`SEMIONT_ROOT`, analogous to
+  `GIT_DIR`): the override is strict (invalid values error, never fall back),
+  else the root is found by walking up from cwd for `.semiont/`. git is not
+  part of discovery — the must-be-a-git-clone invariant applies only where
+  `/kb` is mounted (full start, `--service backend`); sidecars need only the
+  `.semiont/` tree. `semiont status` reports the root(s) in a SEMIONT ROOTS
+  section (plural-shaped: multiple roots are on the roadmap).
+- The launcher remembers every root a real start used in `roots.json` (beside
+  `stack.json`; entries survive stops, vanished paths are flagged not
+  dropped). `semiont start --root <path|name>` selects a root explicitly — a
+  directory, or the basename of a registered root — winning over
+  `SEMIONT_ROOT` and cwd discovery; the SEMIONT ROOTS status section lists
+  the registry with last-used annotations.
 - `start` records what it believes the stack IS — the runtime, and each
   service's container name, runtime-reported ID, and image — in `stack.json`
   in the launcher's state home (`~/Library/Application Support/semiont` on

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -74,6 +74,10 @@ func logArgv(base string, args []string) {
 }
 
 func git(args []string) {
+	// Accept the -C <dir> form; behavior is driven by FAKERT_GIT_ROOT alone.
+	if len(args) >= 2 && args[0] == "-C" {
+		args = args[2:]
+	}
 	if len(args) >= 2 && args[0] == "rev-parse" && args[1] == "--show-toplevel" {
 		root := os.Getenv("FAKERT_GIT_ROOT")
 		if root == "" {

--- a/apps/launcher/internal/launcher/root.go
+++ b/apps/launcher/internal/launcher/root.go
@@ -1,0 +1,200 @@
+package launcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// KB-root discovery, adopted from apps/cli (config-loader.ts): SEMIONT_ROOT
+// is an explicit override analogous to GIT_DIR — strictly validated, never
+// silently ignored — else the root is found by walking up from cwd looking
+// for .semiont/. git is deliberately NOT part of discovery; whether the root
+// must also be a git clone is a separate invariant, enforced only where the
+// /kb mount makes it real (full start, --service backend).
+//
+// Today there is one root; the plural-ready shape (status's SEMIONT ROOTS
+// section, the source annotation) anticipates supporting many.
+
+// resolveKBRoot returns the KB root and where it came from ("SEMIONT_ROOT"
+// or "discovered").
+func resolveKBRoot() (path, source string, err error) {
+	if override := os.Getenv("SEMIONT_ROOT"); override != "" {
+		if fi, statErr := os.Stat(override); statErr != nil || !fi.IsDir() {
+			return "", "", fmt.Errorf("SEMIONT_ROOT points to non-existent directory: %s", override)
+		}
+		if fi, statErr := os.Stat(filepath.Join(override, ".semiont")); statErr != nil || !fi.IsDir() {
+			return "", "", fmt.Errorf("SEMIONT_ROOT does not contain a .semiont/ directory: %s", override)
+		}
+		if abs, absErr := filepath.Abs(override); absErr == nil {
+			override = abs
+		}
+		return override, "SEMIONT_ROOT", nil
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("cannot determine current directory: %v", err)
+	}
+	for {
+		if fi, statErr := os.Stat(filepath.Join(dir, ".semiont")); statErr == nil && fi.IsDir() {
+			return dir, "discovered", nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", "", fmt.Errorf("no .semiont/ directory found in the current directory or any parent")
+		}
+		dir = parent
+	}
+}
+
+// --- The roots registry ---
+//
+// roots.json (beside stack.json in the XDG state home) is the launcher's
+// memory of every KB root it has actually used: real start flows upsert an
+// entry; entries survive stops. A vanished path is annotated when observed,
+// not silently dropped — an unmounted volume may come back. This registry is
+// the substrate for multi-root support and for `--root <name>` selection.
+
+type rootEntry struct {
+	Path        string    `json:"path"`
+	LastUsed    time.Time `json:"lastUsed"`
+	LastStarted time.Time `json:"lastStarted,omitzero"` // last full-stack start
+}
+
+type rootsRegistry struct {
+	Schema int         `json:"schema"`
+	Roots  []rootEntry `json:"roots"`
+}
+
+func rootsPath() string {
+	dir := stateDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "roots.json")
+}
+
+// loadRoots returns the registry, most-recently-used first (empty, never
+// nil-fielded, when absent or unreadable).
+func loadRoots() rootsRegistry {
+	reg := rootsRegistry{Schema: 1}
+	p := rootsPath()
+	if p == "" {
+		return reg
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return reg
+	}
+	_ = json.Unmarshal(b, &reg)
+	sort.Slice(reg.Roots, func(i, j int) bool { return reg.Roots[i].LastUsed.After(reg.Roots[j].LastUsed) })
+	return reg
+}
+
+// registerRootUse upserts a root into the registry. Best-effort: registry
+// trouble never fails the command. fullStart additionally stamps LastStarted.
+func registerRootUse(path string, fullStart bool) {
+	p := rootsPath()
+	if p == "" {
+		return
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	reg := loadRoots()
+	now := time.Now().UTC()
+	found := false
+	for i := range reg.Roots {
+		if reg.Roots[i].Path == path {
+			reg.Roots[i].LastUsed = now
+			if fullStart {
+				reg.Roots[i].LastStarted = now
+			}
+			found = true
+		}
+	}
+	if !found {
+		e := rootEntry{Path: path, LastUsed: now}
+		if fullStart {
+			e.LastStarted = now
+		}
+		reg.Roots = append(reg.Roots, e)
+	}
+	if reg.Schema == 0 {
+		reg.Schema = 1
+	}
+	b, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return
+	}
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, append(b, '\n'), 0o644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, p)
+}
+
+// resolveRootArg resolves a `--root` value: an existing directory path is
+// validated directly (strict, like SEMIONT_ROOT); anything else is looked up
+// in the registry by basename.
+func resolveRootArg(arg string) (string, error) {
+	if fi, err := os.Stat(arg); err == nil && fi.IsDir() {
+		if fi, err := os.Stat(filepath.Join(arg, ".semiont")); err != nil || !fi.IsDir() {
+			return "", fmt.Errorf("--root does not contain a .semiont/ directory: %s", arg)
+		}
+		if abs, err := filepath.Abs(arg); err == nil {
+			arg = abs
+		}
+		return arg, nil
+	}
+	if strings.ContainsRune(arg, os.PathSeparator) {
+		return "", fmt.Errorf("--root points to non-existent directory: %s", arg)
+	}
+	reg := loadRoots()
+	var matches []string
+	for _, e := range reg.Roots {
+		if filepath.Base(e.Path) == arg {
+			matches = append(matches, e.Path)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		known := make([]string, 0, len(reg.Roots))
+		for _, e := range reg.Roots {
+			known = append(known, e.Path)
+		}
+		if len(known) == 0 {
+			return "", fmt.Errorf("--root '%s' is not a directory and no roots are registered yet (roots register on start)", arg)
+		}
+		return "", fmt.Errorf("--root '%s' matches no registered root; known roots:\n  %s", arg, strings.Join(known, "\n  "))
+	case 1:
+		path := matches[0]
+		if fi, err := os.Stat(filepath.Join(path, ".semiont")); err != nil || !fi.IsDir() {
+			return "", fmt.Errorf("registered root %s is missing on disk (or lost its .semiont/)", path)
+		}
+		return path, nil
+	default:
+		return "", fmt.Errorf("--root '%s' is ambiguous; use a full path:\n  %s", arg, strings.Join(matches, "\n  "))
+	}
+}
+
+// requireGitClone enforces the /kb-mount invariant: the backend versions the
+// event log via git, so a real clone is mandatory wherever /kb is mounted.
+// Fails with instructions rather than git's opaque fatal when someone used
+// GitHub's "Download ZIP" (or has no git at all).
+func requireGitClone(u *ui, root string) bool {
+	if _, err := capture("git", "-C", root, "rev-parse", "--show-toplevel"); err != nil {
+		u.fail("The KB root must be a git clone (the backend versions the event log via git): %s", root)
+		fmt.Fprintln(os.Stderr, "  If you used GitHub's 'Download ZIP', clone the repository instead:  git clone <repo-url>")
+		return false
+	}
+	return true
+}

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -79,6 +79,7 @@ type startOptions struct {
 	dryRun         bool
 	ollamaCache    string // "", "host", or "volume"
 	service        string // start just this one service
+	root           string // --root: KB root by path or registered basename
 }
 
 const startUsage = `Usage: semiont start [options]
@@ -90,6 +91,10 @@ the frontend (http://localhost:3000) — all in containers.
 Options:
   --config <name>       Semiontconfig to use (default: ollama-gemma)
   --list-configs        List available configs and exit
+  --root <path|name>    KB root to start: a directory (must contain .semiont/)
+                        or the basename of a registered root (roots register on
+                        every real start; see semiont status). Wins over
+                        SEMIONT_ROOT and cwd discovery.
   --service <name>      Start (restart) just this one service, leaving the rest
                         of the stack untouched: backend, worker, smelter, weaver,
                         frontend, db, graph, vectors, inference, or traces.
@@ -106,6 +111,16 @@ Options:
   --dry-run             Print the exact runtime commands a run would execute, then exit
   --quiet, -q           Suppress informational output
   --help, -h            Show this help
+
+Environment:
+  SEMIONT_ROOT          KB root override, analogous to GIT_DIR: skip discovery
+                        and use this path (must contain .semiont/; invalid
+                        values are an error, never ignored). Default: walk up
+                        from the current directory looking for .semiont/.
+  SEMIONT_VERSION       Image tag to run (default: latest; 'local' uses
+                        locally-built :local images and skips the pull)
+  SEMIONT_WORKER_SECRET Shared backend/sidecar secret (default: generated per
+                        run; --service rejoins the running stack's secret)
 
 Examples:
   # Fully local with Ollama (default, no API key needed)
@@ -152,6 +167,13 @@ func Start(args []string) int {
 				return 1
 			}
 			opts.service = v
+			i++
+		case "--root":
+			v, ok := needVal(i)
+			if !ok {
+				return 1
+			}
+			opts.root = v
 			i++
 		case "--list-configs":
 			opts.listConfigs = true
@@ -235,6 +257,9 @@ func Start(args []string) int {
 		case opts.configSet && !isConfigConsumer(opts.service):
 			u.fail("--config only applies to --service backend, worker, smelter, or weaver.")
 			return 1
+		case opts.root != "" && !isConfigConsumer(opts.service):
+			u.fail("--root only applies to full start or --service backend, worker, smelter, or weaver (this service uses no KB root).")
+			return 1
 		}
 	}
 
@@ -244,26 +269,42 @@ func Start(args []string) int {
 		u.stamp("semiont start")
 	}
 
-	// Resolve the KB root. A git clone is required — the backend versions the
-	// event log via git — so fail with instructions rather than git's opaque
-	// "not a repository" fatal when someone used GitHub's "Download ZIP" (or
-	// has no git at all). Deliberately after arg parsing so --help works
-	// anywhere. Exception: a --service target that never touches the repo
-	// (infra, frontend — no /kb mount, no config) runs from anywhere, so
-	// "just the browser" needs no clone at all.
+	// Resolve the KB root: SEMIONT_ROOT override (strict), else walk up from
+	// cwd for .semiont/ — deliberately after arg parsing so --help works
+	// anywhere. Only flows that read the config need a root at all; only
+	// flows that mount /kb (full start, --service backend) must additionally
+	// be a git clone — the backend versions the event log via git. A
+	// --service target that touches neither (infra, frontend) runs from
+	// anywhere: "just the browser" needs no clone at all.
 	rootNeeded := opts.service == "" || isConfigConsumer(opts.service)
 	root := ""
 	if rootNeeded {
 		var err error
-		root, err = capture("git", "rev-parse", "--show-toplevel")
-		if err != nil || root == "" {
-			u.fail("This must run inside a git clone of the KB (the backend versions the event log via git).")
-			fmt.Fprintln(os.Stderr, "  If you used GitHub's 'Download ZIP', clone the repository instead:  git clone <repo-url>")
+		if opts.root != "" {
+			// --root wins over SEMIONT_ROOT and discovery: a path is
+			// validated directly, anything else resolves via the registry.
+			root, err = resolveRootArg(opts.root)
+		} else {
+			root, _, err = resolveKBRoot()
+		}
+		if err != nil {
+			u.fail("%v", err)
+			fmt.Fprintln(os.Stderr, "  cd into a KB clone, or set SEMIONT_ROOT / pass --root.")
 			return 1
+		}
+		if opts.service == "" || opts.service == "backend" {
+			if !requireGitClone(u, root) {
+				return 1
+			}
 		}
 		if err := os.Chdir(root); err != nil {
 			u.fail("Cannot enter KB root %s: %v", root, err)
 			return 1
+		}
+		// The registry remembers every root a real run used (dry-run is a
+		// machine seam and mutates nothing).
+		if !opts.dryRun {
+			registerRootUse(root, opts.service == "")
 		}
 	}
 

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -175,6 +175,7 @@ func Status(args []string) int {
 			10+utf8.RuneCountInString(rt)-visibleLen(rt), rt, healthCol)
 	}
 	if service == "" {
+		printRoots(u, st)
 		printHostDirs(u)
 	}
 
@@ -182,6 +183,54 @@ func Status(args []string) int {
 		return 0
 	}
 	return 1
+}
+
+// printRoots reports the Semiont roots: every registered root (roots.json —
+// the launcher's memory of roots it has actually used), merged with the one
+// resolvable from here (SEMIONT_ROOT or cwd discovery) and the running
+// stack's, each annotated with everything true about it. Vanished paths are
+// flagged, not hidden.
+func printRoots(u *ui, st *stackState) {
+	fmt.Println()
+	fmt.Println("  SEMIONT ROOTS")
+	order := []string{}
+	labels := map[string][]string{}
+	add := func(path, label string) {
+		if _, ok := labels[path]; !ok {
+			order = append(order, path)
+		}
+		labels[path] = append(labels[path], label)
+	}
+
+	if path, source, err := resolveKBRoot(); err == nil {
+		label := "discovered from cwd"
+		if source == "SEMIONT_ROOT" {
+			label = "SEMIONT_ROOT"
+		}
+		add(path, label)
+	} else if os.Getenv("SEMIONT_ROOT") != "" {
+		// Strictness without failing the report: an invalid override is
+		// surfaced, not silently ignored.
+		fmt.Printf("  %s\n", u.wrap(ansiYellow, fmt.Sprintf("⚠ %v", err)))
+	}
+	if st != nil && st.KBRoot != "" {
+		add(st.KBRoot, "running stack")
+	}
+	for _, e := range loadRoots().Roots {
+		if _, err := os.Stat(e.Path); err != nil {
+			add(e.Path, "missing")
+			continue
+		}
+		add(e.Path, "last used "+e.LastUsed.Format("2006-01-02"))
+	}
+
+	if len(order) == 0 {
+		fmt.Printf("  %s\n", u.dim("(none — cd into a KB clone, set SEMIONT_ROOT, or start with --root)"))
+		return
+	}
+	for _, p := range order {
+		fmt.Printf("  %s %s\n", p, u.dim("("+strings.Join(labels[p], "; ")+")"))
+	}
 }
 
 // printHostDirs reports the host-side directories the stack touches: the

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -104,6 +104,7 @@ type scenario struct {
 	shim      string
 	kb        string // also FAKERT_GIT_ROOT unless gitRoot overridden
 	noGitRoot bool
+	cwd       string // launcher working dir; defaults to kb
 	home      string
 	fakertDir string
 	log       string
@@ -171,6 +172,9 @@ func (s *scenario) run(t *testing.T, args ...string) (stdout, stderr string, cod
 	defer cancel()
 	cmd := exec.CommandContext(ctx, launcherBin, args...)
 	cmd.Dir = s.kb
+	if s.cwd != "" {
+		cmd.Dir = s.cwd
+	}
 	cmd.Env = s.env()
 	cmd.Stdin = strings.NewReader(s.stdin)
 	var out, errb strings.Builder
@@ -468,7 +472,7 @@ func TestStartDryRunDefault(t *testing.T) {
 	}
 	checkGolden(t, "start-dryrun-default.txt", stdout)
 	// Dry run must execute nothing beyond KB-root resolution.
-	if got := s.argv(t); got != "git rev-parse --show-toplevel\n" {
+	if got := s.argv(t); got != "git -C <kb-root> rev-parse --show-toplevel\n" {
 		t.Errorf("dry run executed external commands:\n%s", got)
 	}
 }
@@ -575,6 +579,8 @@ func TestStatusMixed(t *testing.T) {
 	}
 	mustContain(t, "stdout", stdout,
 		"SERVICE", "CONTAINER", "RUNTIME", "HEALTH",
+		"SEMIONT ROOTS",
+		"(discovered from cwd)",
 		"LOCAL HOST DIRECTORIES",
 		"config", "cache", "staging", "/tmp/semiont-config.*",
 		"✓ http://localhost:4000/api/health",
@@ -660,6 +666,154 @@ func TestInvocationLog(t *testing.T) {
 	if strings.Contains(log, "supersecretpw") {
 		t.Error("password leaked into the invocation log")
 	}
+}
+
+// --- SEMIONT_ROOT / KB-root discovery ---
+
+func TestSemiontRootOverride(t *testing.T) {
+	// From an unrelated directory, SEMIONT_ROOT selects the KB — GIT_DIR
+	// style. The git-clone invariant then runs against the override.
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir() // not a KB
+	s.extraEnv = append(s.extraEnv, "SEMIONT_ROOT="+s.kb)
+	stdout, stderr, code := s.run(t, "start", "--dry-run")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	if got := s.argv(t); got != "git -C <kb-root> rev-parse --show-toplevel\n" {
+		t.Errorf("unexpected argv:\n%s", got)
+	}
+}
+
+func TestSemiontRootInvalid(t *testing.T) {
+	// Strict, matching apps/cli: an invalid override is an error, never
+	// silently ignored in favor of discovery.
+	s := newScenario(t, "container")
+	for _, tc := range []struct{ root, want string }{
+		{filepath.Join(t.TempDir(), "nope"), "points to non-existent directory"},
+		{t.TempDir(), "does not contain a .semiont/ directory"},
+	} {
+		s.extraEnv = []string{"SEMIONT_ROOT=" + tc.root}
+		_, stderr, code := s.run(t, "start", "--dry-run")
+		if code != 1 {
+			t.Errorf("SEMIONT_ROOT=%s: want exit 1, got %d", tc.root, code)
+		}
+		mustContain(t, "stderr", stderr, tc.want)
+	}
+}
+
+func TestRootWalkUpFromSubdir(t *testing.T) {
+	// Discovery walks up from cwd looking for .semiont/ — a KB subdirectory
+	// resolves to the KB root (parity with the old git-rev-parse behavior).
+	s := newScenario(t, "container")
+	sub := filepath.Join(s.kb, "docs", "deep")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s.cwd = sub
+	stdout, stderr, code := s.run(t, "start", "--dry-run")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+}
+
+func TestRootNotFound(t *testing.T) {
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	s.noGitRoot = true
+	_, stderr, code := s.run(t, "start", "--dry-run")
+	if code != 1 {
+		t.Fatalf("want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr,
+		"no .semiont/ directory found in the current directory or any parent",
+		"cd into a KB clone, or set SEMIONT_ROOT")
+}
+
+// --- roots registry + --root ---
+
+func rootsPathFor(home string) string {
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Application Support", "semiont", "roots.json")
+	}
+	return filepath.Join(home, ".local", "state", "semiont", "roots.json")
+}
+
+func TestRootsRegistryAndRootFlag(t *testing.T) {
+	// A real start registers its root; --root then selects by basename from
+	// anywhere; --dry-run reads but never writes the registry.
+	s := newScenario(t, "container")
+	if _, stderr, code := s.run(t, "start", "--service", "worker"); code != 0 {
+		t.Fatalf("worker start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	b, err := os.ReadFile(rootsPathFor(s.home))
+	if err != nil {
+		t.Fatalf("roots.json not written: %v", err)
+	}
+	var reg struct {
+		Schema int `json:"schema"`
+		Roots  []struct {
+			Path        string `json:"path"`
+			LastStarted string `json:"lastStarted"`
+		} `json:"roots"`
+	}
+	if err := json.Unmarshal(b, &reg); err != nil {
+		t.Fatalf("roots.json invalid: %v\n%s", err, b)
+	}
+	if len(reg.Roots) != 1 || reg.Roots[0].Path != s.kb {
+		t.Fatalf("registry contents: %s", b)
+	}
+	if reg.Roots[0].LastStarted != "" {
+		t.Error("--service start must not stamp lastStarted (full start only)")
+	}
+
+	// --root by registered basename, from an unrelated cwd.
+	s.killServes()
+	s.cwd = t.TempDir()
+	stdout, stderr, code := s.run(t, "start", "--dry-run", "--root", filepath.Base(s.kb))
+	if code != 0 {
+		t.Fatalf("--root by name: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+
+	// --root by path works without any registry.
+	if _, _, code := s.run(t, "start", "--dry-run", "--root", s.kb); code != 0 {
+		t.Errorf("--root by path: exit %d", code)
+	}
+
+	// Registry unchanged by the dry-runs.
+	after, _ := os.ReadFile(rootsPathFor(s.home))
+	var regAfter struct {
+		Roots []struct{} `json:"roots"`
+	}
+	_ = json.Unmarshal(after, &regAfter)
+	if len(regAfter.Roots) != 1 {
+		t.Errorf("dry-run mutated the registry:\n%s", after)
+	}
+
+	// status shows the registered root.
+	stdout, _, _ = s.run(t, "status")
+	mustContain(t, "status stdout", stdout, "SEMIONT ROOTS", s.kb, "last used ")
+}
+
+func TestRootFlagErrors(t *testing.T) {
+	s := newScenario(t, "container")
+	for _, tc := range []struct{ arg, want string }{
+		{filepath.Join(t.TempDir(), "nope", "deep"), "--root points to non-existent directory"},
+		{t.TempDir(), "--root does not contain a .semiont/ directory"},
+		{"unregistered-name", "no roots are registered yet"},
+	} {
+		_, stderr, code := s.run(t, "start", "--dry-run", "--root", tc.arg)
+		if code != 1 {
+			t.Errorf("--root %s: want exit 1, got %d", tc.arg, code)
+		}
+		mustContain(t, "stderr for --root "+tc.arg, stderr, tc.want)
+	}
+	// Inapplicable service.
+	_, stderr, code := s.run(t, "start", "--service", "frontend", "--root", s.kb)
+	if code != 1 {
+		t.Errorf("--root with frontend: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "--root only applies to")
 }
 
 // --- stack state record ---
@@ -840,11 +994,12 @@ func TestStartServiceFrontendNoClone(t *testing.T) {
 		t.Fatalf("want exit 0 outside a clone, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 	mustContain(t, "stdout", stdout, "Restarting frontend", "🚀 frontend is up")
-	// A config consumer still requires the clone.
-	if _, stderr, code := s.run(t, "start", "--service", "worker"); code != 1 {
-		t.Errorf("worker outside a clone: want exit 1, got %d", code)
+	// The git-clone invariant is scoped to /kb-mount flows: backend still
+	// requires a clone; a sidecar needs only the .semiont/ tree.
+	if _, stderr, code := s.run(t, "start", "--service", "backend"); code != 1 {
+		t.Errorf("backend without git: want exit 1, got %d", code)
 	} else {
-		mustContain(t, "stderr", stderr, "must run inside a git clone")
+		mustContain(t, "stderr", stderr, "must be a git clone")
 	}
 }
 
@@ -865,9 +1020,10 @@ func TestStartServiceDryRunWorker(t *testing.T) {
 	if strings.Contains(stdout, "semiont-neo4j") {
 		t.Error("service plan leaked the wider stack")
 	}
-	// Dry run must execute nothing beyond KB-root resolution.
-	if got := s.argv(t); got != "git rev-parse --show-toplevel\n" {
-		t.Errorf("dry-run executed runtime commands:\n%s", got)
+	// Dry run must execute nothing: worker needs only .semiont/ discovery
+	// (pure Go), not the git-clone invariant (that's /kb-mount flows).
+	if got := s.argv(t); got != "" {
+		t.Errorf("dry-run executed commands:\n%s", got)
 	}
 }
 
@@ -934,7 +1090,7 @@ func TestStatusService(t *testing.T) {
 		t.Fatalf("healthy backend: want exit 0, got %d\nstdout:\n%s", code, stdout)
 	}
 	mustContain(t, "stdout", stdout, "backend", "running", "✓ http://localhost:4000/api/health")
-	for _, absent := range []string{"LOCAL HOST DIRECTORIES", "worker", "traces"} {
+	for _, absent := range []string{"LOCAL HOST DIRECTORIES", "SEMIONT ROOTS", "worker", "traces"} {
 		if strings.Contains(stdout, absent) {
 			t.Errorf("filtered status leaked %q:\n%s", absent, stdout)
 		}

--- a/apps/launcher/testdata/golden/start-default-boot.argv
+++ b/apps/launcher/testdata/golden/start-default-boot.argv
@@ -1,4 +1,4 @@
-git rev-parse --show-toplevel
+git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
 container stop semiont-jaeger
 container rm semiont-jaeger

--- a/apps/launcher/testdata/golden/start-docker-boot.argv
+++ b/apps/launcher/testdata/golden/start-docker-boot.argv
@@ -1,4 +1,4 @@
-git rev-parse --show-toplevel
+git -C <kb-root> rev-parse --show-toplevel
 docker run --rm busybox:1.38.0 nslookup host.docker.internal
 docker stop semiont-jaeger
 docker rm semiont-jaeger

--- a/apps/launcher/testdata/golden/start-host-ollama-boot.argv
+++ b/apps/launcher/testdata/golden/start-host-ollama-boot.argv
@@ -1,4 +1,4 @@
-git rev-parse --show-toplevel
+git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
 container stop semiont-jaeger
 container rm semiont-jaeger

--- a/apps/launcher/testdata/golden/start-local-version-boot.argv
+++ b/apps/launcher/testdata/golden/start-local-version-boot.argv
@@ -1,4 +1,4 @@
-git rev-parse --show-toplevel
+git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
 container stop semiont-jaeger
 container rm semiont-jaeger

--- a/apps/launcher/testdata/golden/start-missing-env.argv
+++ b/apps/launcher/testdata/golden/start-missing-env.argv
@@ -1,1 +1,1 @@
-git rev-parse --show-toplevel
+git -C <kb-root> rev-parse --show-toplevel

--- a/apps/launcher/testdata/golden/start-no-observe-boot.argv
+++ b/apps/launcher/testdata/golden/start-no-observe-boot.argv
@@ -1,4 +1,4 @@
-git rev-parse --show-toplevel
+git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
 container stop semiont-jaeger
 container rm semiont-jaeger

--- a/apps/launcher/testdata/golden/start-port-conflict.argv
+++ b/apps/launcher/testdata/golden/start-port-conflict.argv
@@ -1,4 +1,4 @@
-git rev-parse --show-toplevel
+git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
 container stop semiont-jaeger
 container rm semiont-jaeger

--- a/packages/jobs/src/worker-runtime.ts
+++ b/packages/jobs/src/worker-runtime.ts
@@ -89,7 +89,7 @@ export interface WorkerHealthPayload {
 
 /**
  * The `/health` body (WORKER-LIVENESS.md P1). Additive: existing
- * consumers (image HEALTHCHECK, compose `service_healthy`, start.sh)
+ * consumers (image HEALTHCHECK, compose `service_healthy`, `semiont start`)
  * keep reading `status`/`agents`; the per-agent vitals expose
  * claim-loop progress so a stalled worker is *visible*, not just alive.
  */

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -39,7 +39,7 @@ who built — `CONTAINER_RUNTIME` picks the *build* engine only:
 
 # 2. Run the full stack from your KB against the :local images
 cd /path/to/your-kb
-SEMIONT_VERSION=local ./.semiont/scripts/start.sh \
+SEMIONT_VERSION=local semiont start \
   --email admin@example.com --password password
 
 # 3. Iterate — edit code, rebuild only what changed:


### PR DESCRIPTION
Adopts the `SEMIONT_ROOT` concept from `apps/cli` into the launcher, and gives the launcher a persistent memory of roots. Follow-up to #1042.

## SEMIONT_ROOT, matching apps/cli semantics

KB-root discovery now mirrors `apps/cli`'s `config-loader.ts` (the `GIT_DIR` analogue):

- `SEMIONT_ROOT` set → use it, **strictly** validated (must exist and contain `.semiont/`; an invalid value is an error, never silently ignored in favor of discovery) — same error wording as apps/cli.
- Else walk up from cwd looking for `.semiont/` (pure Go — git is no longer part of discovery).
- Else a pointed failure: cd into a KB clone, set `SEMIONT_ROOT`, or pass `--root`.

The must-be-a-git-clone invariant (the backend versions the event log via git) is now **scoped to where `/kb` is actually mounted**: full start and `--service backend`. Sidecars need only the `.semiont/` tree; infra/frontend targets still need nothing. `semiont start --help` gained an Environment section documenting `SEMIONT_ROOT` / `SEMIONT_VERSION` / `SEMIONT_WORKER_SECRET`.

## roots.json: the launcher remembers roots

Every real (non-`--dry-run`) start upserts `{path, lastUsed, lastStarted}` into `roots.json` beside `stack.json` in the XDG state home. Entries **survive stops** — this is root memory, not stack state — `lastStarted` stamps full-stack starts only, and a vanished path is annotated `(missing)` when observed, never silently dropped (an unmounted volume may return). One active root today; this registry is the data substrate for the planned multi-root support.

## `semiont start --root <path|name>`

Explicit root selection, winning over `SEMIONT_ROOT` and cwd discovery:

- a **directory** → validated strictly like the env override;
- a **bare name** → basename match against the registry (unknown → error listing known roots; ambiguous → error listing matches; registered-but-missing-on-disk → says so);
- rejected for `--service` targets that use no root, consistent with the existing flag-scoping rules.

## `semiont status`: SEMIONT ROOTS section

A dedicated section (deliberately **not** a LOCAL HOST DIRECTORIES row, and deliberately plural-shaped): merges the here-resolved root (`SEMIONT_ROOT` / `discovered from cwd`), the running stack's root (from `stack.json`), and the full registry, with combined annotations per path (`last used YYYY-MM-DD`, `missing`). An invalid `SEMIONT_ROOT` is surfaced as a ⚠ line without failing the report.

## Testing

43 hermetic tests (up from 37): override honored from unrelated cwd, both strict-invalid error shapes, walk-up from a KB subdirectory, registry lifecycle (registered on real start, untouched by dry-run, no `lastStarted` for `--service`), every `--root` error shape, and the narrowed git invariant (backend requires a clone; worker runs from a bare `.semiont/` tree). Boot argv goldens regenerated — the diff is exactly `git rev-parse` → `git -C <kb-root> rev-parse` and nothing else.
