### PR TITLE
Launcher: design-review remediation — record-lifecycle fixes, role-executor, logs --service, loud secret recovery, image overrides

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -54,7 +54,9 @@ semiont stop
   stop, shown as "external" in status); `platform = "posix"` → host-process
   reuse; section absent / unreferenced → nothing launched, "not configured"
   in status. Moving `database.port` moves the publish/checks/gates with it;
-  inference runs only when the config references ollama. `--dry-run` renders
+  inference runs only when the config references ollama. An optional `image`
+  key per role section overrides the catalog's default image — a KB can pin
+  or upgrade an infra image without a launcher release. `--dry-run` renders
   the derived plan.
 - KB-root discovery matches the npm CLI (`SEMIONT_ROOT`, analogous to
   `GIT_DIR`): the override is strict (invalid values error, never fall back),

--- a/apps/launcher/internal/launcher/config.go
+++ b/apps/launcher/internal/launcher/config.go
@@ -9,9 +9,60 @@ package launcher
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"sort"
+	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
 )
+
+// The config TOMLs reference env vars as ${VAR} (required) or ${VAR:-default}
+// (optional); only the required form is matched here. These are the ones the
+// launcher injects itself and never demands from the user.
+var injectedVars = map[string]bool{
+	"BACKEND_HOST": true, "NEO4J_HOST": true, "QDRANT_HOST": true,
+	"OLLAMA_HOST": true, "POSTGRES_HOST": true, "SEMIONT_WORKER_SECRET": true,
+	"ADMIN_EMAIL": true, "ADMIN_PASSWORD": true,
+}
+
+var envRefRe = regexp.MustCompile(`\$\{[A-Z_][A-Z0-9_]*\}`)
+
+// requiredVars walks every string value in the parsed document for required
+// ${VAR} references, minus the launcher-injected set. Deliberately the WHOLE
+// document, not the typed model: the containers interpolate refs in keys the
+// launcher doesn't consume (apiKey, custom sections), and refs may live in
+// any environment. Walking parsed VALUES (not raw bytes) means a ${VAR} in a
+// TOML comment no longer creates a phantom requirement.
+func requiredVars(doc any) []string {
+	set := map[string]bool{}
+	var walk func(v any)
+	walk = func(v any) {
+		switch t := v.(type) {
+		case string:
+			for _, m := range envRefRe.FindAllString(t, -1) {
+				name := strings.TrimSuffix(strings.TrimPrefix(m, "${"), "}")
+				if !injectedVars[name] {
+					set[name] = true
+				}
+			}
+		case map[string]any:
+			for _, vv := range t {
+				walk(vv)
+			}
+		case []any:
+			for _, vv := range t {
+				walk(vv)
+			}
+		}
+	}
+	walk(doc)
+	names := make([]string, 0, len(set))
+	for n := range set {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
 
 type semiontConfig struct {
 	Defaults struct {
@@ -81,25 +132,31 @@ type bindingCfg struct {
 	} `toml:"inference"`
 }
 
-// loadConfig parses a semiontconfig TOML and selects the defaults.environment
-// block. ${VAR} references stay verbatim in the values — classification of
-// addresses happens at derivation, interpolation stays the containers' job.
-func loadConfig(path string) (*envConfig, string, error) {
+// loadConfig parses a semiontconfig TOML once, selecting the
+// defaults.environment block and extracting the required ${VAR} references
+// (the launcher's single reader of the file). ${VAR} values stay verbatim —
+// classification happens at derivation, interpolation stays the containers'
+// job.
+func loadConfig(path string) (*envConfig, string, []string, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return nil, "", fmt.Errorf("reading %s: %v", path, err)
+		return nil, "", nil, fmt.Errorf("reading %s: %v", path, err)
 	}
 	var cfg semiontConfig
 	if err := toml.Unmarshal(b, &cfg); err != nil {
-		return nil, "", fmt.Errorf("%s is not valid TOML: %v", path, err)
+		return nil, "", nil, fmt.Errorf("%s is not valid TOML: %v", path, err)
+	}
+	var doc any
+	if err := toml.Unmarshal(b, &doc); err != nil {
+		return nil, "", nil, fmt.Errorf("%s is not valid TOML: %v", path, err)
 	}
 	envName := cfg.Defaults.Environment
 	if envName == "" {
-		return nil, "", fmt.Errorf("%s: [defaults] environment is not set", path)
+		return nil, "", nil, fmt.Errorf("%s: [defaults] environment is not set", path)
 	}
 	env, ok := cfg.Environments[envName]
 	if !ok {
-		return nil, "", fmt.Errorf("%s: environment %q selected by [defaults] is not defined", path, envName)
+		return nil, "", nil, fmt.Errorf("%s: environment %q selected by [defaults] is not defined", path, envName)
 	}
-	return &env, envName, nil
+	return &env, envName, requiredVars(doc), nil
 }

--- a/apps/launcher/internal/launcher/config.go
+++ b/apps/launcher/internal/launcher/config.go
@@ -93,6 +93,7 @@ type graphCfg struct {
 	URI      string `toml:"uri"`
 	Username string `toml:"username"`
 	Password string `toml:"password"`
+	Image    string `toml:"image"` // optional: override the catalog's default image
 }
 
 type vectorsCfg struct {
@@ -100,6 +101,7 @@ type vectorsCfg struct {
 	Type     string `toml:"type"`
 	Host     string `toml:"host"`
 	Port     int    `toml:"port"`
+	Image    string `toml:"image"` // optional: override the catalog's default image
 }
 
 type embeddingCfg struct {
@@ -113,6 +115,7 @@ type providerCfg struct {
 	Endpoint string `toml:"endpoint"`
 	BaseURL  string `toml:"baseURL"`
 	APIKey   string `toml:"apiKey"`
+	Image    string `toml:"image"` // optional (ollama): override the catalog's default image
 }
 
 type databaseCfg struct {
@@ -123,6 +126,7 @@ type databaseCfg struct {
 	Name     string `toml:"name"`
 	User     string `toml:"user"`
 	Password string `toml:"password"`
+	Image    string `toml:"image"` // optional: override the catalog's default image
 }
 
 type bindingCfg struct {

--- a/apps/launcher/internal/launcher/dryrun.go
+++ b/apps/launcher/internal/launcher/dryrun.go
@@ -1,11 +1,6 @@
 package launcher
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-)
+import "strings"
 
 // renderCmd prints one runtime invocation the way a shell would take it,
 // quoting args that contain whitespace (the sh -c scripts).
@@ -20,117 +15,12 @@ func renderCmd(rt string, args ...string) string {
 	return strings.Join(parts, " ")
 }
 
-// renderStartPlan is the --dry-run output: the exact runtime argv sequence a
-// real `semiont start` would execute, with probe-derived values as
-// placeholders. This is the legibility replacement for reading the old bash —
+// renderStartPlan is the --dry-run output: the same full-start flow walked
+// in plan mode. This is the legibility replacement for reading the old bash —
 // and the extraction seam for the stack-parity gate.
 func renderStartPlan(rt, version string, opts startOptions, userEnv []string, plan *launchPlan) {
-	const addr = "<host-addr>"
-	const stage = "<config-stage>"
-	p := func(args ...string) { fmt.Println(renderCmd(rt, args...)) }
-	c := func(format string, a ...any) { fmt.Printf("# "+format+"\n", a...) }
-
-	c("semiont start --dry-run — the exact runtime commands a real run would")
-	c("execute, in order. Values known only at runtime appear as <placeholders>.")
-	switch rt {
-	case "container":
-		c(`probe: container run --rm busybox:1.38.0 sh -c "ip route | awk '/default/{print $3}'" → <host-addr>`)
-	case "docker":
-		c("probe: docker run --rm busybox:1.38.0 nslookup host.docker.internal (fallback: default-gateway probe) → <host-addr>")
-	case "podman":
-		c("probe: podman run --rm busybox:1.38.0 nslookup host.containers.internal (fallback: default-gateway probe) → <host-addr>")
-	}
-	for _, name := range preflightNames {
-		p("stop", name)
-		p("rm", name)
-	}
-	c("remove staged config copies: /tmp/semiont-config.*")
-	checks := planPortChecks(plan, opts.observe)
-	ports := make([]string, 0, len(checks))
-	for _, pc := range checks {
-		ports = append(ports, fmt.Sprintf("%d", pc.port))
-	}
-	c("require free ports: %s", strings.Join(ports, " "))
-	c("stage per-service config copies under <config-stage>: backend.toml worker.toml smelter.toml weaver.toml")
-
-	if version == "local" {
-		c("SEMIONT_VERSION=local — using locally-built :local images (no pull)")
-	} else {
-		for _, svc := range semiontServices {
-			p(pullArgs(rt, image(svc, version))...)
-		}
-	}
-
-	var otel []string
-	if opts.observe {
-		p(tracesArgs()...)
-		c("wait: http://localhost:16686 (30s)")
-		otel = otelArgs(addr)
-	}
-	renderRolePlan(rt, "graph", plan, opts, c, p)
-	renderRolePlan(rt, "vectors", plan, opts, c, p)
-	renderRolePlan(rt, "inference", plan, opts, c, p)
-	renderRolePlan(rt, "database", plan, opts, c, p)
-
-	var admin []string
-	if opts.adminEmail != "" {
-		admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=<admin-password>"}
-	}
-	p(backendArgs("<kb-root>", stage, addr, "<worker-secret>", version, plan.BackendPort, userEnv, otel, admin)...)
-	c("wait: http://localhost:%d/api/health (120s)", plan.BackendPort)
-	c(`probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:%d/api/health" (up to 20 tries)`, rt, plan.BackendPort)
-
-	for _, sc := range []struct {
-		svc, mem string
-		port     int
-	}{{"worker", "2G", 9090}, {"smelter", "2G", 9091}, {"weaver", "3G", 9092}} {
-		p(sidecarArgs(sc.svc, sc.mem, sc.port, stage, addr, "<worker-secret>", version, userEnv, otel)...)
-		c("wait: http://localhost:%d/health (30s)", sc.port)
-	}
-	p(frontendArgs(version)...)
-	c("wait: http://localhost:3000 (30s)")
-}
-
-// renderRolePlan renders one dependency role's slice of the plan, obligations
-// as comments (matching the plan style: conditionals stay legible).
-func renderRolePlan(rt, role string, plan *launchPlan, opts startOptions, c func(string, ...any), p func(...string)) {
-	rp := plan.Roles[role]
-	switch rp.Obligation {
-	case obligationAbsent:
-		c("%s: not referenced by the config — nothing to launch", role)
-	case obligationExternal:
-		c("%s: externally provided at %s:%d — verify reachability, launch nothing", role, rp.Address, rp.Port)
-	case obligationHostProcess:
-		if role != "inference" {
-			c("%s: host process at localhost:%d — verify reachability, launch nothing", role, rp.Port)
-			return
-		}
-		c("probe: host Ollama at http://localhost:%d/api/version", rp.Port)
-		c(`if present — probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:%d/api/version" — and use it`, rt, rp.Port)
-		c("else:")
-		p("stop", "semiont-ollama")
-		c("require free port: %d", rp.Port)
-		volume := "<ollama-volume>"
-		switch opts.ollamaCache {
-		case "host":
-			if home, err := os.UserHomeDir(); err == nil {
-				volume = filepath.Join(home, ".ollama")
-			}
-		case "volume":
-			volume = "semiont-ollama-models"
-		}
-		p(providedRunArgs("inference", rp, "-m", "24G", "-v", volume+":/root/.ollama")...)
-		c("wait: http://localhost:%d/api/version (30s)", rp.Port)
-	case obligationProvided:
-		p(providedRunArgs(role, rp)...)
-		switch role {
-		case "graph":
-			c("wait: http://localhost:%d (30s)", plan.AuxPorts("graph")[0].port)
-		case "vectors":
-			c("wait: http://localhost:%d/readyz (15s)", rp.Port)
-		case "database":
-			c("wait: tcp localhost:%d (20s)", rp.Port)
-			c("probe: %s run --rm busybox:1.38.0 nc -z -w 2 <host-addr> %d", rt, rp.Port)
-		}
-	}
+	x := &planExec{rt: rt}
+	x.c("semiont start --dry-run — the exact runtime commands a real run would")
+	x.c("execute, in order. Values known only at runtime appear as <placeholders>.")
+	flowFullStart(x, flowCtx{plan: plan, opts: opts, version: version, root: "<kb-root>", configFile: opts.configName, userEnv: userEnv})
 }

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -1,0 +1,451 @@
+package launcher
+
+// executor.go — the two walking modes for launch flows (see
+// .plans/LAUNCHER-ROLE-EXECUTOR.md). Flows (flows.go) touch the world only
+// through this interface; liveExec runs the stack, planExec renders
+// --dry-run. EFFECT methods are the drift-proof boundary: argv, ports, URLs,
+// tries, and record contents exist once, in the flow. DECORATION methods are
+// deliberately one-sided (say = live narration, note = plan comments): a
+// plan is a plan, not a transcript.
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type executor interface {
+	// --- effects ---
+	stopRm(name string) bool // teardown; reports whether anything existed
+	pause()                  // the settle sleep after teardown
+	sweepStaging()           // /tmp/semiont-config.* removal (+ state forget)
+	portChecks(ports []portNeed, forceKill bool) bool
+	portCheck(p portNeed, forceKill bool) bool // singular wording in plan mode
+	stopEcho(name string)                      // the echoed best-effort stop (ollama teardown)
+	hostOllamaReachable(addr string, port int) bool
+	stageAll(configFile string) (string, bool)           // per-service config copies; returns stage dir
+	stageOne(svc, configFile string) (string, bool)      // one service's fresh private copy
+	initStack(root, config, version, addr, stage string) // begin the belief record
+	pull(img string) bool
+	runDetached(args []string) (string, bool) // echo + run -d; returns runtime-reported id
+	waitHTTP(label, url string, tries int) (time.Duration, bool)
+	waitPG(addr string, port, tries int) (time.Duration, bool)
+	probeTCP(role string, rp rolePlan) bool // external-role reachability
+	backendReachable(addr string, port int) bool
+	resolveAddr() (string, bool) // container→host address ("<host-addr>" in plan mode)
+	either(cond func() bool, then, els func() int) int
+	otelDetect(addr string) []string       // --service: OTel iff traces is up
+	recoverSecret() (string, bool)         // --service: rejoin the running stack's secret
+	workerSecret() (string, bool)          // full start: env or generated
+	ollamaVolume(opts startOptions) string // model-cache choice (prompt is live-only)
+	record(role, id, image, provided, endpoint, driver string)
+	val(live, plan string) string // mode-scoped value (kb root, admin password)
+	rtName() string
+
+	// --- decoration ---
+	banner(s string)
+	dim(s string) string
+	bold(s string) string
+	say(kind sayKind, format string, a ...any) // live narration; nothing in plan mode
+	note(format string, a ...any)              // plan comment; nothing in live mode
+}
+
+type sayKind int
+
+const (
+	sayLog sayKind = iota
+	sayOK
+	sayWarn
+	sayFail // also marks the run failed (stderr)
+)
+
+// --- live ---
+
+type liveExec struct {
+	u  *ui
+	rt string
+	st *stackState
+}
+
+func (x *liveExec) stopRm(name string) bool {
+	stopped := runSilent(x.rt, "stop", name) == nil
+	rmed := runSilent(x.rt, "rm", name) == nil
+	return stopped || rmed
+}
+
+func (x *liveExec) pause() { time.Sleep(time.Second) }
+
+func (x *liveExec) portCheck(p portNeed, forceKill bool) bool {
+	return requirePortFree(x.u, p.port, p.label, forceKill)
+}
+
+func (x *liveExec) stopEcho(name string) {
+	x.u.echoCmd(x.rt, "stop", name)
+	runPassthrough(x.rt, "stop", name)
+}
+
+// hostOllamaReachable: a host Ollama is serving — confirm containers can
+// reach it, else print the Ollama-Desktop diagnostics and fail (measured:
+// Docker Desktop's bridge gateway does not reach the Mac host).
+func (x *liveExec) hostOllamaReachable(addr string, port int) bool {
+	if runSilent(x.rt, "run", "--rm", "busybox:1.38.0", "sh", "-c",
+		fmt.Sprintf("wget -q -O- http://%s:%d/api/version", addr, port)) == nil {
+		return true
+	}
+	fmt.Println()
+	x.u.warn("Ollama is running on the host but not reachable from containers.")
+	fmt.Printf("   The backend runs in a container and needs Ollama at %s:%d.\n", addr, port)
+	fmt.Println()
+	if runSilent("pgrep", "-f", "Ollama.app/Contents") == nil {
+		fmt.Println("   Detected: Ollama Desktop app")
+	} else if runSilent("pgrep", "-f", "ollama serve") == nil {
+		fmt.Println("   Detected: ollama serve daemon")
+	}
+	fmt.Println()
+	fmt.Println("   Fix: configure Ollama to listen on all interfaces:")
+	fmt.Printf("     %s\n", x.u.bold("launchctl setenv OLLAMA_HOST 0.0.0.0"))
+	fmt.Println("   Then fully quit Ollama Desktop from the menu bar and relaunch it.")
+	fmt.Println()
+	fmt.Println("   (If launchctl doesn't stick, quit Ollama Desktop entirely and run")
+	fmt.Printf("    %s from a terminal.)\n", x.u.bold("OLLAMA_HOST=0.0.0.0:11434 ollama serve"))
+	fmt.Println()
+	return false
+}
+
+func (x *liveExec) sweepStaging() {
+	removeStagedConfigs()
+	removeState()
+}
+
+func (x *liveExec) portChecks(ports []portNeed, forceKill bool) bool {
+	for _, pc := range ports {
+		if !requirePortFree(x.u, pc.port, pc.label, forceKill) {
+			return false
+		}
+	}
+	return true
+}
+
+func (x *liveExec) stageDir() (string, bool) {
+	stage, err := os.MkdirTemp("/tmp", "semiont-config.")
+	if err != nil {
+		x.u.fail("Cannot create config staging dir: %v", err)
+		return "", false
+	}
+	return stage, true
+}
+
+func (x *liveExec) stageAll(configFile string) (string, bool) {
+	stage, ok := x.stageDir()
+	if !ok {
+		return "", false
+	}
+	cfg, err := os.ReadFile(configFile)
+	if err != nil {
+		x.u.fail("Reading %s: %v", configFile, err)
+		return "", false
+	}
+	for _, svc := range []string{"backend", "worker", "smelter", "weaver"} {
+		if err := os.WriteFile(filepath.Join(stage, svc+".toml"), cfg, 0o644); err != nil {
+			x.u.fail("Staging config for %s: %v", svc, err)
+			return "", false
+		}
+	}
+	return stage, true
+}
+
+func (x *liveExec) stageOne(svc, configFile string) (string, bool) {
+	stage, ok := x.stageDir()
+	if !ok {
+		return "", false
+	}
+	cfg, err := os.ReadFile(configFile)
+	if err != nil {
+		x.u.fail("Reading %s: %v", configFile, err)
+		return "", false
+	}
+	if err := os.WriteFile(filepath.Join(stage, svc+".toml"), cfg, 0o644); err != nil {
+		x.u.fail("Staging config for %s: %v", svc, err)
+		return "", false
+	}
+	return stage, true
+}
+
+func (x *liveExec) initStack(root, config, version, addr, stage string) {
+	x.st = &stackState{
+		Runtime: x.rt, KBRoot: root, KBDid: loadKBIdentity(root).didWeb(),
+		Config: config, Version: version,
+		HostAddr: addr, Stage: stage, Services: map[string]serviceState{},
+	}
+}
+
+func (x *liveExec) pull(img string) bool {
+	args := pullArgs(x.rt, img)
+	x.u.echoCmd(x.rt, args...)
+	if err := runVisible(x.rt, args...); err != nil {
+		x.u.fail("Pull failed: %s", img)
+		return false
+	}
+	return true
+}
+
+func (x *liveExec) runDetached(args []string) (string, bool) {
+	x.u.echoCmd(x.rt, args...)
+	id, err := runDetached(x.rt, args...)
+	if err != nil {
+		return "", false
+	}
+	return id, true
+}
+
+func (x *liveExec) waitHTTP(label, url string, tries int) (time.Duration, bool) {
+	return waitForHTTP(x.u, label, url, tries)
+}
+
+func (x *liveExec) waitPG(addr string, port, tries int) (time.Duration, bool) {
+	return waitForPG(x.u, x.rt, addr, port, tries)
+}
+
+func (x *liveExec) probeTCP(role string, rp rolePlan) bool {
+	return verifyExternal(x.u, role, rp)
+}
+
+func (x *liveExec) backendReachable(addr string, port int) bool {
+	x.u.log("Verifying backend reachable from containers...")
+	t0 := time.Now()
+	for i := 0; i < 20; i++ {
+		if runSilent(x.rt, "run", "--rm", "busybox:1.38.0", "sh", "-c",
+			fmt.Sprintf("wget -q -O- http://%s:%d/api/health", addr, port)) == nil {
+			x.u.ok("Backend reachable from containers %s", x.u.dim("("+took(time.Since(t0))+")"))
+			return true
+		}
+		time.Sleep(time.Second)
+	}
+	x.u.fail("Backend not reachable from containers at %s:%d within 20s.", addr, port)
+	return false
+}
+
+func (x *liveExec) resolveAddr() (string, bool) {
+	addr := resolveHostAddr(x.rt)
+	if addr == "" {
+		x.u.fail("Could not determine host address for container networking.")
+		fmt.Fprintln(os.Stderr, "  Neither the runtime's host alias nor the default-gateway probe returned a result.")
+		return "", false
+	}
+	return addr, true
+}
+
+func (x *liveExec) either(cond func() bool, then, els func() int) int {
+	if cond() {
+		return then()
+	}
+	return els()
+}
+
+func (x *liveExec) otelDetect(addr string) []string {
+	if httpOK("http://localhost:16686") {
+		x.u.log("Jaeger detected — OTel export enabled")
+		return otelArgs(addr)
+	}
+	return nil
+}
+
+func (x *liveExec) recoverSecret() (string, bool) {
+	return serviceSecret(x.u, x.rt)
+}
+
+func (x *liveExec) workerSecret() (string, bool) {
+	return fullStartSecret(x.u)
+}
+
+func (x *liveExec) ollamaVolume(opts startOptions) string {
+	return chooseOllamaVolume(x.u, opts)
+}
+
+func (x *liveExec) record(role, id, image, provided, endpoint, driver string) {
+	if x.st == nil { // --service mode: load-or-create
+		x.st = loadState()
+		if x.st == nil {
+			x.st = &stackState{Runtime: x.rt, Services: map[string]serviceState{}}
+		}
+	}
+	x.st.recordService(role, id, image, provided, endpoint, driver)
+}
+
+func (x *liveExec) val(live, _ string) string { return live }
+func (x *liveExec) rtName() string            { return x.rt }
+func (x *liveExec) dim(s string) string       { return x.u.dim(s) }
+func (x *liveExec) bold(s string) string      { return x.u.bold(s) }
+
+func (x *liveExec) banner(s string) { x.u.banner(s) }
+
+func (x *liveExec) say(kind sayKind, format string, a ...any) {
+	switch kind {
+	case sayLog:
+		x.u.log(format, a...)
+	case sayOK:
+		x.u.ok(format, a...)
+	case sayWarn:
+		x.u.warn(format, a...)
+	case sayFail:
+		x.u.fail(format, a...)
+	}
+}
+
+func (x *liveExec) note(string, ...any) {}
+
+// --- plan (--dry-run) ---
+
+type planExec struct {
+	rt string
+}
+
+func (x *planExec) p(args ...string)          { fmt.Println(renderCmd(x.rt, args...)) }
+func (x *planExec) c(format string, a ...any) { fmt.Printf("# "+format+"\n", a...) }
+func (x *planExec) stopRm(name string) bool   { x.p("stop", name); x.p("rm", name); return false }
+func (x *planExec) pause()                    {}
+func (x *planExec) sweepStaging()             { x.c("remove staged config copies: /tmp/semiont-config.*") }
+
+func (x *planExec) portChecks(ports []portNeed, _ bool) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	strs := make([]string, 0, len(ports))
+	for _, pc := range ports {
+		strs = append(strs, fmt.Sprintf("%d", pc.port))
+	}
+	x.c("require free ports: %s", strings.Join(strs, " "))
+	return true
+}
+
+func (x *planExec) stageAll(string) (string, bool) {
+	x.c("stage per-service config copies under <config-stage>: backend.toml worker.toml smelter.toml weaver.toml")
+	return "<config-stage>", true
+}
+
+func (x *planExec) stageOne(svc, _ string) (string, bool) {
+	x.c("stage a fresh private config copy under <config-stage>: %s.toml", svc)
+	return "<config-stage>", true
+}
+
+func (x *planExec) initStack(_, _, _, _, _ string) {}
+
+func (x *planExec) pull(img string) bool {
+	x.p(pullArgs(x.rt, img)...)
+	return true
+}
+
+func (x *planExec) runDetached(args []string) (string, bool) {
+	x.p(args...)
+	return "", true
+}
+
+func (x *planExec) waitHTTP(_, url string, tries int) (time.Duration, bool) {
+	x.c("wait: %s (%ds)", url, tries)
+	return 0, true
+}
+
+func (x *planExec) waitPG(addr string, port, tries int) (time.Duration, bool) {
+	x.c("wait: tcp localhost:%d (%ds)", port, tries)
+	x.c("probe: %s run --rm busybox:1.38.0 nc -z -w 2 %s %d", x.rt, addr, port)
+	return 0, true
+}
+
+func (x *planExec) probeTCP(string, rolePlan) bool { return true }
+
+func (x *planExec) portCheck(p portNeed, _ bool) bool {
+	x.c("require free port: %d", p.port)
+	return true
+}
+
+func (x *planExec) stopEcho(name string) { x.p("stop", name) }
+
+func (x *planExec) hostOllamaReachable(string, int) bool { return true }
+
+func (x *planExec) backendReachable(addr string, port int) bool {
+	x.c(`probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://%s:%d/api/health" (up to 20 tries)`, x.rt, addr, port)
+	return true
+}
+
+func (x *planExec) resolveAddr() (string, bool) {
+	switch x.rt {
+	case "container":
+		x.c(`probe: container run --rm busybox:1.38.0 sh -c "ip route | awk '/default/{print $3}'" → <host-addr>`)
+	case "docker":
+		x.c("probe: docker run --rm busybox:1.38.0 nslookup host.docker.internal (fallback: default-gateway probe) → <host-addr>")
+	case "podman":
+		x.c("probe: podman run --rm busybox:1.38.0 nslookup host.containers.internal (fallback: default-gateway probe) → <host-addr>")
+	}
+	return "<host-addr>", true
+}
+
+func (x *planExec) either(_ func() bool, then, els func() int) int {
+	then()
+	x.c("else:")
+	els()
+	return 0
+}
+
+func (x *planExec) otelDetect(string) []string {
+	x.c("probe: Jaeger at http://localhost:16686 — if running, add --env OTEL_EXPORTER_OTLP_ENDPOINT=http://<host-addr>:4318")
+	return nil
+}
+
+func (x *planExec) recoverSecret() (string, bool) {
+	x.c("worker secret: recovered from a running Semiont container's env (inspect), else $SEMIONT_WORKER_SECRET, else generated")
+	return "<worker-secret>", true
+}
+
+func (x *planExec) workerSecret() (string, bool) { return "<worker-secret>", true }
+
+func (x *planExec) ollamaVolume(opts startOptions) string {
+	volume := "<ollama-volume>"
+	switch opts.ollamaCache {
+	case "host":
+		if home, err := os.UserHomeDir(); err == nil {
+			volume = filepath.Join(home, ".ollama")
+		}
+	case "volume":
+		volume = "semiont-ollama-models"
+	}
+	return volume
+}
+
+func (x *planExec) record(_, _, _, _, _, _ string) {}
+
+func (x *planExec) val(_, plan string) string { return plan }
+func (x *planExec) rtName() string            { return x.rt }
+func (x *planExec) dim(s string) string       { return s }
+func (x *planExec) bold(s string) string      { return s }
+
+func (x *planExec) banner(string) {}
+
+func (x *planExec) say(sayKind, string, ...any) {}
+
+func (x *planExec) note(format string, a ...any) { x.c(format, a...) }
+
+// probeHostOllama: the live host-reuse condition (plan mode never calls it —
+// either() renders both branches there).
+func probeHostOllama(port int) func() bool {
+	return func() bool {
+		return httpOK(fmt.Sprintf("http://localhost:%d/api/version", port))
+	}
+}
+
+// verifyExternal confirms an externally-provided role is reachable at its
+// configured address — the launcher launches nothing but refuses to bring up
+// dependents against a dead dependency.
+func verifyExternal(u *ui, role string, rp rolePlan) bool {
+	addr := net.JoinHostPort(rp.Address, fmt.Sprintf("%d", rp.Port))
+	conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+	if err != nil {
+		u.fail("%s is externally provided at %s but unreachable: %v", role, addr, err)
+		return false
+	}
+	conn.Close()
+	u.ok("%s — externally provided at %s %s", role, addr, u.dim("(reachable)"))
+	return true
+}

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -65,9 +65,11 @@ const (
 // --- live ---
 
 type liveExec struct {
-	u  *ui
-	rt string
-	st *stackState
+	u       *ui
+	rt      string
+	st      *stackState
+	version string // SEMIONT_VERSION, for records created lazily (--service mode)
+	root    string // KB root, ditto ("" for root-free services)
 }
 
 func (x *liveExec) stopRm(name string) bool {
@@ -266,10 +268,13 @@ func (x *liveExec) ollamaVolume(opts startOptions) string {
 }
 
 func (x *liveExec) record(role, id, image, provided, endpoint, driver string) {
-	if x.st == nil { // --service mode: load-or-create
+	if x.st == nil { // --service mode: load, or create with full metadata
 		x.st = loadState()
 		if x.st == nil {
-			x.st = &stackState{Runtime: x.rt, Services: map[string]serviceState{}}
+			x.st = &stackState{
+				Runtime: x.rt, KBRoot: x.root, KBDid: loadKBIdentity(x.root).didWeb(),
+				Version: x.version, Services: map[string]serviceState{},
+			}
 		}
 	}
 	x.st.recordService(role, id, image, provided, endpoint, driver)

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -1,0 +1,469 @@
+package launcher
+
+// flows.go — each launch sequence written ONCE, walked by an executor in
+// live or plan mode (.plans/LAUNCHER-ROLE-EXECUTOR.md). Effects (argv,
+// ports, URLs, gate tries, record contents) exist only here: start cannot
+// change what it does without --dry-run showing the same change. Decoration
+// (say vs note) is deliberately one-sided per mode.
+
+import (
+	"fmt"
+	"time"
+)
+
+type flowCtx struct {
+	plan       *launchPlan
+	opts       startOptions
+	version    string
+	root       string
+	configFile string
+	userEnv    []string
+}
+
+var depRoleTitles = map[string]string{
+	"graph": "Graph", "vectors": "Vectors", "database": "Database",
+}
+
+// flowFullStart is THE full-start sequence: preflight → ports → staging →
+// pulls → traces → graph → vectors → inference → database → backend →
+// sidecars → frontend.
+func flowFullStart(x executor, fc flowCtx) int {
+	addr, ok := x.resolveAddr()
+	if !ok {
+		return 1
+	}
+	x.say(sayLog, "Host address: %s", x.dim(addr))
+
+	x.banner("Preflight")
+	x.say(sayLog, "Removing prior containers %s", x.dim(fmt.Sprintf("(stop+rm, %d names; exact commands: semiont start --dry-run)", len(preflightNames))))
+	removed := 0
+	for _, c := range preflightNames {
+		if x.stopRm(c) {
+			removed++
+		}
+	}
+	x.sweepStaging()
+	x.pause()
+	if removed == 0 {
+		x.say(sayOK, "No prior containers")
+	} else {
+		x.say(sayOK, "Removed %d prior container(s)", removed)
+	}
+
+	if !x.portChecks(planPortChecks(fc.plan, fc.opts.observe), fc.opts.forceKillPorts) {
+		return 1
+	}
+	x.say(sayOK, "Required ports are free")
+
+	stage, ok := x.stageAll(fc.configFile)
+	if !ok {
+		return 1
+	}
+	x.initStack(fc.root, fc.opts.configName, fc.version, addr, stage)
+
+	x.banner("Pulling Images")
+	if fc.version == "local" {
+		x.say(sayLog, "Using locally-built %s images (skipping pull)", x.bold(":local"))
+		x.note("SEMIONT_VERSION=local — using locally-built :local images (no pull)")
+	} else {
+		for _, svc := range semiontServices {
+			if !x.pull(image(svc, fc.version)) {
+				return 1
+			}
+		}
+		x.say(sayOK, "Images pulled")
+	}
+
+	var otel []string
+	if fc.opts.observe {
+		x.banner("Traces (Jaeger)")
+		args := tracesArgs()
+		id, ok := x.runDetached(args)
+		if !ok {
+			x.say(sayFail, "traces (Jaeger) failed to start.")
+			return 1
+		}
+		d, ok := x.waitHTTP("traces (Jaeger)", "http://localhost:16686", 30)
+		if !ok {
+			return 1
+		}
+		x.say(sayOK, "traces — Jaeger UI on http://localhost:16686 (OTLP collector: %s:4318) %s", addr, x.dim("("+took(d)+")"))
+		x.record("traces", id, args[len(args)-1], providedLauncher, "http://localhost:16686", "jaeger")
+		otel = otelArgs(addr)
+	}
+
+	if code := flowDepRole(x, "graph", fc, addr); code != 0 {
+		return code
+	}
+	if code := flowDepRole(x, "vectors", fc, addr); code != 0 {
+		return code
+	}
+	if code := flowInferenceRole(x, fc, addr); code != 0 {
+		return code
+	}
+	if code := flowDepRole(x, "database", fc, addr); code != 0 {
+		return code
+	}
+
+	secret, ok := x.workerSecret()
+	if !ok {
+		return 1
+	}
+
+	x.banner("Starting Backend")
+	x.say(sayLog, "http://localhost:%d", fc.plan.BackendPort)
+	x.say(sayLog, "Worker secret: %s", x.dim("(generated)"))
+	var admin []string
+	if fc.opts.adminEmail != "" && fc.opts.adminPassword != "" {
+		admin = []string{"--env", "ADMIN_EMAIL=" + fc.opts.adminEmail, "--env", "ADMIN_PASSWORD=" + x.val(fc.opts.adminPassword, "<admin-password>")}
+		x.say(sayLog, "Admin user: %s", x.bold(fc.opts.adminEmail))
+	}
+	if code := flowBackend(x, fc, addr, stage, secret, admin, otel); code != 0 {
+		return code
+	}
+
+	// The weaver note: the graph projection is standalone-only — without the
+	// weaver the graph stays empty and every gather 404s at the
+	// buildKnowledgeGraph barrier.
+	for _, sc := range sidecarSpecs {
+		x.banner(sc.banner)
+		if code := flowSidecar(x, fc, sc, addr, stage, secret, otel); code != 0 {
+			return code
+		}
+	}
+
+	// Frontend: a static SPA server — no config mount and no service env.
+	x.banner("Starting Frontend")
+	args := frontendArgs(fc.version)
+	id, ok := x.runDetached(args)
+	if !ok {
+		x.say(sayFail, "Frontend failed to start.")
+		return 1
+	}
+	d, ok := x.waitHTTP("Frontend", "http://localhost:3000", 30)
+	if !ok {
+		return 1
+	}
+	x.say(sayOK, "Frontend on http://localhost:3000 %s", x.dim("("+took(d)+")"))
+	x.record("frontend", id, image("frontend", fc.version), providedLauncher, "http://localhost:3000", "")
+	return 0
+}
+
+// flowDepRole: the uniform dependency-role shape for graph / vectors /
+// database, obligation-dispatched.
+func flowDepRole(x executor, role string, fc flowCtx, addr string) int {
+	rp := fc.plan.Roles[role]
+	disp := driverDisplay(role, rp.Driver)
+	x.banner(depRoleTitles[role] + " (" + disp + ")")
+	switch rp.Obligation {
+	case obligationProvided:
+		args := providedRunArgs(role, rp)
+		id, ok := x.runDetached(args)
+		if !ok {
+			x.say(sayFail, "%s (%s) failed to start.", role, disp)
+			return 1
+		}
+		switch role {
+		case "graph":
+			aux := fc.plan.AuxPorts("graph")[0].port
+			d, ok := x.waitHTTP("graph ("+disp+")", fmt.Sprintf("http://localhost:%d", aux), 30)
+			if !ok {
+				return 1
+			}
+			x.say(sayOK, "graph — bolt://localhost:%d (browser: http://localhost:%d) %s", rp.Port, aux, x.dim("("+took(d)+")"))
+			x.record(role, id, rp.Image, providedLauncher, fmt.Sprintf("http://localhost:%d", aux), rp.Driver)
+		case "vectors":
+			d, ok := x.waitHTTP("vectors ("+disp+")", fmt.Sprintf("http://localhost:%d/readyz", rp.Port), 15)
+			if !ok {
+				return 1
+			}
+			x.say(sayOK, "vectors — http://localhost:%d %s", rp.Port, x.dim("("+took(d)+")"))
+			x.record(role, id, rp.Image, providedLauncher, fmt.Sprintf("http://localhost:%d/readyz", rp.Port), rp.Driver)
+		case "database":
+			d, ok := x.waitPG(addr, rp.Port, 20)
+			if !ok {
+				return 1
+			}
+			x.say(sayOK, "database — %s on port %d %s", disp, rp.Port, x.dim("("+took(d)+")"))
+			x.record(role, id, rp.Image, providedLauncher, fmt.Sprintf("tcp:localhost:%d", rp.Port), rp.Driver)
+		}
+	case obligationAbsent:
+		x.say(sayLog, "%s — not configured; skipping", role)
+		x.note("%s: not referenced by the config — nothing to launch", role)
+		x.record(role, "", "", providedNone, "", "")
+	case obligationHostProcess:
+		x.note("%s: host process at localhost:%d — verify reachability, launch nothing", role, rp.Port)
+		if !x.probeTCP(role, rp) {
+			return 1
+		}
+		x.record(role, "", "", providedExternal, externalEndpoint(role, rp), rp.Driver)
+	case obligationExternal:
+		x.note("%s: externally provided at %s:%d — verify reachability, launch nothing", role, rp.Address, rp.Port)
+		if !x.probeTCP(role, rp) {
+			return 1
+		}
+		x.record(role, "", "", providedExternal, externalEndpoint(role, rp), rp.Driver)
+	}
+	return 0
+}
+
+// externalEndpoint: the status probe for an externally-provided role.
+func externalEndpoint(role string, rp rolePlan) string {
+	switch role {
+	case "vectors":
+		return fmt.Sprintf("http://%s:%d/readyz", rp.Address, rp.Port)
+	case "inference":
+		return fmt.Sprintf("http://%s:%d/api/version", rp.Address, rp.Port)
+	default: // graph, database: not HTTP — TCP dial
+		return fmt.Sprintf("tcp:%s:%d", rp.Address, rp.Port)
+	}
+}
+
+// flowInferenceRole: obligation dispatch for inference (the host-process
+// dance lives in flowInference).
+func flowInferenceRole(x executor, fc flowCtx, addr string) int {
+	rp := fc.plan.Roles["inference"]
+	switch rp.Obligation {
+	case obligationHostProcess:
+		return flowInference(x, fc, rp, addr)
+	case obligationExternal:
+		x.banner("Inference (" + driverDisplay("inference", rp.Driver) + ")")
+		x.note("inference: externally provided at %s:%d — verify reachability, launch nothing", rp.Address, rp.Port)
+		if !x.probeTCP("inference", rp) {
+			return 1
+		}
+		x.record("inference", "", "", providedExternal, externalEndpoint("inference", rp), rp.Driver)
+	case obligationAbsent:
+		x.banner("Inference")
+		x.say(sayLog, "inference — not referenced by the config; skipping")
+		x.note("inference: not referenced by the config — nothing to launch")
+		x.record("inference", "", "", providedNone, "", "")
+	}
+	return 0
+}
+
+// flowInference: host-Ollama reuse when serving and reachable from
+// containers; else the semiont-ollama container with the model-cache choice.
+func flowInference(x executor, fc flowCtx, rp rolePlan, addr string) int {
+	x.banner("Inference (" + driverDisplay("inference", rp.Driver) + ")")
+	x.note("probe: host Ollama at http://localhost:%d/api/version", rp.Port)
+	x.note(`if present — probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://%s:%d/api/version" — and use it`, x.rtName(), addr, rp.Port)
+	return x.either(probeHostOllama(rp.Port),
+		func() int {
+			if !x.hostOllamaReachable(addr, rp.Port) {
+				return 1
+			}
+			x.say(sayOK, "inference — using host Ollama at http://localhost:%d", rp.Port)
+			x.record("inference", "", "", providedHost, fmt.Sprintf("http://localhost:%d/api/version", rp.Port), rp.Driver)
+			return 0
+		},
+		func() int {
+			x.say(sayLog, "No host Ollama detected — starting container...")
+			x.stopEcho("semiont-ollama")
+			x.pause()
+			if !x.portCheck(portNeed{rp.Port, "Ollama"}, fc.opts.forceKillPorts) {
+				return 1
+			}
+			volume := x.ollamaVolume(fc.opts)
+			args := providedRunArgs("inference", rp, "-m", "24G", "-v", volume+":/root/.ollama")
+			id, ok := x.runDetached(args)
+			if !ok {
+				x.say(sayFail, "Ollama container failed to start.")
+				return 1
+			}
+			d, ok := x.waitHTTP("inference (Ollama)", fmt.Sprintf("http://localhost:%d/api/version", rp.Port), 30)
+			if !ok {
+				return 1
+			}
+			x.say(sayOK, "inference — Ollama container on http://localhost:%d (24 GB memory) %s", rp.Port, x.dim("("+took(d)+")"))
+			x.record("inference", id, rp.Image, providedLauncher, fmt.Sprintf("http://localhost:%d/api/version", rp.Port), rp.Driver)
+			return 0
+		})
+}
+
+// flowBackend: run + host-side health gate + container-gateway reachability
+// gate (the sidecars dial addr:port and fatally exit if their first backend
+// fetch fails — host health alone doesn't prove the path they need).
+func flowBackend(x executor, fc flowCtx, addr, stage, secret string, admin, otel []string) int {
+	port := fc.plan.BackendPort
+	bArgs := backendArgs(x.val(fc.root, "<kb-root>"), stage, addr, secret, fc.version, port, fc.userEnv, otel, admin)
+	id, ok := x.runDetached(bArgs)
+	if !ok {
+		x.say(sayFail, "Backend failed to start.")
+		return 1
+	}
+	x.say(sayLog, "Waiting for backend health...")
+	d, ok := x.waitHTTP("Backend", fmt.Sprintf("http://localhost:%d/api/health", port), 120)
+	if !ok {
+		return 1
+	}
+	x.say(sayOK, "Backend healthy %s", x.dim("("+took(d)+")"))
+	if !x.backendReachable(addr, port) {
+		return 1
+	}
+	x.record("backend", id, image("backend", fc.version), providedLauncher, fmt.Sprintf("http://localhost:%d/api/health", port), "")
+	return 0
+}
+
+func flowSidecar(x executor, fc flowCtx, sc sidecarSpec, addr, stage, secret string, otel []string) int {
+	args := sidecarArgs(sc.svc, sc.mem, sc.port, stage, addr, secret, fc.version, fc.userEnv, otel)
+	id, ok := x.runDetached(args)
+	if !ok {
+		x.say(sayFail, "%s failed to start.", sc.label)
+		return 1
+	}
+	d, ok := x.waitHTTP(sc.label, fmt.Sprintf("http://localhost:%d/health", sc.port), 30)
+	if !ok {
+		return 1
+	}
+	x.say(sayOK, "%s healthy (http://localhost:%d) %s", sc.label, sc.port, x.dim("("+took(d)+")"))
+	x.record(sc.svc, id, image(sc.svc, fc.version), providedLauncher, fmt.Sprintf("http://localhost:%d/health", sc.port), "")
+	return 0
+}
+
+// flowOneService: `start --service` — the no-op obligation gate, the
+// service's own teardown/ports/pull, secret rejoin + OTel detection + fresh
+// staging for config consumers, then the service's launch and gate.
+func flowOneService(x executor, fc flowCtx) int {
+	svc := fc.opts.service
+	if fc.plan != nil {
+		if rp, ok := fc.plan.Roles[svc]; ok {
+			switch rp.Obligation {
+			case obligationExternal:
+				x.say(sayWarn, "%s is externally provided per %s (%s:%d); nothing to launch.", svc, fc.configFile, rp.Address, rp.Port)
+				x.note("%s: externally provided at %s:%d — verify reachability, launch nothing", svc, rp.Address, rp.Port)
+				return 0
+			case obligationAbsent:
+				x.say(sayWarn, "%s is not referenced by %s; nothing to launch.", svc, fc.configFile)
+				x.note("%s: not referenced by the config — nothing to launch", svc)
+				return 0
+			}
+		}
+	}
+
+	x.banner("Restarting " + roleTitle(svc))
+	if svc != "inference" {
+		if x.stopRm(roles[svc].container) {
+			x.say(sayLog, "Removed prior %s container", svc)
+			x.pause()
+		}
+		// Port claims follow the plan (config-driven ports) for planned
+		// roles; static role ports otherwise (frontend, traces).
+		ports := roles[svc].ports
+		if fc.plan != nil {
+			if rp, ok := fc.plan.Roles[svc]; ok && rp.Obligation == obligationProvided {
+				spec := driverCatalog[svc][rp.Driver]
+				ports = append(append([]portNeed{}, spec.auxPorts...), portNeed{rp.Port, spec.portLabel})
+			}
+		}
+		if !x.portChecks(ports, fc.opts.forceKillPorts) {
+			return 1
+		}
+	}
+
+	addr := ""
+	if serviceNeedsAddr(svc) {
+		var ok bool
+		if addr, ok = x.resolveAddr(); !ok {
+			return 1
+		}
+		x.say(sayLog, "Host address: %s", x.dim(addr))
+	}
+
+	if isConfigConsumer(svc) || svc == "frontend" {
+		if fc.version == "local" {
+			x.note("SEMIONT_VERSION=local — using locally-built :local images (no pull)")
+		} else if !x.pull(image(svc, fc.version)) {
+			return 1
+		}
+	}
+
+	var otel []string
+	if isConfigConsumer(svc) {
+		otel = x.otelDetect(addr)
+	}
+	secret, stage := "", ""
+	if isConfigConsumer(svc) {
+		var ok bool
+		if secret, ok = x.recoverSecret(); !ok {
+			return 1
+		}
+		if stage, ok = x.stageOne(svc, fc.configFile); !ok {
+			return 1
+		}
+	}
+
+	var d time.Duration
+	switch svc {
+	case "traces":
+		args := tracesArgs()
+		id, ok := x.runDetached(args)
+		if !ok {
+			x.say(sayFail, "traces (Jaeger) failed to start.")
+			return 1
+		}
+		if d, ok = x.waitHTTP("traces (Jaeger UI)", "http://localhost:16686", 30); !ok {
+			return 1
+		}
+		x.record(svc, id, args[len(args)-1], providedLauncher, serviceEndpoint(svc, fc.plan), "jaeger")
+	case "graph", "vectors", "database":
+		rp := fc.plan.Roles[svc]
+		disp := driverDisplay(svc, rp.Driver)
+		args := providedRunArgs(svc, rp)
+		id, ok := x.runDetached(args)
+		if !ok {
+			x.say(sayFail, "%s (%s) failed to start.", svc, disp)
+			return 1
+		}
+		switch svc {
+		case "graph":
+			if d, ok = x.waitHTTP("graph ("+disp+")", fmt.Sprintf("http://localhost:%d", fc.plan.AuxPorts("graph")[0].port), 30); !ok {
+				return 1
+			}
+		case "vectors":
+			if d, ok = x.waitHTTP("vectors ("+disp+")", fmt.Sprintf("http://localhost:%d/readyz", rp.Port), 15); !ok {
+				return 1
+			}
+		case "database":
+			if d, ok = x.waitPG(addr, rp.Port, 20); !ok {
+				return 1
+			}
+		}
+		x.record(svc, id, rp.Image, providedLauncher, serviceEndpoint(svc, fc.plan), rp.Driver)
+	case "inference":
+		if code := flowInference(x, fc, fc.plan.Roles[svc], addr); code != 0 {
+			return code
+		}
+	case "backend":
+		var admin []string
+		if fc.opts.adminEmail != "" && fc.opts.adminPassword != "" {
+			admin = []string{"--env", "ADMIN_EMAIL=" + fc.opts.adminEmail, "--env", "ADMIN_PASSWORD=" + x.val(fc.opts.adminPassword, "<admin-password>")}
+		}
+		if code := flowBackend(x, fc, addr, stage, secret, admin, otel); code != 0 {
+			return code
+		}
+	case "worker", "smelter", "weaver":
+		for _, sc := range sidecarSpecs {
+			if sc.svc == svc {
+				if code := flowSidecar(x, fc, sc, addr, stage, secret, otel); code != 0 {
+					return code
+				}
+			}
+		}
+	case "frontend":
+		args := frontendArgs(fc.version)
+		id, ok := x.runDetached(args)
+		if !ok {
+			x.say(sayFail, "Frontend failed to start.")
+			return 1
+		}
+		if d, ok = x.waitHTTP("Frontend", "http://localhost:3000", 30); !ok {
+			return 1
+		}
+		x.record(svc, id, image("frontend", fc.version), providedLauncher, serviceEndpoint(svc, fc.plan), "")
+	}
+	if d > 0 {
+		x.say(sayOK, "%s healthy %s", svc, x.dim("("+took(d)+")"))
+	}
+	return 0
+}

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -347,10 +347,14 @@ func flowOneService(x executor, fc flowCtx) int {
 			x.say(sayLog, "Removed prior %s container", svc)
 			x.pause()
 		}
-		// Port claims follow the plan (config-driven ports) for planned
-		// roles; static role ports otherwise (frontend, traces).
+		// Port claims follow the plan for config-owned ports (dependency
+		// roles, backend); the static role table covers only the
+		// launcher-fiat ports (sidecars, frontend, traces).
 		ports := roles[svc].ports
-		if fc.plan != nil {
+		switch {
+		case svc == "backend" && fc.plan != nil:
+			ports = []portNeed{{fc.plan.BackendPort, "Backend"}}
+		case fc.plan != nil:
 			if rp, ok := fc.plan.Roles[svc]; ok && rp.Obligation == obligationProvided {
 				spec := driverCatalog[svc][rp.Driver]
 				ports = append(append([]portNeed{}, spec.auxPorts...), portNeed{rp.Port, spec.portLabel})

--- a/apps/launcher/internal/launcher/logs.go
+++ b/apps/launcher/internal/launcher/logs.go
@@ -11,13 +11,19 @@ import (
 	"syscall"
 )
 
-const logsUsage = `Usage: semiont logs [--runtime container|docker|podman]
+const logsUsage = `Usage: semiont logs [--service <name>] [--runtime container|docker|podman]
 
 Follow the Semiont service logs, one [svc]-prefixed stream per service.
 Ctrl+C stops *following* — it does not stop the stack (that's semiont stop).
 
-Pass the same --runtime you started with; default is the runtime actually
-running the stack.
+By default follows the five Semiont services (backend, worker, smelter,
+weaver, frontend). With --service <name>, follow any ONE service including
+the infrastructure roles: backend, worker, smelter, weaver, frontend,
+database, graph, vectors, inference, or traces.
+
+The runtime and container identities come from the recorded stack state when
+present (--runtime overrides); otherwise the stack is discovered by
+name-scan.
 `
 
 var logServices = []string{"backend", "worker", "smelter", "weaver", "frontend"}
@@ -26,6 +32,7 @@ var logServices = []string{"backend", "worker", "smelter", "weaver", "frontend"}
 func Logs(args []string) int {
 	u := newUI(false)
 	runtime := ""
+	service := ""
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--runtime":
@@ -35,6 +42,13 @@ func Logs(args []string) int {
 			}
 			runtime = args[i+1]
 			i++
+		case "--service":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --service")
+				return 1
+			}
+			service = args[i+1]
+			i++
 		case "--help", "-h":
 			fmt.Print(logsUsage)
 			return 0
@@ -43,7 +57,17 @@ func Logs(args []string) int {
 			return 1
 		}
 	}
+	if service != "" {
+		if _, known := roles[service]; !known {
+			u.fail("Unknown --service '%s' (expected: %s)", service, roleList)
+			return 1
+		}
+	}
 
+	// The record supplies the runtime and container identities; --runtime
+	// overrides, and a record about a different runtime doesn't apply. No
+	// record: the historical name-scan discovery.
+	st := loadState()
 	rt := ""
 	if runtime != "" {
 		if !onPath(runtime) {
@@ -51,7 +75,14 @@ func Logs(args []string) int {
 			return 1
 		}
 		rt = runtime
+		if st != nil && st.Runtime != runtime {
+			st = nil
+		}
+	} else if st != nil && st.Runtime != "" && onPath(st.Runtime) {
+		rt = st.Runtime
+		u.log("Using recorded stack state %s", u.dim("("+rt+" per "+statePath()+")"))
 	} else {
+		st = nil
 		rt = stackRuntime()
 	}
 	if rt == "" {
@@ -60,7 +91,44 @@ func Logs(args []string) int {
 		return 1
 	}
 
-	fmt.Println("Following backend · worker · smelter · weaver · frontend — Ctrl+C stops following (semiont stop stops the stack)")
+	// handle: recorded runtime-issued ID when we have one, container name
+	// otherwise. Roles someone else provides have no container to follow.
+	handleFor := func(svc string) (string, bool) {
+		if st != nil {
+			if e, ok := st.Services[svc]; ok {
+				switch e.Provided {
+				case providedHost:
+					u.fail("%s is provided by a host process — no container logs (check the host service's own logs).", svc)
+					return "", false
+				case providedExternal:
+					u.fail("%s is externally provided (%s) — no local container logs.", svc, e.Endpoint)
+					return "", false
+				case providedNone:
+					u.fail("%s is not referenced by the running stack's config — nothing to follow.", svc)
+					return "", false
+				}
+				if e.ID != "" {
+					return e.ID, true
+				}
+			}
+		}
+		return roles[svc].container, true
+	}
+
+	follow := logServices
+	if service != "" {
+		follow = []string{service}
+	}
+	targets := make(map[string]string, len(follow)) // svc → handle
+	for _, svc := range follow {
+		h, ok := handleFor(svc)
+		if !ok {
+			return 1
+		}
+		targets[svc] = h
+	}
+
+	fmt.Printf("Following %s — Ctrl+C stops following (semiont stop stops the stack)\n", strings.Join(follow, " · "))
 
 	// One follower per service; each container's stderr is kept in-stream —
 	// crash traces and uncaught exceptions land there, and they're exactly
@@ -68,8 +136,8 @@ func Logs(args []string) int {
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	var cmds []*exec.Cmd
-	for _, svc := range logServices {
-		cmd := exec.Command(rt, "logs", "--follow", "semiont-"+svc)
+	for _, svc := range follow {
+		cmd := exec.Command(rt, "logs", "--follow", targets[svc])
 		stdout, err1 := cmd.StdoutPipe()
 		stderr, err2 := cmd.StderrPipe()
 		if err1 != nil || err2 != nil {

--- a/apps/launcher/internal/launcher/plan.go
+++ b/apps/launcher/internal/launcher/plan.go
@@ -199,17 +199,21 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 		if port == 0 {
 			port = spec.defaultPort
 		}
+		img := spec.image
+		if g.Image != "" {
+			img = g.Image
+		}
 		rp := rolePlan{Role: "graph", Driver: g.Type, Port: port}
 		switch {
 		case g.Platform == "posix":
 			rp.Obligation = obligationHostProcess
-			rp.Image = spec.image
+			rp.Image = img
 		case classify(host, "NEO4J_HOST") == obligationProvided:
 			if g.Username == "" || g.Password == "" {
 				return nil, secErr("graph", "missing required key %q (needed to provision the container)", "username/password")
 			}
 			rp.Obligation = obligationProvided
-			rp.Image = spec.image
+			rp.Image = img
 			rp.Env = []string{"NEO4J_AUTH=" + g.Username + "/" + g.Password, "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes"}
 		default:
 			rp.Obligation = obligationExternal
@@ -241,6 +245,9 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 		if classify(v.Host, "QDRANT_HOST") == obligationProvided {
 			rp.Obligation = obligationProvided
 			rp.Image = spec.image
+			if v.Image != "" {
+				rp.Image = v.Image
+			}
 		} else {
 			rp.Obligation = obligationExternal
 			rp.Address = v.Host
@@ -277,6 +284,9 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 			}
 			rp.Obligation = obligationProvided
 			rp.Image = spec.image
+			if d.Image != "" {
+				rp.Image = d.Image
+			}
 			rp.Env = []string{"POSTGRES_PASSWORD=" + d.Password, "POSTGRES_DB=" + d.Name}
 			// POSTGRES_USER only when it departs from the image default —
 			// keeps derivation byte-identical with today's argv.
@@ -321,7 +331,11 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 		if port == 0 {
 			port = spec.defaultPort
 		}
-		rp := rolePlan{Role: "inference", Driver: "ollama", Port: port, Image: spec.image}
+		img := spec.image
+		if p, ok := env.Inference["ollama"]; ok && p.Image != "" {
+			img = p.Image
+		}
+		rp := rolePlan{Role: "inference", Driver: "ollama", Port: port, Image: img}
 		if host == "${OLLAMA_HOST}" {
 			rp.Obligation = obligationHostProcess
 		} else {

--- a/apps/launcher/internal/launcher/plan_test.go
+++ b/apps/launcher/internal/launcher/plan_test.go
@@ -16,7 +16,7 @@ import (
 
 func loadFixtureEnv(t *testing.T, name string) (*envConfig, string) {
 	t.Helper()
-	env, envName, err := loadConfig(filepath.Join("..", "..", "testdata", "kb", ".semiont", "semiontconfig", name))
+	env, envName, _, err := loadConfig(filepath.Join("..", "..", "testdata", "kb", ".semiont", "semiontconfig", name))
 	if err != nil {
 		t.Fatalf("loading fixture %s: %v", name, err)
 	}
@@ -92,7 +92,7 @@ model = "claude-sonnet-4-5-20250929"
 
 func mustDerive(t *testing.T, path string) *launchPlan {
 	t.Helper()
-	env, envName, err := loadConfig(path)
+	env, envName, _, err := loadConfig(path)
 	if err != nil {
 		t.Fatalf("loadConfig: %v", err)
 	}
@@ -134,7 +134,7 @@ func checkRole(t *testing.T, plan *launchPlan, role string, want rolePlan) {
 func TestDerivePlanTemplateConfigs(t *testing.T) {
 	for _, name := range []string{"ollama-gemma.toml", "anthropic.toml"} {
 		t.Run(name, func(t *testing.T) {
-			env, envName, err := loadConfig(filepath.Join("..", "..", "testdata", "kb", ".semiont", "semiontconfig", name))
+			env, envName, _, err := loadConfig(filepath.Join("..", "..", "testdata", "kb", ".semiont", "semiontconfig", name))
 			if err != nil {
 				t.Fatalf("loadConfig: %v", err)
 			}
@@ -223,7 +223,7 @@ func TestDerivePlanUnknownType(t *testing.T) {
 type = "janusgraph"
 uri = "bolt://${NEO4J_HOST}:7687"
 `})
-	env, envName, err := loadConfig(p)
+	env, envName, _, err := loadConfig(p)
 	if err != nil {
 		t.Fatalf("loadConfig: %v", err)
 	}
@@ -239,7 +239,7 @@ type = "neo4j"
 username = "neo4j"
 password = "localpass"
 `})
-	env, envName, err := loadConfig(p)
+	env, envName, _, err := loadConfig(p)
 	if err != nil {
 		t.Fatalf("loadConfig: %v", err)
 	}
@@ -250,10 +250,42 @@ password = "localpass"
 }
 
 func TestLoadConfigErrors(t *testing.T) {
-	if _, _, err := loadConfig(writeVariant(t, "not [ valid toml")); err == nil {
+	if _, _, _, err := loadConfig(writeVariant(t, "not [ valid toml")); err == nil {
 		t.Error("invalid TOML must error")
 	}
-	if _, _, err := loadConfig(writeVariant(t, "[defaults]\nenvironment = \"prod\"\n")); err == nil || !strings.Contains(err.Error(), "prod") {
+	if _, _, _, err := loadConfig(writeVariant(t, "[defaults]\nenvironment = \"prod\"\n")); err == nil || !strings.Contains(err.Error(), "prod") {
 		t.Errorf("missing environment block must name it, got: %v", err)
+	}
+}
+
+func TestRequiredVarsFromParse(t *testing.T) {
+	p := writeVariant(t, `[defaults]
+environment = "local"
+
+[environments.local.backend]
+platform = "posix"
+port = 4000
+
+[environments.local.inference.anthropic]
+platform = "external"
+# commented-out refs are not requirements: apiKey = "${PHANTOM_KEY}"
+apiKey = "${ANTHROPIC_API_KEY}"
+
+[environments.local.graph]
+type = "neo4j"
+uri = "bolt://${NEO4J_HOST}:7687"
+username = "neo4j"
+password = "localpass"
+
+[environments.other.database]
+host = "${OTHER_ENV_VAR}"
+`)
+	_, _, vars, err := loadConfig(p)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	got := strings.Join(vars, ",")
+	if got != "ANTHROPIC_API_KEY,OTHER_ENV_VAR" {
+		t.Errorf("required vars: got %q — want the real ref and the other-environment ref, minus injected (${NEO4J_HOST}) and comment phantoms (${PHANTOM_KEY})", got)
 	}
 }

--- a/apps/launcher/internal/launcher/plan_test.go
+++ b/apps/launcher/internal/launcher/plan_test.go
@@ -289,3 +289,51 @@ host = "${OTHER_ENV_VAR}"
 		t.Errorf("required vars: got %q — want the real ref and the other-environment ref, minus injected (${NEO4J_HOST}) and comment phantoms (${PHANTOM_KEY})", got)
 	}
 }
+
+func TestDerivePlanImageOverride(t *testing.T) {
+	// The config's optional image key wins over the catalog default — a KB
+	// can pin or upgrade an infra image without a launcher release.
+	p := variantConfig(t, map[string]string{
+		"graph": `[environments.local.graph]
+type = "neo4j"
+uri = "bolt://${NEO4J_HOST}:7687"
+username = "neo4j"
+password = "localpass"
+image = "neo4j:6.0.1-community"
+`,
+		"database": `[environments.local.database]
+host = "${POSTGRES_HOST}"
+name = "semiont"
+password = "localpass"
+image = "postgres:17.2-alpine"
+`,
+	})
+	plan := mustDerive(t, p)
+	if got := plan.Roles["graph"].Image; got != "neo4j:6.0.1-community" {
+		t.Errorf("graph image: got %q", got)
+	}
+	if got := plan.Roles["database"].Image; got != "postgres:17.2-alpine" {
+		t.Errorf("database image: got %q", got)
+	}
+	// Unset override: catalog default (the parity everything else relies on).
+	if got := plan.Roles["vectors"].Image; got != "qdrant/qdrant:v1.18.3" {
+		t.Errorf("vectors default image: got %q", got)
+	}
+	// The override flows into the argv the runtime sees.
+	args := providedRunArgs("graph", plan.Roles["graph"])
+	if args[len(args)-1] != "neo4j:6.0.1-community" {
+		t.Errorf("run argv image: got %q", args[len(args)-1])
+	}
+}
+
+func TestDerivePlanInferenceImageOverride(t *testing.T) {
+	p := variantConfig(t, map[string]string{"inference": `[environments.local.inference.ollama]
+platform = "posix"
+baseURL = "http://${OLLAMA_HOST}:11434"
+image = "ollama/ollama:0.9.5"
+`})
+	plan := mustDerive(t, p)
+	if got := plan.Roles["inference"].Image; got != "ollama/ollama:0.9.5" {
+		t.Errorf("inference image: got %q", got)
+	}
+}

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -73,12 +73,18 @@ func serviceNeedsAddr(svc string) bool {
 // container's env via the runtime's inspect — restarting one service rejoins
 // the incumbent stack's secret instead of minting a fresh one (which would
 // silently break sidecar↔backend auth). Returns the secret and the container
-// it came from, or "".
-func recoverWorkerSecret(rt string) (string, string) {
+// it came from — and, crucially, whether any Semiont container was SEEN at
+// all: "seen but unreadable" is the brittle-parse failure mode (a runtime
+// inspect-schema change) and must be loud, never silently degraded to a
+// generated secret.
+func recoverWorkerSecret(rt string) (secret, from, seen string) {
 	for _, c := range []string{"semiont-backend", "semiont-worker", "semiont-smelter", "semiont-weaver"} {
 		out, err := capture(rt, "inspect", c)
 		if err != nil || out == "" {
 			continue
+		}
+		if seen == "" {
+			seen = c
 		}
 		var entries []map[string]any
 		if json.Unmarshal([]byte(out), &entries) != nil || len(entries) == 0 {
@@ -86,11 +92,11 @@ func recoverWorkerSecret(rt string) (string, string) {
 		}
 		for _, env := range inspectEnv(entries[0]) {
 			if v, ok := strings.CutPrefix(env, "SEMIONT_WORKER_SECRET="); ok && v != "" {
-				return v, c
+				return v, c, seen
 			}
 		}
 	}
-	return "", ""
+	return "", "", seen
 }
 
 // inspectEnv digs the env list out of one inspect entry, wherever the
@@ -131,15 +137,29 @@ func inspectEnv(entry map[string]any) []string {
 
 // serviceSecret resolves the worker secret for a --service start: a running
 // stack's secret wins (rejoin, don't break), then the environment, then a
-// fresh one (nothing running to disagree with).
+// fresh one — but ONLY when no Semiont container was seen at all. A
+// container that exists yet yields no secret means the inspect parse broke
+// (or the container is genuinely secret-less); generating there would
+// silently break backend↔sidecar auth, so it fails loudly instead.
 func serviceSecret(u *ui, rt string) (string, bool) {
-	if s, from := recoverWorkerSecret(rt); s != "" {
+	s, from, seen := recoverWorkerSecret(rt)
+	if s != "" {
 		u.log("Worker secret: %s", u.dim("(recovered from "+from+")"))
 		return s, true
 	}
 	if s := os.Getenv("SEMIONT_WORKER_SECRET"); s != "" {
+		if seen != "" {
+			u.warn("A Semiont container (%s) exists but its worker secret could not be read from `%s inspect` — using $SEMIONT_WORKER_SECRET; if it doesn't match the running stack's secret, sidecar auth will fail.", seen, rt)
+		}
 		u.log("Worker secret: %s", u.dim("(from environment)"))
 		return s, true
+	}
+	if seen != "" {
+		u.fail("A Semiont container (%s) exists but its worker secret could not be recovered from `%s inspect` — the runtime's inspect schema may have changed.", seen, rt)
+		fmt.Fprintln(os.Stderr, "  Generating a new secret would silently break backend↔sidecar auth. Either:")
+		fmt.Fprintln(os.Stderr, "    - set SEMIONT_WORKER_SECRET to the running stack's secret, or")
+		fmt.Fprintln(os.Stderr, "    - restart the whole stack:  semiont start")
+		return "", false
 	}
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -26,7 +25,7 @@ type portNeed struct {
 type roleSpec struct {
 	product   string // concrete product behind an infra role; "" = a Semiont service
 	container string
-	ports     []portNeed // must-be-free ports (inference: owned by startInference)
+	ports     []portNeed // must-be-free ports (inference: owned by flowInference)
 }
 
 var roles = map[string]roleSpec{
@@ -151,288 +150,32 @@ func serviceSecret(u *ui, rt string) (string, bool) {
 	return hex.EncodeToString(b), true
 }
 
-// runStartService is `semiont start --service <name>`: one service's slice of
-// the full-start flow — its own stop+rm, port checks, pull, fresh private
-// config copy, run, and health gate. The rest of the stack is untouched.
+// runStartService: the live `start --service` — flowOneService with
+// liveExec, plus the live-only rocket summary (skipped for the external/
+// absent no-ops, which launch nothing).
 func runStartService(u *ui, rt, version, root, configFile string, opts startOptions, userEnv []string, plan *launchPlan) int {
 	t0 := time.Now()
-	svc := opts.service
-	cname := roles[svc].container
-
-	// The config decides whether this role is the launcher's to (re)start.
-	// A role someone else provides is a no-op, not an error (P0 q5): warn,
-	// exit 0.
+	x := &liveExec{u: u, rt: rt}
+	if code := flowOneService(x, flowCtx{plan: plan, opts: opts, version: version, root: root, configFile: configFile, userEnv: userEnv}); code != 0 {
+		return code
+	}
 	if plan != nil {
-		if rp, ok := plan.Roles[svc]; ok {
-			switch rp.Obligation {
-			case obligationExternal:
-				u.warn("%s is externally provided per %s (%s:%d); nothing to launch.", svc, configFile, rp.Address, rp.Port)
-				return 0
-			case obligationAbsent:
-				u.warn("%s is not referenced by %s; nothing to launch.", svc, configFile)
-				return 0
-			}
+		if rp, ok := plan.Roles[opts.service]; ok && (rp.Obligation == obligationExternal || rp.Obligation == obligationAbsent) {
+			return 0
 		}
 	}
-
-	u.banner("Restarting " + roleTitle(svc))
-
-	// The service's own teardown (idempotent across running/stopped/absent) —
-	// except inference, whose start path owns this (a host Ollama may make
-	// the container unnecessary).
-	if svc != "inference" {
-		stopped := runSilent(rt, "stop", cname) == nil
-		rmed := runSilent(rt, "rm", cname) == nil
-		if stopped || rmed {
-			u.log("Removed prior %s container", svc)
-			time.Sleep(time.Second)
-		}
-		for _, pc := range roles[svc].ports {
-			if !requirePortFree(u, pc.port, pc.label, opts.forceKillPorts) {
-				return 1
-			}
-		}
-	}
-
-	addr := ""
-	if serviceNeedsAddr(svc) {
-		addr = resolveHostAddr(rt)
-		if addr == "" {
-			u.fail("Could not determine host address for container networking.")
-			return 1
-		}
-		u.log("Host address: %s", u.dim(addr))
-	}
-
-	// Pull the image for Semiont services (infra images are pinned tags, same
-	// as full start: their run pulls on first use and the cache stays valid).
-	if isConfigConsumer(svc) || svc == "frontend" {
-		if version != "local" {
-			args := pullArgs(rt, image(svc, version))
-			u.echoCmd(rt, args...)
-			if err := runVisible(rt, args...); err != nil {
-				u.fail("Pull failed: %s", image(svc, version))
-				return 1
-			}
-		}
-	}
-
-	// Observability is auto-detected, not flagged: if Jaeger is up, the
-	// restarted service points at it like the rest of the stack does.
-	var otel []string
-	if isConfigConsumer(svc) && httpOK("http://localhost:16686") {
-		otel = otelArgs(addr)
-		u.log("Jaeger detected — OTel export enabled")
-	}
-
-	secret := ""
-	stage := ""
-	if isConfigConsumer(svc) {
-		var ok bool
-		if secret, ok = serviceSecret(u, rt); !ok {
-			return 1
-		}
-		// A FRESH private staging dir for this service only: the running
-		// containers keep mounting their existing copies, and a new file is by
-		// definition not mounted anywhere else (the Apple-container same-file
-		// double-mount race cannot trigger). Swept by the next full
-		// start/stop.
-		var err error
-		stage, err = os.MkdirTemp("/tmp", "semiont-config.")
-		if err != nil {
-			u.fail("Cannot create config staging dir: %v", err)
-			return 1
-		}
-		cfg, err := os.ReadFile(configFile)
-		if err != nil {
-			u.fail("Reading %s: %v", configFile, err)
-			return 1
-		}
-		if err := os.WriteFile(filepath.Join(stage, svc+".toml"), cfg, 0o644); err != nil {
-			u.fail("Staging config for %s: %v", svc, err)
-			return 1
-		}
-	}
-
-	var d time.Duration
-	var id string
-	var img string
-	hostReuse := false
-	ok := false
-	switch svc {
-	case "traces":
-		args := tracesArgs()
-		img = args[len(args)-1]
-		id, d, ok = runGated(u, rt, args, "traces (Jaeger)", "traces (Jaeger UI)", "http://localhost:16686", 30)
-	case "graph":
-		rp := plan.Roles[svc]
-		args := providedRunArgs("graph", rp)
-		img = rp.Image
-		id, d, ok = runGated(u, rt, args, "graph ("+driverDisplay("graph", rp.Driver)+")", "graph ("+driverDisplay("graph", rp.Driver)+")",
-			fmt.Sprintf("http://localhost:%d", plan.AuxPorts("graph")[0].port), 30)
-	case "vectors":
-		rp := plan.Roles[svc]
-		args := providedRunArgs("vectors", rp)
-		img = rp.Image
-		id, d, ok = runGated(u, rt, args, "vectors ("+driverDisplay("vectors", rp.Driver)+")", "vectors ("+driverDisplay("vectors", rp.Driver)+")",
-			fmt.Sprintf("http://localhost:%d/readyz", rp.Port), 15)
-	case "inference":
-		rp := plan.Roles[svc]
-		var code int
-		id, hostReuse, code = startInference(u, rt, addr, opts, rp)
-		if code != 0 {
-			return code
-		}
-		if !hostReuse {
-			img = rp.Image
-		}
-		ok = true
-	case "database":
-		rp := plan.Roles[svc]
-		args := providedRunArgs("database", rp)
-		img = rp.Image
-		u.echoCmd(rt, args...)
-		var err error
-		id, err = runDetached(rt, args...)
-		if err != nil {
-			u.fail("database (%s) failed to start.", driverDisplay("database", rp.Driver))
-			return 1
-		}
-		d, ok = waitForPG(u, rt, addr, rp.Port, 20)
-	case "backend":
-		var admin []string
-		if opts.adminEmail != "" && opts.adminPassword != "" {
-			admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=" + opts.adminPassword}
-		}
-		var code int
-		id, code = runBackend(u, rt, root, stage, addr, secret, version, plan.BackendPort, userEnv, otel, admin)
-		if code != 0 {
-			return code
-		}
-		img = image("backend", version)
-		ok = true
-	case "worker", "smelter", "weaver":
-		for _, sc := range sidecarSpecs {
-			if sc.svc == svc {
-				var code int
-				id, code = runSidecar(u, rt, sc, stage, addr, secret, version, userEnv, otel)
-				if code != 0 {
-					return code
-				}
-				img = image(svc, version)
-			}
-		}
-		ok = true
-	case "frontend":
-		img = image("frontend", version)
-		id, d, ok = runGated(u, rt, frontendArgs(version), "Frontend", "Frontend", "http://localhost:3000", 30)
-	}
-	if !ok {
-		return 1
-	}
-	if d > 0 {
-		u.ok("%s healthy %s", svc, u.dim("("+took(d)+")"))
-	}
-
-	// Update the belief record: this service's entry replaces its predecessor;
-	// the rest of the record (untouched services) stands.
-	st := loadState()
-	if st == nil {
-		st = &stackState{Runtime: rt, Version: version, Services: map[string]serviceState{}}
-	}
-	provided := providedLauncher
-	if hostReuse {
-		provided = providedHost
-	}
-	driver := ""
-	if plan != nil {
-		driver = plan.Roles[svc].Driver
-	}
-	if svc == "traces" {
-		driver = "jaeger"
-	}
-	st.recordService(svc, id, img, provided, serviceEndpoint(svc, plan), driver)
-
 	fmt.Println()
-	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 "+svc+" is up"), u.dim("("+took(time.Since(t0))+")"))
+	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 "+opts.service+" is up"), u.dim("("+took(time.Since(t0))+")"))
 	fmt.Printf("  Check health:  %s\n", u.bold("semiont status"))
 	return 0
 }
 
-// renderServicePlan is --dry-run for --service: the one service's slice of
-// the plan, conditionals as comments (matching renderStartPlan's style).
+// renderServicePlan is --dry-run for --service: the same flow, plan mode.
 func renderServicePlan(rt, version string, opts startOptions, userEnv []string, plan *launchPlan) {
-	const addr = "<host-addr>"
-	const stage = "<config-stage>"
-	svc := opts.service
-	p := func(args ...string) { fmt.Println(renderCmd(rt, args...)) }
-	c := func(format string, a ...any) { fmt.Printf("# "+format+"\n", a...) }
-
-	c("semiont start --service %s --dry-run — the exact runtime commands a real", svc)
-	c("run would execute, in order. Values known only at runtime appear as <placeholders>.")
-	if plan != nil {
-		if rp, ok := plan.Roles[svc]; ok && (rp.Obligation == obligationExternal || rp.Obligation == obligationAbsent) {
-			renderRolePlan(rt, svc, plan, opts, c, p)
-			return
-		}
-	}
-	if svc != "inference" {
-		p("stop", roles[svc].container)
-		p("rm", roles[svc].container)
-		if rp, ok := plan.Roles[svc]; ok && rp.Obligation == obligationProvided {
-			spec := driverCatalog[svc][rp.Driver]
-			ports := make([]string, 0, 2)
-			for _, ap := range spec.auxPorts {
-				ports = append(ports, fmt.Sprintf("%d", ap.port))
-			}
-			ports = append(ports, fmt.Sprintf("%d", rp.Port))
-			c("require free ports: %s", strings.Join(ports, " "))
-		} else if len(roles[svc].ports) > 0 {
-			ports := make([]string, 0, 2)
-			for _, pc := range roles[svc].ports {
-				ports = append(ports, fmt.Sprintf("%d", pc.port))
-			}
-			c("require free ports: %s", strings.Join(ports, " "))
-		}
-	}
-	if isConfigConsumer(svc) || svc == "frontend" {
-		if version == "local" {
-			c("SEMIONT_VERSION=local — using locally-built :local images (no pull)")
-		} else {
-			p(pullArgs(rt, image(svc, version))...)
-		}
-	}
-	var otel []string
-	if isConfigConsumer(svc) {
-		c("probe: Jaeger at http://localhost:16686 — if running, add --env OTEL_EXPORTER_OTLP_ENDPOINT=http://<host-addr>:4318")
-		c("worker secret: recovered from a running Semiont container's env (inspect), else $SEMIONT_WORKER_SECRET, else generated")
-		c("stage a fresh private config copy under <config-stage>: %s.toml", svc)
-	}
-	switch svc {
-	case "traces":
-		p(tracesArgs()...)
-		c("wait: http://localhost:16686 (30s)")
-	case "graph", "vectors", "inference", "database":
-		renderRolePlan(rt, svc, plan, opts, c, p)
-	case "backend":
-		var admin []string
-		if opts.adminEmail != "" {
-			admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=<admin-password>"}
-		}
-		p(backendArgs("<kb-root>", stage, addr, "<worker-secret>", version, plan.BackendPort, userEnv, otel, admin)...)
-		c("wait: http://localhost:%d/api/health (120s)", plan.BackendPort)
-		c(`probe: %s run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:%d/api/health" (up to 20 tries)`, rt, plan.BackendPort)
-	case "worker", "smelter", "weaver":
-		for _, sc := range sidecarSpecs {
-			if sc.svc == svc {
-				p(sidecarArgs(sc.svc, sc.mem, sc.port, stage, addr, "<worker-secret>", version, userEnv, otel)...)
-				c("wait: http://localhost:%d/health (30s)", sc.port)
-			}
-		}
-	case "frontend":
-		p(frontendArgs(version)...)
-		c("wait: http://localhost:3000 (30s)")
-	}
+	x := &planExec{rt: rt}
+	x.c("semiont start --service %s --dry-run — the exact runtime commands a real", opts.service)
+	x.c("run would execute, in order. Values known only at runtime appear as <placeholders>.")
+	flowOneService(x, flowCtx{plan: plan, opts: opts, version: version, root: "<kb-root>", configFile: opts.configName, userEnv: userEnv})
 }
 
 // serviceEndpoint: the health endpoint status should probe for a service the

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -175,7 +175,7 @@ func serviceSecret(u *ui, rt string) (string, bool) {
 // absent no-ops, which launch nothing).
 func runStartService(u *ui, rt, version, root, configFile string, opts startOptions, userEnv []string, plan *launchPlan) int {
 	t0 := time.Now()
-	x := &liveExec{u: u, rt: rt}
+	x := &liveExec{u: u, rt: rt, version: version, root: root}
 	if code := flowOneService(x, flowCtx{plan: plan, opts: opts, version: version, root: root, configFile: configFile, userEnv: userEnv}); code != 0 {
 		return code
 	}

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -29,19 +28,7 @@ var preflightNames = []string{
 	"semiont-frontend",
 }
 
-// The config TOMLs reference env vars as ${VAR} (required) or ${VAR:-default}
-// (optional); only the required form is matched here. These are the ones the
-// launcher injects itself and never demands from the user.
-var injectedVars = map[string]bool{
-	"BACKEND_HOST": true, "NEO4J_HOST": true, "QDRANT_HOST": true,
-	"OLLAMA_HOST": true, "POSTGRES_HOST": true, "SEMIONT_WORKER_SECRET": true,
-	"ADMIN_EMAIL": true, "ADMIN_PASSWORD": true,
-}
-
-var (
-	envRefRe = regexp.MustCompile(`\$\{[A-Z_][A-Z0-9_]*\}`)
-	emailRe  = regexp.MustCompile(`^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$`)
-)
+var emailRe = regexp.MustCompile(`^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$`)
 
 type startOptions struct {
 	configName     string
@@ -314,6 +301,7 @@ func Start(args []string) int {
 	}
 	configFile := filepath.Join(configDir, opts.configName+".toml")
 	var plan *launchPlan
+	var userVars []string
 	if configNeeded {
 		if _, err := os.Stat(configFile); err != nil {
 			u.fail("Config not found: %s", configFile)
@@ -321,11 +309,13 @@ func Start(args []string) int {
 			printConfigNames()
 			return 1
 		}
-		envCfg, envName, err := loadConfig(configFile)
+		var uv []string
+		envCfg, envName, uv, err := loadConfig(configFile)
 		if err != nil {
 			u.fail("%v", err)
 			return 1
 		}
+		userVars = uv
 		if plan, err = derivePlan(envCfg, envName, configFile); err != nil {
 			u.fail("%v", err)
 			return 1
@@ -387,15 +377,11 @@ func Start(args []string) int {
 	}
 	u.log("Image version: %s", u.bold(version))
 
-	// User env vars (API keys the config references) are demanded only where
-	// a Semiont service will consume the config — never for infra restarts.
+	// User env vars (API keys the config references, extracted by
+	// loadConfig's single parse) are demanded only where a Semiont service
+	// will consume the config — never for infra restarts.
 	var userEnv []string
 	if opts.service == "" || isConfigConsumer(opts.service) {
-		userVars, err := requiredConfigVars(configFile)
-		if err != nil {
-			u.fail("Reading %s: %v", configFile, err)
-			return 1
-		}
 		for _, v := range userVars {
 			if opts.dryRun {
 				userEnv = append(userEnv, "--env", v+"=<env:"+v+">")
@@ -429,28 +415,6 @@ func printConfigNames() {
 	for _, f := range files {
 		fmt.Printf("  %s\n", strings.TrimSuffix(filepath.Base(f), ".toml"))
 	}
-}
-
-// requiredConfigVars extracts the sorted set of required ${VAR} references
-// from a config file, minus the launcher-injected ones.
-func requiredConfigVars(configFile string) ([]string, error) {
-	b, err := os.ReadFile(configFile)
-	if err != nil {
-		return nil, err
-	}
-	set := map[string]bool{}
-	for _, m := range envRefRe.FindAllString(string(b), -1) {
-		name := strings.TrimSuffix(strings.TrimPrefix(m, "${"), "}")
-		if !injectedVars[name] {
-			set[name] = true
-		}
-	}
-	names := make([]string, 0, len(set))
-	for n := range set {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	return names, nil
 }
 
 // --- Command builders (shared by the real run and --dry-run) ---

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -336,6 +336,23 @@ func Start(args []string) int {
 	if !ok {
 		return 1
 	}
+	// The record binds a running stack to its runtime. Implicit selection
+	// prefers it (a bare `start --service worker` must rejoin the stack that
+	// exists, not whatever auto-detect finds first); an EXPLICIT mismatch on
+	// a non-dry-run refuses rather than orphan the recorded stack — start's
+	// preflight would erase its record and delete staged configs out from
+	// under its live mounts. A record whose runtime is no longer installed is
+	// stale (that stack cannot be running) and doesn't bind anything.
+	if recSt := loadState(); recSt != nil && recSt.Runtime != "" && recSt.Runtime != rt && onPath(recSt.Runtime) {
+		if opts.runtime == "" {
+			rt = recSt.Runtime
+			u.log("Using recorded stack's runtime: %s %s", u.bold(rt), u.dim("(per "+statePath()+")"))
+		} else if !opts.dryRun {
+			u.fail("A recorded stack is running under %s (per %s).", recSt.Runtime, statePath())
+			fmt.Fprintln(os.Stderr, "  Stop it first (semiont stop), or start with --runtime "+recSt.Runtime+".")
+			return 1
+		}
+	}
 
 	if opts.cleanOllama {
 		u.log("Removing Ollama model cache volume...")

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -524,397 +524,33 @@ func pullArgs(rt, img string) []string {
 var semiontServices = []string{"backend", "worker", "smelter", "weaver", "frontend"}
 
 // sidecarSpecs: the three make-meaning sidecars, in start order.
-var sidecarSpecs = []struct {
+type sidecarSpec struct {
 	svc, label, mem, banner string
 	port                    int
-}{
+}
+
+var sidecarSpecs = []sidecarSpec{
 	{"worker", "Worker pool", "2G", "Starting Worker Pool", 9090},
 	{"smelter", "Smelter", "2G", "Starting Smelter", 9091},
 	{"weaver", "Weaver", "3G", "Starting Weaver", 9092},
 }
 
-// runGated: the common run-detached-then-health-gate shape. Returns the
-// container identifier the runtime printed (recorded in stack.json).
-func runGated(u *ui, rt string, args []string, failLabel, waitLabel, url string, tries int) (string, time.Duration, bool) {
-	u.echoCmd(rt, args...)
-	id, err := runDetached(rt, args...)
-	if err != nil {
-		u.fail("%s failed to start.", failLabel)
-		return "", 0, false
-	}
-	d, ok := waitForHTTP(u, waitLabel, url, tries)
-	return id, d, ok
-}
-
-// runBackend starts the backend and runs BOTH its gates: host-side health,
-// then container-gateway reachability — the sidecars dial addr:4000 (not
-// localhost) and fatally exit if their first backend fetch fails, so host
-// health alone doesn't prove the path they need.
-func runBackend(u *ui, rt, root, stage, addr, secret, version string, port int, userEnv, otel, admin []string) (string, int) {
-	bArgs := backendArgs(root, stage, addr, secret, version, port, userEnv, otel, admin)
-	u.echoCmd(rt, bArgs...)
-	id, err := runDetached(rt, bArgs...)
-	if err != nil {
-		u.fail("Backend failed to start.")
-		return "", 1
-	}
-	u.log("Waiting for backend health...")
-	d, ok := waitForHTTP(u, "Backend", fmt.Sprintf("http://localhost:%d/api/health", port), 120)
-	if !ok {
-		return "", 1
-	}
-	u.ok("Backend healthy %s", u.dim("("+took(d)+")"))
-
-	u.log("Verifying backend reachable from containers...")
-	reachT0 := time.Now()
-	reachable := false
-	for i := 0; i < 20; i++ {
-		if runSilent(rt, "run", "--rm", "busybox:1.38.0", "sh", "-c",
-			fmt.Sprintf("wget -q -O- http://%s:%d/api/health", addr, port)) == nil {
-			reachable = true
-			break
-		}
-		time.Sleep(time.Second)
-	}
-	if !reachable {
-		u.fail("Backend not reachable from containers at %s:%d within 20s.", addr, port)
-		return "", 1
-	}
-	u.ok("Backend reachable from containers %s", u.dim("("+took(time.Since(reachT0))+")"))
-	return id, 0
-}
-
-// runSidecar starts one make-meaning sidecar and gates on its /health.
-func runSidecar(u *ui, rt string, sc struct {
-	svc, label, mem, banner string
-	port                    int
-}, stage, addr, secret, version string, userEnv, otel []string) (string, int) {
-	args := sidecarArgs(sc.svc, sc.mem, sc.port, stage, addr, secret, version, userEnv, otel)
-	id, d, ok := runGated(u, rt, args, sc.label, sc.label, fmt.Sprintf("http://localhost:%d/health", sc.port), 30)
-	if !ok {
-		return "", 1
-	}
-	u.ok("%s healthy (http://localhost:%d) %s", sc.label, sc.port, u.dim("("+took(d)+")"))
-	return id, 0
-}
-
 // --- The real run ---
 
-// verifyExternal confirms an externally-provided role is reachable at its
-// configured address — the launcher launches nothing but refuses to bring up
-// dependents against a dead dependency.
-func verifyExternal(u *ui, role string, rp rolePlan) bool {
-	addr := fmt.Sprintf("%s:%d", rp.Address, rp.Port)
-	conn, err := netDialTimeout(addr)
-	if err != nil {
-		u.fail("%s is externally provided at %s but unreachable: %v", role, addr, err)
-		return false
-	}
-	conn.Close()
-	u.ok("%s — externally provided at %s %s", role, addr, u.dim("(reachable)"))
-	return true
-}
-
+// runStart: the live full start — flowFullStart with liveExec, plus the
+// live-only bookends (timing stamp, summary table).
 func runStart(u *ui, rt, version, root, configFile string, opts startOptions, userEnv []string, plan *launchPlan) int {
 	t0 := time.Now()
-	// Resolve the host address for container networking. Every inter-service
-	// hop dials the HOST (hub-and-spoke over published ports), so this must be
-	// an address that reaches the host FROM INSIDE a container — and that is
-	// runtime-specific:
-	//   - Apple container: one VM per container; the default gateway on the
-	//     shared bridge IS the Mac host. The gateway probe is correct.
-	//   - Docker Desktop (mac/win): the bridge gateway is internal to Docker's
-	//     Linux VM and does NOT reach the host (measured: host Ollama on
-	//     0.0.0.0 was unreachable at 172.17.0.1). The injected DNS name
-	//     host.docker.internal does. Docker on Linux injects no such name by
-	//     default — there the bridge gateway DOES reach host-published ports,
-	//     so the gateway probe is the fallback.
-	//   - podman: same pattern with host.containers.internal.
-	// Probe, don't assume.
-	addr := resolveHostAddr(rt)
-	if addr == "" {
-		u.fail("Could not determine host address for container networking.")
-		fmt.Fprintln(os.Stderr, "  Neither the runtime's host alias nor the default-gateway probe returned a result.")
-		return 1
-	}
-	u.log("Host address: %s", u.dim(addr))
-
-	// Preflight: stop prior Semiont containers, verify required ports are
-	// free — up front so a conflict surfaces before any image work.
-	//
-	// `stop` only halts a running container; under Apple Container the stopped
-	// instance persists and the next `run --name <c>` fails with "already
-	// exists". `rm` after `stop` (both best-effort) makes the loop idempotent
-	// across all three states: not present, running, or stopped-but-not-removed.
-	u.banner("Preflight")
-	u.log("Removing prior containers %s", u.dim(fmt.Sprintf("(stop+rm, %d names; exact commands: semiont start --dry-run)", len(preflightNames))))
-	removed := 0
-	for _, c := range preflightNames {
-		stopped := runSilent(rt, "stop", c) == nil
-		rmed := runSilent(rt, "rm", c) == nil
-		if stopped || rmed {
-			removed++
-		}
-	}
-	if removed == 0 {
-		u.ok("No prior containers")
-	} else {
-		u.ok("Removed %d prior container(s)", removed)
-	}
-	// Staged config copies from previous runs (semiont stop also removes
-	// these). Safe to delete only here, after the old stack's containers
-	// (which mounted them) are stopped — this run's own staging is created
-	// below, after this sweep. The recorded stack state describes the stack
-	// the sweep just destroyed — forget it; this run re-records as it goes.
-	removeStagedConfigs()
-	removeState()
-	time.Sleep(time.Second)
-
-	for _, pc := range planPortChecks(plan, opts.observe) {
-		if !requirePortFree(u, pc.port, pc.label, opts.forceKillPorts) {
-			return 1
-		}
-	}
-	u.ok("Required ports are free")
-
-	// Stage per-service config copies — each service gets its OWN copy to
-	// mount; do not "simplify" this back to one shared file. Under Apple
-	// Container (one VM per container, each with its own virtiofs share),
-	// mounting the same host file into a second VM transiently breaks existing
-	// mounts of that file in other VMs (measured: a 50ms-interval read loop
-	// showed ~100ms of read failures exactly when another container mounted
-	// the same file). The backend is the victim: its CMD re-reads
-	// ~/.semiontconfig across several CLI invocations while the sidecars
-	// launch and mount theirs, and the CLI treats an unreadable config as
-	// "not configured" — a shared file intermittently killed a healthy backend
-	// mid-chain. Private copies mean no host file is ever mounted twice.
-	//
-	// docker/podman don't need this, but the copies are harmless there, so one
-	// code path serves all runtimes. The staging dir deliberately outlives
-	// this process — the running containers mount these copies; semiont stop
-	// (and the next run's preflight sweep) removes it.
-	//
-	// The staging dir MUST be under /tmp, not $TMPDIR: Apple Container cannot
-	// sustain mounts from /var/folders (macOS's per-user private temp) — the
-	// first read succeeds, then every subsequent read fails (measured: 1 ok /
-	// 29 fail over 30s, vs 30/30 ok from /tmp).
-	stage, err := os.MkdirTemp("/tmp", "semiont-config.")
-	if err != nil {
-		u.fail("Cannot create config staging dir: %v", err)
-		return 1
-	}
-	cfg, err := os.ReadFile(configFile)
-	if err != nil {
-		u.fail("Reading %s: %v", configFile, err)
-		return 1
-	}
-	for _, svc := range []string{"backend", "worker", "smelter", "weaver"} {
-		if err := os.WriteFile(filepath.Join(stage, svc+".toml"), cfg, 0o644); err != nil {
-			u.fail("Staging config for %s: %v", svc, err)
-			return 1
-		}
-	}
-
-	// The belief record: what this run starts, identified by what the runtime
-	// reports. Saved after every service so a failed start still leaves an
-	// accurate partial record for stop/status to work from.
-	st := &stackState{
-		Runtime: rt, KBRoot: root, KBDid: loadKBIdentity(root).didWeb(),
-		Config: opts.configName, Version: version,
-		HostAddr: addr, Stage: stage, Services: map[string]serviceState{},
-	}
-
-	// Pull explicitly, up front, so a bad version/registry fails before any
-	// dep containers start — a `run` alone reuses a cached :latest forever.
-	u.banner("Pulling Images")
-	if version == "local" {
-		u.log("Using locally-built %s images (skipping pull)", u.bold(":local"))
-	} else {
-		for _, svc := range semiontServices {
-			args := pullArgs(rt, image(svc, version))
-			u.echoCmd(rt, args...)
-			if err := runVisible(rt, args...); err != nil {
-				u.fail("Pull failed: %s", image(svc, version))
-				return 1
-			}
-		}
-		u.ok("Images pulled")
-	}
-
-	// Jaeger — on by default (skip with --no-observe): the Semiont processes
-	// push OTLP traces + metrics to it over one endpoint env var.
-	var otel []string
-	if opts.observe {
-		u.banner("Traces (Jaeger)")
-		args := tracesArgs()
-		id, d, ok := runGated(u, rt, args, "traces (Jaeger)", "traces (Jaeger)", "http://localhost:16686", 30)
-		if !ok {
-			return 1
-		}
-		u.ok("traces — Jaeger UI on http://localhost:16686 (OTLP collector: %s:4318) %s", addr, u.dim("("+took(d)+")"))
-		st.recordService("traces", id, args[len(args)-1], providedLauncher, "http://localhost:16686", "jaeger")
-		otel = otelArgs(addr)
-	}
-
-	graphRP := plan.Roles["graph"]
-	u.banner("Graph (" + driverDisplay("graph", graphRP.Driver) + ")")
-	switch graphRP.Obligation {
-	case obligationProvided:
-		args := providedRunArgs("graph", graphRP)
-		auxPort := plan.AuxPorts("graph")[0].port
-		id, d, ok := runGated(u, rt, args, "graph ("+driverDisplay("graph", graphRP.Driver)+")", "graph ("+driverDisplay("graph", graphRP.Driver)+")",
-			fmt.Sprintf("http://localhost:%d", auxPort), 30)
-		if !ok {
-			return 1
-		}
-		u.ok("graph — bolt://localhost:%d (browser: http://localhost:%d) %s",
-			graphRP.Port, auxPort, u.dim("("+took(d)+")"))
-		st.recordService("graph", id, graphRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d", auxPort), graphRP.Driver)
-	case obligationAbsent:
-		u.log("graph — not configured; skipping")
-		st.recordService("graph", "", "", providedNone, "", "")
-	default:
-		if !verifyExternal(u, "graph", graphRP) {
-			return 1
-		}
-		st.recordService("graph", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", graphRP.Address, graphRP.Port), graphRP.Driver)
-	}
-
-	vecRP := plan.Roles["vectors"]
-	u.banner("Vectors (" + driverDisplay("vectors", vecRP.Driver) + ")")
-	switch vecRP.Obligation {
-	case obligationProvided:
-		args := providedRunArgs("vectors", vecRP)
-		id, d, ok := runGated(u, rt, args, "vectors ("+driverDisplay("vectors", vecRP.Driver)+")", "vectors ("+driverDisplay("vectors", vecRP.Driver)+")",
-			fmt.Sprintf("http://localhost:%d/readyz", vecRP.Port), 15)
-		if !ok {
-			return 1
-		}
-		u.ok("vectors — http://localhost:%d %s", vecRP.Port, u.dim("("+took(d)+")"))
-		st.recordService("vectors", id, vecRP.Image, providedLauncher, fmt.Sprintf("http://localhost:%d/readyz", vecRP.Port), vecRP.Driver)
-	case obligationAbsent:
-		u.log("vectors — not configured; skipping")
-		st.recordService("vectors", "", "", providedNone, "", "")
-	default:
-		if !verifyExternal(u, "vectors", vecRP) {
-			return 1
-		}
-		st.recordService("vectors", "", "", providedExternal, fmt.Sprintf("http://%s:%d/readyz", vecRP.Address, vecRP.Port), vecRP.Driver)
-	}
-
-	infRP := plan.Roles["inference"]
-	switch infRP.Obligation {
-	case obligationHostProcess:
-		infID, hostReuse, code := startInference(u, rt, addr, opts, infRP)
-		if code != 0 {
-			return code
-		}
-		infImage := ""
-		infProvided := providedHost
-		if !hostReuse {
-			infImage = infRP.Image
-			infProvided = providedLauncher
-		}
-		st.recordService("inference", infID, infImage, infProvided, fmt.Sprintf("http://localhost:%d/api/version", infRP.Port), infRP.Driver)
-	case obligationExternal:
-		u.banner("Inference (" + driverDisplay("inference", infRP.Driver) + ")")
-		if !verifyExternal(u, "inference", infRP) {
-			return 1
-		}
-		st.recordService("inference", "", "", providedExternal, fmt.Sprintf("http://%s:%d/api/version", infRP.Address, infRP.Port), infRP.Driver)
-	case obligationAbsent:
-		u.banner("Inference")
-		u.log("inference — not referenced by the config; skipping")
-		st.recordService("inference", "", "", providedNone, "", "")
-	}
-
-	dbRP := plan.Roles["database"]
-	u.banner("Database (" + driverDisplay("database", dbRP.Driver) + ")")
-	switch dbRP.Obligation {
-	case obligationProvided:
-		args := providedRunArgs("database", dbRP)
-		u.echoCmd(rt, args...)
-		var id string
-		id, err = runDetached(rt, args...)
-		if err != nil {
-			u.fail("database (%s) failed to start.", driverDisplay("database", dbRP.Driver))
-			return 1
-		}
-		d, ok := waitForPG(u, rt, addr, dbRP.Port, 20)
-		if !ok {
-			return 1
-		}
-		u.ok("database — %s on port %d %s", driverDisplay("database", dbRP.Driver), dbRP.Port, u.dim("("+took(d)+")"))
-		st.recordService("database", id, dbRP.Image, providedLauncher, fmt.Sprintf("tcp:localhost:%d", dbRP.Port), dbRP.Driver)
-	case obligationAbsent:
-		u.log("database — not configured; skipping")
-		st.recordService("database", "", "", providedNone, "", "")
-	default:
-		if !verifyExternal(u, "database", dbRP) {
-			return 1
-		}
-		st.recordService("database", "", "", providedExternal, fmt.Sprintf("tcp:%s:%d", dbRP.Address, dbRP.Port), dbRP.Driver)
-	}
-
-	secret := os.Getenv("SEMIONT_WORKER_SECRET")
-	if secret == "" {
-		b := make([]byte, 32)
-		if _, err := rand.Read(b); err != nil {
-			u.fail("Generating worker secret: %v", err)
-			return 1
-		}
-		secret = hex.EncodeToString(b)
-	}
-
-	u.banner("Starting Backend")
-	u.log("http://localhost:%d", plan.BackendPort)
-	u.log("Worker secret: %s", u.dim("(generated)"))
-	var admin []string
-	if opts.adminEmail != "" && opts.adminPassword != "" {
-		admin = []string{"--env", "ADMIN_EMAIL=" + opts.adminEmail, "--env", "ADMIN_PASSWORD=" + opts.adminPassword}
-		u.log("Admin user: %s", u.bold(opts.adminEmail))
-	}
-	backendID, code := runBackend(u, rt, root, stage, addr, secret, version, plan.BackendPort, userEnv, otel, admin)
-	if code != 0 {
+	x := &liveExec{u: u, rt: rt}
+	if code := flowFullStart(x, flowCtx{plan: plan, opts: opts, version: version, root: root, configFile: configFile, userEnv: userEnv}); code != 0 {
 		return code
 	}
-	st.recordService("backend", backendID, image("backend", version), providedLauncher, fmt.Sprintf("http://localhost:%d/api/health", plan.BackendPort), "")
-
-	// The weaver note: the graph projection is standalone-only — the backend
-	// no longer applies events to Neo4j in-process. Without the weaver the
-	// graph stays empty and every gather 404s at the buildKnowledgeGraph
-	// barrier. Its health reports readiness before catch-up completes.
-	for _, sc := range sidecarSpecs {
-		u.banner(sc.banner)
-		scID, code := runSidecar(u, rt, sc, stage, addr, secret, version, userEnv, otel)
-		if code != 0 {
-			return code
-		}
-		st.recordService(sc.svc, scID, image(sc.svc, version), providedLauncher, fmt.Sprintf("http://localhost:%d/health", sc.port), "")
-	}
-
-	// Frontend: a static SPA server — no config mount and no service env; the
-	// browser talks to the backend directly on localhost:4000.
-	u.banner("Starting Frontend")
-	feID, feD, feOK := runGated(u, rt, frontendArgs(version), "Frontend", "Frontend", "http://localhost:3000", 30)
-	if !feOK {
-		return 1
-	}
-	u.ok("Frontend on http://localhost:3000 %s", u.dim("("+took(feD)+")"))
-	st.recordService("frontend", feID, image("frontend", version), providedLauncher, "http://localhost:3000", "")
 
 	// Summary; the stack runs detached and this process exits — bring the
-	// stack up, say where everything is, and get out of the way (compose up
-	// -d / supabase start style). Logs and teardown are explicit follow-up
-	// commands, not a resident supervisor. URLs are printed bare because
-	// terminals auto-link plain URLs; OSC 8 support is uneven.
-	//
-	// Restart story, honestly: these containers run --rm with NO restart
-	// policy (docker forbids --rm + --restart, and Apple `container` has no
-	// restart policies) — a crashed service stays down until you rerun
-	// `semiont start`. Services fail FAST by design; a dead container is the
-	// visible, diagnosable signal. The compose path adds `restart: on-failure`;
-	// this launcher deliberately does not pretend to.
+	// stack up, say where everything is, and get out of the way. These
+	// containers run --rm with NO restart policy; a crashed service stays
+	// down until you rerun semiont start (fail-fast is the design; the
+	// compose path adds restart: on-failure).
 	u.stamp("semiont start: containers ready")
 	fmt.Println()
 	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 Semiont stack is up"), u.dim("("+took(time.Since(t0))+")"))
@@ -938,81 +574,41 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 	return 0
 }
 
-// startInference reuses a host Ollama when one is serving 11434 and reachable
-// from containers; otherwise starts the semiont-ollama container.
-func startInference(u *ui, rt, addr string, opts startOptions, rp rolePlan) (id string, hostReuse bool, code int) {
-	u.banner("Inference (" + driverDisplay("inference", rp.Driver) + ")")
-	if httpOK(fmt.Sprintf("http://localhost:%d/api/version", rp.Port)) {
-		if runSilent(rt, "run", "--rm", "busybox:1.38.0", "sh", "-c",
-			fmt.Sprintf("wget -q -O- http://%s:%d/api/version", addr, rp.Port)) == nil {
-			u.ok("inference — using host Ollama at http://localhost:%d", rp.Port)
-			return "", true, 0
-		}
-		fmt.Println()
-		u.warn("Ollama is running on the host but not reachable from containers.")
-		fmt.Printf("   The backend runs in a container and needs Ollama at %s:%d.\n", addr, rp.Port)
-		fmt.Println()
-		if runSilent("pgrep", "-f", "Ollama.app/Contents") == nil {
-			fmt.Println("   Detected: Ollama Desktop app")
-		} else if runSilent("pgrep", "-f", "ollama serve") == nil {
-			fmt.Println("   Detected: ollama serve daemon")
-		}
-		fmt.Println()
-		fmt.Println("   Fix: configure Ollama to listen on all interfaces:")
-		fmt.Printf("     %s\n", u.bold("launchctl setenv OLLAMA_HOST 0.0.0.0"))
-		fmt.Println("   Then fully quit Ollama Desktop from the menu bar and relaunch it.")
-		fmt.Println()
-		fmt.Println("   (If launchctl doesn't stick, quit Ollama Desktop entirely and run")
-		fmt.Printf("    %s from a terminal.)\n", u.bold("OLLAMA_HOST=0.0.0.0:11434 ollama serve"))
-		fmt.Println()
-		return "", false, 1
+// fullStartSecret: $SEMIONT_WORKER_SECRET or freshly generated.
+func fullStartSecret(u *ui) (string, bool) {
+	if secret := os.Getenv("SEMIONT_WORKER_SECRET"); secret != "" {
+		return secret, true
 	}
-
-	u.log("No host Ollama detected — starting container...")
-	u.echoCmd(rt, "stop", "semiont-ollama")
-	runPassthrough(rt, "stop", "semiont-ollama")
-	time.Sleep(time.Second)
-	if !requirePortFree(u, rp.Port, "Ollama", opts.forceKillPorts) {
-		return "", false, 1
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		u.fail("Generating worker secret: %v", err)
+		return "", false
 	}
+	return hex.EncodeToString(b), true
+}
 
+// chooseOllamaVolume: --ollama-cache override, else the ~/.ollama share
+// prompt (auto-yes in 10s), else the named volume.
+func chooseOllamaVolume(u *ui, opts startOptions) string {
 	home, _ := os.UserHomeDir()
-	volume := ""
 	switch opts.ollamaCache {
 	case "host":
-		volume = filepath.Join(home, ".ollama")
 		u.log("Using host model cache.")
+		return filepath.Join(home, ".ollama")
 	case "volume":
-		volume = "semiont-ollama-models"
 		u.log("Using named volume semiont-ollama-models for model cache.")
-	default:
-		if home != "" {
-			if _, err := os.Stat(filepath.Join(home, ".ollama")); err == nil {
-				if promptShareCache(home) {
-					volume = filepath.Join(home, ".ollama")
-					u.log("Using host model cache.")
-				}
+		return "semiont-ollama-models"
+	}
+	if home != "" {
+		if _, err := os.Stat(filepath.Join(home, ".ollama")); err == nil {
+			if promptShareCache(home) {
+				u.log("Using host model cache.")
+				return filepath.Join(home, ".ollama")
 			}
 		}
-		if volume == "" {
-			volume = "semiont-ollama-models"
-			u.log("Using named volume semiont-ollama-models for model cache.")
-		}
 	}
-
-	args := providedRunArgs("inference", rp, "-m", "24G", "-v", volume+":/root/.ollama")
-	u.echoCmd(rt, args...)
-	id, err := runDetached(rt, args...)
-	if err != nil {
-		u.fail("Ollama container failed to start.")
-		return "", false, 1
-	}
-	d, ok := waitForHTTP(u, "inference (Ollama)", fmt.Sprintf("http://localhost:%d/api/version", rp.Port), 30)
-	if !ok {
-		return "", false, 1
-	}
-	u.ok("inference — Ollama container on http://localhost:%d (24 GB memory) %s", rp.Port, u.dim("("+took(d)+")"))
-	return id, false, 0
+	u.log("Using named volume semiont-ollama-models for model cache.")
+	return "semiont-ollama-models"
 }
 
 // promptShareCache asks whether to mount ~/.ollama, auto-yes after 10s (and

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -146,10 +146,13 @@ func Stop(args []string) int {
 				fmt.Println(renderCmd(rt, "rm", c))
 			}
 		}
-		if service == "" {
-			fmt.Println("# remove staged config copies: /tmp/semiont-config.*")
-		} else {
+		switch {
+		case service != "":
 			fmt.Println("# staged config copies left in place (--service)")
+		case st != nil && !useState:
+			fmt.Println("# staged config copies and stack.json left in place (recorded stack is under " + st.Runtime + ")")
+		default:
+			fmt.Println("# remove staged config copies: /tmp/semiont-config.*")
 		}
 		return 0
 	}
@@ -184,6 +187,18 @@ func Stop(args []string) int {
 			saveState(st)
 		}
 		fmt.Printf("%s stopped (staged configs left in place; rest of the stack untouched).\n", service)
+		return 0
+	}
+
+	// Shared-artifact cleanup is safe only when this sweep actually covered
+	// the recorded stack (or no record exists): with an explicit --runtime
+	// that mismatches the record, the REAL stack may still be running — its
+	// staged configs are live mounts (deleting them under a running backend
+	// is the measured Apple-container failure this staging exists to
+	// prevent), and its record still describes reality.
+	if st != nil && !useState {
+		u.warn("Recorded stack (under %s) left untouched — staged configs and stack.json kept.", st.Runtime)
+		fmt.Printf("Swept %s only. Run semiont stop (without --runtime) to tear down the recorded stack.\n", strings.Join(runtimes, ", "))
 		return 0
 	}
 

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -963,6 +963,50 @@ func TestRootFlagErrors(t *testing.T) {
 	mustContain(t, "stderr", stderr, "--root only applies to services that read the KB config")
 }
 
+func TestLogsService(t *testing.T) {
+	// --service reaches ANY role's logs — infra included (record-less stack:
+	// discovery by name-scan, follow by container name).
+	s := newScenario(t, "container")
+	s.extraEnv = append(s.extraEnv, "FAKERT_STACK_RUNTIME=container")
+	stdout, stderr, code := s.run(t, "logs", "--service", "graph")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout, "Following graph —", "[graph] neo4j out", "[graph] neo4j err")
+	mustContain(t, "argv", s.argv(t), "container logs --follow semiont-neo4j")
+}
+
+func TestLogsRecordAware(t *testing.T) {
+	// With a record: no name-scan probes, recorded runtime + IDs drive the
+	// follow; a host-provided role explains itself instead of failing weirdly.
+	s := newScenario(t, "container", "docker")
+	writeStackState(t, s, "container")
+	stdout, _, code := s.run(t, "logs", "--service", "backend")
+	if code != 0 {
+		t.Fatalf("exit %d\n%s", code, stdout)
+	}
+	mustContain(t, "stdout", stdout, "Using recorded stack state", "[backend]")
+	argv := s.argv(t)
+	mustContain(t, "argv", argv, "container logs --follow fid-semiont-backend")
+	for _, absent := range []string{"container list", "docker ps"} {
+		if strings.Contains(argv, absent) {
+			t.Errorf("record-aware logs still name-scanned: %q", absent)
+		}
+	}
+
+	// Host-provided inference: no container logs, pointed message.
+	v2 := `{"schema":2,"runtime":"container","services":{
+	  "inference":{"provided":"host","endpoint":"http://localhost:11434/api/version","startedAt":"2026-07-19T00:00:00Z"}}}`
+	if err := os.WriteFile(statePathFor(s.home), []byte(v2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, code := s.run(t, "logs", "--service", "inference")
+	if code != 1 {
+		t.Errorf("host-provided logs: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "inference is provided by a host process — no container logs")
+}
+
 // --- stack state record ---
 
 // statePathFor mirrors the launcher's statePath for the scenario's fake HOME.

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -814,6 +814,30 @@ func TestStartServiceExternalIsNoop(t *testing.T) {
 	}
 }
 
+func TestServiceBackendPortFollowsConfig(t *testing.T) {
+	// --service backend port-claims the CONFIG's backend port, not a static
+	// 4000 (the last vestige of the pre-config-sync port table).
+	s := newScenario(t, "container")
+	writeKBConfig(t, s, "moved-backend",
+		stdGraph+stdVectors+stdEmbedding+stdDatabase)
+	// writeKBConfig's header pins backend.port = 4000; rewrite it to 4001.
+	p := filepath.Join(s.kb, ".semiont", "semiontconfig", "moved-backend.toml")
+	b, _ := os.ReadFile(p)
+	if err := os.WriteFile(p, []byte(strings.Replace(string(b), "port = 4000", "port = 4001", 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, code := s.run(t, "start", "--service", "backend", "--config", "moved-backend", "--dry-run")
+	if code != 0 {
+		t.Fatalf("exit %d\n%s", code, stdout)
+	}
+	mustContain(t, "stdout", stdout,
+		"require free ports: 4001",
+		"wait: http://localhost:4001/api/health (120s)")
+	if strings.Contains(stdout, "4000") {
+		t.Errorf("static backend port leaked into the plan:\n%s", stdout)
+	}
+}
+
 // --- SEMIONT_ROOT / KB-root discovery ---
 
 func TestSemiontRootOverride(t *testing.T) {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1301,6 +1301,18 @@ func TestStartServiceWorker(t *testing.T) {
 			t.Errorf("--service worker touched the wider stack: %q in argv", absent)
 		}
 	}
+
+	// A record created lazily by a --service start carries full metadata,
+	// not just the runtime (regression guard: the executor refactor briefly
+	// dropped these).
+	b, err := os.ReadFile(statePathFor(s.home))
+	if err != nil {
+		t.Fatalf("stack.json not written: %v", err)
+	}
+	mustContain(t, "stack.json", string(b),
+		`"imageVersion": "latest"`,
+		`"kbRoot": "`+s.kb+`"`,
+		`"kbDid": "did:web:example.github.io:test-kb"`)
 }
 
 func TestStartServiceGraph(t *testing.T) {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -109,15 +109,16 @@ func mkKB(t *testing.T) string {
 }
 
 type scenario struct {
-	shim      string
-	kb        string // also FAKERT_GIT_ROOT unless gitRoot overridden
-	noGitRoot bool
-	cwd       string // launcher working dir; defaults to kb
-	home      string
-	fakertDir string
-	log       string
-	extraEnv  []string
-	stdin     string
+	shim           string
+	kb             string // also FAKERT_GIT_ROOT unless gitRoot overridden
+	noGitRoot      bool
+	noWorkerSecret bool   // drop SEMIONT_WORKER_SECRET from the env
+	cwd            string // launcher working dir; defaults to kb
+	home           string
+	fakertDir      string
+	log            string
+	extraEnv       []string
+	stdin          string
 }
 
 func newScenario(t *testing.T, runtimes ...string) *scenario {
@@ -166,7 +167,9 @@ func (s *scenario) env() []string {
 		"HOME=" + s.home,
 		"FAKERT_LOG=" + s.log,
 		"FAKERT_DIR=" + s.fakertDir,
-		"SEMIONT_WORKER_SECRET=test-worker-secret",
+	}
+	if !s.noWorkerSecret {
+		env = append(env, "SEMIONT_WORKER_SECRET=test-worker-secret")
 	}
 	if !s.noGitRoot {
 		env = append(env, "FAKERT_GIT_ROOT="+s.kb)
@@ -1356,6 +1359,38 @@ func TestStartServiceRejections(t *testing.T) {
 		}
 		mustContain(t, fmt.Sprintf("stderr for %v", tc.args), stderr, tc.want)
 	}
+}
+
+func TestStartServiceSecretUnreadableIsLoud(t *testing.T) {
+	// A Semiont container EXISTS but yields no secret (the inspect-schema
+	// break case): without an explicit $SEMIONT_WORKER_SECRET the restart
+	// fails with instructions — never a silently generated secret that would
+	// break sidecar auth.
+	s := newScenario(t, "container")
+	s.noWorkerSecret = true
+	s.extraEnv = append(s.extraEnv, "FAKERT_STATE_backend=running") // no FAKERT_SECRET
+	_, stderr, code := s.run(t, "start", "--service", "worker")
+	if code != 1 {
+		t.Fatalf("want exit 1, got %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "stderr", stderr,
+		"worker secret could not be recovered",
+		"inspect schema may have changed",
+		"set SEMIONT_WORKER_SECRET",
+		"semiont start")
+
+	// With an explicit env secret: proceeds, but warns about the mismatch
+	// risk instead of pretending recovery worked.
+	s.noWorkerSecret = false
+	serveHealth(t, 9090)
+	stdout, stderr2, code := s.run(t, "start", "--service", "worker")
+	if code != 0 {
+		t.Fatalf("env-secret path: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr2)
+	}
+	mustContain(t, "stdout+stderr", stdout+stderr2,
+		"exists but its worker secret could not be read",
+		"using $SEMIONT_WORKER_SECRET",
+		"Worker secret: (from environment)")
 }
 
 // --- stop --service ---

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1106,6 +1106,87 @@ func TestStopSchema1Compat(t *testing.T) {
 	}
 }
 
+// writeStackState plants a schema-2 stack.json for the scenario.
+func writeStackState(t *testing.T, s *scenario, runtime string) {
+	t.Helper()
+	st := `{"schema":2,"runtime":"` + runtime + `","services":{
+	  "backend":{"container":"semiont-backend","id":"fid-semiont-backend","provided":"launcher","startedAt":"2026-07-19T00:00:00Z"}}}`
+	p := statePathFor(s.home)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(st), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStopRuntimeMismatchKeepsRecordAndStaging(t *testing.T) {
+	// stop --runtime <other> must not delete the recorded stack's staged
+	// configs (live mounts!) or its record — the real stack may be running.
+	s := newScenario(t, "container", "docker")
+	writeStackState(t, s, "container")
+	stage, err := os.MkdirTemp("/tmp", "semiont-config.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(stage) })
+
+	stdout, stderr, code := s.run(t, "stop", "--runtime", "docker")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout+stderr", stdout+stderr,
+		"Recorded stack (under container) left untouched",
+		"Swept docker only")
+	if _, err := os.Stat(stage); err != nil {
+		t.Error("staged configs deleted under the recorded stack's live mounts")
+	}
+	if _, err := os.Stat(statePathFor(s.home)); err != nil {
+		t.Error("stack.json erased by a mismatched-runtime stop")
+	}
+	argv := s.argv(t)
+	mustContain(t, "argv", argv, "docker stop semiont-frontend")
+	if strings.Contains(argv, "container stop") {
+		t.Errorf("mismatched stop touched the recorded runtime:\n%s", argv)
+	}
+}
+
+func TestStartRefusesRecordedRuntimeMismatch(t *testing.T) {
+	// An explicit --runtime that mismatches a live record refuses: preflight
+	// would orphan the recorded stack, erase its record, and delete staging
+	// under its mounts.
+	s := newScenario(t, "container", "docker")
+	writeStackState(t, s, "docker")
+	for _, args := range [][]string{
+		{"start", "--runtime", "container"},
+		{"start", "--service", "worker", "--runtime", "container"},
+	} {
+		_, stderr, code := s.run(t, args...)
+		if code != 1 {
+			t.Errorf("%v: want exit 1, got %d", args, code)
+		}
+		mustContain(t, "stderr", stderr,
+			"A recorded stack is running under docker",
+			"Stop it first (semiont stop), or start with --runtime docker.")
+	}
+}
+
+func TestStartPrefersRecordedRuntime(t *testing.T) {
+	// Implicit runtime selection follows the record, not auto-detect order —
+	// a bare restart must rejoin the stack that exists.
+	s := newScenario(t, "container", "docker")
+	s.extraEnv = append(s.extraEnv, "FAKERT_NSLOOKUP=ok")
+	writeStackState(t, s, "docker")
+	stdout, stderr, code := s.run(t, "start", "--dry-run")
+	if code != 0 {
+		t.Fatalf("exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "stdout", stdout, "docker pull ghcr.io/the-ai-alliance/semiont-backend:latest")
+	if strings.Contains(stdout, "container stop semiont-") {
+		t.Errorf("dry-run planned against auto-detected runtime, not the recorded one:\n%s", stdout)
+	}
+}
+
 // --- start --service ---
 
 func TestStartServiceWorker(t *testing.T) {

--- a/docs/system/administration/CONFIGURATION.md
+++ b/docs/system/administration/CONFIGURATION.md
@@ -7,7 +7,9 @@ Semiont uses a two-layer TOML configuration model, analogous to Git's `~/.gitcon
 > launch plan from a KB's `.semiont/semiontconfig/*.toml`: per dependency role
 > (`graph`, `vectors`, `database`, `inference`/`embedding`) it reads `type`,
 > the address/port, and credentials to decide whether to launch a container,
-> verify an external endpoint, or reuse a host process. The launcher reads only
+> verify an external endpoint, or reuse a host process — plus an optional
+> `image` key per role section to override its default container image. The
+> launcher reads only
 > those keys and ignores the rest; this document remains the schema's source of
 > truth. See `apps/launcher/README.md` and `.plans/LAUNCHER-CONFIG-SYNC.md`.
 


### PR DESCRIPTION
A design review of the launcher (post #1044) and the full remediation round it produced: two record-lifecycle defects fixed, the plan-walk unified behind a role-executor abstraction, and four ranked improvement items closed. Design record for the executor: `.plans/LAUNCHER-ROLE-EXECUTOR.md`.

## Record-lifecycle defect fixes

- **`stop --runtime <other>` could destroy the real stack's state.** Shared-artifact cleanup (staged-config sweep + record removal) is now gated on the sweep actually covering the recorded stack. A mismatched `--runtime` sweep warns, keeps `/tmp/semiont-config.*` (they're **live mounts** — deleting them under a running backend is the measured Apple-container kill class) and `stack.json`, and points at bare `semiont stop`.
- **`start` now binds to the recorded stack's runtime.** Implicit selection prefers the record (a bare `start --service worker` rejoins the stack that exists, not whatever auto-detect finds first); an explicit `--runtime` contradicting a live record refuses with instructions instead of orphaning it. Stale records (runtime uninstalled) bind nothing.

## Role-executor: one plan-walk, two modes

The launch plan was executed/rendered in three hand-wired places (`runStart`, `runStartService`, the dry-run renderers) — goldens were the only thing keeping them aligned. Now every sequence is written once in `flows.go` and walked through an `executor` interface: `liveExec` runs the stack, `planExec` renders `--dry-run`. **Effects (argv, ports, URLs, gate tries, record contents) are drift-proof by construction**; decoration (live narration vs plan comments) stays deliberately one-sided. Gates: the dry-run golden passed **byte-identical on the first run** after rewiring, and the full suite (boot argv goldens, stdout asserts, state lifecycle) passed unchanged. start.go 1,078→~700, dryrun.go 136→26, service.go 464→~210; three walks → one.

## Review items closed

- **Single reader of the config**: `loadConfig` extracts required `${VAR}` refs by walking every string value of the parsed document (whole-document scope preserved — containers interpolate keys the launcher doesn't model); the raw-bytes regex grep is deleted. Improvement: a `${VAR}` in a TOML *comment* no longer creates a phantom requirement.
- **`logs` modernized**: `--service <role>` reaches any of the ten (infra logs now in-launcher: `semiont logs --service graph`); the record supplies runtime + container IDs (no name-scan when a record exists; scan stays the record-less fallback); host/external/absent roles explain themselves instead of following nothing. Default (the five Semiont services) unchanged.
- **Loud secret recovery**: `recoverWorkerSecret` reports whether any Semiont container was *seen*; seen-but-unreadable (the inspect-schema-break case) now **fails the `--service` start with instructions** instead of silently generating an auth-breaking secret; an explicit `$SEMIONT_WORKER_SECRET` proceeds with a mismatch-risk warning; nothing-running keeps the quiet correct generation.
- **Config `image` override per role**: optional `image` key on `graph`/`vectors`/`database` sections and the `inference.ollama` provider entry beats the catalog default — a KB can pin or upgrade an infra image without a launcher release. Unset = byte-identical to today (template-config parity tests still prove it).

## Post-remediation re-review fixes

- **`roles[].ports` cruft deleted**: static port entries survive only for genuinely launcher-fiat ports (sidecars, frontend, traces). The cleanup exposed that `--service backend` was still port-checking a static 4000 — it now claims `plan.BackendPort` (`backend.port = 4001` → `require free ports: 4001`, gates to match).
- **Lazy-record metadata**: a `stack.json` created by a `--service` start on a record-less host now carries `imageVersion`/`kbRoot`/`kbDid`, not just the runtime.

## Testing

68 tests, all green; pre-existing goldens untouched through the executor rewiring (the refactor's proof). New coverage: runtime-mismatch stop/start guards, record-driven and infra `logs`, both loud-secret paths, image overrides (including argv flow-through), config-driven backend port claims, and lazy-record metadata.

Remaining from the review, deliberately open: the **singleton-stack decision** (per-root records, config-declared sidecar/frontend ports, per-stack container names) — a design call gating multi-root, tracked in `.plans/LAUNCHER-CONFIG-SYNC.md` Follow-ups.
