### PR TITLE
Launcher: derive launch plan from semiontconfig TOML (drivers, obligations, did:web identity)

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -44,6 +44,18 @@ semiont stop
   semiont` on macOS, `$XDG_STATE_HOME/semiont` (default
   `~/.local/state/semiont`) on Linux. `semiont status` lists the dir under
   LOCAL HOST DIRECTORIES. Logging is best-effort — it never blocks a command.
+- **The launcher derives its work from the KB's semiontconfig TOML** — the
+  same file the Semiont containers read (see
+  `docs/system/administration/CONFIGURATION.md`). Per dependency role
+  (graph, vectors, database, inference) the config decides the obligation:
+  an address on a launcher-injected `${*_HOST}` var → the launcher provides
+  a container (driver by `type`, credentials/ports from the config); any
+  other address → externally provided (verified, never launched, skipped by
+  stop, shown as "external" in status); `platform = "posix"` → host-process
+  reuse; section absent / unreferenced → nothing launched, "not configured"
+  in status. Moving `database.port` moves the publish/checks/gates with it;
+  inference runs only when the config references ollama. `--dry-run` renders
+  the derived plan.
 - KB-root discovery matches the npm CLI (`SEMIONT_ROOT`, analogous to
   `GIT_DIR`): the override is strict (invalid values error, never fall back),
   else the root is found by walking up from cwd for `.semiont/`. git is not

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -68,7 +68,7 @@ semiont stop
   belief — `status` still verifies every claim against the runtime.
 - `start`, `stop`, and `status` take `--service <name>` to act on one service
   (any of the ten, named by role: backend, worker, smelter, weaver, frontend,
-  db, graph, vectors, inference, traces — the concrete products PostgreSQL,
+  database, graph, vectors, inference, traces — the concrete products PostgreSQL,
   Neo4j, Qdrant, Ollama, and Jaeger appear as detail alongside). A `--service` start rejoins the running stack's
   worker secret automatically (recovered from a running container's env via
   the runtime's inspect), auto-enables OTel iff Jaeger is up, and stages a

--- a/apps/launcher/go.mod
+++ b/apps/launcher/go.mod
@@ -1,3 +1,5 @@
 module github.com/The-AI-Alliance/semiont/apps/launcher
 
 go 1.25
+
+require github.com/pelletier/go-toml/v2 v2.4.3

--- a/apps/launcher/go.sum
+++ b/apps/launcher/go.sum
@@ -1,0 +1,2 @@
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=

--- a/apps/launcher/internal/launcher/about.go
+++ b/apps/launcher/internal/launcher/about.go
@@ -51,7 +51,7 @@ func About(args []string) int {
 
 	fmt.Println()
 	fmt.Println(u.dim("This launcher runs the local Semiont stack — graph (Neo4j), vectors"))
-	fmt.Println(u.dim("(Qdrant), inference (Ollama), db (PostgreSQL), traces (Jaeger), and the"))
+	fmt.Println(u.dim("(Qdrant), inference (Ollama), database (PostgreSQL), traces (Jaeger), and the"))
 	fmt.Println(u.dim("Semiont backend, worker, smelter, weaver, and frontend — by driving your"))
 	fmt.Println(u.dim("container runtime directly. Try: semiont start --help"))
 	fmt.Println()

--- a/apps/launcher/internal/launcher/config.go
+++ b/apps/launcher/internal/launcher/config.go
@@ -1,0 +1,105 @@
+package launcher
+
+// config.go — the launcher's read-side of the semiontconfig TOML schema
+// (owned by packages/core; documented in docs/system/administration/
+// CONFIGURATION.md). Only the keys the launcher consumes are modeled;
+// everything else is deliberately ignored — the launcher is a consumer of
+// the schema, never a fork of it. See .plans/LAUNCHER-CONFIG-SYNC.md.
+
+import (
+	"fmt"
+	"os"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+type semiontConfig struct {
+	Defaults struct {
+		Environment string `toml:"environment"`
+	} `toml:"defaults"`
+	Environments map[string]envConfig `toml:"environments"`
+}
+
+type envConfig struct {
+	Backend   *backendCfg            `toml:"backend"`
+	Graph     *graphCfg              `toml:"graph"`
+	Vectors   *vectorsCfg            `toml:"vectors"`
+	Embedding *embeddingCfg          `toml:"embedding"`
+	Inference map[string]providerCfg `toml:"inference"`
+	Database  *databaseCfg           `toml:"database"`
+	Actors    map[string]bindingCfg  `toml:"actors"`
+	Workers   map[string]bindingCfg  `toml:"workers"`
+}
+
+type backendCfg struct {
+	Platform string `toml:"platform"`
+	Port     int    `toml:"port"`
+}
+
+type graphCfg struct {
+	Platform string `toml:"platform"`
+	Type     string `toml:"type"`
+	URI      string `toml:"uri"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+}
+
+type vectorsCfg struct {
+	Platform string `toml:"platform"`
+	Type     string `toml:"type"`
+	Host     string `toml:"host"`
+	Port     int    `toml:"port"`
+}
+
+type embeddingCfg struct {
+	Platform string `toml:"platform"`
+	Type     string `toml:"type"`
+	BaseURL  string `toml:"baseURL"`
+}
+
+type providerCfg struct {
+	Platform string `toml:"platform"`
+	Endpoint string `toml:"endpoint"`
+	BaseURL  string `toml:"baseURL"`
+	APIKey   string `toml:"apiKey"`
+}
+
+type databaseCfg struct {
+	Platform string `toml:"platform"`
+	Type     string `toml:"type"`
+	Host     string `toml:"host"`
+	Port     int    `toml:"port"`
+	Name     string `toml:"name"`
+	User     string `toml:"user"`
+	Password string `toml:"password"`
+}
+
+type bindingCfg struct {
+	Inference struct {
+		Type  string `toml:"type"`
+		Model string `toml:"model"`
+	} `toml:"inference"`
+}
+
+// loadConfig parses a semiontconfig TOML and selects the defaults.environment
+// block. ${VAR} references stay verbatim in the values — classification of
+// addresses happens at derivation, interpolation stays the containers' job.
+func loadConfig(path string) (*envConfig, string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("reading %s: %v", path, err)
+	}
+	var cfg semiontConfig
+	if err := toml.Unmarshal(b, &cfg); err != nil {
+		return nil, "", fmt.Errorf("%s is not valid TOML: %v", path, err)
+	}
+	envName := cfg.Defaults.Environment
+	if envName == "" {
+		return nil, "", fmt.Errorf("%s: [defaults] environment is not set", path)
+	}
+	env, ok := cfg.Environments[envName]
+	if !ok {
+		return nil, "", fmt.Errorf("%s: environment %q selected by [defaults] is not defined", path, envName)
+	}
+	return &env, envName, nil
+}

--- a/apps/launcher/internal/launcher/dryrun.go
+++ b/apps/launcher/internal/launcher/dryrun.go
@@ -24,7 +24,7 @@ func renderCmd(rt string, args ...string) string {
 // real `semiont start` would execute, with probe-derived values as
 // placeholders. This is the legibility replacement for reading the old bash —
 // and the extraction seam for the stack-parity gate.
-func renderStartPlan(rt, version string, opts startOptions, userEnv []string) {
+func renderStartPlan(rt, version string, opts startOptions, userEnv []string, plan *launchPlan) {
 	const addr = "<host-addr>"
 	const stage = "<config-stage>"
 	p := func(args ...string) { fmt.Println(renderCmd(rt, args...)) }
@@ -45,11 +45,9 @@ func renderStartPlan(rt, version string, opts startOptions, userEnv []string) {
 		p("rm", name)
 	}
 	c("remove staged config copies: /tmp/semiont-config.*")
-	ports := make([]string, 0, len(portChecks))
-	for _, pc := range portChecks {
-		if pc.observe && !opts.observe {
-			continue
-		}
+	checks := planPortChecks(plan, opts.observe)
+	ports := make([]string, 0, len(checks))
+	for _, pc := range checks {
 		ports = append(ports, fmt.Sprintf("%d", pc.port))
 	}
 	c("require free ports: %s", strings.Join(ports, " "))
@@ -69,39 +67,18 @@ func renderStartPlan(rt, version string, opts startOptions, userEnv []string) {
 		c("wait: http://localhost:16686 (30s)")
 		otel = otelArgs(addr)
 	}
-	p(graphArgs()...)
-	c("wait: http://localhost:7474 (30s)")
-	p(vectorsArgs()...)
-	c("wait: http://localhost:6333/readyz (15s)")
-
-	c("probe: host Ollama at http://localhost:11434/api/version")
-	c(`if present — probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:11434/api/version" — and use it`, rt)
-	c("else:")
-	p("stop", "semiont-ollama")
-	c("require free port: 11434")
-	volume := "<ollama-volume>"
-	switch opts.ollamaCache {
-	case "host":
-		if home, err := os.UserHomeDir(); err == nil {
-			volume = filepath.Join(home, ".ollama")
-		}
-	case "volume":
-		volume = "semiont-ollama-models"
-	}
-	p(inferenceArgs(volume)...)
-	c("wait: http://localhost:11434/api/version (30s)")
-
-	p(dbArgs()...)
-	c("wait: tcp localhost:5432 (20s)")
-	c("probe: %s run --rm busybox:1.38.0 nc -z -w 2 <host-addr> 5432", rt)
+	renderRolePlan(rt, "graph", plan, opts, c, p)
+	renderRolePlan(rt, "vectors", plan, opts, c, p)
+	renderRolePlan(rt, "inference", plan, opts, c, p)
+	renderRolePlan(rt, "database", plan, opts, c, p)
 
 	var admin []string
 	if opts.adminEmail != "" {
 		admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=<admin-password>"}
 	}
-	p(backendArgs("<kb-root>", stage, addr, "<worker-secret>", version, userEnv, otel, admin)...)
-	c("wait: http://localhost:4000/api/health (120s)")
-	c(`probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:4000/api/health" (up to 20 tries)`, rt)
+	p(backendArgs("<kb-root>", stage, addr, "<worker-secret>", version, plan.BackendPort, userEnv, otel, admin)...)
+	c("wait: http://localhost:%d/api/health (120s)", plan.BackendPort)
+	c(`probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:%d/api/health" (up to 20 tries)`, rt, plan.BackendPort)
 
 	for _, sc := range []struct {
 		svc, mem string
@@ -112,4 +89,48 @@ func renderStartPlan(rt, version string, opts startOptions, userEnv []string) {
 	}
 	p(frontendArgs(version)...)
 	c("wait: http://localhost:3000 (30s)")
+}
+
+// renderRolePlan renders one dependency role's slice of the plan, obligations
+// as comments (matching the plan style: conditionals stay legible).
+func renderRolePlan(rt, role string, plan *launchPlan, opts startOptions, c func(string, ...any), p func(...string)) {
+	rp := plan.Roles[role]
+	switch rp.Obligation {
+	case obligationAbsent:
+		c("%s: not referenced by the config — nothing to launch", role)
+	case obligationExternal:
+		c("%s: externally provided at %s:%d — verify reachability, launch nothing", role, rp.Address, rp.Port)
+	case obligationHostProcess:
+		if role != "inference" {
+			c("%s: host process at localhost:%d — verify reachability, launch nothing", role, rp.Port)
+			return
+		}
+		c("probe: host Ollama at http://localhost:%d/api/version", rp.Port)
+		c(`if present — probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:%d/api/version" — and use it`, rt, rp.Port)
+		c("else:")
+		p("stop", "semiont-ollama")
+		c("require free port: %d", rp.Port)
+		volume := "<ollama-volume>"
+		switch opts.ollamaCache {
+		case "host":
+			if home, err := os.UserHomeDir(); err == nil {
+				volume = filepath.Join(home, ".ollama")
+			}
+		case "volume":
+			volume = "semiont-ollama-models"
+		}
+		p(providedRunArgs("inference", rp, "-m", "24G", "-v", volume+":/root/.ollama")...)
+		c("wait: http://localhost:%d/api/version (30s)", rp.Port)
+	case obligationProvided:
+		p(providedRunArgs(role, rp)...)
+		switch role {
+		case "graph":
+			c("wait: http://localhost:%d (30s)", plan.AuxPorts("graph")[0].port)
+		case "vectors":
+			c("wait: http://localhost:%d/readyz (15s)", rp.Port)
+		case "database":
+			c("wait: tcp localhost:%d (20s)", rp.Port)
+			c("probe: %s run --rm busybox:1.38.0 nc -z -w 2 <host-addr> %d", rt, rp.Port)
+		}
+	}
 }

--- a/apps/launcher/internal/launcher/kbconfig.go
+++ b/apps/launcher/internal/launcher/kbconfig.go
@@ -1,0 +1,60 @@
+package launcher
+
+// kbconfig.go — the read-side of `.semiont/config`, the KB's committed
+// identity card: [project] name/version, [git] sync, and [site] — whose
+// `domain` is the permanent did:web identity everything the KB mints is
+// stamped with (a committed literal naming the repo, never a machine
+// address; see the DID/site.domain history before treating it as one).
+// The launcher consumes identity for DISPLAY and the roots registry only —
+// best-effort throughout: a KB without this file (or with a partial one)
+// must never break a command.
+
+import (
+	"os"
+	"path/filepath"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+type kbIdentity struct {
+	Name     string // [project] name
+	Version  string // [project] version
+	SiteName string // [site] siteName
+	Domain   string // [site] domain — did:web colon-path form
+}
+
+// didWeb renders the full did:web identifier, "" when no domain is declared.
+func (k *kbIdentity) didWeb() string {
+	if k == nil || k.Domain == "" {
+		return ""
+	}
+	return "did:web:" + k.Domain
+}
+
+// loadKBIdentity reads <root>/.semiont/config. nil when absent or unreadable
+// — identity is display metadata, not launch instructions.
+func loadKBIdentity(root string) *kbIdentity {
+	b, err := os.ReadFile(filepath.Join(root, ".semiont", "config"))
+	if err != nil {
+		return nil
+	}
+	var raw struct {
+		Project struct {
+			Name    string `toml:"name"`
+			Version string `toml:"version"`
+		} `toml:"project"`
+		Site struct {
+			Domain   string `toml:"domain"`
+			SiteName string `toml:"siteName"`
+		} `toml:"site"`
+	}
+	if toml.Unmarshal(b, &raw) != nil {
+		return nil
+	}
+	return &kbIdentity{
+		Name:     raw.Project.Name,
+		Version:  raw.Project.Version,
+		SiteName: raw.Site.SiteName,
+		Domain:   raw.Site.Domain,
+	}
+}

--- a/apps/launcher/internal/launcher/plan.go
+++ b/apps/launcher/internal/launcher/plan.go
@@ -1,0 +1,269 @@
+package launcher
+
+// plan.go — derivePlan: the pure function from a parsed semiontconfig
+// environment to the launcher's work (LAUNCHER-CONFIG-SYNC.md's derivation
+// model). Per dependency role the config decides the OBLIGATION and owns
+// address/port/credentials; the driver catalog owns what the config doesn't
+// declare (image, aux ports). Validation is strict for keys the launcher
+// consumes (P0 q4): missing required keys fail naming file, section, and
+// key; keys with documented defaults (vectors.platform, database.type,
+// ports) don't trip it.
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type obligation int
+
+const (
+	obligationAbsent      obligation = iota // no section / not referenced: not needed
+	obligationProvided                      // launcher launches a container (driver by type)
+	obligationExternal                      // provided elsewhere: verify, never launch
+	obligationHostProcess                   // host process preferred (container fallback per driver)
+)
+
+func (o obligation) String() string {
+	return [...]string{"absent", "provided", "external", "host-process"}[o]
+}
+
+type rolePlan struct {
+	Role       string
+	Obligation obligation
+	Driver     string   // config `type` (catalog key)
+	Image      string   // catalog, for provided/host-fallback launches
+	Address    string   // external host, for reachability probes
+	Port       int      // primary port (config, else driver default)
+	Env        []string // container env derived from config (creds)
+}
+
+type launchPlan struct {
+	Roles       map[string]rolePlan
+	BackendPort int
+}
+
+// driverSpec: what the config does NOT declare about a driver — the
+// launcher-side analogue of the containers' driver selection.
+type driverSpec struct {
+	image       string
+	defaultPort int
+	auxPorts    []portNeed
+}
+
+var driverCatalog = map[string]map[string]driverSpec{
+	"graph": {
+		"neo4j": {image: "neo4j:5.26.28-community", defaultPort: 7687, auxPorts: []portNeed{{7474, "Neo4j HTTP"}}},
+	},
+	"vectors": {
+		"qdrant": {image: "qdrant/qdrant:v1.18.3", defaultPort: 6333},
+	},
+	"database": {
+		"postgres": {image: "postgres:15.18-alpine", defaultPort: 5432},
+	},
+	"inference": {
+		"ollama": {image: "ollama/ollama", defaultPort: 11434},
+	},
+}
+
+func knownDrivers(role string) string {
+	names := make([]string, 0, len(driverCatalog[role]))
+	for n := range driverCatalog[role] {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// AuxPorts: catalog-owned secondary ports for a role's selected driver
+// (Neo4j's 7474 browser — the config only declares bolt).
+func (p *launchPlan) AuxPorts(role string) []portNeed {
+	return driverCatalog[role][p.Roles[role].Driver].auxPorts
+}
+
+// parseHostPort splits "scheme://host:port", "host:port", or bare "host" —
+// the host may be a verbatim ${VAR} reference (never interpolated here).
+func parseHostPort(s string) (host string, port int) {
+	if _, rest, ok := strings.Cut(s, "://"); ok {
+		s = rest
+	}
+	if i := strings.LastIndex(s, ":"); i >= 0 {
+		if p, err := strconv.Atoi(s[i+1:]); err == nil {
+			return s[:i], p
+		}
+	}
+	return s, 0
+}
+
+// derivePlan maps the selected environment to per-role launch obligations.
+func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
+	plan := &launchPlan{Roles: map[string]rolePlan{}, BackendPort: 4000}
+	if env.Backend != nil && env.Backend.Port != 0 {
+		plan.BackendPort = env.Backend.Port
+	}
+	secErr := func(section, format string, a ...any) error {
+		return fmt.Errorf("%s: [environments.%s.%s] %s", path, envName, section, fmt.Sprintf(format, a...))
+	}
+	// classify: an address that is exactly the launcher-injected var means
+	// "the launcher provides this"; anything else is externally provided.
+	classify := func(host, injectedVar string) obligation {
+		if host == "${"+injectedVar+"}" {
+			return obligationProvided
+		}
+		return obligationExternal
+	}
+
+	// graph
+	if g := env.Graph; g == nil {
+		plan.Roles["graph"] = rolePlan{Role: "graph", Obligation: obligationAbsent}
+	} else {
+		if g.Type == "" {
+			return nil, secErr("graph", "missing required key %q", "type")
+		}
+		spec, ok := driverCatalog["graph"][g.Type]
+		if !ok {
+			return nil, secErr("graph", "unknown type %q (known drivers: %s)", g.Type, knownDrivers("graph"))
+		}
+		if g.URI == "" {
+			return nil, secErr("graph", "missing required key %q", "uri")
+		}
+		host, port := parseHostPort(g.URI)
+		if port == 0 {
+			port = spec.defaultPort
+		}
+		rp := rolePlan{Role: "graph", Driver: g.Type, Port: port}
+		switch {
+		case g.Platform == "posix":
+			rp.Obligation = obligationHostProcess
+			rp.Image = spec.image
+		case classify(host, "NEO4J_HOST") == obligationProvided:
+			if g.Username == "" || g.Password == "" {
+				return nil, secErr("graph", "missing required key %q (needed to provision the container)", "username/password")
+			}
+			rp.Obligation = obligationProvided
+			rp.Image = spec.image
+			rp.Env = []string{"NEO4J_AUTH=" + g.Username + "/" + g.Password, "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes"}
+		default:
+			rp.Obligation = obligationExternal
+			rp.Address = host
+		}
+		plan.Roles["graph"] = rp
+	}
+
+	// vectors — platform defaults to "external" (the template omits it);
+	// type is required.
+	if v := env.Vectors; v == nil {
+		plan.Roles["vectors"] = rolePlan{Role: "vectors", Obligation: obligationAbsent}
+	} else {
+		if v.Type == "" {
+			return nil, secErr("vectors", "missing required key %q", "type")
+		}
+		spec, ok := driverCatalog["vectors"][v.Type]
+		if !ok {
+			return nil, secErr("vectors", "unknown type %q (known drivers: %s)", v.Type, knownDrivers("vectors"))
+		}
+		if v.Host == "" {
+			return nil, secErr("vectors", "missing required key %q", "host")
+		}
+		port := v.Port
+		if port == 0 {
+			port = spec.defaultPort
+		}
+		rp := rolePlan{Role: "vectors", Driver: v.Type, Port: port}
+		if classify(v.Host, "QDRANT_HOST") == obligationProvided {
+			rp.Obligation = obligationProvided
+			rp.Image = spec.image
+		} else {
+			rp.Obligation = obligationExternal
+			rp.Address = v.Host
+		}
+		plan.Roles["vectors"] = rp
+	}
+
+	// database — type defaults to "postgres" (the template omits it).
+	if d := env.Database; d == nil {
+		plan.Roles["database"] = rolePlan{Role: "database", Obligation: obligationAbsent}
+	} else {
+		typ := d.Type
+		if typ == "" {
+			typ = "postgres"
+		}
+		spec, ok := driverCatalog["database"][typ]
+		if !ok {
+			return nil, secErr("database", "unknown type %q (known drivers: %s)", typ, knownDrivers("database"))
+		}
+		if d.Host == "" {
+			return nil, secErr("database", "missing required key %q", "host")
+		}
+		port := d.Port
+		if port == 0 {
+			port = spec.defaultPort
+		}
+		rp := rolePlan{Role: "database", Driver: typ, Port: port}
+		if classify(d.Host, "POSTGRES_HOST") == obligationProvided {
+			if d.Password == "" {
+				return nil, secErr("database", "missing required key %q (needed to provision the container)", "password")
+			}
+			if d.Name == "" {
+				return nil, secErr("database", "missing required key %q (needed to provision the container)", "name")
+			}
+			rp.Obligation = obligationProvided
+			rp.Image = spec.image
+			rp.Env = []string{"POSTGRES_PASSWORD=" + d.Password, "POSTGRES_DB=" + d.Name}
+			// POSTGRES_USER only when it departs from the image default —
+			// keeps derivation byte-identical with today's argv.
+			if d.User != "" && d.User != "postgres" {
+				rp.Env = append(rp.Env, "POSTGRES_USER="+d.User)
+			}
+		} else {
+			rp.Obligation = obligationExternal
+			rp.Address = d.Host
+		}
+		plan.Roles["database"] = rp
+	}
+
+	// inference — needed iff the config references ollama (embedding, or any
+	// actor/worker binding); the anthropic provider is remote SaaS, nothing
+	// for the launcher to run. Address ${OLLAMA_HOST} means the host-process-
+	// preferred dance (probe host Ollama, container fallback) — the config's
+	// inference.ollama.platform = "posix" made explicit.
+	ollamaUsed := env.Embedding != nil && env.Embedding.Type == "ollama"
+	for _, bindings := range []map[string]bindingCfg{env.Actors, env.Workers} {
+		for _, b := range bindings {
+			if b.Inference.Type == "ollama" {
+				ollamaUsed = true
+			}
+		}
+	}
+	if !ollamaUsed {
+		plan.Roles["inference"] = rolePlan{Role: "inference", Obligation: obligationAbsent}
+	} else {
+		spec := driverCatalog["inference"]["ollama"]
+		baseURL := ""
+		if env.Embedding != nil && env.Embedding.Type == "ollama" {
+			baseURL = env.Embedding.BaseURL
+		}
+		if p, ok := env.Inference["ollama"]; ok && baseURL == "" {
+			baseURL = p.BaseURL
+		}
+		if baseURL == "" {
+			return nil, secErr("embedding", "missing required key %q (ollama is referenced but has no baseURL)", "baseURL")
+		}
+		host, port := parseHostPort(baseURL)
+		if port == 0 {
+			port = spec.defaultPort
+		}
+		rp := rolePlan{Role: "inference", Driver: "ollama", Port: port, Image: spec.image}
+		if host == "${OLLAMA_HOST}" {
+			rp.Obligation = obligationHostProcess
+		} else {
+			rp.Obligation = obligationExternal
+			rp.Address = host
+			rp.Image = ""
+		}
+		plan.Roles["inference"] = rp
+	}
+
+	return plan, nil
+}

--- a/apps/launcher/internal/launcher/plan.go
+++ b/apps/launcher/internal/launcher/plan.go
@@ -45,26 +45,88 @@ type launchPlan struct {
 }
 
 // driverSpec: what the config does NOT declare about a driver — the
-// launcher-side analogue of the containers' driver selection.
+// launcher-side analogue of the containers' driver selection. defaultPort is
+// both the config default AND the container-side listen port: a config that
+// moves a port moves the HOST side only (publish host:containerDefault).
 type driverSpec struct {
 	image       string
+	display     string // product name for banners/messages
 	defaultPort int
+	portLabel   string // primary port's name in conflict errors
 	auxPorts    []portNeed
 }
 
 var driverCatalog = map[string]map[string]driverSpec{
 	"graph": {
-		"neo4j": {image: "neo4j:5.26.28-community", defaultPort: 7687, auxPorts: []portNeed{{7474, "Neo4j HTTP"}}},
+		"neo4j": {image: "neo4j:5.26.28-community", display: "Neo4j", defaultPort: 7687, portLabel: "Neo4j Bolt", auxPorts: []portNeed{{7474, "Neo4j HTTP"}}},
 	},
 	"vectors": {
-		"qdrant": {image: "qdrant/qdrant:v1.18.3", defaultPort: 6333},
+		"qdrant": {image: "qdrant/qdrant:v1.18.3", display: "Qdrant", defaultPort: 6333, portLabel: "Qdrant"},
 	},
 	"database": {
-		"postgres": {image: "postgres:15.18-alpine", defaultPort: 5432},
+		"postgres": {image: "postgres:15.18-alpine", display: "PostgreSQL", defaultPort: 5432, portLabel: "PostgreSQL"},
 	},
 	"inference": {
-		"ollama": {image: "ollama/ollama", defaultPort: 11434},
+		"ollama": {image: "ollama/ollama", display: "Ollama", defaultPort: 11434, portLabel: "Ollama"},
 	},
+}
+
+// driverDisplay: the product name behind a role's selected driver.
+func driverDisplay(role, driver string) string {
+	if s, ok := driverCatalog[role][driver]; ok {
+		return s.display
+	}
+	return driver
+}
+
+// providedRunArgs builds the `run -d` argv for a launcher-provided role from
+// its plan: aux ports first (byte-parity with the historical builders), then
+// the primary publish (host side from config, container side the driver
+// default), driver extras (inference's memory/volume), config-derived env,
+// image.
+func providedRunArgs(role string, rp rolePlan, extra ...string) []string {
+	spec := driverCatalog[role][rp.Driver]
+	a := []string{"run", "-d", "--rm", "--name", roles[role].container}
+	for _, ap := range spec.auxPorts {
+		a = append(a, "-p", fmt.Sprintf("%d:%d", ap.port, ap.port))
+	}
+	a = append(a, "-p", fmt.Sprintf("%d:%d", rp.Port, spec.defaultPort))
+	a = append(a, extra...)
+	for _, e := range rp.Env {
+		a = append(a, "-e", e)
+	}
+	return append(a, rp.Image)
+}
+
+// planPortChecks: the must-be-free ports, derived from the plan — only roles
+// the launcher actually provides claim ports. Order preserves the historical
+// check order (graph aux, graph, vectors, database, backend, sidecars,
+// frontend, traces-when-observing).
+func planPortChecks(plan *launchPlan, observe bool) []portNeed {
+	var checks []portNeed
+	addRole := func(role string) {
+		rp := plan.Roles[role]
+		if rp.Obligation != obligationProvided {
+			return
+		}
+		spec := driverCatalog[role][rp.Driver]
+		checks = append(checks, spec.auxPorts...)
+		checks = append(checks, portNeed{rp.Port, spec.portLabel})
+	}
+	addRole("graph")
+	addRole("vectors")
+	addRole("database")
+	checks = append(checks,
+		portNeed{plan.BackendPort, "Backend"},
+		portNeed{9090, "Worker"},
+		portNeed{9091, "Smelter"},
+		portNeed{9092, "Weaver"},
+		portNeed{3000, "Frontend"},
+	)
+	if observe {
+		checks = append(checks, portNeed{16686, "Jaeger UI"}, portNeed{4318, "Jaeger OTLP"})
+	}
+	return checks
 }
 
 func knownDrivers(role string) string {

--- a/apps/launcher/internal/launcher/plan.go
+++ b/apps/launcher/internal/launcher/plan.go
@@ -69,6 +69,11 @@ var driverCatalog = map[string]map[string]driverSpec{
 	"inference": {
 		"ollama": {image: "ollama/ollama", display: "Ollama", defaultPort: 11434, portLabel: "Ollama"},
 	},
+	// traces is launcher-owned (no config section yet) — catalog entry
+	// carries the display name for status's TECH column.
+	"traces": {
+		"jaeger": {image: "jaegertracing/all-in-one:1.76.0", display: "Jaeger", defaultPort: 16686, portLabel: "Jaeger UI"},
+	},
 }
 
 // driverDisplay: the product name behind a role's selected driver.

--- a/apps/launcher/internal/launcher/plan_test.go
+++ b/apps/launcher/internal/launcher/plan_test.go
@@ -1,0 +1,259 @@
+package launcher
+
+// The executable spec for LAUNCHER-CONFIG-SYNC.md P1: derivePlan(config) must
+// reproduce today's hardcoded behavior for the two real template configs
+// (field-for-field — the parity constraint), and derive the documented
+// alternatives for variant configs. Fixtures for the real configs are the
+// same files the black-box suite uses (testdata/kb — copies of the template
+// KB's own TOMLs); variants are inline.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func loadFixtureEnv(t *testing.T, name string) (*envConfig, string) {
+	t.Helper()
+	env, envName, err := loadConfig(filepath.Join("..", "..", "testdata", "kb", ".semiont", "semiontconfig", name))
+	if err != nil {
+		t.Fatalf("loading fixture %s: %v", name, err)
+	}
+	return env, envName
+}
+
+func writeVariant(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "variant.toml")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// variantConfig is a minimal but complete config for variant tests; sections
+// are replaced via the replace map (empty string = drop the section).
+func variantConfig(t *testing.T, replace map[string]string) string {
+	t.Helper()
+	sections := map[string]string{
+		"graph": `[environments.local.graph]
+platform = "external"
+type = "neo4j"
+uri = "bolt://${NEO4J_HOST}:7687"
+username = "neo4j"
+password = "localpass"
+`,
+		"vectors": `[environments.local.vectors]
+type = "qdrant"
+host = "${QDRANT_HOST}"
+port = 6333
+`,
+		"database": `[environments.local.database]
+platform = "external"
+host = "${POSTGRES_HOST}"
+port = 5432
+name = "semiont"
+user = "postgres"
+password = "localpass"
+`,
+		"embedding": `[environments.local.embedding]
+platform = "external"
+type = "ollama"
+model = "nomic-embed-text"
+baseURL = "http://${OLLAMA_HOST}:11434"
+`,
+		"inference": `[environments.local.inference.anthropic]
+platform = "external"
+endpoint = "https://api.anthropic.com"
+apiKey = "${ANTHROPIC_API_KEY}"
+
+[environments.local.workers.default.inference]
+type = "anthropic"
+model = "claude-sonnet-4-5-20250929"
+`,
+	}
+	for k, v := range replace {
+		if v == "" {
+			delete(sections, k)
+			continue
+		}
+		sections[k] = v
+	}
+	var b strings.Builder
+	b.WriteString("[defaults]\nenvironment = \"local\"\n\n[environments.local.backend]\nplatform = \"posix\"\nport = 4000\n\n")
+	for _, k := range []string{"graph", "vectors", "database", "embedding", "inference"} {
+		if s, ok := sections[k]; ok {
+			b.WriteString(s + "\n")
+		}
+	}
+	return writeVariant(t, b.String())
+}
+
+func mustDerive(t *testing.T, path string) *launchPlan {
+	t.Helper()
+	env, envName, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	plan, err := derivePlan(env, envName, path)
+	if err != nil {
+		t.Fatalf("derivePlan: %v", err)
+	}
+	return plan
+}
+
+func checkRole(t *testing.T, plan *launchPlan, role string, want rolePlan) {
+	t.Helper()
+	got, ok := plan.Roles[role]
+	if !ok {
+		t.Fatalf("role %s missing from plan", role)
+	}
+	if got.Obligation != want.Obligation {
+		t.Errorf("%s obligation: got %v want %v", role, got.Obligation, want.Obligation)
+	}
+	if got.Driver != want.Driver {
+		t.Errorf("%s driver: got %q want %q", role, got.Driver, want.Driver)
+	}
+	if got.Image != want.Image {
+		t.Errorf("%s image: got %q want %q", role, got.Image, want.Image)
+	}
+	if got.Port != want.Port {
+		t.Errorf("%s port: got %d want %d", role, got.Port, want.Port)
+	}
+	if strings.Join(got.Env, " ") != strings.Join(want.Env, " ") {
+		t.Errorf("%s env: got %v want %v", role, got.Env, want.Env)
+	}
+	if got.Address != want.Address {
+		t.Errorf("%s address: got %q want %q", role, got.Address, want.Address)
+	}
+}
+
+// The parity spec: both real template configs derive exactly today's
+// hardcoded behavior.
+func TestDerivePlanTemplateConfigs(t *testing.T) {
+	for _, name := range []string{"ollama-gemma.toml", "anthropic.toml"} {
+		t.Run(name, func(t *testing.T) {
+			env, envName, err := loadConfig(filepath.Join("..", "..", "testdata", "kb", ".semiont", "semiontconfig", name))
+			if err != nil {
+				t.Fatalf("loadConfig: %v", err)
+			}
+			plan, err := derivePlan(env, envName, name)
+			if err != nil {
+				t.Fatalf("derivePlan: %v", err)
+			}
+			checkRole(t, plan, "graph", rolePlan{
+				Obligation: obligationProvided, Driver: "neo4j",
+				Image: "neo4j:5.26.28-community", Port: 7687,
+				Env: []string{"NEO4J_AUTH=neo4j/localpass", "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes"},
+			})
+			checkRole(t, plan, "vectors", rolePlan{
+				Obligation: obligationProvided, Driver: "qdrant",
+				Image: "qdrant/qdrant:v1.18.3", Port: 6333,
+			})
+			checkRole(t, plan, "database", rolePlan{
+				Obligation: obligationProvided, Driver: "postgres",
+				Image: "postgres:15.18-alpine", Port: 5432,
+				Env: []string{"POSTGRES_PASSWORD=localpass", "POSTGRES_DB=semiont"},
+			})
+			// Both templates use ollama embedding, so inference is needed in
+			// both — host-process preferred with container fallback (the
+			// config's platform="posix" made explicit).
+			checkRole(t, plan, "inference", rolePlan{
+				Obligation: obligationHostProcess, Driver: "ollama",
+				Image: "ollama/ollama", Port: 11434,
+			})
+			if plan.BackendPort != 4000 {
+				t.Errorf("backend port: got %d want 4000", plan.BackendPort)
+			}
+			if len(plan.AuxPorts("graph")) != 1 || plan.AuxPorts("graph")[0].port != 7474 {
+				t.Errorf("graph aux ports: got %v", plan.AuxPorts("graph"))
+			}
+		})
+	}
+}
+
+func TestDerivePlanExternalGraph(t *testing.T) {
+	p := variantConfig(t, map[string]string{"graph": `[environments.local.graph]
+platform = "external"
+type = "neo4j"
+uri = "bolt://graph.example.com:9999"
+username = "neo4j"
+password = "s3cret"
+`})
+	plan := mustDerive(t, p)
+	checkRole(t, plan, "graph", rolePlan{
+		Obligation: obligationExternal, Driver: "neo4j",
+		Address: "graph.example.com", Port: 9999,
+	})
+}
+
+func TestDerivePlanMovedPort(t *testing.T) {
+	p := variantConfig(t, map[string]string{"database": `[environments.local.database]
+host = "${POSTGRES_HOST}"
+port = 5433
+name = "semiont"
+user = "postgres"
+password = "localpass"
+`})
+	plan := mustDerive(t, p)
+	if got := plan.Roles["database"]; got.Port != 5433 || got.Obligation != obligationProvided {
+		t.Errorf("moved port: got %+v", got)
+	}
+}
+
+func TestDerivePlanAbsentVectors(t *testing.T) {
+	plan := mustDerive(t, variantConfig(t, map[string]string{"vectors": ""}))
+	if got := plan.Roles["vectors"]; got.Obligation != obligationAbsent {
+		t.Errorf("absent vectors: got %+v", got)
+	}
+}
+
+func TestDerivePlanNoOllamaAnywhere(t *testing.T) {
+	// No embedding section and no ollama-typed binding: inference is absent —
+	// the launcher launches Ollama only when the config references it.
+	plan := mustDerive(t, variantConfig(t, map[string]string{"embedding": ""}))
+	if got := plan.Roles["inference"]; got.Obligation != obligationAbsent {
+		t.Errorf("no-ollama config: got %+v", got)
+	}
+}
+
+func TestDerivePlanUnknownType(t *testing.T) {
+	p := variantConfig(t, map[string]string{"graph": `[environments.local.graph]
+type = "janusgraph"
+uri = "bolt://${NEO4J_HOST}:7687"
+`})
+	env, envName, err := loadConfig(p)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	_, err = derivePlan(env, envName, p)
+	if err == nil || !strings.Contains(err.Error(), "janusgraph") || !strings.Contains(err.Error(), "neo4j") {
+		t.Errorf("unknown type must name the offender and the known drivers, got: %v", err)
+	}
+}
+
+func TestDerivePlanMissingRequiredKey(t *testing.T) {
+	p := variantConfig(t, map[string]string{"graph": `[environments.local.graph]
+type = "neo4j"
+username = "neo4j"
+password = "localpass"
+`})
+	env, envName, err := loadConfig(p)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	_, err = derivePlan(env, envName, p)
+	if err == nil || !strings.Contains(err.Error(), "graph") || !strings.Contains(err.Error(), "uri") {
+		t.Errorf("missing key must name section and key, got: %v", err)
+	}
+}
+
+func TestLoadConfigErrors(t *testing.T) {
+	if _, _, err := loadConfig(writeVariant(t, "not [ valid toml")); err == nil {
+		t.Error("invalid TOML must error")
+	}
+	if _, _, err := loadConfig(writeVariant(t, "[defaults]\nenvironment = \"prod\"\n")); err == nil || !strings.Contains(err.Error(), "prod") {
+		t.Errorf("missing environment block must name it, got: %v", err)
+	}
+}

--- a/apps/launcher/internal/launcher/root.go
+++ b/apps/launcher/internal/launcher/root.go
@@ -62,6 +62,8 @@ func resolveKBRoot() (path, source string, err error) {
 
 type rootEntry struct {
 	Path        string    `json:"path"`
+	Did         string    `json:"did,omitempty"`      // did:web identity from .semiont/config [site] domain
+	SiteName    string    `json:"siteName,omitempty"` // human label — kept here so even a missing root stays identifiable
 	LastUsed    time.Time `json:"lastUsed"`
 	LastStarted time.Time `json:"lastStarted,omitzero"` // last full-stack start
 }
@@ -108,6 +110,8 @@ func registerRootUse(path string, fullStart bool) {
 	}
 	reg := loadRoots()
 	now := time.Now().UTC()
+	// Identity refreshes on every use — the KB's .semiont/config can change.
+	ident := loadKBIdentity(path)
 	found := false
 	for i := range reg.Roots {
 		if reg.Roots[i].Path == path {
@@ -115,11 +119,18 @@ func registerRootUse(path string, fullStart bool) {
 			if fullStart {
 				reg.Roots[i].LastStarted = now
 			}
+			if ident != nil {
+				reg.Roots[i].Did = ident.didWeb()
+				reg.Roots[i].SiteName = ident.SiteName
+			}
 			found = true
 		}
 	}
 	if !found {
-		e := rootEntry{Path: path, LastUsed: now}
+		e := rootEntry{Path: path, LastUsed: now, Did: ident.didWeb()}
+		if ident != nil {
+			e.SiteName = ident.SiteName
+		}
 		if fullStart {
 			e.LastStarted = now
 		}

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -154,10 +154,26 @@ func serviceSecret(u *ui, rt string) (string, bool) {
 // runStartService is `semiont start --service <name>`: one service's slice of
 // the full-start flow — its own stop+rm, port checks, pull, fresh private
 // config copy, run, and health gate. The rest of the stack is untouched.
-func runStartService(u *ui, rt, version, root, configFile string, opts startOptions, userEnv []string) int {
+func runStartService(u *ui, rt, version, root, configFile string, opts startOptions, userEnv []string, plan *launchPlan) int {
 	t0 := time.Now()
 	svc := opts.service
 	cname := roles[svc].container
+
+	// The config decides whether this role is the launcher's to (re)start.
+	// A role someone else provides is a no-op, not an error (P0 q5): warn,
+	// exit 0.
+	if plan != nil {
+		if rp, ok := plan.Roles[svc]; ok {
+			switch rp.Obligation {
+			case obligationExternal:
+				u.warn("%s is externally provided per %s (%s:%d); nothing to launch.", svc, configFile, rp.Address, rp.Port)
+				return 0
+			case obligationAbsent:
+				u.warn("%s is not referenced by %s; nothing to launch.", svc, configFile)
+				return 0
+			}
+		}
+	}
 
 	u.banner("Restarting " + roleTitle(svc))
 
@@ -249,41 +265,47 @@ func runStartService(u *ui, rt, version, root, configFile string, opts startOpti
 		img = args[len(args)-1]
 		id, d, ok = runGated(u, rt, args, "traces (Jaeger)", "traces (Jaeger UI)", "http://localhost:16686", 30)
 	case "graph":
-		args := graphArgs()
-		img = args[len(args)-1]
-		id, d, ok = runGated(u, rt, args, "graph (Neo4j)", "graph (Neo4j)", "http://localhost:7474", 30)
+		rp := plan.Roles[svc]
+		args := providedRunArgs("graph", rp)
+		img = rp.Image
+		id, d, ok = runGated(u, rt, args, "graph ("+driverDisplay("graph", rp.Driver)+")", "graph ("+driverDisplay("graph", rp.Driver)+")",
+			fmt.Sprintf("http://localhost:%d", plan.AuxPorts("graph")[0].port), 30)
 	case "vectors":
-		args := vectorsArgs()
-		img = args[len(args)-1]
-		id, d, ok = runGated(u, rt, args, "vectors (Qdrant)", "vectors (Qdrant)", "http://localhost:6333/readyz", 15)
+		rp := plan.Roles[svc]
+		args := providedRunArgs("vectors", rp)
+		img = rp.Image
+		id, d, ok = runGated(u, rt, args, "vectors ("+driverDisplay("vectors", rp.Driver)+")", "vectors ("+driverDisplay("vectors", rp.Driver)+")",
+			fmt.Sprintf("http://localhost:%d/readyz", rp.Port), 15)
 	case "inference":
+		rp := plan.Roles[svc]
 		var code int
-		id, hostReuse, code = startInference(u, rt, addr, opts)
+		id, hostReuse, code = startInference(u, rt, addr, opts, rp)
 		if code != 0 {
 			return code
 		}
 		if !hostReuse {
-			img = "ollama/ollama"
+			img = rp.Image
 		}
 		ok = true
 	case "database":
-		args := dbArgs()
-		img = args[len(args)-1]
+		rp := plan.Roles[svc]
+		args := providedRunArgs("database", rp)
+		img = rp.Image
 		u.echoCmd(rt, args...)
 		var err error
 		id, err = runDetached(rt, args...)
 		if err != nil {
-			u.fail("database (PostgreSQL) failed to start.")
+			u.fail("database (%s) failed to start.", driverDisplay("database", rp.Driver))
 			return 1
 		}
-		d, ok = waitForPG(u, rt, addr, 5432, 20)
+		d, ok = waitForPG(u, rt, addr, rp.Port, 20)
 	case "backend":
 		var admin []string
 		if opts.adminEmail != "" && opts.adminPassword != "" {
 			admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=" + opts.adminPassword}
 		}
 		var code int
-		id, code = runBackend(u, rt, root, stage, addr, secret, version, userEnv, otel, admin)
+		id, code = runBackend(u, rt, root, stage, addr, secret, version, plan.BackendPort, userEnv, otel, admin)
 		if code != 0 {
 			return code
 		}
@@ -328,7 +350,7 @@ func runStartService(u *ui, rt, version, root, configFile string, opts startOpti
 
 // renderServicePlan is --dry-run for --service: the one service's slice of
 // the plan, conditionals as comments (matching renderStartPlan's style).
-func renderServicePlan(rt, version string, opts startOptions, userEnv []string) {
+func renderServicePlan(rt, version string, opts startOptions, userEnv []string, plan *launchPlan) {
 	const addr = "<host-addr>"
 	const stage = "<config-stage>"
 	svc := opts.service
@@ -337,14 +359,28 @@ func renderServicePlan(rt, version string, opts startOptions, userEnv []string) 
 
 	c("semiont start --service %s --dry-run — the exact runtime commands a real", svc)
 	c("run would execute, in order. Values known only at runtime appear as <placeholders>.")
+	if plan != nil {
+		if rp, ok := plan.Roles[svc]; ok && (rp.Obligation == obligationExternal || rp.Obligation == obligationAbsent) {
+			renderRolePlan(rt, svc, plan, opts, c, p)
+			return
+		}
+	}
 	if svc != "inference" {
 		p("stop", roles[svc].container)
 		p("rm", roles[svc].container)
-		ports := make([]string, 0, 2)
-		for _, pc := range roles[svc].ports {
-			ports = append(ports, fmt.Sprintf("%d", pc.port))
-		}
-		if len(ports) > 0 {
+		if rp, ok := plan.Roles[svc]; ok && rp.Obligation == obligationProvided {
+			spec := driverCatalog[svc][rp.Driver]
+			ports := make([]string, 0, 2)
+			for _, ap := range spec.auxPorts {
+				ports = append(ports, fmt.Sprintf("%d", ap.port))
+			}
+			ports = append(ports, fmt.Sprintf("%d", rp.Port))
+			c("require free ports: %s", strings.Join(ports, " "))
+		} else if len(roles[svc].ports) > 0 {
+			ports := make([]string, 0, 2)
+			for _, pc := range roles[svc].ports {
+				ports = append(ports, fmt.Sprintf("%d", pc.port))
+			}
 			c("require free ports: %s", strings.Join(ports, " "))
 		}
 	}
@@ -365,32 +401,16 @@ func renderServicePlan(rt, version string, opts startOptions, userEnv []string) 
 	case "traces":
 		p(tracesArgs()...)
 		c("wait: http://localhost:16686 (30s)")
-	case "graph":
-		p(graphArgs()...)
-		c("wait: http://localhost:7474 (30s)")
-	case "vectors":
-		p(vectorsArgs()...)
-		c("wait: http://localhost:6333/readyz (15s)")
-	case "inference":
-		c("probe: host Ollama at http://localhost:11434/api/version")
-		c(`if present — probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:11434/api/version" — and use it`, rt)
-		c("else:")
-		p("stop", "semiont-ollama")
-		c("require free port: 11434")
-		p(inferenceArgs("<ollama-volume>")...)
-		c("wait: http://localhost:11434/api/version (30s)")
-	case "database":
-		p(dbArgs()...)
-		c("wait: tcp localhost:5432 (20s)")
-		c("probe: %s run --rm busybox:1.38.0 nc -z -w 2 <host-addr> 5432", rt)
+	case "graph", "vectors", "inference", "database":
+		renderRolePlan(rt, svc, plan, opts, c, p)
 	case "backend":
 		var admin []string
 		if opts.adminEmail != "" {
 			admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=<admin-password>"}
 		}
-		p(backendArgs("<kb-root>", stage, addr, "<worker-secret>", version, userEnv, otel, admin)...)
-		c("wait: http://localhost:4000/api/health (120s)")
-		c(`probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:4000/api/health" (up to 20 tries)`, rt)
+		p(backendArgs("<kb-root>", stage, addr, "<worker-secret>", version, plan.BackendPort, userEnv, otel, admin)...)
+		c("wait: http://localhost:%d/api/health (120s)", plan.BackendPort)
+		c(`probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:%d/api/health" (up to 20 tries)`, rt, plan.BackendPort)
 	case "worker", "smelter", "weaver":
 		for _, sc := range sidecarSpecs {
 			if sc.svc == svc {

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -340,7 +340,11 @@ func runStartService(u *ui, rt, version, root, configFile string, opts startOpti
 	if st == nil {
 		st = &stackState{Runtime: rt, Version: version, Services: map[string]serviceState{}}
 	}
-	st.recordService(svc, id, img, hostReuse)
+	provided := providedLauncher
+	if hostReuse {
+		provided = providedHost
+	}
+	st.recordService(svc, id, img, provided, serviceEndpoint(svc, plan))
 
 	fmt.Println()
 	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 "+svc+" is up"), u.dim("("+took(time.Since(t0))+")"))
@@ -422,4 +426,32 @@ func renderServicePlan(rt, version string, opts startOptions, userEnv []string, 
 		p(frontendArgs(version)...)
 		c("wait: http://localhost:3000 (30s)")
 	}
+}
+
+// serviceEndpoint: the health endpoint status should probe for a service the
+// launcher just (re)started. plan is nil only for frontend/traces (config-free).
+func serviceEndpoint(svc string, plan *launchPlan) string {
+	switch svc {
+	case "traces":
+		return "http://localhost:16686"
+	case "frontend":
+		return "http://localhost:3000"
+	case "backend":
+		return fmt.Sprintf("http://localhost:%d/api/health", plan.BackendPort)
+	case "worker":
+		return "http://localhost:9090/health"
+	case "smelter":
+		return "http://localhost:9091/health"
+	case "weaver":
+		return "http://localhost:9092/health"
+	case "graph":
+		return fmt.Sprintf("http://localhost:%d", plan.AuxPorts("graph")[0].port)
+	case "vectors":
+		return fmt.Sprintf("http://localhost:%d/readyz", plan.Roles[svc].Port)
+	case "inference":
+		return fmt.Sprintf("http://localhost:%d/api/version", plan.Roles[svc].Port)
+	case "database":
+		return fmt.Sprintf("tcp:localhost:%d", plan.Roles[svc].Port)
+	}
+	return ""
 }

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -344,7 +344,14 @@ func runStartService(u *ui, rt, version, root, configFile string, opts startOpti
 	if hostReuse {
 		provided = providedHost
 	}
-	st.recordService(svc, id, img, provided, serviceEndpoint(svc, plan))
+	driver := ""
+	if plan != nil {
+		driver = plan.Roles[svc].Driver
+	}
+	if svc == "traces" {
+		driver = "jaeger"
+	}
+	st.recordService(svc, id, img, provided, serviceEndpoint(svc, plan), driver)
 
 	fmt.Println()
 	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 "+svc+" is up"), u.dim("("+took(time.Since(t0))+")"))

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -12,7 +12,7 @@ import (
 )
 
 // The launcher's primary vocabulary is the ROLE a container plays in the
-// stack: db, graph, vectors, inference, traces — plus Semiont's own services
+// stack: database, graph, vectors, inference, traces — plus Semiont's own services
 // by name. The concrete product behind an infra role (PostgreSQL, Neo4j, …)
 // and its image string are DETAIL, shown where there's room for it (banners,
 // echoed argv, error messages); container names and config env vars stay at
@@ -34,7 +34,7 @@ var roles = map[string]roleSpec{
 	"graph":     {"Neo4j", "semiont-neo4j", []portNeed{{7474, "Neo4j HTTP"}, {7687, "Neo4j Bolt"}}},
 	"vectors":   {"Qdrant", "semiont-qdrant", []portNeed{{6333, "Qdrant"}}},
 	"inference": {"Ollama", "semiont-ollama", nil},
-	"db":        {"PostgreSQL", "semiont-postgres", []portNeed{{5432, "PostgreSQL"}}},
+	"database":  {"PostgreSQL", "semiont-postgres", []portNeed{{5432, "PostgreSQL"}}},
 	"backend":   {"", "semiont-backend", []portNeed{{4000, "Backend"}}},
 	"worker":    {"", "semiont-worker", []portNeed{{9090, "Worker"}}},
 	"smelter":   {"", "semiont-smelter", []portNeed{{9091, "Smelter"}}},
@@ -42,7 +42,7 @@ var roles = map[string]roleSpec{
 	"frontend":  {"", "semiont-frontend", []portNeed{{3000, "Frontend"}}},
 }
 
-const roleList = "backend, worker, smelter, weaver, frontend, db, graph, vectors, inference, or traces"
+const roleList = "backend, worker, smelter, weaver, frontend, database, graph, vectors, inference, or traces"
 
 // roleByContainer inverts the roles table (container name → role).
 var roleByContainer = func() map[string]string {
@@ -67,7 +67,7 @@ func isConfigConsumer(svc string) bool {
 }
 
 func serviceNeedsAddr(svc string) bool {
-	return isConfigConsumer(svc) || svc == "db" || svc == "inference"
+	return isConfigConsumer(svc) || svc == "database" || svc == "inference"
 }
 
 // recoverWorkerSecret pulls SEMIONT_WORKER_SECRET out of a running Semiont
@@ -266,14 +266,14 @@ func runStartService(u *ui, rt, version, root, configFile string, opts startOpti
 			img = "ollama/ollama"
 		}
 		ok = true
-	case "db":
+	case "database":
 		args := dbArgs()
 		img = args[len(args)-1]
 		u.echoCmd(rt, args...)
 		var err error
 		id, err = runDetached(rt, args...)
 		if err != nil {
-			u.fail("db (PostgreSQL) failed to start.")
+			u.fail("database (PostgreSQL) failed to start.")
 			return 1
 		}
 		d, ok = waitForPG(u, rt, addr, 5432, 20)
@@ -379,7 +379,7 @@ func renderServicePlan(rt, version string, opts startOptions, userEnv []string) 
 		c("require free port: 11434")
 		p(inferenceArgs("<ollama-volume>")...)
 		c("wait: http://localhost:11434/api/version (30s)")
-	case "db":
+	case "database":
 		p(dbArgs()...)
 		c("wait: tcp localhost:5432 (20s)")
 		c("probe: %s run --rm busybox:1.38.0 nc -z -w 2 <host-addr> 5432", rt)

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -29,27 +29,6 @@ var preflightNames = []string{
 	"semiont-frontend",
 }
 
-// portChecks: every published port the stack needs, checked up front so a
-// conflict surfaces before any image work. Ollama's 11434 is checked later —
-// only needed if no host Ollama is already serving it.
-var portChecks = []struct {
-	port    int
-	service string
-	observe bool // only checked when the Jaeger sidecar runs
-}{
-	{7474, "Neo4j HTTP", false},
-	{7687, "Neo4j Bolt", false},
-	{6333, "Qdrant", false},
-	{5432, "PostgreSQL", false},
-	{4000, "Backend", false},
-	{9090, "Worker", false},
-	{9091, "Smelter", false},
-	{9092, "Weaver", false},
-	{3000, "Frontend", false},
-	{16686, "Jaeger UI", true},
-	{4318, "Jaeger OTLP", true},
-}
-
 // The config TOMLs reference env vars as ${VAR} (required) or ${VAR:-default}
 // (optional); only the required form is matched here. These are the ones the
 // launcher injects itself and never demands from the user.
@@ -254,11 +233,11 @@ func Start(args []string) int {
 		case opts.ollamaCache != "" && opts.service != "inference":
 			u.fail("--ollama-cache only applies to --service inference.")
 			return 1
-		case opts.configSet && !isConfigConsumer(opts.service):
-			u.fail("--config only applies to --service backend, worker, smelter, or weaver.")
+		case opts.configSet && (opts.service == "frontend" || opts.service == "traces"):
+			u.fail("--config does not apply to --service %s (it reads no config).", opts.service)
 			return 1
-		case opts.root != "" && !isConfigConsumer(opts.service):
-			u.fail("--root only applies to full start or --service backend, worker, smelter, or weaver (this service uses no KB root).")
+		case opts.root != "" && (opts.service == "frontend" || opts.service == "traces"):
+			u.fail("--root only applies to services that read the KB config (--service %s does not).", opts.service)
 			return 1
 		}
 	}
@@ -276,7 +255,12 @@ func Start(args []string) int {
 	// be a git clone — the backend versions the event log via git. A
 	// --service target that touches neither (infra, frontend) runs from
 	// anywhere: "just the browser" needs no clone at all.
-	rootNeeded := opts.service == "" || isConfigConsumer(opts.service)
+	// Everything except frontend and traces is config-driven now: infra
+	// roles need the config to know their OBLIGATION (provided / external /
+	// host-process / absent), so they need the KB root too. frontend (absent
+	// from the config) and traces (launcher-owned) keep the no-clone freedom.
+	configNeeded := opts.service == "" || (opts.service != "frontend" && opts.service != "traces")
+	rootNeeded := configNeeded
 	root := ""
 	if rootNeeded {
 		var err error
@@ -328,14 +312,22 @@ func Start(args []string) int {
 		printConfigNames()
 		return 0
 	}
-	// Services that never read the config (infra, frontend) don't require it.
-	configNeeded := opts.service == "" || isConfigConsumer(opts.service)
 	configFile := filepath.Join(configDir, opts.configName+".toml")
+	var plan *launchPlan
 	if configNeeded {
 		if _, err := os.Stat(configFile); err != nil {
 			u.fail("Config not found: %s", configFile)
 			fmt.Println("Available configs:")
 			printConfigNames()
+			return 1
+		}
+		envCfg, envName, err := loadConfig(configFile)
+		if err != nil {
+			u.fail("%v", err)
+			return 1
+		}
+		if plan, err = derivePlan(envCfg, envName, configFile); err != nil {
+			u.fail("%v", err)
 			return 1
 		}
 	}
@@ -373,8 +365,10 @@ func Start(args []string) int {
 	}
 	u.log("Image version: %s", u.bold(version))
 
+	// User env vars (API keys the config references) are demanded only where
+	// a Semiont service will consume the config — never for infra restarts.
 	var userEnv []string
-	if configNeeded {
+	if opts.service == "" || isConfigConsumer(opts.service) {
 		userVars, err := requiredConfigVars(configFile)
 		if err != nil {
 			u.fail("Reading %s: %v", configFile, err)
@@ -396,16 +390,16 @@ func Start(args []string) int {
 
 	if opts.dryRun {
 		if opts.service != "" {
-			renderServicePlan(rt, version, opts, userEnv)
+			renderServicePlan(rt, version, opts, userEnv, plan)
 		} else {
-			renderStartPlan(rt, version, opts, userEnv)
+			renderStartPlan(rt, version, opts, userEnv, plan)
 		}
 		return 0
 	}
 	if opts.service != "" {
-		return runStartService(u, rt, version, root, configFile, opts, userEnv)
+		return runStartService(u, rt, version, root, configFile, opts, userEnv, plan)
 	}
-	return runStart(u, rt, version, root, configFile, opts, userEnv)
+	return runStart(u, rt, version, root, configFile, opts, userEnv, plan)
 }
 
 func printConfigNames() {
@@ -448,35 +442,12 @@ func tracesArgs() []string {
 		"-p", "16686:16686", "-p", "4318:4318", "jaegertracing/all-in-one:1.76.0"}
 }
 
-func graphArgs() []string {
-	return []string{"run", "-d", "--rm", "--name", "semiont-neo4j",
-		"-p", "7474:7474", "-p", "7687:7687",
-		"-e", "NEO4J_AUTH=neo4j/localpass", "-e", "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes",
-		"neo4j:5.26.28-community"}
-}
-
-func vectorsArgs() []string {
-	return []string{"run", "-d", "--rm", "--name", "semiont-qdrant",
-		"-p", "6333:6333", "qdrant/qdrant:v1.18.3"}
-}
-
-func inferenceArgs(volume string) []string {
-	return []string{"run", "-d", "--rm", "--name", "semiont-ollama",
-		"-p", "11434:11434", "-m", "24G", "-v", volume + ":/root/.ollama", "ollama/ollama"}
-}
-
-func dbArgs() []string {
-	return []string{"run", "-d", "--rm", "--name", "semiont-postgres",
-		"-p", "5432:5432", "-e", "POSTGRES_PASSWORD=localpass", "-e", "POSTGRES_DB=semiont",
-		"postgres:15.18-alpine"}
-}
-
 // backendArgs: the backend takes the four dependency hosts but must NOT
 // receive BACKEND_HOST (publicURL derives from it; see the DID/site.domain
 // history before ever changing this).
-func backendArgs(kbRoot, stage, addr, secret, version string, userEnv, otel, admin []string) []string {
+func backendArgs(kbRoot, stage, addr, secret, version string, port int, userEnv, otel, admin []string) []string {
 	a := []string{"run", "-d", "--rm", "--name", "semiont-backend",
-		"--publish", "4000:4000", "--memory", "8G",
+		"--publish", fmt.Sprintf("%d:%d", port, port), "--memory", "8G",
 		"--volume", kbRoot + ":/kb",
 		"--volume", stage + "/backend.toml:/home/semiont/.semiontconfig:ro"}
 	a = append(a, userEnv...)
@@ -557,8 +528,8 @@ func runGated(u *ui, rt string, args []string, failLabel, waitLabel, url string,
 // then container-gateway reachability — the sidecars dial addr:4000 (not
 // localhost) and fatally exit if their first backend fetch fails, so host
 // health alone doesn't prove the path they need.
-func runBackend(u *ui, rt, root, stage, addr, secret, version string, userEnv, otel, admin []string) (string, int) {
-	bArgs := backendArgs(root, stage, addr, secret, version, userEnv, otel, admin)
+func runBackend(u *ui, rt, root, stage, addr, secret, version string, port int, userEnv, otel, admin []string) (string, int) {
+	bArgs := backendArgs(root, stage, addr, secret, version, port, userEnv, otel, admin)
 	u.echoCmd(rt, bArgs...)
 	id, err := runDetached(rt, bArgs...)
 	if err != nil {
@@ -566,7 +537,7 @@ func runBackend(u *ui, rt, root, stage, addr, secret, version string, userEnv, o
 		return "", 1
 	}
 	u.log("Waiting for backend health...")
-	d, ok := waitForHTTP(u, "Backend", "http://localhost:4000/api/health", 120)
+	d, ok := waitForHTTP(u, "Backend", fmt.Sprintf("http://localhost:%d/api/health", port), 120)
 	if !ok {
 		return "", 1
 	}
@@ -577,14 +548,14 @@ func runBackend(u *ui, rt, root, stage, addr, secret, version string, userEnv, o
 	reachable := false
 	for i := 0; i < 20; i++ {
 		if runSilent(rt, "run", "--rm", "busybox:1.38.0", "sh", "-c",
-			fmt.Sprintf("wget -q -O- http://%s:4000/api/health", addr)) == nil {
+			fmt.Sprintf("wget -q -O- http://%s:%d/api/health", addr, port)) == nil {
 			reachable = true
 			break
 		}
 		time.Sleep(time.Second)
 	}
 	if !reachable {
-		u.fail("Backend not reachable from containers at %s:4000 within 20s.", addr)
+		u.fail("Backend not reachable from containers at %s:%d within 20s.", addr, port)
 		return "", 1
 	}
 	u.ok("Backend reachable from containers %s", u.dim("("+took(time.Since(reachT0))+")"))
@@ -607,7 +578,22 @@ func runSidecar(u *ui, rt string, sc struct {
 
 // --- The real run ---
 
-func runStart(u *ui, rt, version, root, configFile string, opts startOptions, userEnv []string) int {
+// verifyExternal confirms an externally-provided role is reachable at its
+// configured address — the launcher launches nothing but refuses to bring up
+// dependents against a dead dependency.
+func verifyExternal(u *ui, role string, rp rolePlan) bool {
+	addr := fmt.Sprintf("%s:%d", rp.Address, rp.Port)
+	conn, err := netDialTimeout(addr)
+	if err != nil {
+		u.fail("%s is externally provided at %s but unreachable: %v", role, addr, err)
+		return false
+	}
+	conn.Close()
+	u.ok("%s — externally provided at %s %s", role, addr, u.dim("(reachable)"))
+	return true
+}
+
+func runStart(u *ui, rt, version, root, configFile string, opts startOptions, userEnv []string, plan *launchPlan) int {
 	t0 := time.Now()
 	// Resolve the host address for container networking. Every inter-service
 	// hop dials the HOST (hub-and-spoke over published ports), so this must be
@@ -662,11 +648,8 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	removeState()
 	time.Sleep(time.Second)
 
-	for _, pc := range portChecks {
-		if pc.observe && !opts.observe {
-			continue
-		}
-		if !requirePortFree(u, pc.port, pc.service, opts.forceKillPorts) {
+	for _, pc := range planPortChecks(plan, opts.observe) {
+		if !requirePortFree(u, pc.port, pc.label, opts.forceKillPorts) {
 			return 1
 		}
 	}
@@ -750,48 +733,95 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		otel = otelArgs(addr)
 	}
 
-	u.banner("Graph (Neo4j)")
-	args := graphArgs()
-	id, d, ok := runGated(u, rt, args, "graph (Neo4j)", "graph (Neo4j)", "http://localhost:7474", 30)
-	if !ok {
-		return 1
+	graphRP := plan.Roles["graph"]
+	u.banner("Graph (" + driverDisplay("graph", graphRP.Driver) + ")")
+	switch graphRP.Obligation {
+	case obligationProvided:
+		args := providedRunArgs("graph", graphRP)
+		auxPort := plan.AuxPorts("graph")[0].port
+		id, d, ok := runGated(u, rt, args, "graph ("+driverDisplay("graph", graphRP.Driver)+")", "graph ("+driverDisplay("graph", graphRP.Driver)+")",
+			fmt.Sprintf("http://localhost:%d", auxPort), 30)
+		if !ok {
+			return 1
+		}
+		u.ok("graph — bolt://localhost:%d (browser: http://localhost:%d) %s",
+			graphRP.Port, auxPort, u.dim("("+took(d)+")"))
+		st.recordService("graph", id, graphRP.Image, false)
+	case obligationAbsent:
+		u.log("graph — not configured; skipping")
+	default:
+		if !verifyExternal(u, "graph", graphRP) {
+			return 1
+		}
 	}
-	u.ok("graph — bolt://localhost:7687 (browser: http://localhost:7474) %s", u.dim("("+took(d)+")"))
-	st.recordService("graph", id, args[len(args)-1], false)
 
-	u.banner("Vectors (Qdrant)")
-	args = vectorsArgs()
-	id, d, ok = runGated(u, rt, args, "vectors (Qdrant)", "vectors (Qdrant)", "http://localhost:6333/readyz", 15)
-	if !ok {
-		return 1
+	vecRP := plan.Roles["vectors"]
+	u.banner("Vectors (" + driverDisplay("vectors", vecRP.Driver) + ")")
+	switch vecRP.Obligation {
+	case obligationProvided:
+		args := providedRunArgs("vectors", vecRP)
+		id, d, ok := runGated(u, rt, args, "vectors ("+driverDisplay("vectors", vecRP.Driver)+")", "vectors ("+driverDisplay("vectors", vecRP.Driver)+")",
+			fmt.Sprintf("http://localhost:%d/readyz", vecRP.Port), 15)
+		if !ok {
+			return 1
+		}
+		u.ok("vectors — http://localhost:%d %s", vecRP.Port, u.dim("("+took(d)+")"))
+		st.recordService("vectors", id, vecRP.Image, false)
+	case obligationAbsent:
+		u.log("vectors — not configured; skipping")
+	default:
+		if !verifyExternal(u, "vectors", vecRP) {
+			return 1
+		}
 	}
-	u.ok("vectors — http://localhost:6333 %s", u.dim("("+took(d)+")"))
-	st.recordService("vectors", id, args[len(args)-1], false)
 
-	infID, hostReuse, code := startInference(u, rt, addr, opts)
-	if code != 0 {
-		return code
+	infRP := plan.Roles["inference"]
+	switch infRP.Obligation {
+	case obligationHostProcess:
+		infID, hostReuse, code := startInference(u, rt, addr, opts, infRP)
+		if code != 0 {
+			return code
+		}
+		infImage := ""
+		if !hostReuse {
+			infImage = infRP.Image
+		}
+		st.recordService("inference", infID, infImage, hostReuse)
+	case obligationExternal:
+		u.banner("Inference (" + driverDisplay("inference", infRP.Driver) + ")")
+		if !verifyExternal(u, "inference", infRP) {
+			return 1
+		}
+	case obligationAbsent:
+		u.banner("Inference")
+		u.log("inference — not referenced by the config; skipping")
 	}
-	infImage := ""
-	if !hostReuse {
-		infImage = "ollama/ollama"
-	}
-	st.recordService("inference", infID, infImage, hostReuse)
 
-	u.banner("Database (PostgreSQL)")
-	args = dbArgs()
-	u.echoCmd(rt, args...)
-	id, err = runDetached(rt, args...)
-	if err != nil {
-		u.fail("database (PostgreSQL) failed to start.")
-		return 1
+	dbRP := plan.Roles["database"]
+	u.banner("Database (" + driverDisplay("database", dbRP.Driver) + ")")
+	switch dbRP.Obligation {
+	case obligationProvided:
+		args := providedRunArgs("database", dbRP)
+		u.echoCmd(rt, args...)
+		var id string
+		id, err = runDetached(rt, args...)
+		if err != nil {
+			u.fail("database (%s) failed to start.", driverDisplay("database", dbRP.Driver))
+			return 1
+		}
+		d, ok := waitForPG(u, rt, addr, dbRP.Port, 20)
+		if !ok {
+			return 1
+		}
+		u.ok("database — %s on port %d %s", driverDisplay("database", dbRP.Driver), dbRP.Port, u.dim("("+took(d)+")"))
+		st.recordService("database", id, dbRP.Image, false)
+	case obligationAbsent:
+		u.log("database — not configured; skipping")
+	default:
+		if !verifyExternal(u, "database", dbRP) {
+			return 1
+		}
 	}
-	d, ok = waitForPG(u, rt, addr, 5432, 20)
-	if !ok {
-		return 1
-	}
-	u.ok("database — PostgreSQL on port 5432 %s", u.dim("("+took(d)+")"))
-	st.recordService("database", id, args[len(args)-1], false)
 
 	secret := os.Getenv("SEMIONT_WORKER_SECRET")
 	if secret == "" {
@@ -804,14 +834,14 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	}
 
 	u.banner("Starting Backend")
-	u.log("http://localhost:4000")
+	u.log("http://localhost:%d", plan.BackendPort)
 	u.log("Worker secret: %s", u.dim("(generated)"))
 	var admin []string
 	if opts.adminEmail != "" && opts.adminPassword != "" {
 		admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=" + opts.adminPassword}
 		u.log("Admin user: %s", u.bold(opts.adminEmail))
 	}
-	backendID, code := runBackend(u, rt, root, stage, addr, secret, version, userEnv, otel, admin)
+	backendID, code := runBackend(u, rt, root, stage, addr, secret, version, plan.BackendPort, userEnv, otel, admin)
 	if code != 0 {
 		return code
 	}
@@ -833,12 +863,11 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	// Frontend: a static SPA server — no config mount and no service env; the
 	// browser talks to the backend directly on localhost:4000.
 	u.banner("Starting Frontend")
-	var feID string
-	feID, d, ok = runGated(u, rt, frontendArgs(version), "Frontend", "Frontend", "http://localhost:3000", 30)
-	if !ok {
+	feID, feD, feOK := runGated(u, rt, frontendArgs(version), "Frontend", "Frontend", "http://localhost:3000", 30)
+	if !feOK {
 		return 1
 	}
-	u.ok("Frontend on http://localhost:3000 %s", u.dim("("+took(d)+")"))
+	u.ok("Frontend on http://localhost:3000 %s", u.dim("("+took(feD)+")"))
 	st.recordService("frontend", feID, image("frontend", version), false)
 
 	// Summary; the stack runs detached and this process exits — bring the
@@ -878,17 +907,17 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 
 // startInference reuses a host Ollama when one is serving 11434 and reachable
 // from containers; otherwise starts the semiont-ollama container.
-func startInference(u *ui, rt, addr string, opts startOptions) (id string, hostReuse bool, code int) {
-	u.banner("Inference (Ollama)")
-	if httpOK("http://localhost:11434/api/version") {
+func startInference(u *ui, rt, addr string, opts startOptions, rp rolePlan) (id string, hostReuse bool, code int) {
+	u.banner("Inference (" + driverDisplay("inference", rp.Driver) + ")")
+	if httpOK(fmt.Sprintf("http://localhost:%d/api/version", rp.Port)) {
 		if runSilent(rt, "run", "--rm", "busybox:1.38.0", "sh", "-c",
-			fmt.Sprintf("wget -q -O- http://%s:11434/api/version", addr)) == nil {
-			u.ok("inference — using host Ollama at http://localhost:11434")
+			fmt.Sprintf("wget -q -O- http://%s:%d/api/version", addr, rp.Port)) == nil {
+			u.ok("inference — using host Ollama at http://localhost:%d", rp.Port)
 			return "", true, 0
 		}
 		fmt.Println()
 		u.warn("Ollama is running on the host but not reachable from containers.")
-		fmt.Printf("   The backend runs in a container and needs Ollama at %s:11434.\n", addr)
+		fmt.Printf("   The backend runs in a container and needs Ollama at %s:%d.\n", addr, rp.Port)
 		fmt.Println()
 		if runSilent("pgrep", "-f", "Ollama.app/Contents") == nil {
 			fmt.Println("   Detected: Ollama Desktop app")
@@ -910,7 +939,7 @@ func startInference(u *ui, rt, addr string, opts startOptions) (id string, hostR
 	u.echoCmd(rt, "stop", "semiont-ollama")
 	runPassthrough(rt, "stop", "semiont-ollama")
 	time.Sleep(time.Second)
-	if !requirePortFree(u, 11434, "Ollama", opts.forceKillPorts) {
+	if !requirePortFree(u, rp.Port, "Ollama", opts.forceKillPorts) {
 		return "", false, 1
 	}
 
@@ -938,17 +967,18 @@ func startInference(u *ui, rt, addr string, opts startOptions) (id string, hostR
 		}
 	}
 
-	u.echoCmd(rt, inferenceArgs(volume)...)
-	id, err := runDetached(rt, inferenceArgs(volume)...)
+	args := providedRunArgs("inference", rp, "-m", "24G", "-v", volume+":/root/.ollama")
+	u.echoCmd(rt, args...)
+	id, err := runDetached(rt, args...)
 	if err != nil {
 		u.fail("Ollama container failed to start.")
 		return "", false, 1
 	}
-	d, ok := waitForHTTP(u, "inference (Ollama)", "http://localhost:11434/api/version", 30)
+	d, ok := waitForHTTP(u, "inference (Ollama)", fmt.Sprintf("http://localhost:%d/api/version", rp.Port), 30)
 	if !ok {
 		return "", false, 1
 	}
-	u.ok("inference — Ollama container on http://localhost:11434 (24 GB memory) %s", u.dim("("+took(d)+")"))
+	u.ok("inference — Ollama container on http://localhost:%d (24 GB memory) %s", rp.Port, u.dim("("+took(d)+")"))
 	return id, false, 0
 }
 

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -729,7 +729,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			return 1
 		}
 		u.ok("traces — Jaeger UI on http://localhost:16686 (OTLP collector: %s:4318) %s", addr, u.dim("("+took(d)+")"))
-		st.recordService("traces", id, args[len(args)-1], false)
+		st.recordService("traces", id, args[len(args)-1], providedLauncher, "http://localhost:16686")
 		otel = otelArgs(addr)
 	}
 
@@ -746,13 +746,15 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		}
 		u.ok("graph — bolt://localhost:%d (browser: http://localhost:%d) %s",
 			graphRP.Port, auxPort, u.dim("("+took(d)+")"))
-		st.recordService("graph", id, graphRP.Image, false)
+		st.recordService("graph", id, graphRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d", auxPort))
 	case obligationAbsent:
 		u.log("graph — not configured; skipping")
+		st.recordService("graph", "", "", providedNone, "")
 	default:
 		if !verifyExternal(u, "graph", graphRP) {
 			return 1
 		}
+		st.recordService("graph", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", graphRP.Address, graphRP.Port))
 	}
 
 	vecRP := plan.Roles["vectors"]
@@ -766,13 +768,15 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			return 1
 		}
 		u.ok("vectors — http://localhost:%d %s", vecRP.Port, u.dim("("+took(d)+")"))
-		st.recordService("vectors", id, vecRP.Image, false)
+		st.recordService("vectors", id, vecRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d/readyz", vecRP.Port))
 	case obligationAbsent:
 		u.log("vectors — not configured; skipping")
+		st.recordService("vectors", "", "", providedNone, "")
 	default:
 		if !verifyExternal(u, "vectors", vecRP) {
 			return 1
 		}
+		st.recordService("vectors", "", "", providedExternal, fmt.Sprintf("http://%s:%d/readyz", vecRP.Address, vecRP.Port))
 	}
 
 	infRP := plan.Roles["inference"]
@@ -783,18 +787,22 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			return code
 		}
 		infImage := ""
+		infProvided := providedHost
 		if !hostReuse {
 			infImage = infRP.Image
+			infProvided = providedLauncher
 		}
-		st.recordService("inference", infID, infImage, hostReuse)
+		st.recordService("inference", infID, infImage, infProvided, fmt.Sprintf("http://localhost:%d/api/version", infRP.Port))
 	case obligationExternal:
 		u.banner("Inference (" + driverDisplay("inference", infRP.Driver) + ")")
 		if !verifyExternal(u, "inference", infRP) {
 			return 1
 		}
+		st.recordService("inference", "", "", providedExternal, fmt.Sprintf("http://%s:%d/api/version", infRP.Address, infRP.Port))
 	case obligationAbsent:
 		u.banner("Inference")
 		u.log("inference — not referenced by the config; skipping")
+		st.recordService("inference", "", "", providedNone, "")
 	}
 
 	dbRP := plan.Roles["database"]
@@ -814,13 +822,15 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			return 1
 		}
 		u.ok("database — %s on port %d %s", driverDisplay("database", dbRP.Driver), dbRP.Port, u.dim("("+took(d)+")"))
-		st.recordService("database", id, dbRP.Image, false)
+		st.recordService("database", id, dbRP.Image, providedLauncher, fmt.Sprintf("tcp:localhost:%d", dbRP.Port))
 	case obligationAbsent:
 		u.log("database — not configured; skipping")
+		st.recordService("database", "", "", providedNone, "")
 	default:
 		if !verifyExternal(u, "database", dbRP) {
 			return 1
 		}
+		st.recordService("database", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", dbRP.Address, dbRP.Port))
 	}
 
 	secret := os.Getenv("SEMIONT_WORKER_SECRET")
@@ -845,7 +855,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	if code != 0 {
 		return code
 	}
-	st.recordService("backend", backendID, image("backend", version), false)
+	st.recordService("backend", backendID, image("backend", version), providedLauncher, fmt.Sprintf("http://localhost:%d/api/health", plan.BackendPort))
 
 	// The weaver note: the graph projection is standalone-only — the backend
 	// no longer applies events to Neo4j in-process. Without the weaver the
@@ -857,7 +867,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		if code != 0 {
 			return code
 		}
-		st.recordService(sc.svc, scID, image(sc.svc, version), false)
+		st.recordService(sc.svc, scID, image(sc.svc, version), providedLauncher, fmt.Sprintf("http://localhost:%d/health", sc.port))
 	}
 
 	// Frontend: a static SPA server — no config mount and no service env; the
@@ -868,7 +878,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		return 1
 	}
 	u.ok("Frontend on http://localhost:3000 %s", u.dim("("+took(feD)+")"))
-	st.recordService("frontend", feID, image("frontend", version), false)
+	st.recordService("frontend", feID, image("frontend", version), providedLauncher, "http://localhost:3000")
 
 	// Summary; the stack runs detached and this process exits — bring the
 	// stack up, say where everything is, and get out of the way (compose up

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -359,6 +359,11 @@ func Start(args []string) int {
 	}
 
 	u.banner("Semiont Local Backend")
+	if rootNeeded {
+		if ident := loadKBIdentity(root); ident != nil && ident.SiteName != "" {
+			u.log("KB: %s %s", u.bold(ident.SiteName), u.dim(ident.didWeb()))
+		}
+	}
 	u.log("Container runtime: %s", u.bold(rt))
 	if configNeeded {
 		u.log("Config: %s", u.bold(opts.configName))
@@ -697,7 +702,8 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	// reports. Saved after every service so a failed start still leaves an
 	// accurate partial record for stop/status to work from.
 	st := &stackState{
-		Runtime: rt, KBRoot: root, Config: opts.configName, Version: version,
+		Runtime: rt, KBRoot: root, KBDid: loadKBIdentity(root).didWeb(),
+		Config: opts.configName, Version: version,
 		HostAddr: addr, Stage: stage, Services: map[string]serviceState{},
 	}
 

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -85,7 +85,7 @@ type startOptions struct {
 const startUsage = `Usage: semiont start [options]
 
 Start a local Semiont stack — graph (Neo4j), vectors (Qdrant), inference
-(Ollama), db (PostgreSQL), the Semiont backend, worker, smelter, weaver, and
+(Ollama), database (PostgreSQL), the Semiont backend, worker, smelter, weaver, and
 the frontend (http://localhost:3000) — all in containers.
 
 Options:
@@ -97,7 +97,7 @@ Options:
                         SEMIONT_ROOT and cwd discovery.
   --service <name>      Start (restart) just this one service, leaving the rest
                         of the stack untouched: backend, worker, smelter, weaver,
-                        frontend, db, graph, vectors, inference, or traces.
+                        frontend, database, graph, vectors, inference, or traces.
                         Rejoins a running stack's worker secret automatically;
                         OTel export is enabled iff traces (Jaeger) is up.
   --email <email>       Admin user email (requires --password)
@@ -778,20 +778,20 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	}
 	st.recordService("inference", infID, infImage, hostReuse)
 
-	u.banner("DB (PostgreSQL)")
+	u.banner("Database (PostgreSQL)")
 	args = dbArgs()
 	u.echoCmd(rt, args...)
 	id, err = runDetached(rt, args...)
 	if err != nil {
-		u.fail("db (PostgreSQL) failed to start.")
+		u.fail("database (PostgreSQL) failed to start.")
 		return 1
 	}
 	d, ok = waitForPG(u, rt, addr, 5432, 20)
 	if !ok {
 		return 1
 	}
-	u.ok("db — PostgreSQL on port 5432 %s", u.dim("("+took(d)+")"))
-	st.recordService("db", id, args[len(args)-1], false)
+	u.ok("database — PostgreSQL on port 5432 %s", u.dim("("+took(d)+")"))
+	st.recordService("database", id, args[len(args)-1], false)
 
 	secret := os.Getenv("SEMIONT_WORKER_SECRET")
 	if secret == "" {

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -735,7 +735,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			return 1
 		}
 		u.ok("traces — Jaeger UI on http://localhost:16686 (OTLP collector: %s:4318) %s", addr, u.dim("("+took(d)+")"))
-		st.recordService("traces", id, args[len(args)-1], providedLauncher, "http://localhost:16686")
+		st.recordService("traces", id, args[len(args)-1], providedLauncher, "http://localhost:16686", "jaeger")
 		otel = otelArgs(addr)
 	}
 
@@ -752,15 +752,15 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		}
 		u.ok("graph — bolt://localhost:%d (browser: http://localhost:%d) %s",
 			graphRP.Port, auxPort, u.dim("("+took(d)+")"))
-		st.recordService("graph", id, graphRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d", auxPort))
+		st.recordService("graph", id, graphRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d", auxPort), graphRP.Driver)
 	case obligationAbsent:
 		u.log("graph — not configured; skipping")
-		st.recordService("graph", "", "", providedNone, "")
+		st.recordService("graph", "", "", providedNone, "", "")
 	default:
 		if !verifyExternal(u, "graph", graphRP) {
 			return 1
 		}
-		st.recordService("graph", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", graphRP.Address, graphRP.Port))
+		st.recordService("graph", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", graphRP.Address, graphRP.Port), graphRP.Driver)
 	}
 
 	vecRP := plan.Roles["vectors"]
@@ -774,15 +774,15 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			return 1
 		}
 		u.ok("vectors — http://localhost:%d %s", vecRP.Port, u.dim("("+took(d)+")"))
-		st.recordService("vectors", id, vecRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d/readyz", vecRP.Port))
+		st.recordService("vectors", id, vecRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d/readyz", vecRP.Port), vecRP.Driver)
 	case obligationAbsent:
 		u.log("vectors — not configured; skipping")
-		st.recordService("vectors", "", "", providedNone, "")
+		st.recordService("vectors", "", "", providedNone, "", "")
 	default:
 		if !verifyExternal(u, "vectors", vecRP) {
 			return 1
 		}
-		st.recordService("vectors", "", "", providedExternal, fmt.Sprintf("http://%s:%d/readyz", vecRP.Address, vecRP.Port))
+		st.recordService("vectors", "", "", providedExternal, fmt.Sprintf("http://%s:%d/readyz", vecRP.Address, vecRP.Port), vecRP.Driver)
 	}
 
 	infRP := plan.Roles["inference"]
@@ -798,17 +798,17 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			infImage = infRP.Image
 			infProvided = providedLauncher
 		}
-		st.recordService("inference", infID, infImage, infProvided, fmt.Sprintf("http://localhost:%d/api/version", infRP.Port))
+		st.recordService("inference", infID, infImage, infProvided, fmt.Sprintf("http://localhost:%d/api/version", infRP.Port), infRP.Driver)
 	case obligationExternal:
 		u.banner("Inference (" + driverDisplay("inference", infRP.Driver) + ")")
 		if !verifyExternal(u, "inference", infRP) {
 			return 1
 		}
-		st.recordService("inference", "", "", providedExternal, fmt.Sprintf("http://%s:%d/api/version", infRP.Address, infRP.Port))
+		st.recordService("inference", "", "", providedExternal, fmt.Sprintf("http://%s:%d/api/version", infRP.Address, infRP.Port), infRP.Driver)
 	case obligationAbsent:
 		u.banner("Inference")
 		u.log("inference — not referenced by the config; skipping")
-		st.recordService("inference", "", "", providedNone, "")
+		st.recordService("inference", "", "", providedNone, "", "")
 	}
 
 	dbRP := plan.Roles["database"]
@@ -828,15 +828,15 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 			return 1
 		}
 		u.ok("database — %s on port %d %s", driverDisplay("database", dbRP.Driver), dbRP.Port, u.dim("("+took(d)+")"))
-		st.recordService("database", id, dbRP.Image, providedLauncher, fmt.Sprintf("tcp:localhost:%d", dbRP.Port))
+		st.recordService("database", id, dbRP.Image, providedLauncher, fmt.Sprintf("tcp:localhost:%d", dbRP.Port), dbRP.Driver)
 	case obligationAbsent:
 		u.log("database — not configured; skipping")
-		st.recordService("database", "", "", providedNone, "")
+		st.recordService("database", "", "", providedNone, "", "")
 	default:
 		if !verifyExternal(u, "database", dbRP) {
 			return 1
 		}
-		st.recordService("database", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", dbRP.Address, dbRP.Port))
+		st.recordService("database", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", dbRP.Address, dbRP.Port), dbRP.Driver)
 	}
 
 	secret := os.Getenv("SEMIONT_WORKER_SECRET")
@@ -861,7 +861,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	if code != 0 {
 		return code
 	}
-	st.recordService("backend", backendID, image("backend", version), providedLauncher, fmt.Sprintf("http://localhost:%d/api/health", plan.BackendPort))
+	st.recordService("backend", backendID, image("backend", version), providedLauncher, fmt.Sprintf("http://localhost:%d/api/health", plan.BackendPort), "")
 
 	// The weaver note: the graph projection is standalone-only — the backend
 	// no longer applies events to Neo4j in-process. Without the weaver the
@@ -873,7 +873,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		if code != 0 {
 			return code
 		}
-		st.recordService(sc.svc, scID, image(sc.svc, version), providedLauncher, fmt.Sprintf("http://localhost:%d/health", sc.port))
+		st.recordService(sc.svc, scID, image(sc.svc, version), providedLauncher, fmt.Sprintf("http://localhost:%d/health", sc.port), "")
 	}
 
 	// Frontend: a static SPA server — no config mount and no service env; the
@@ -884,7 +884,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		return 1
 	}
 	u.ok("Frontend on http://localhost:3000 %s", u.dim("("+took(feD)+")"))
-	st.recordService("frontend", feID, image("frontend", version), providedLauncher, "http://localhost:3000")
+	st.recordService("frontend", feID, image("frontend", version), providedLauncher, "http://localhost:3000", "")
 
 	// Summary; the stack runs detached and this process exits — bring the
 	// stack up, say where everything is, and get out of the way (compose up

--- a/apps/launcher/internal/launcher/statefile.go
+++ b/apps/launcher/internal/launcher/statefile.go
@@ -40,6 +40,7 @@ type stackState struct {
 	Launcher  string                  `json:"launcherVersion"`
 	Runtime   string                  `json:"runtime"`
 	KBRoot    string                  `json:"kbRoot,omitempty"`
+	KBDid     string                  `json:"kbDid,omitempty"` // did:web from .semiont/config
 	Config    string                  `json:"config,omitempty"`
 	Version   string                  `json:"imageVersion,omitempty"`
 	HostAddr  string                  `json:"hostAddr,omitempty"`

--- a/apps/launcher/internal/launcher/statefile.go
+++ b/apps/launcher/internal/launcher/statefile.go
@@ -29,6 +29,7 @@ type serviceState struct {
 	ID        string    `json:"id,omitempty"`        // identifier the runtime printed at run -d
 	Image     string    `json:"image,omitempty"`     // full image ref
 	Provided  string    `json:"provided,omitempty"`  // schema 2: launcher|host|external|none
+	Driver    string    `json:"driver,omitempty"`    // config `type` (infra roles)
 	Endpoint  string    `json:"endpoint,omitempty"`  // health probe: http(s) URL or tcp:<host>:<port>
 	HostReuse bool      `json:"hostReuse,omitempty"` // schema 1 (read-compat only; no longer written)
 	StartedAt time.Time `json:"startedAt"`
@@ -140,12 +141,13 @@ func removeState() {
 
 // recordService updates one service's entry and saves. provided says who
 // provides the role; endpoint is the health probe status should use.
-func (st *stackState) recordService(role, id, image, provided, endpoint string) {
+func (st *stackState) recordService(role, id, image, provided, endpoint, driver string) {
 	e := serviceState{
 		ID:        id,
 		Image:     image,
 		Provided:  provided,
 		Endpoint:  endpoint,
+		Driver:    driver,
 		StartedAt: time.Now().UTC(),
 	}
 	if provided == providedLauncher {

--- a/apps/launcher/internal/launcher/statefile.go
+++ b/apps/launcher/internal/launcher/statefile.go
@@ -16,11 +16,21 @@ import (
 // by an older launcher). The record is belief, not ground truth: status
 // still verifies every claim against the runtime and the health endpoints.
 
+// Provided values (schema 2): who provides this role.
+const (
+	providedLauncher = "launcher" // a container this launcher started
+	providedHost     = "host"     // a host process (reused, not launched)
+	providedExternal = "external" // config-declared external endpoint
+	providedNone     = "none"     // not referenced by the config
+)
+
 type serviceState struct {
-	Container string    `json:"container"`           // container name
+	Container string    `json:"container,omitempty"` // container name (launcher-provided only)
 	ID        string    `json:"id,omitempty"`        // identifier the runtime printed at run -d
 	Image     string    `json:"image,omitempty"`     // full image ref
-	HostReuse bool      `json:"hostReuse,omitempty"` // inference served by a host Ollama, no container
+	Provided  string    `json:"provided,omitempty"`  // schema 2: launcher|host|external|none
+	Endpoint  string    `json:"endpoint,omitempty"`  // health probe: http(s) URL or tcp:<host>:<port>
+	HostReuse bool      `json:"hostReuse,omitempty"` // schema 1 (read-compat only; no longer written)
 	StartedAt time.Time `json:"startedAt"`
 }
 
@@ -81,6 +91,18 @@ func loadState() *stackState {
 	if json.Unmarshal(b, &st) != nil || st.Services == nil {
 		return nil
 	}
+	// Schema 1 read-compat: hostReuse was the only non-launcher marker.
+	if st.Schema < 2 {
+		for role, e := range st.Services {
+			if e.Provided == "" {
+				e.Provided = providedLauncher
+				if e.HostReuse {
+					e.Provided = providedHost
+				}
+				st.Services[role] = e
+			}
+		}
+	}
 	return &st
 }
 
@@ -93,9 +115,7 @@ func saveState(st *stackState) {
 	}
 	st.UpdatedAt = time.Now().UTC()
 	st.Launcher = BuildVersion
-	if st.Schema == 0 {
-		st.Schema = 1
-	}
+	st.Schema = 2
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		return
@@ -117,14 +137,19 @@ func removeState() {
 	}
 }
 
-// recordService updates one service's entry and saves.
-func (st *stackState) recordService(role, id, image string, hostReuse bool) {
-	st.Services[role] = serviceState{
-		Container: roles[role].container,
+// recordService updates one service's entry and saves. provided says who
+// provides the role; endpoint is the health probe status should use.
+func (st *stackState) recordService(role, id, image, provided, endpoint string) {
+	e := serviceState{
 		ID:        id,
 		Image:     image,
-		HostReuse: hostReuse,
+		Provided:  provided,
+		Endpoint:  endpoint,
 		StartedAt: time.Now().UTC(),
 	}
+	if provided == providedLauncher {
+		e.Container = roles[role].container
+	}
+	st.Services[role] = e
 	saveState(st)
 }

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -255,8 +255,26 @@ func printRoots(u *ui, st *stackState) {
 		fmt.Printf("  %s\n", u.dim("(none — cd into a KB clone, set SEMIONT_ROOT, or start with --root)"))
 		return
 	}
+	// Identity per root: the registry's stored did/siteName (survives the
+	// path vanishing), refreshed by a live read when the root is present.
+	reg := loadRoots()
 	for _, p := range order {
 		fmt.Printf("  %s %s\n", p, u.dim("("+strings.Join(labels[p], "; ")+")"))
+		did, site := "", ""
+		for _, e := range reg.Roots {
+			if e.Path == p {
+				did, site = e.Did, e.SiteName
+			}
+		}
+		if ident := loadKBIdentity(p); ident != nil {
+			did, site = ident.didWeb(), ident.SiteName
+		}
+		switch {
+		case did != "" && site != "":
+			fmt.Printf("    %s %s\n", u.dim(did), u.dim("— "+site))
+		case did != "":
+			fmt.Printf("    %s\n", u.dim(did))
+		}
 	}
 }
 

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -111,7 +111,11 @@ func Status(args []string) int {
 		}
 	} else if st != nil && st.Runtime != "" && onPath(st.Runtime) {
 		runtimes = []string{st.Runtime}
-		u.log("Using recorded stack state %s", u.dim("("+st.Runtime+" per "+statePath()+")"))
+		note := st.Runtime
+		if st.Version != "" {
+			note += "; images " + st.Version
+		}
+		u.log("Using recorded stack state %s", u.dim("("+note+"; "+statePath()+")"))
 	} else {
 		st = nil
 		runtimes = installedRuntimes()
@@ -150,19 +154,14 @@ func Status(args []string) int {
 			continue
 		}
 
-		// TECH: the concrete product behind the role. Infra roles: the
-		// recorded driver (survives config changes since start), falling back
-		// to the static product for records that predate the driver field.
-		// Semiont services (no product of their own): the recorded image tag
-		// — which doubles as the running version.
+		// TECH: the concrete product behind an infra role — the recorded
+		// driver (survives config changes since start), falling back to the
+		// static product for records that predate the driver field. Semiont
+		// services stay blank: the role name already says what they are, and
+		// their image version is stack-level (shown once in the header line).
 		tech := roles[svc.name].product
-		switch {
-		case rec != nil && rec.Driver != "":
+		if rec != nil && rec.Driver != "" {
 			tech = driverDisplay(svc.name, rec.Driver)
-		case rec != nil && tech == "" && rec.Image != "":
-			if i := strings.LastIndex(rec.Image, ":"); i >= 0 {
-				tech = rec.Image[i+1:]
-			}
 		}
 		if tech == "" {
 			tech = "—"

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -127,20 +127,43 @@ func Status(args []string) int {
 		if service != "" && svc.name != service {
 			continue
 		}
-		// Query by the recorded identifier when we have one; the container
-		// name is the fallback handle.
+		// The record supplies the identifier, the endpoint, and who provides
+		// the role; the runtime and the probe stay the ground truth.
 		handle := roles[svc.name].container
+		endpoint := svc.endpoint
+		var rec *serviceState
 		if st != nil {
-			if e, ok := st.Services[svc.name]; ok && e.ID != "" {
-				handle = e.ID
+			if e, ok := st.Services[svc.name]; ok {
+				rec = &e
+				if e.ID != "" {
+					handle = e.ID
+				}
+				if e.Endpoint != "" {
+					endpoint = e.Endpoint
+				}
 			}
 		}
-		state, rt := containerState(runtimes, handle)
-		healthy := probeHealth(svc.endpoint)
 
-		// Host Ollama reuse: no container, but the endpoint answers — that is
-		// a healthy configuration, not a gap.
-		if svc.name == "inference" && state == "" && healthy {
+		// Not referenced by the config: no probe, no exit-status impact.
+		if rec != nil && rec.Provided == providedNone {
+			fmt.Printf("  %-10s %-10s %-10s %s\n", svc.name, "—", "—", u.dim("not configured"))
+			continue
+		}
+
+		state, rt := "", ""
+		switch {
+		case rec != nil && rec.Provided == providedExternal:
+			rt = "external"
+		case rec != nil && rec.Provided == providedHost:
+			rt = "host"
+		default:
+			state, rt = containerState(runtimes, handle)
+		}
+		healthy := probeHealth(endpoint)
+
+		// Host Ollama reuse heuristic for record-less stacks: no container,
+		// but the endpoint answers — a healthy configuration, not a gap.
+		if svc.name == "inference" && rec == nil && state == "" && healthy {
 			rt = "host"
 		}
 
@@ -162,9 +185,13 @@ func Status(args []string) int {
 		if rt == "" {
 			rt = u.dim("—")
 		}
-		label := svc.endpoint
-		if port, ok := strings.CutPrefix(label, "tcp:"); ok {
-			label = "tcp://localhost:" + port
+		label := endpoint
+		if rest, ok := strings.CutPrefix(label, "tcp:"); ok {
+			if strings.Contains(rest, ":") {
+				label = "tcp://" + rest
+			} else {
+				label = "tcp://localhost:" + rest
+			}
 		}
 		healthCol := u.wrap(ansiRed, "✗") + " " + u.dim(label)
 		if healthy {
@@ -330,8 +357,12 @@ func containerState(runtimes []string, name string) (state, rt string) {
 // probeHealth runs one host-side application probe: 2xx for http endpoints,
 // an accepted dial for tcp ones.
 func probeHealth(endpoint string) bool {
-	if port, ok := strings.CutPrefix(endpoint, "tcp:"); ok {
-		conn, err := net.DialTimeout("tcp", "localhost:"+port, time.Second)
+	if rest, ok := strings.CutPrefix(endpoint, "tcp:"); ok {
+		addr := rest
+		if !strings.Contains(rest, ":") {
+			addr = "localhost:" + rest
+		}
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err != nil {
 			return false
 		}

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -29,14 +29,14 @@ Exit status: 0 when every core service is healthy (Jaeger is observability,
 not core), 1 otherwise.
 
 With --service <name>, report just that one service (backend, worker,
-smelter, weaver, frontend, db, graph, vectors, inference, or traces) — the
+smelter, weaver, frontend, database, graph, vectors, inference, or traces) — the
 exit status then reflects that service alone (traces included), making it
 scriptable:
   semiont status --service backend && echo up
 `
 
 // statusServices drives the report, in user-facing-first order with each
-// service beside its primary store (backend→db, worker→inference,
+// service beside its primary store (backend→database, worker→inference,
 // weaver→graph, smelter→vectors), observability last. Deliberately unrelated
 // to start/stop ordering (which is dependency order). Names are the abstract
 // roles; the roles table maps them to containers. Health probes are
@@ -48,7 +48,7 @@ var statusServices = []struct {
 }{
 	{"frontend", "http://localhost:3000", true},
 	{"backend", "http://localhost:4000/api/health", true},
-	{"db", "tcp:5432", true},
+	{"database", "tcp:5432", true},
 	{"worker", "http://localhost:9090/health", true},
 	{"inference", "http://localhost:11434/api/version", true},
 	{"weaver", "http://localhost:9092/health", true},

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -121,7 +121,7 @@ func Status(args []string) int {
 		return 1
 	}
 
-	fmt.Printf("  %-10s %-10s %-10s %s\n", "SERVICE", "CONTAINER", "RUNTIME", "HEALTH")
+	fmt.Printf("  %-10s %-12s %-10s %-10s %s\n", "SERVICE", "TECH", "CONTAINER", "RUNTIME", "HEALTH")
 	allCoreHealthy := true
 	for _, svc := range statusServices {
 		if service != "" && svc.name != service {
@@ -146,8 +146,26 @@ func Status(args []string) int {
 
 		// Not referenced by the config: no probe, no exit-status impact.
 		if rec != nil && rec.Provided == providedNone {
-			fmt.Printf("  %-10s %-10s %-10s %s\n", svc.name, "—", "—", u.dim("not configured"))
+			fmt.Printf("  %-10s %-12s %-10s %-10s %s\n", svc.name, "—", "—", "—", u.dim("not configured"))
 			continue
+		}
+
+		// TECH: the concrete product behind the role. Infra roles: the
+		// recorded driver (survives config changes since start), falling back
+		// to the static product for records that predate the driver field.
+		// Semiont services (no product of their own): the recorded image tag
+		// — which doubles as the running version.
+		tech := roles[svc.name].product
+		switch {
+		case rec != nil && rec.Driver != "":
+			tech = driverDisplay(svc.name, rec.Driver)
+		case rec != nil && tech == "" && rec.Image != "":
+			if i := strings.LastIndex(rec.Image, ":"); i >= 0 {
+				tech = rec.Image[i+1:]
+			}
+		}
+		if tech == "" {
+			tech = "—"
 		}
 
 		state, rt := "", ""
@@ -197,8 +215,8 @@ func Status(args []string) int {
 		if healthy {
 			healthCol = u.wrap(ansiGreen, "✓") + " " + u.dim(label)
 		}
-		fmt.Printf("  %-10s %-*s %-*s %s\n",
-			svc.name, 10+utf8.RuneCountInString(stateCol)-visibleLen(stateCol), stateCol,
+		fmt.Printf("  %-10s %-12s %-*s %-*s %s\n",
+			svc.name, tech, 10+utf8.RuneCountInString(stateCol)-visibleLen(stateCol), stateCol,
 			10+utf8.RuneCountInString(rt)-visibleLen(rt), rt, healthCol)
 	}
 	if service == "" {

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -121,7 +121,10 @@ func Stop(args []string) int {
 		for _, c := range names {
 			role := roleByContainer[c]
 			if e, ok := st.Services[role]; ok {
-				if e.HostReuse {
+				// Only containers this launcher started are ours to stop:
+				// host processes, external endpoints, and unreferenced roles
+				// have nothing to sweep.
+				if e.Provided != "" && e.Provided != providedLauncher {
 					continue
 				}
 				if e.ID != "" {

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -18,7 +18,7 @@ With no --runtime, EVERY installed runtime is swept — stopping via the wrong
 runtime is a silent no-op that leaves the real stack running.
 
 With --service <name>, stop just that one service (backend, worker, smelter,
-weaver, frontend, db, graph, vectors, inference, or traces). The staged
+weaver, frontend, database, graph, vectors, inference, or traces). The staged
 config copies are left in place — the rest of the stack is still mounting
 them.
 `

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -209,6 +209,11 @@ func selectRuntime(u *ui, requested string) (string, bool) {
 
 var healthClient = &http.Client{Timeout: 2 * time.Second}
 
+// netDialTimeout: one TCP reachability check (external-role verification).
+func netDialTimeout(addr string) (net.Conn, error) {
+	return net.DialTimeout("tcp", addr, 3*time.Second)
+}
+
 func httpOK(url string) bool {
 	resp, err := healthClient.Get(url)
 	if err != nil {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -97,6 +97,14 @@ func mkKB(t *testing.T) string {
 			t.Fatal(err)
 		}
 	}
+	// The KB's committed identity card (.semiont/config).
+	b, err := os.ReadFile(filepath.Join("testdata", "kb", ".semiont", "config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".semiont", "config"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	return root
 }
 
@@ -248,6 +256,7 @@ func TestStartDefaultBoot(t *testing.T) {
 	}
 	checkGolden(t, "start-default-boot.argv", s.argv(t))
 	mustContain(t, "stdout", stdout,
+		"KB: Test Knowledge Base did:web:example.github.io:test-kb",
 		"No prior containers",
 		"🚀 Semiont stack is up",
 		"http://localhost:3000",
@@ -896,6 +905,9 @@ func TestRootsRegistryAndRootFlag(t *testing.T) {
 	if len(reg.Roots) != 1 || reg.Roots[0].Path != s.kb {
 		t.Fatalf("registry contents: %s", b)
 	}
+	mustContain(t, "roots.json", string(b),
+		`"did": "did:web:example.github.io:test-kb"`,
+		`"siteName": "Test Knowledge Base"`)
 	if reg.Roots[0].LastStarted != "" {
 		t.Error("--service start must not stamp lastStarted (full start only)")
 	}
@@ -923,9 +935,10 @@ func TestRootsRegistryAndRootFlag(t *testing.T) {
 		t.Errorf("dry-run mutated the registry:\n%s", after)
 	}
 
-	// status shows the registered root.
+	// status shows the registered root, with its did:web identity line.
 	stdout, _, _ = s.run(t, "status")
-	mustContain(t, "status stdout", stdout, "SEMIONT ROOTS", s.kb, "last used ")
+	mustContain(t, "status stdout", stdout, "SEMIONT ROOTS", s.kb, "last used ",
+		"did:web:example.github.io:test-kb — Test Knowledge Base")
 }
 
 func TestRootFlagErrors(t *testing.T) {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -706,6 +706,34 @@ func TestStartExternalGraphBoot(t *testing.T) {
 			t.Errorf("external graph still touched %q in argv", absent)
 		}
 	}
+
+	// The record knows graph is external; status shows it and probes the real
+	// endpoint; stop leaves it alone.
+	b, err := os.ReadFile(statePathFor(s.home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustContain(t, "stack.json", string(b), `"provided": "external"`, "tcp:127.0.0.1:7777")
+
+	stdout, _, code = s.run(t, "status")
+	if code != 0 {
+		t.Errorf("status: exit %d\n%s", code, stdout)
+	}
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.Contains(line, "graph") && strings.Contains(line, "tcp://") {
+			mustContain(t, "graph status row", line, "external", "✓", "tcp://127.0.0.1:7777")
+		}
+	}
+
+	preStop := s.argv(t)
+	if _, _, code := s.run(t, "stop"); code != 0 {
+		t.Fatalf("stop: exit %d", code)
+	}
+	stopArgv := strings.TrimPrefix(s.argv(t), preStop)
+	if strings.Contains(stopArgv, "semiont-neo4j") {
+		t.Errorf("stop touched the external graph:\n%s", stopArgv)
+	}
+	mustContain(t, "stop argv", stopArgv, "stop fid-semiont-backend")
 }
 
 func TestStartMovedDBPortBoot(t *testing.T) {
@@ -739,6 +767,21 @@ func TestStartNoInferenceBoot(t *testing.T) {
 	mustContain(t, "stdout", stdout, "inference — not referenced by the config; skipping")
 	if argv := s.argv(t); strings.Contains(argv, "ollama") {
 		t.Errorf("no-ollama config still touched ollama:\n%s", argv)
+	}
+
+	// status: inference reads "not configured", exits healthy without it;
+	// stop never touches an ollama container.
+	stdout, _, code = s.run(t, "status")
+	if code != 0 {
+		t.Errorf("status: exit %d\n%s", code, stdout)
+	}
+	mustContain(t, "status stdout", stdout, "not configured")
+	preStop := s.argv(t)
+	if _, _, code := s.run(t, "stop"); code != 0 {
+		t.Fatalf("stop: exit %d", code)
+	}
+	if stopArgv := strings.TrimPrefix(s.argv(t), preStop); strings.Contains(stopArgv, "ollama") {
+		t.Errorf("stop touched ollama:\n%s", stopArgv)
 	}
 }
 
@@ -938,12 +981,14 @@ func TestStackStateLifecycle(t *testing.T) {
 			Container string `json:"container"`
 			ID        string `json:"id"`
 			Image     string `json:"image"`
+			Provided  string `json:"provided"`
+			Endpoint  string `json:"endpoint"`
 		} `json:"services"`
 	}
 	if err := json.Unmarshal(b, &st); err != nil {
 		t.Fatalf("stack.json not valid JSON: %v\n%s", err, b)
 	}
-	if st.Schema != 1 || st.Runtime != "container" {
+	if st.Schema != 2 || st.Runtime != "container" {
 		t.Errorf("schema/runtime: got %d/%q", st.Schema, st.Runtime)
 	}
 	for _, role := range []string{"traces", "graph", "vectors", "inference", "database", "backend", "worker", "smelter", "weaver", "frontend"} {
@@ -957,6 +1002,12 @@ func TestStackStateLifecycle(t *testing.T) {
 		}
 		if e.Image == "" {
 			t.Errorf("%s: image not recorded", role)
+		}
+		if e.Provided != "launcher" {
+			t.Errorf("%s: provided = %q, want launcher", role, e.Provided)
+		}
+		if e.Endpoint == "" {
+			t.Errorf("%s: endpoint not recorded", role)
 		}
 	}
 
@@ -1008,6 +1059,34 @@ func TestStackStateLifecycle(t *testing.T) {
 	}
 	if _, err := os.Stat(statePathFor(s.home)); !os.IsNotExist(err) {
 		t.Error("stack.json survived a full stop")
+	}
+}
+
+func TestStopSchema1Compat(t *testing.T) {
+	// A schema-1 stack.json (hostReuse flag, no provided field) still steers
+	// stop: host-reused inference is skipped, launcher containers stop by ID.
+	s := newScenario(t, "container", "docker")
+	v1 := `{"schema":1,"runtime":"container","services":{
+	  "backend":{"container":"semiont-backend","id":"fid-semiont-backend","startedAt":"2026-07-18T00:00:00Z"},
+	  "inference":{"container":"semiont-ollama","hostReuse":true,"startedAt":"2026-07-18T00:00:00Z"}}}`
+	p := statePathFor(s.home)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(v1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, code := s.run(t, "stop")
+	if code != 0 {
+		t.Fatalf("stop: exit %d\n%s", code, stdout)
+	}
+	argv := s.argv(t)
+	mustContain(t, "argv", argv, "container stop fid-semiont-backend")
+	if strings.Contains(argv, "ollama") {
+		t.Errorf("schema-1 hostReuse not honored:\n%s", argv)
+	}
+	if strings.Contains(argv, "docker stop") {
+		t.Errorf("recorded runtime not honored:\n%s", argv)
 	}
 }
 

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -856,7 +856,7 @@ func TestStackStateLifecycle(t *testing.T) {
 	if st.Schema != 1 || st.Runtime != "container" {
 		t.Errorf("schema/runtime: got %d/%q", st.Schema, st.Runtime)
 	}
-	for _, role := range []string{"traces", "graph", "vectors", "inference", "db", "backend", "worker", "smelter", "weaver", "frontend"} {
+	for _, role := range []string{"traces", "graph", "vectors", "inference", "database", "backend", "worker", "smelter", "weaver", "frontend"} {
 		e, ok := st.Services[role]
 		if !ok {
 			t.Errorf("service %q missing from record", role)

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1026,9 +1026,11 @@ func TestStackStateLifecycle(t *testing.T) {
 	}
 
 	preStatus := s.argv(t)
-	if _, _, code := s.run(t, "status"); code != 0 {
+	statusOut, _, code := s.run(t, "status")
+	if code != 0 {
 		t.Errorf("status on healthy stack: exit %d", code)
 	}
+	mustContain(t, "status header", statusOut, "images latest")
 	statusArgv := strings.TrimPrefix(s.argv(t), preStatus)
 	mustContain(t, "status argv", statusArgv, "container inspect fid-semiont-backend")
 	for _, bad := range []string{"docker inspect", "podman inspect"} {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -587,7 +587,8 @@ func TestStatusMixed(t *testing.T) {
 		t.Fatalf("want exit 1 with unhealthy core services, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 	mustContain(t, "stdout", stdout,
-		"SERVICE", "CONTAINER", "RUNTIME", "HEALTH",
+		"SERVICE", "TECH", "CONTAINER", "RUNTIME", "HEALTH",
+		"PostgreSQL", "Neo4j", "Qdrant", "Ollama", "Jaeger",
 		"SEMIONT ROOTS",
 		"(discovered from cwd)",
 		"LOCAL HOST DIRECTORIES",
@@ -730,7 +731,7 @@ func TestStartExternalGraphBoot(t *testing.T) {
 	}
 	for _, line := range strings.Split(stdout, "\n") {
 		if strings.Contains(line, "graph") && strings.Contains(line, "tcp://") {
-			mustContain(t, "graph status row", line, "external", "✓", "tcp://127.0.0.1:7777")
+			mustContain(t, "graph status row", line, "Neo4j", "external", "✓", "tcp://127.0.0.1:7777")
 		}
 	}
 

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -668,6 +668,96 @@ func TestInvocationLog(t *testing.T) {
 	}
 }
 
+// --- config-driven boots (LAUNCHER-CONFIG-SYNC P2) ---
+
+// writeKBConfig drops a variant semiontconfig into the scenario's KB.
+func writeKBConfig(t *testing.T, s *scenario, name, body string) {
+	t.Helper()
+	head := "[defaults]\nenvironment = \"local\"\n\n[environments.local.backend]\nplatform = \"posix\"\nport = 4000\n\n"
+	p := filepath.Join(s.kb, ".semiont", "semiontconfig", name+".toml")
+	if err := os.WriteFile(p, []byte(head+body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const stdVectors = "[environments.local.vectors]\ntype = \"qdrant\"\nhost = \"${QDRANT_HOST}\"\nport = 6333\n\n"
+const stdEmbedding = "[environments.local.embedding]\ntype = \"ollama\"\nbaseURL = \"http://${OLLAMA_HOST}:11434\"\n\n"
+const stdDatabase = "[environments.local.database]\nhost = \"${POSTGRES_HOST}\"\nport = 5432\nname = \"semiont\"\nuser = \"postgres\"\npassword = \"localpass\"\n\n"
+const stdGraph = "[environments.local.graph]\ntype = \"neo4j\"\nuri = \"bolt://${NEO4J_HOST}:7687\"\nusername = \"neo4j\"\npassword = \"localpass\"\n\n"
+
+func TestStartExternalGraphBoot(t *testing.T) {
+	// graph at a literal address: verify reachability, launch no container,
+	// claim no graph ports.
+	s := newScenario(t, "container")
+	writeKBConfig(t, s, "external-graph",
+		"[environments.local.graph]\ntype = \"neo4j\"\nuri = \"bolt://127.0.0.1:7777\"\nusername = \"neo4j\"\npassword = \"remotepass\"\n\n"+
+			stdVectors+stdEmbedding+stdDatabase)
+	serveHealth(t, 7777)
+	stdout, stderr, code := s.run(t, "start", "--config", "external-graph")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout,
+		"graph — externally provided at 127.0.0.1:7777 (reachable)",
+		"🚀 Semiont stack is up")
+	argv := s.argv(t)
+	for _, absent := range []string{"run -d --rm --name semiont-neo4j", "NEO4J_AUTH", "lsof -ti :7474"} {
+		if strings.Contains(argv, absent) {
+			t.Errorf("external graph still touched %q in argv", absent)
+		}
+	}
+}
+
+func TestStartMovedDBPortBoot(t *testing.T) {
+	// database.port moves the HOST side of the publish; container side stays
+	// the driver default, and every check/gate follows the config.
+	s := newScenario(t, "container")
+	writeKBConfig(t, s, "moved-db",
+		stdGraph+stdVectors+stdEmbedding+
+			"[environments.local.database]\nhost = \"${POSTGRES_HOST}\"\nport = 5433\nname = \"semiont\"\nuser = \"postgres\"\npassword = \"localpass\"\n\n")
+	stdout, stderr, code := s.run(t, "start", "--config", "moved-db")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout, "database — PostgreSQL on port 5433")
+	mustContain(t, "argv", s.argv(t), "-p 5433:5432", "nc -z -w 2 192.168.64.1 5433")
+}
+
+func TestStartNoInferenceBoot(t *testing.T) {
+	// A config that references no ollama anywhere: the launcher launches no
+	// inference at all — derived fact, not folklore.
+	s := newScenario(t, "container")
+	writeKBConfig(t, s, "no-ollama",
+		stdGraph+stdVectors+stdDatabase+
+			"[environments.local.inference.anthropic]\nplatform = \"external\"\nendpoint = \"https://api.anthropic.com\"\napiKey = \"${ANTHROPIC_API_KEY}\"\n\n"+
+			"[environments.local.workers.default.inference]\ntype = \"anthropic\"\nmodel = \"claude-sonnet-4-5-20250929\"\n\n")
+	s.extraEnv = append(s.extraEnv, "ANTHROPIC_API_KEY=test-key")
+	stdout, stderr, code := s.run(t, "start", "--config", "no-ollama")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout, "inference — not referenced by the config; skipping")
+	if argv := s.argv(t); strings.Contains(argv, "ollama") {
+		t.Errorf("no-ollama config still touched ollama:\n%s", argv)
+	}
+}
+
+func TestStartServiceExternalIsNoop(t *testing.T) {
+	// P0 q5: --service on an externally-provided role warns and exits 0.
+	s := newScenario(t, "container")
+	writeKBConfig(t, s, "external-graph",
+		"[environments.local.graph]\ntype = \"neo4j\"\nuri = \"bolt://graph.example.com:7687\"\nusername = \"neo4j\"\npassword = \"remotepass\"\n\n"+
+			stdVectors+stdEmbedding+stdDatabase)
+	stdout, stderr, code := s.run(t, "start", "--service", "graph", "--config", "external-graph")
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout+stderr", stdout+stderr, "graph is externally provided per", "graph.example.com:7687", "nothing to launch")
+	if argv := s.argv(t); strings.Contains(argv, "semiont-neo4j") {
+		t.Errorf("no-op still touched the container:\n%s", argv)
+	}
+}
+
 // --- SEMIONT_ROOT / KB-root discovery ---
 
 func TestSemiontRootOverride(t *testing.T) {
@@ -813,7 +903,7 @@ func TestRootFlagErrors(t *testing.T) {
 	if code != 1 {
 		t.Errorf("--root with frontend: want exit 1, got %d", code)
 	}
-	mustContain(t, "stderr", stderr, "--root only applies to")
+	mustContain(t, "stderr", stderr, "--root only applies to services that read the KB config")
 }
 
 // --- stack state record ---
@@ -1035,7 +1125,7 @@ func TestStartServiceRejections(t *testing.T) {
 	}{
 		{[]string{"start", "--service", "bogus"}, "Unknown --service 'bogus'"},
 		{[]string{"start", "--service", "worker", "--email", "a@b.co", "--password", "password123"}, "--email/--password only apply to --service backend."},
-		{[]string{"start", "--service", "graph", "--config", "anthropic"}, "--config only applies to --service backend, worker, smelter, or weaver."},
+		{[]string{"start", "--service", "frontend", "--config", "anthropic"}, "--config does not apply to --service frontend"},
 		{[]string{"start", "--service", "worker", "--no-observe"}, "--no-observe does not apply to --service"},
 		{[]string{"start", "--service", "worker", "--ollama-cache", "host"}, "--ollama-cache only applies to --service inference."},
 		{[]string{"start", "--service", "worker", "--list-configs"}, "--list-configs cannot be combined with --service."},

--- a/apps/launcher/testdata/kb/.semiont/config
+++ b/apps/launcher/testdata/kb/.semiont/config
@@ -1,0 +1,12 @@
+[project]
+name = "Test Knowledge Base"
+version = "0.1.0"
+
+[git]
+sync = true
+
+[site]
+domain = "example.github.io:test-kb"
+siteName = "Test Knowledge Base"
+adminEmail = ""
+oauthAllowedDomains = ["example.com"]

--- a/docs/system/administration/CONFIGURATION.md
+++ b/docs/system/administration/CONFIGURATION.md
@@ -2,6 +2,15 @@
 
 Semiont uses a two-layer TOML configuration model, analogous to Git's `~/.gitconfig` + `.git/config`.
 
+> **Consumers of this schema.** Besides the Semiont services themselves (which
+> select drivers by each role's `type`), the **`semiont` launcher** derives its
+> launch plan from a KB's `.semiont/semiontconfig/*.toml`: per dependency role
+> (`graph`, `vectors`, `database`, `inference`/`embedding`) it reads `type`,
+> the address/port, and credentials to decide whether to launch a container,
+> verify an external endpoint, or reuse a host process. The launcher reads only
+> those keys and ignores the rest; this document remains the schema's source of
+> truth. See `apps/launcher/README.md` and `.plans/LAUNCHER-CONFIG-SYNC.md`.
+
 ## Configuration Layers
 
 | Scope | Path | Committed? | Content |

--- a/docs/system/administration/CONFIGURATION.md
+++ b/docs/system/administration/CONFIGURATION.md
@@ -16,19 +16,38 @@ Semiont uses a two-layer TOML configuration model, analogous to Git's `~/.gitcon
 | Scope | Path | Committed? | Content |
 |---|---|---|---|
 | Global | `~/.semiontconfig` | No | All environment config: services, ports, URLs, credentials, inference |
-| Project | `.semiont/config` | Yes | Project name only |
+| Project | `.semiont/config` | Yes | Project identity: name, git sync, site identity (did:web) |
 | Secrets | `$XDG_CONFIG_HOME/semiont/secrets` | No | JWT secret (mode 0600) |
 
 ### `.semiont/config` (project-local, committed)
 
-Created by `semiont init`. Contains only the project name:
+Created by `semiont init`. The project's committed identity card:
 
 ```toml
 [project]
-name = "my-semiont-project"
+name = "My Knowledge Base"
+version = "0.1.0"
+
+[git]
+sync = true                # backend stages event-log writes with git
+
+[site]
+# Permanent did:web identity for everything this KB mints (stamped into the
+# committed event log). Names the repo, not a deployment — a committed
+# literal, never env-templated, never a machine address.
+domain = "example.github.io:my-kb"    # ⇔ did:web:example.github.io:my-kb
+siteName = "My Knowledge Base"
+adminEmail = ""
+oauthAllowedDomains = ["example.com"]
 ```
 
-Everything else lives in `~/.semiontconfig`, keyed to this name.
+`[site] domain` is identity, not addressing: it names the repository in
+did:web's colon-path form and must stay stable across deployments (the same
+invariant that keeps `BACKEND_HOST` off the backend container — `publicURL`
+derivation). The `semiont` launcher parses this file for display and its
+roots registry (`roots.json` records each root's did:web and siteName);
+environment wiring stays in `~/.semiontconfig` / the KB's
+`.semiont/semiontconfig/` variants, keyed to the project name.
 
 ### `~/.semiontconfig` (user-global, never committed)
 


### PR DESCRIPTION
The launcher now derives its work from the same config files the Semiont containers read — `.semiont/semiontconfig/*.toml` for wiring, `.semiont/config` for identity — instead of hardcoding parallel copies of ports, credentials, images, and the host-Ollama special case. Design + full execution log: `.plans/LAUNCHER-CONFIG-SYNC.md`. Follow-up to #1043.

## The derivation model

One pure function, `configFile → launchPlan`. Per dependency role (`graph`, `vectors`, `database` — renamed from `db` to match the config section — and `inference`/`embedding`), the config decides the **obligation**:

| Config says | Launcher does |
|---|---|
| address on a launcher-injected `${*_HOST}` var | **provides** a container — driver selected by `type` from a catalog, credentials/ports from the config |
| any other address | **external**: verify reachability (TCP dial), never launch, never claim ports |
| `platform = "posix"` | **host process**: probe-and-reuse (the Ollama dance, generalized into policy) |
| section absent / unreferenced | **nothing**: not launched, "not configured" in status, no exit-status impact |

The driver **catalog** owns only what the config doesn't declare (image, aux ports like Neo4j's 7474 browser, probe shapes); the config owns addresses, ports, and credentials — the launcher's duplicated `localpass` and hardcoded port table are gone. An alternative backing service (memgraph, pgvector, a managed Neo4j/RDS endpoint) is now one catalog entry or zero code.

Concrete behaviors this unlocks, each pinned by a black-box test:
- `database.port = 5433` → `-p 5433:5432` publish, port check, health gate, and container-side probe all follow.
- `uri = "bolt://graph.example.com:9999"` → no Neo4j container, reachability verify, status shows `external ✓ tcp://graph.example.com:9999`, stop leaves it alone.
- A config with no ollama reference anywhere → zero Ollama activity ("anthropic still runs Ollama" is now a *derived* fact: it only holds because `embedding.type = "ollama"`).
- `start --service <role>` on an externally-provided role is a **no-op**: warning + exit 0.

**The parity gate:** every pre-existing boot, dry-run, and stdout golden passed **unchanged** through the rewiring — byte-identical derivation for the real template configs, proven rather than asserted.

## First dependency + strictness

- `github.com/pelletier/go-toml/v2` (no transitive deps) — the module's first dependency; SBOM/attestation pick it up automatically.
- Validation is strict for keys the launcher consumes: missing required keys fail fast naming file, section, and key; documented defaults (`vectors.platform`, `database.type`, ports) don't trip it. Unknown `type` errors name the known drivers.

## stack.json schema 2

`hostReuse` generalizes to `provided` (`launcher` | `host` | `external` | `none`), with read-compat for schema 1 (a v1 file still steers stop — tested). Every entry records its health `endpoint`; `stop` sweeps only `provided=launcher` containers; `status` probes recorded endpoints.

## `.semiont/config` identity

The launcher also parses the KB's committed identity card (best-effort, display-only): `roots.json` entries carry **did:web** + siteName (a missing root stays identifiable), `stack.json` records `kbDid`, `start` opens with `KB: <siteName> did:web:…`, and status's SEMIONT ROOTS section prints an identity sub-line per root. CONFIGURATION.md's stale ".semiont/config = project name only" is corrected to document the real `[project]`/`[git]`/`[site]` layout and the did:web invariant.

## Testing

59 tests (including subtests): 8 derivation unit tests (RED-first against a stub) + black-box boots for external-graph/moved-port/no-inference each chained through status and stop, schema-1 compat, identity assertions — all green, with the pre-existing goldens untouched as the refactor's proof.
