### PR TITLE
Launcher: codespace placement, multi-stack records, and concurrent KB forwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Open **http://localhost:3000**. In the Semiont browser's Knowledge Bases panel, 
 **Just the browser?** To point a Semiont browser at an already-running or remote knowledge base, run the frontend on its own — no clone needed, from any directory (the launcher auto-detects your container runtime and pulls the published image):
 
 ```bash
-semiont start --service frontend
+semiont start --service frontend            # http://localhost:3000
+semiont start --service frontend --port 3001   # 3000 busy? move the browser
 ```
 
 For local-network access notes, supply-chain verification, the native [desktop app](https://github.com/The-AI-Alliance/semiont/releases) alternative, and frontend dev setup, see **[docs/browser/](docs/browser/README.md)**.

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -89,7 +89,14 @@ semiont stop
   creation; `start` and `status` read them fresh over ssh and display them —
   never stored, never logged (`useradd` refuses and points at `status`).
   Preflights fail fast with fixes: `gh` missing/unauthenticated, the
-  `codespace` scope, and the `ANTHROPIC_API_KEY` Codespaces user secret.
+  `codespace` scope, the `ANTHROPIC_API_KEY` Codespaces user secret, and the
+  VM class. The machine list GitHub returns for a repo is filtered by the
+  devcontainer's `hostRequirements`, so anything offered is adequate by the
+  KB's own declaration — `--machine` defaults to `premiumLinux` when your
+  account can use it and otherwise falls back to the largest it can,
+  announced with the reason; an explicit `--machine` that isn't available is
+  a hard error listing what is (never a silent substitution), and on a
+  resume the flag is called out as inert rather than looking effective.
   Codespace placement is never sticky — every codespace start says
   `--runtime codespace` (or rides an existing record).
 - `semiont useradd` creates or updates users in the RUNNING stack: the

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -54,14 +54,31 @@ semiont stop
   clone's origin, or `--repo owner/name` from anywhere, needed only at
   creation: the stack record carries it afterwards, so a bare `semiont
   start` resumes the recorded codespace from any directory, and `status` /
-  `logs` / `stop` dispatch off the record as always. The launcher keeps at
+  `logs` / `stop` dispatch off the records as always. The launcher keeps at
   most one codespace per repo (it adopts and resumes what exists — the
   codespace *name* is a PID, shown by status, input only via `--codespace`
   when raw `gh` left several). `semiont stop` maps to `gh codespace stop` —
   billing halts, state and credentials persist, the record is kept; `semiont
-  stop --delete` destroys and forgets. Port forwards (3000/4000 + sidecar
-  vitals) run as a recorded detached process that `status` re-establishes
-  and `stop` ends. Admin credentials are generated inside the codespace at
+  stop --delete` destroys and forgets.
+- **Many codespace stacks run concurrently — each forwards its KB on its
+  own local port.** The record store (`stack.json`, schema 3) is a keyed
+  collection: the machine's one local stack (fixed ports and container
+  names keep it singleton) plus one entry per codespace repo. Each
+  codespace stack forwards exactly ONE port — its KB (remote 4000) — on
+  local 4000 when free, else the lowest free port above it (4001, …), so a
+  single browser's Knowledge Bases panel works N codespace KBs at once
+  (Host localhost, Port 400x each; browser, sidecars, and infra stay inside
+  the codespace). Forwards are recorded detached processes: `status`
+  re-establishes a dead one, `stop --repo` ends its own, and a LOCAL start
+  drops only forwards squatting on ports it actually claims — concurrent
+  KBs on allocated ports keep running. With several stacks recorded:
+  `status` opens with a STACKS fleet overview (each stack's state and
+  `KB localhost:<port>`) and details the lone forwarded stack (`--repo`
+  details any); bare `logs` follows the local stack, else the lone
+  codespace; bare `stop` refuses to guess — `--repo <owner/name>` targets a
+  codespace stack, `--runtime` the local one. `useradd` targets the local
+  backend when one exists. Schema 1/2 single-stack records migrate on read.
+- Codespace admin credentials are generated inside the codespace at
   creation; `start` and `status` read them fresh over ssh and display them —
   never stored, never logged (`useradd` refuses and points at `status`).
   Preflights fail fast with fixes: `gh` missing/unauthenticated, the

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -31,6 +31,13 @@ semiont stop
 
 - `semiont start --help` lists all flags (`--config`, `--runtime`,
   `--no-observe`, `--ollama-cache`, …).
+- `semiont start --service frontend --port <n>` moves the browser — the ONE
+  port a flag may move (it's absent from the KB config and nothing in the
+  stack dials it; every other port belongs to the config, and a codespace
+  forwards only its KB on an allocated port). Move, not multiply: the
+  browser restarts on the chosen port, the record carries the endpoint, and
+  status/stop follow it. A non-3000 port warns that backends configured
+  with `frontendURL http://localhost:3000` may reject the origin.
 - **`semiont secret` registers where config secrets come from** — pointers,
   never values. `semiont secret set ANTHROPIC_API_KEY` walks an interactive
   provider-then-path flow (or pass the source directly:

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -47,6 +47,27 @@ semiont stop
   1Password at all: **exporting the variable always wins** — a plain
   `ANTHROPIC_API_KEY=… semiont start` behaves exactly as it always has.
   `--dry-run` reaches for nothing (plan shows `<env:VAR>` placeholders).
+- **`semiont start --runtime codespace` runs the same stack on a
+  GitHub-hosted machine** (the KB's devcontainer + compose own the inside;
+  the launcher orchestrates the outside via `gh`, which is required on PATH
+  for this placement only). The REPO is the identity — derived from the KB
+  clone's origin, or `--repo owner/name` from anywhere, needed only at
+  creation: the stack record carries it afterwards, so a bare `semiont
+  start` resumes the recorded codespace from any directory, and `status` /
+  `logs` / `stop` dispatch off the record as always. The launcher keeps at
+  most one codespace per repo (it adopts and resumes what exists — the
+  codespace *name* is a PID, shown by status, input only via `--codespace`
+  when raw `gh` left several). `semiont stop` maps to `gh codespace stop` —
+  billing halts, state and credentials persist, the record is kept; `semiont
+  stop --delete` destroys and forgets. Port forwards (3000/4000 + sidecar
+  vitals) run as a recorded detached process that `status` re-establishes
+  and `stop` ends. Admin credentials are generated inside the codespace at
+  creation; `start` and `status` read them fresh over ssh and display them —
+  never stored, never logged (`useradd` refuses and points at `status`).
+  Preflights fail fast with fixes: `gh` missing/unauthenticated, the
+  `codespace` scope, and the `ANTHROPIC_API_KEY` Codespaces user secret.
+  Codespace placement is never sticky — every codespace start says
+  `--runtime codespace` (or rides an existing record).
 - `semiont useradd` creates or updates users in the RUNNING stack: the
   launcher execs the in-container Semiont CLI's `useradd` inside the backend
   container (record-driven runtime + container ID, name-scan fallback) and

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -54,6 +54,14 @@ semiont stop
   1Password at all: **exporting the variable always wins** — a plain
   `ANTHROPIC_API_KEY=… semiont start` behaves exactly as it always has.
   `--dry-run` reaches for nothing (plan shows `<env:VAR>` placeholders).
+  `semiont secret push <VAR> --repo <owner/name>` is the one place a value
+  *moves*: a codespace runs on GitHub's machine and can't reach your local
+  provider, so this copies the current value into your GitHub Codespaces user
+  secrets. Same discipline — resolved fresh and announced, handed to `gh` on
+  **stdin** so it never appears in argv (where `ps` could read it), encrypted
+  by `gh` before it leaves the machine, never written to disk or logs by us.
+  The repo selection is a **union**, never a replacement, so pushing for one
+  repo can't silently revoke the secret from others already using it.
 - **`semiont start --runtime codespace` runs the same stack on a
   GitHub-hosted machine** (the KB's devcontainer + compose own the inside;
   the launcher orchestrates the outside via `gh`, which is required on PATH

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -54,6 +54,8 @@ func main() {
 		os.Exit(1)
 	case "op":
 		opCmd(os.Args[1:])
+	case "gh":
+		ghCmd(os.Args[1:])
 	case "container", "docker", "podman":
 		runtimeCmd(base, os.Args[1:])
 	default:
@@ -89,8 +91,140 @@ func git(args []string) {
 		fmt.Println(root)
 		return
 	}
+	if len(args) >= 3 && args[0] == "remote" && args[1] == "get-url" && args[2] == "origin" {
+		if o := os.Getenv("FAKERT_GIT_ORIGIN"); o != "" {
+			fmt.Println(o)
+			return
+		}
+		fmt.Fprintln(os.Stderr, "error: No such remote 'origin'")
+		os.Exit(2)
+	}
+	if len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
+		if os.Getenv("FAKERT_GIT_DIRTY") != "" {
+			fmt.Println(" M .semiont/semiontconfig/anthropic.toml")
+		}
+		return
+	}
 	fmt.Fprintf(os.Stderr, "fakert git: unscripted args %v\n", args)
 	os.Exit(64)
+}
+
+// ghCmd fakes the GitHub CLI for the codespace flows. Scripted via:
+//
+//	FAKERT_GH_SCOPES        auth-status scopes list (default "'codespace', 'repo'")
+//	FAKERT_GH_AUTH_FAIL     `gh auth status` fails (not logged in)
+//	FAKERT_GH_SECRET_404    the ANTHROPIC_API_KEY secret does not exist
+//	FAKERT_GH_SECRET_REPOS  JSON body for …/secrets/…/repositories (default: empty selection)
+//	FAKERT_GH_CS_LIST       JSON array for `codespace list` (default [])
+//	FAKERT_GH_CS_NAME       name printed by `codespace create` (default "fake-cs-1")
+//	FAKERT_GH_CREATE_FAILS  N leading 503 failures before create succeeds (cursor file)
+//	FAKERT_GH_SSH_FAIL      ssh fails with the no-sshd error
+//	FAKERT_GH_ADMIN         admin.json content for `ssh -- cat .devcontainer/admin.json`
+//
+// `codespace ports forward A:B …` binds every host port and parks (the fake
+// dev tunnel), writing a serve pidfile so killServes reaps it.
+func ghCmd(args []string) {
+	joined := strings.Join(args, " ")
+	switch {
+	case len(args) >= 2 && args[0] == "auth" && args[1] == "status":
+		if os.Getenv("FAKERT_GH_AUTH_FAIL") != "" {
+			fmt.Fprintln(os.Stderr, "You are not logged into any GitHub hosts.")
+			os.Exit(1)
+		}
+		scopes := os.Getenv("FAKERT_GH_SCOPES")
+		if scopes == "" {
+			scopes = "'codespace', 'repo'"
+		}
+		fmt.Println("github.com")
+		fmt.Println("  ✓ Logged in to github.com")
+		fmt.Println("  - Token scopes: " + scopes)
+	case len(args) >= 2 && args[0] == "api" && strings.Contains(args[1], "/codespaces/secrets/"):
+		if os.Getenv("FAKERT_GH_SECRET_404") != "" {
+			fmt.Fprintln(os.Stderr, "gh: Not Found (HTTP 404)")
+			os.Exit(1)
+		}
+		body := os.Getenv("FAKERT_GH_SECRET_REPOS")
+		if body == "" {
+			body = `{"total_count":0,"repositories":[]}`
+		}
+		fmt.Println(body)
+	case args[0] == "codespace":
+		ghCodespace(args[1:], joined)
+	default:
+		fmt.Fprintf(os.Stderr, "fakert gh: unscripted args %v\n", args)
+		os.Exit(64)
+	}
+}
+
+func ghCodespace(args []string, joined string) {
+	switch args[0] {
+	case "list":
+		body := os.Getenv("FAKERT_GH_CS_LIST")
+		if body == "" {
+			body = "[]"
+		}
+		fmt.Println(body)
+	case "create":
+		if n := os.Getenv("FAKERT_GH_CREATE_FAILS"); n != "" {
+			// Countdown via cursor file: each failing attempt burns one.
+			f := filepath.Join(os.Getenv("FAKERT_DIR"), "gh-create-fails")
+			left, _ := strconv.Atoi(n)
+			if b, err := os.ReadFile(f); err == nil {
+				left, _ = strconv.Atoi(strings.TrimSpace(string(b)))
+			}
+			if left > 0 {
+				_ = os.WriteFile(f, []byte(strconv.Itoa(left-1)), 0o644)
+				fmt.Fprintln(os.Stderr, "HTTP 503: No server is currently available (https://api.github.com/user/codespaces)")
+				os.Exit(1)
+			}
+		}
+		name := os.Getenv("FAKERT_GH_CS_NAME")
+		if name == "" {
+			name = "fake-cs-1"
+		}
+		fmt.Println(name)
+	case "ports":
+		// forward: bind host ports, park like a dev tunnel. Pidfile so the
+		// harness's killServes reaps the parked process between tests.
+		var ports []string
+		for _, a := range args {
+			if pair := strings.SplitN(a, ":", 2); len(pair) == 2 && pair[0] != "" {
+				if _, err := strconv.Atoi(pair[0]); err == nil {
+					ports = append(ports, pair[0])
+				}
+			}
+		}
+		if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+			_ = os.WriteFile(filepath.Join(dir, "serve-gh-forward.pid"),
+				[]byte(strconv.Itoa(os.Getpid())), 0o644)
+		}
+		serve(ports)
+	case "stop", "delete":
+		// ok — argv log is the observable
+	case "ssh":
+		if os.Getenv("FAKERT_GH_SSH_FAIL") != "" {
+			fmt.Fprintln(os.Stderr, "failed to start SSH server")
+			os.Exit(1)
+		}
+		switch {
+		case strings.Contains(joined, "cat .devcontainer/admin.json"):
+			body := os.Getenv("FAKERT_GH_ADMIN")
+			if body == "" {
+				body = `{"email":"admin@example.com","password":"fake-admin-pw"}`
+			}
+			fmt.Println(body)
+		case strings.Contains(joined, "docker logs"):
+			name := strings.TrimPrefix(args[len(args)-1], "semiont-")
+			fmt.Println(name + " out")
+			fmt.Fprintln(os.Stderr, name+" err")
+		default:
+			fmt.Fprintf(os.Stderr, "fakert gh ssh: unscripted %v\n", args)
+			os.Exit(64)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "fakert gh codespace: unscripted %v\n", args)
+		os.Exit(64)
+	}
 }
 
 func lsof(args []string) {

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -138,6 +138,22 @@ func ghCmd(args []string) {
 		fmt.Println("github.com")
 		fmt.Println("  ✓ Logged in to github.com")
 		fmt.Println("  - Token scopes: " + scopes)
+	case len(args) >= 2 && args[0] == "api" && strings.Contains(args[1], "/codespaces/machines"):
+		// Shape mirrors the real endpoint (captured 2026-07-20). The default
+		// is what a hostRequirements-declaring KB actually offers: GitHub
+		// filters the 2-core class out.
+		body := os.Getenv("FAKERT_GH_MACHINES")
+		switch body {
+		case "ERROR":
+			fmt.Fprintln(os.Stderr, "gh: Not Found (HTTP 404)")
+			os.Exit(1)
+		case "":
+			body = `{"machines":[` +
+				`{"name":"standardLinux32gb","display_name":"4 cores, 16 GB RAM, 32 GB storage","cpus":4,"memory_in_bytes":17179869184},` +
+				`{"name":"premiumLinux","display_name":"8 cores, 32 GB RAM, 64 GB storage","cpus":8,"memory_in_bytes":34359738368},` +
+				`{"name":"largePremiumLinux","display_name":"16 cores, 64 GB RAM, 128 GB storage","cpus":16,"memory_in_bytes":68719476736}],"total_count":3}`
+		}
+		fmt.Println(body)
 	case len(args) >= 2 && args[0] == "api" && strings.Contains(args[1], "/codespaces/secrets/"):
 		if os.Getenv("FAKERT_GH_SECRET_404") != "" {
 			fmt.Fprintln(os.Stderr, "gh: Not Found (HTTP 404)")

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -194,8 +194,10 @@ func ghCodespace(args []string, joined string) {
 				}
 			}
 		}
-		if dir := os.Getenv("FAKERT_DIR"); dir != "" {
-			_ = os.WriteFile(filepath.Join(dir, "serve-gh-forward.pid"),
+		// Pidfile per forward (keyed by local port): several forwards run
+		// concurrently — one per codespace stack's KB.
+		if dir := os.Getenv("FAKERT_DIR"); dir != "" && len(ports) > 0 {
+			_ = os.WriteFile(filepath.Join(dir, "serve-gh-forward-"+ports[0]+".pid"),
 				[]byte(strconv.Itoa(os.Getpid())), 0o644)
 		}
 		serve(ports)
@@ -264,6 +266,19 @@ func psCmd(args []string) {
 	// The launcher calls `ps -p <pid> -o comm=`.
 	if len(args) == 4 && args[0] == "-p" && args[2] == "-o" && args[3] == "comm=" {
 		comm := os.Getenv("FAKERT_PS_" + args[1])
+		if comm == "" {
+			// A pid matching one of our own serve pidfiles IS the fake gh
+			// forward — report it as gh, the comm the real forward has
+			// (the launcher's forwardAlive depends on this).
+			if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+				files, _ := filepath.Glob(filepath.Join(dir, "serve-*.pid"))
+				for _, f := range files {
+					if b, err := os.ReadFile(f); err == nil && strings.TrimSpace(string(b)) == args[1] {
+						comm = "gh"
+					}
+				}
+			}
+		}
 		if comm == "" {
 			comm = "fakeproc"
 		}

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -27,6 +27,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -164,6 +165,17 @@ func ghCmd(args []string) {
 			body = `{"total_count":0,"repositories":[]}`
 		}
 		fmt.Println(body)
+	case len(args) >= 2 && args[0] == "secret" && args[1] == "set":
+		// gh reads the value from stdin when --body is absent. Record it so
+		// tests can assert the secret travelled by stdin, never argv.
+		val, _ := io.ReadAll(os.Stdin)
+		if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+			_ = os.WriteFile(filepath.Join(dir, "secret-set-stdin"), val, 0o600)
+		}
+		if os.Getenv("FAKERT_GH_SECRET_SET_FAIL") != "" {
+			fmt.Fprintln(os.Stderr, "gh: HTTP 403 (missing scope)")
+			os.Exit(1)
+		}
 	case args[0] == "codespace":
 		ghCodespace(args[1:], joined)
 	default:

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -26,6 +26,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -187,11 +188,14 @@ func ghCmd(args []string) {
 func ghCodespace(args []string, joined string) {
 	switch args[0] {
 	case "list":
+		// Explicit scripting wins; otherwise reflect what THIS fake has
+		// created, as real gh would — a created codespace must show up
+		// (and reach Available) or callers that wait for it hang.
 		body := os.Getenv("FAKERT_GH_CS_LIST")
 		if body == "" {
-			body = "[]"
+			body = "[" + strings.Join(createdCodespaces(), ",") + "]"
 		}
-		fmt.Println(body)
+		fmt.Println(applyWakes(body))
 	case "create":
 		if n := os.Getenv("FAKERT_GH_CREATE_FAILS"); n != "" {
 			// Countdown via cursor file: each failing attempt burns one.
@@ -210,15 +214,25 @@ func ghCodespace(args []string, joined string) {
 		if name == "" {
 			name = "fake-cs-1"
 		}
+		repo := ""
+		for i, a := range args {
+			if a == "--repo" && i+1 < len(args) {
+				repo = args[i+1]
+			}
+		}
+		recordCreated(name, repo)
 		fmt.Println(name)
 	case "ports":
 		// forward: bind host ports, park like a dev tunnel. Pidfile so the
 		// harness's killServes reaps the parked process between tests.
+		// Real gh takes <codespacePort>:<localPort> and listens on the
+		// LOCAL one. Modelling this correctly is what would have caught the
+		// reversed-argument bug found live on 2026-07-20.
 		var ports []string
 		for _, a := range args {
-			if pair := strings.SplitN(a, ":", 2); len(pair) == 2 && pair[0] != "" {
-				if _, err := strconv.Atoi(pair[0]); err == nil {
-					ports = append(ports, pair[0])
+			if pair := strings.SplitN(a, ":", 2); len(pair) == 2 {
+				if _, err := strconv.Atoi(pair[1]); err == nil {
+					ports = append(ports, pair[1])
 				}
 			}
 		}
@@ -237,7 +251,22 @@ func ghCodespace(args []string, joined string) {
 			os.Exit(1)
 		}
 		switch {
-		case strings.Contains(joined, "cat .devcontainer/admin.json"):
+		case strings.HasSuffix(strings.TrimSpace(joined), "true"):
+			// The wake probe: connecting is what resumes a codespace, so
+			// record it — subsequent `list` calls must report it Available,
+			// exactly as GitHub does.
+			if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+				f, err := os.OpenFile(filepath.Join(dir, "woken"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+				if err == nil {
+					for i, a := range args {
+						if a == "-c" && i+1 < len(args) {
+							fmt.Fprintln(f, args[i+1])
+						}
+					}
+					f.Close()
+				}
+			}
+		case strings.Contains(joined, "admin.json"):
 			body := os.Getenv("FAKERT_GH_ADMIN")
 			if body == "" {
 				body = `{"email":"admin@example.com","password":"fake-admin-pw"}`
@@ -462,6 +491,72 @@ func run(args []string) {
 	} else {
 		fmt.Println("0123456789ab")
 	}
+}
+
+// createdCodespaces: JSON objects for every codespace this fake created,
+// reported Available (the real API reaches Available on its own).
+func createdCodespaces() []string {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return nil
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "created-codespaces"))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		nameRepo := strings.SplitN(line, " ", 2)
+		if len(nameRepo) != 2 {
+			continue
+		}
+		out = append(out, fmt.Sprintf(`{"name":%q,"state":"Available","repository":%q}`, nameRepo[0], nameRepo[1]))
+	}
+	return out
+}
+
+// applyWakes reports a woken codespace as Available regardless of the
+// scripted initial state — a stopped codespace that something connected to
+// really does come back, and a fake that never transitions would let the
+// launcher wait forever (it did, until this was added).
+func applyWakes(body string) string {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return body
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "woken"))
+	if err != nil {
+		return body
+	}
+	var entries []map[string]any
+	if json.Unmarshal([]byte(body), &entries) != nil {
+		return body
+	}
+	for _, name := range strings.Fields(string(b)) {
+		for _, e := range entries {
+			if e["name"] == name {
+				e["state"] = "Available"
+			}
+		}
+	}
+	out, err := json.Marshal(entries)
+	if err != nil {
+		return body
+	}
+	return string(out)
+}
+
+func recordCreated(name, repo string) {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "created-codespaces"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%s %s\n", name, repo)
 }
 
 // handleName resolves a launcher-supplied handle (container name or the

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -219,6 +219,15 @@ func startCodespace(u *ui, opts startOptions) int {
 	fmt.Println()
 	fmt.Printf("  Semiont KB         %s %s\n", u.bold(fmt.Sprintf("http://localhost:%d", kbPort)),
 		u.dim("(add Host localhost, Port "+fmt.Sprintf("%d", kbPort)+" in the browser's Knowledge Bases panel)"))
+	// The browser is NOT forwarded — only the KB is. It runs locally and
+	// connects to any number of KBs, cloud or local; without this pointer a
+	// codespace-only user has no browser at all.
+	if httpOK("http://localhost:3000") {
+		fmt.Printf("  Semiont Browser    %s %s\n", u.bold("http://localhost:3000"), u.dim("(already running)"))
+	} else {
+		fmt.Printf("  Semiont Browser    %s %s\n", u.bold("semiont start --service frontend"),
+			u.dim("(runs locally; one browser works any number of KBs)"))
+	}
 	fmt.Println()
 	fmt.Printf("  %s\n", u.dim("Runs "+repo+" as pushed — local uncommitted changes don't travel."))
 	if creds != nil {

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -1,0 +1,567 @@
+package launcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// codespace.go — the "codespace" placement value on the runtime axis
+// (.plans/CODESPACE-KB-LAUNCH.md §2). The REPO is the user-facing identity;
+// the codespace NAME is a PID (shown by status, input only via the
+// --codespace disambiguation corner). The launcher keeps at most ONE
+// codespace per repo: it resumes what exists, and creates only when nothing
+// does. Inside the codespace the stack stays on compose — the launcher
+// orchestrates the outside only (create, wait, forward, credentials,
+// lifecycle) by shelling out to `gh`, which owns auth and the tunnel client.
+
+// forwardPorts: the local ports the detached `gh codespace ports forward`
+// binds — browser, backend, and the three sidecar vitals.
+var forwardPorts = []portNeed{
+	{3000, "Frontend"}, {4000, "Backend"},
+	{9090, "Worker"}, {9091, "Smelter"}, {9092, "Weaver"},
+}
+
+var repoSlugRe = regexp.MustCompile(`^[\w.-]+/[\w.-]+$`)
+
+// startCodespace is the whole §1 recipe as one blocking command, with
+// local-start parity as the contract: preflight, create-or-resume, forward,
+// health-gate, summary-and-exit.
+func startCodespace(u *ui, opts startOptions) int {
+	if !onPath("gh") {
+		u.fail("--runtime codespace needs the GitHub CLI, and 'gh' is not on PATH.")
+		fmt.Fprintln(os.Stderr, "  Install it: https://cli.github.com  (then: gh auth login)")
+		return 1
+	}
+
+	// A recorded LOCAL stack binds exactly like a recorded runtime mismatch:
+	// proceeding would leave it orphaned behind a codespace record.
+	st := loadState()
+	if st != nil && st.Runtime != "" && st.Runtime != "codespace" {
+		if !opts.dryRun {
+			u.fail("A recorded stack is running under %s (per %s).", st.Runtime, statePath())
+			fmt.Fprintln(os.Stderr, "  Stop it first (semiont stop).")
+			return 1
+		}
+		st = nil
+	}
+
+	// Identity ladder: record → --repo → root's origin (create-path
+	// convenience only — a recorded codespace stack never touches root
+	// discovery, so bare resume works from any directory).
+	name, repo := "", ""
+	if st != nil && st.Runtime == "codespace" {
+		name, repo = st.Codespace, st.Repo
+		if opts.repo != "" && opts.repo != repo {
+			u.fail("The recorded codespace stack is for %s (per %s).", repo, statePath())
+			fmt.Fprintln(os.Stderr, "  Stop it first (semiont stop, or semiont stop --delete), then start --repo "+opts.repo+".")
+			return 1
+		}
+	} else {
+		repo = opts.repo
+		if repo == "" {
+			var code int
+			if repo, code = repoFromRoot(u, opts); code != 0 {
+				return code
+			}
+		} else if !repoSlugRe.MatchString(repo) {
+			u.fail("--repo must be owner/name, got '%s'.", repo)
+			return 1
+		}
+	}
+
+	if opts.dryRun {
+		renderCodespacePlan(opts, repo, name)
+		return 0
+	}
+
+	u.log("KB repo: %s %s", u.bold(repo), u.dim("(codespace placement — the stack runs on a GitHub-hosted machine)"))
+
+	// Preflights, early and loud — §1's silent/late failures become
+	// first-second failures.
+	if code := preflightGhScope(u); code != 0 {
+		return code
+	}
+	secretOK := codespacesSecretSelected(repo)
+
+	if name == "" {
+		// No record: the cloud is the source of truth — adopt what exists,
+		// create only when the repo truly has no codespace.
+		instances, err := ghCodespaceList(repo)
+		if err != nil {
+			u.fail("Could not list codespaces (`gh codespace list`): %v", err)
+			return 1
+		}
+		switch {
+		case len(instances) == 0:
+			if !secretOK {
+				u.fail("ANTHROPIC_API_KEY is not a Codespaces user secret selected for %s — the stack would come up with inference dead, silently.", repo)
+				fmt.Fprintln(os.Stderr, "  Fix:  gh secret set ANTHROPIC_API_KEY --user --app codespaces   (then select the repo)")
+				fmt.Fprintln(os.Stderr, "  Check:  gh api user/codespaces/secrets/ANTHROPIC_API_KEY/repositories")
+				return 1
+			}
+			var code int
+			if name, code = createCodespace(u, repo, opts); code != 0 {
+				return code
+			}
+		case len(instances) == 1:
+			name = instances[0].Name
+			u.log("Found existing codespace for %s: %s %s", repo, u.bold(name),
+				u.dim("(state: "+instances[0].State+") — resuming, not creating"))
+		default:
+			if opts.csName != "" {
+				for _, c := range instances {
+					if c.Name == opts.csName {
+						name = c.Name
+					}
+				}
+				if name == "" {
+					u.fail("--codespace '%s' is not among %s's codespaces.", opts.csName, repo)
+					return 1
+				}
+			} else {
+				u.fail("%s has %d codespaces — the launcher manages at most one per repo.", repo, len(instances))
+				for _, c := range instances {
+					fmt.Fprintf(os.Stderr, "    %s  (%s)\n", c.Name, c.State)
+				}
+				fmt.Fprintln(os.Stderr, "  Pick one with --codespace <name>, or delete extras:  gh codespace delete -c <name>")
+				return 1
+			}
+		}
+	} else {
+		u.log("Resuming recorded codespace %s %s", u.bold(name), u.dim("("+repo+")"))
+		if !secretOK {
+			u.warn("ANTHROPIC_API_KEY is not selected for %s in the Codespaces user secrets — inference may be dead inside the stack.", repo)
+		}
+		// A dead recorded forward is normal here; a live one means the
+		// stack is already reachable and respawning would fail the binds.
+		if forwardAlive(st.ForwardPID) {
+			_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	// The forward is the only thing binding LOCAL ports; check them like any
+	// other start would (foreign holders fail with names — never killed).
+	for _, p := range forwardPorts {
+		if !requirePortFree(u, p.port, p.label+" (forward)") {
+			return 1
+		}
+	}
+	pid, code := spawnForward(u, name)
+	if code != 0 {
+		return code
+	}
+
+	// The record binds the stack to its executor before the health gate —
+	// belief, verified by status; a failed wait leaves an honest record.
+	newSt := &stackState{
+		Runtime: "codespace", Codespace: name, Repo: repo, ForwardPID: pid,
+		Services: map[string]serviceState{},
+	}
+	for _, p := range forwardPorts {
+		newSt.Ports = append(newSt.Ports, p.port)
+	}
+	saveState(newSt)
+
+	// Health, not VM state, is readiness ("Available ≠ hooks finished" —
+	// on a fresh create the devcontainer hooks run minutes past Available).
+	u.log("Waiting for the stack %s", u.dim("(a fresh create runs devcontainer hooks — image and model pulls take minutes)"))
+	d, ok := waitForHTTP(u, "Backend (through the forward)", "http://localhost:4000/api/health", 600)
+	if !ok {
+		return 1
+	}
+	u.ok("Backend healthy %s", u.dim("("+took(d)+")"))
+
+	creds := fetchAdminCreds(u, name)
+
+	fmt.Println()
+	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 Semiont stack is up in codespace "+name), u.dim("("+took(d)+" to healthy)"))
+	fmt.Println()
+	fmt.Printf("  Semiont Browser    %s\n", u.bold("http://localhost:3000"))
+	fmt.Println("  Semiont KB         http://localhost:4000")
+	fmt.Println()
+	fmt.Printf("  %s\n", u.dim("Runs "+repo+" as pushed — local uncommitted changes don't travel."))
+	if creds != nil {
+		fmt.Printf("  Sign in at http://localhost:3000 as %s / %s %s\n",
+			u.bold(creds.Email), u.bold(creds.Password), u.dim("(generated at creation; never stored by the launcher)"))
+	}
+	fmt.Println()
+	fmt.Printf("  Check health:  %s\n", u.bold("semiont status"))
+	fmt.Printf("  Follow logs:   %s\n", u.bold("semiont logs"))
+	fmt.Printf("  Halt billing:  %s %s\n", u.bold("semiont stop"), u.dim("(state persists; semiont stop --delete destroys)"))
+	fmt.Println()
+	return 0
+}
+
+// repoFromRoot: the create-path convenience — resolve the KB root as usual
+// and read the slug from its origin remote.
+func repoFromRoot(u *ui, opts startOptions) (string, int) {
+	var root string
+	var err error
+	if opts.root != "" {
+		root, err = resolveRootArg(opts.root)
+	} else {
+		root, _, err = resolveKBRoot()
+	}
+	if err != nil {
+		u.fail("%v", err)
+		fmt.Fprintln(os.Stderr, "  Pass --repo <owner>/<name>, or run from a KB clone (its origin supplies the repo).")
+		return "", 1
+	}
+	origin, err := capture("git", "-C", root, "remote", "get-url", "origin")
+	if err != nil || origin == "" {
+		u.fail("Cannot read the origin remote of %s.", root)
+		fmt.Fprintln(os.Stderr, "  Pass --repo <owner>/<name>.")
+		return "", 1
+	}
+	slug, ok := parseGitHubSlug(origin)
+	if !ok {
+		u.fail("The origin of %s is not a GitHub repo (%s) — codespaces are GitHub-only.", root, origin)
+		fmt.Fprintln(os.Stderr, "  Pass --repo <owner>/<name>, or run from a GitHub clone.")
+		return "", 1
+	}
+	// Pushed-state honesty: locally an uncommitted config edit is live via
+	// the /kb bind mount; in a codespace it silently doesn't exist.
+	if out, err := capture("git", "-C", root, "status", "--porcelain"); err == nil && out != "" {
+		u.warn("%s has uncommitted changes — the codespace runs %s as PUSHED; they don't travel.", root, slug)
+	}
+	return slug, 0
+}
+
+// parseGitHubSlug: owner/name from either remote form —
+// git@github.com:owner/name(.git) or https://github.com/owner/name(.git).
+func parseGitHubSlug(origin string) (string, bool) {
+	s := origin
+	switch {
+	case strings.HasPrefix(s, "git@github.com:"):
+		s = strings.TrimPrefix(s, "git@github.com:")
+	case strings.HasPrefix(s, "https://github.com/"):
+		s = strings.TrimPrefix(s, "https://github.com/")
+	case strings.HasPrefix(s, "ssh://git@github.com/"):
+		s = strings.TrimPrefix(s, "ssh://git@github.com/")
+	default:
+		return "", false
+	}
+	s = strings.TrimSuffix(strings.TrimSuffix(s, "/"), ".git")
+	if !repoSlugRe.MatchString(s) {
+		return "", false
+	}
+	return s, true
+}
+
+// preflightGhScope: §1 precondition 1 — the scope gap otherwise surfaces
+// later as a misleading "must have admin rights to Repository".
+func preflightGhScope(u *ui) int {
+	out, err := captureBoth("gh", "auth", "status")
+	if err != nil {
+		u.fail("gh is not authenticated.")
+		fmt.Fprintln(os.Stderr, "  Run:  gh auth login")
+		return 1
+	}
+	if !strings.Contains(out, "codespace") {
+		u.fail("The gh token is missing the 'codespace' scope (it surfaces later as a misleading admin-rights error).")
+		fmt.Fprintln(os.Stderr, "  Grant it:  gh auth refresh -h github.com -s codespace")
+		return 1
+	}
+	return 0
+}
+
+// codespacesSecretSelected: §1 precondition 2 — ANTHROPIC_API_KEY as a
+// Codespaces user secret with the repo selected. Without it the stack comes
+// up with inference dead, silently.
+func codespacesSecretSelected(repo string) bool {
+	out, err := capture("gh", "api", "user/codespaces/secrets/ANTHROPIC_API_KEY/repositories")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(out, `"`+repo+`"`) || strings.Contains(out, `"full_name":"`+repo+`"`) ||
+		strings.Contains(out, `"full_name": "`+repo+`"`)
+}
+
+type codespaceInstance struct {
+	Name       string `json:"name"`
+	State      string `json:"state"`
+	Repository string `json:"repository"`
+}
+
+func ghCodespaceList(repo string) ([]codespaceInstance, error) {
+	out, err := capture("gh", "codespace", "list", "--json", "name,state,repository")
+	if err != nil {
+		return nil, err
+	}
+	var all []codespaceInstance
+	if err := json.Unmarshal([]byte(out), &all); err != nil {
+		return nil, fmt.Errorf("unexpected `gh codespace list` output: %v", err)
+	}
+	var mine []codespaceInstance
+	for _, c := range all {
+		if strings.EqualFold(c.Repository, repo) {
+			mine = append(mine, c)
+		}
+	}
+	return mine, nil
+}
+
+// createCodespace with the §1 503-aware backoff: GitHub-side incidents are
+// retried (bounded), everything else fails with the CLI's own words.
+func createCodespace(u *ui, repo string, opts startOptions) (string, int) {
+	machine := opts.machine
+	if machine == "" {
+		machine = "premiumLinux"
+	}
+	u.log("Creating codespace for %s %s", u.bold(repo), u.dim("(--machine "+machine+"; ~4 min to Available, hooks run minutes past it)"))
+	u.echoCmd("gh", "codespace", "create", "--repo", repo, "--machine", machine)
+	for attempt := 1; ; attempt++ {
+		out, err := captureBoth("gh", "codespace", "create", "--repo", repo, "--machine", machine)
+		if err == nil {
+			lines := strings.Fields(out)
+			if len(lines) == 0 {
+				u.fail("`gh codespace create` printed no codespace name.")
+				return "", 1
+			}
+			return lines[len(lines)-1], 0
+		}
+		if strings.Contains(out, "503") && attempt < 5 {
+			u.warn("GitHub returned 503 (their side — attempt %d/5); retrying in %ds...", attempt, attempt*2)
+			time.Sleep(time.Duration(attempt*2) * time.Second)
+			continue
+		}
+		u.fail("Create failed: %s", strings.TrimSpace(out))
+		return "", 1
+	}
+}
+
+// spawnForward starts the detached dev-tunnel forward — a long-lived
+// process the bring-up-and-exit launcher deliberately leaves behind, PID
+// recorded in stack.json (status re-establishes it, stop kills it).
+func spawnForward(u *ui, name string) (int, int) {
+	args := []string{"codespace", "ports", "forward"}
+	for _, p := range forwardPorts {
+		args = append(args, fmt.Sprintf("%d:%d", p.port, p.port))
+	}
+	args = append(args, "-c", name)
+	u.echoCmd("gh", args...)
+	cmd := exec.Command("gh", args...)
+	cmd.Stdout, cmd.Stderr = nil, nil
+	if err := cmd.Start(); err != nil {
+		u.fail("Could not start the port forward: %v", err)
+		return 0, 1
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Process.Release()
+	u.log("Port forward running %s", u.dim(fmt.Sprintf("(detached, pid %d — recorded; semiont stop ends it)", pid)))
+	return pid, 0
+}
+
+type adminCreds struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// fetchAdminCreds reads the §1 credentials — generated once at post-create
+// INSIDE the codespace. Mirror image of `semiont secret` (an output, not an
+// input) but same discipline: announced before the reach, read fresh,
+// displayed on purpose, never persisted or logged. An unreadable admin.json
+// (the pre-sshd-feature gap) degrades with the fix named — never blocks a
+// healthy stack.
+func fetchAdminCreds(u *ui, name string) *adminCreds {
+	u.log("Reading admin credentials %s", u.dim("(gh codespace ssh -c "+name+" -- cat .devcontainer/admin.json — generated at creation, never stored locally)"))
+	out, err := capture("gh", "codespace", "ssh", "-c", name, "--", "cat", ".devcontainer/admin.json")
+	if err != nil {
+		u.warn("Could not read credentials over ssh (a codespace created before the devcontainer sshd feature?).")
+		fmt.Println("    Recreate from current main to fix, or read them from the codespace terminal: cat .devcontainer/admin.json")
+		return nil
+	}
+	var c adminCreds
+	if json.Unmarshal([]byte(out), &c) != nil || c.Email == "" {
+		u.warn("admin.json was unreadable; see the codespace's .devcontainer/admin.json directly.")
+		return nil
+	}
+	return &c
+}
+
+// renderCodespacePlan is --dry-run for the codespace placement: the gh
+// commands a real run would execute. Reaches for nothing.
+func renderCodespacePlan(opts startOptions, repo, recorded string) {
+	fmt.Println("# semiont start --runtime codespace --dry-run — the gh commands a real run")
+	fmt.Println("# would execute, in order. Values known only at runtime appear as <placeholders>.")
+	fmt.Println(`gh auth status                                   # preflight: 'codespace' scope`)
+	fmt.Println("gh api user/codespaces/secrets/ANTHROPIC_API_KEY/repositories   # preflight: secret selected for " + repo)
+	if recorded != "" {
+		fmt.Println("# recorded codespace: " + recorded + " — resume (no create)")
+	} else {
+		fmt.Println("gh codespace list --json name,state,repository   # adopt-or-create decision for " + repo)
+		machine := opts.machine
+		if machine == "" {
+			machine = "premiumLinux"
+		}
+		fmt.Println("gh codespace create --repo " + repo + " --machine " + machine + "   # only when none exists (503-aware retry)")
+	}
+	fwd := []string{"gh", "codespace", "ports", "forward"}
+	for _, p := range forwardPorts {
+		fwd = append(fwd, fmt.Sprintf("%d:%d", p.port, p.port))
+	}
+	fmt.Println(strings.Join(append(fwd, "-c", "<codespace>"), " ") + "   # detached; pid recorded")
+	fmt.Println("# wait: http://localhost:4000/api/health (600s)")
+	fmt.Println("gh codespace ssh -c <codespace> -- cat .devcontainer/admin.json   # credentials (displayed, never stored)")
+}
+
+// stopCodespace: `semiont stop` for a codespace stack. Stop halts billing
+// and KEEPS the record — the rule is that the record mirrors existence, and
+// a stopped codespace still exists (state, credentials, billing identity).
+// --delete destroys and forgets. Both kill the recorded forward first.
+func stopCodespace(u *ui, st *stackState, service string, del, dryRun bool) int {
+	if service != "" {
+		u.fail("--service does not apply to a codespace stack (compose owns the services inside).")
+		return 1
+	}
+	if dryRun {
+		fmt.Println("# semiont stop --dry-run — the exact commands a real run would execute.")
+		if st.ForwardPID != 0 {
+			fmt.Printf("# kill the recorded port forward (pid %d)\n", st.ForwardPID)
+		}
+		if del {
+			fmt.Println("gh codespace delete -c " + st.Codespace + " --force")
+			fmt.Println("# forget stack.json (the codespace no longer exists)")
+		} else {
+			fmt.Println("gh codespace stop -c " + st.Codespace)
+			fmt.Println("# keep stack.json (the codespace still exists — state and credentials persist)")
+		}
+		return 0
+	}
+	if forwardAlive(st.ForwardPID) {
+		u.log("Stopping the port forward %s", u.dim(fmt.Sprintf("(pid %d)", st.ForwardPID)))
+		_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
+	}
+	if del {
+		u.log("Deleting codespace %s %s", u.bold(st.Codespace), u.dim("("+st.Repo+" — destroys its state and credentials)"))
+		u.echoCmd("gh", "codespace", "delete", "-c", st.Codespace, "--force")
+		if out, err := captureBoth("gh", "codespace", "delete", "-c", st.Codespace, "--force"); err != nil {
+			u.fail("Delete failed: %s", strings.TrimSpace(out))
+			return 1
+		}
+		removeState()
+		verifyPortsReleased(u, st.Ports)
+		fmt.Println("Codespace deleted — stack, state, and credentials destroyed.")
+		return 0
+	}
+	u.log("Stopping codespace %s %s", u.bold(st.Codespace), u.dim("("+st.Repo+" — billing halts; state persists)"))
+	u.echoCmd("gh", "codespace", "stop", "-c", st.Codespace)
+	if out, err := captureBoth("gh", "codespace", "stop", "-c", st.Codespace); err != nil {
+		u.fail("Stop failed: %s", strings.TrimSpace(out))
+		return 1
+	}
+	st.ForwardPID = 0
+	saveState(st)
+	verifyPortsReleased(u, st.Ports)
+	fmt.Println("Codespace stopped — billing halted; state and credentials persist.")
+	fmt.Println("  Resume:   semiont start")
+	fmt.Println("  Destroy:  semiont stop --delete")
+	return 0
+}
+
+// statusCodespace: `semiont status` for a codespace stack — VM state from
+// gh, health through the forwards (re-established if the recorded one
+// died), credentials read fresh, and a LOCAL section that doesn't pretend
+// the remote VM's directories are here.
+func statusCodespace(u *ui, st *stackState) int {
+	fmt.Println()
+	fmt.Println("  CODESPACE")
+	state := "unknown"
+	if instances, err := ghCodespaceList(st.Repo); err == nil {
+		state = "deleted"
+		for _, c := range instances {
+			if c.Name == st.Codespace {
+				state = c.State
+			}
+		}
+	}
+	fmt.Printf("  %s  %s %s\n", u.bold(st.Codespace), st.Repo, u.dim("(state: "+state+")"))
+	switch state {
+	case "deleted":
+		u.warn("The recorded codespace no longer exists — forget the record with: semiont stop --delete")
+		printRoots(u, st)
+		return 1
+	case "Available":
+	default:
+		fmt.Printf("  %s\n", u.dim("stopped — state and credentials persist; billing halted"))
+		fmt.Printf("  Resume:   %s\n", u.bold("semiont start"))
+		printRoots(u, st)
+		return 1
+	}
+
+	if !forwardAlive(st.ForwardPID) {
+		u.log("Recorded port forward is not running — re-establishing")
+		if pid, code := spawnForward(u, st.Codespace); code == 0 {
+			st.ForwardPID = pid
+			saveState(st)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("  SERVICE     HEALTH (through the forward)")
+	healthy := true
+	for _, p := range []struct{ svc, url string }{
+		{"frontend", "http://localhost:3000"},
+		{"backend", "http://localhost:4000/api/health"},
+		{"worker", "http://localhost:9090/health"},
+		{"smelter", "http://localhost:9091/health"},
+		{"weaver", "http://localhost:9092/health"},
+	} {
+		ok := false
+		for i := 0; i < 10; i++ { // a just-respawned forward needs a beat
+			if httpOK(p.url) {
+				ok = true
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		mark := u.wrap(ansiGreen, "healthy")
+		if !ok {
+			mark = u.wrap(ansiRed, "unreachable")
+			healthy = false
+		}
+		fmt.Printf("  %-10s  %s  %s\n", p.svc, mark, u.dim(p.url))
+	}
+	fmt.Printf("  %s\n", u.dim("(infra — database, graph, vectors, inference, traces — runs inside the codespace via compose)"))
+
+	if creds := fetchAdminCreds(u, st.Codespace); creds != nil {
+		fmt.Printf("  Sign in at http://localhost:3000 as %s / %s\n", u.bold(creds.Email), u.bold(creds.Password))
+	}
+
+	fmt.Println()
+	fmt.Println("  LOCAL")
+	fmt.Printf("  state      %s\n", statePath())
+	fmt.Printf("  forward    pid %d %s\n", st.ForwardPID, u.dim("(ports 3000 4000 9090 9091 9092)"))
+
+	printRoots(u, st)
+	if healthy {
+		return 0
+	}
+	return 1
+}
+
+// captureBoth: trimmed stdout+stderr combined — gh writes diagnostics (auth
+// status, HTTP errors) to stderr.
+func captureBoth(name string, args ...string) (string, error) {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// forwardAlive: is the recorded forward PID still OUR forward? A bare
+// liveness signal is not enough — PIDs get reused, and trusting (or worse,
+// SIGTERMing) a recycled PID hits an unrelated process. The PID counts only
+// if it is alive AND running gh.
+func forwardAlive(pid int) bool {
+	if pid == 0 || syscall.Kill(pid, 0) != nil {
+		return false
+	}
+	comm, err := capture("ps", "-p", fmt.Sprintf("%d", pid), "-o", "comm=")
+	return err == nil && strings.Contains(comm, "gh")
+}

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -576,9 +576,11 @@ type adminCreds struct {
 // fetchAdminCreds reads the §1 credentials — generated once at post-create
 // INSIDE the codespace. Mirror image of `semiont secret` (an output, not an
 // input) but same discipline: announced before the reach, read fresh,
-// displayed on purpose, never persisted or logged. An unreadable admin.json
-// (the pre-sshd-feature gap) degrades with the fix named — never blocks a
-// healthy stack.
+// displayed on purpose, never persisted or logged. A failed read degrades
+// (returns nil, caller omits the line) rather than blocking a healthy stack;
+// the usual cause is setup still finishing, the rare one a devcontainer
+// predating the sshd feature — so report gh's OWN words instead of guessing
+// between them.
 func fetchAdminCreds(u *ui, name string) *adminCreds {
 	// ABSOLUTE (globbed) path: `gh codespace ssh` lands in /home/vscode, not
 	// the workspace, so the relative form the recipe used silently fails
@@ -586,14 +588,20 @@ func fetchAdminCreds(u *ui, name string) *adminCreds {
 	// not depend on the workspace directory's name. Found live 2026-07-20.
 	const credPath = "/workspaces/*/.devcontainer/admin.json"
 	u.log("Reading admin credentials %s", u.dim("(gh codespace ssh -c "+name+" -- cat "+credPath+" — generated at creation, never stored locally)"))
-	out, err := capture("gh", "codespace", "ssh", "-c", name, "--", "cat", credPath)
+	// captureBoth, not capture: gh reports WHY on stderr, and discarding it
+	// forces this code to guess between causes out loud. Show what gh said.
+	out, err := captureBoth("gh", "codespace", "ssh", "-c", name, "--", "cat", credPath)
 	if err != nil {
-		// Two very different causes; naming only the rare one (as this
-		// message used to) misdiagnoses the common case out loud.
 		u.warn("Could not read admin credentials over ssh yet.")
-		fmt.Println("    Usually this means setup is still finishing inside the codespace (sshd comes up with it) —")
-		fmt.Println("    semiont status re-reads them. If it persists, the devcontainer may predate the sshd feature:")
-		fmt.Println("    recreate from current main, or read them in the codespace terminal: cat .devcontainer/admin.json")
+		if msg := strings.TrimSpace(out); msg != "" {
+			for _, line := range strings.Split(msg, "\n") {
+				fmt.Println("    gh: " + line)
+			}
+		}
+		fmt.Println("    Usually setup is still finishing inside the codespace (sshd comes up with it) —")
+		fmt.Println("    semiont status re-reads them. If it persists, the devcontainer may predate the")
+		fmt.Println("    sshd feature: recreate from current main, or open the codespace and read")
+		fmt.Println("    .devcontainer/admin.json from its terminal (which starts in the workspace).")
 		return nil
 	}
 	var c adminCreds

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -106,7 +106,7 @@ func startCodespace(u *ui, opts startOptions) int {
 		return 1
 	}
 	st := ss.Stacks["codespace:"+repo]
-	name := ""
+	name, created := "", false
 	if st != nil {
 		name = st.Codespace
 	}
@@ -145,6 +145,7 @@ func startCodespace(u *ui, opts startOptions) int {
 			if name, code = createCodespace(u, repo, opts); code != 0 {
 				return code
 			}
+			created = true
 		case len(instances) == 1:
 			name = instances[0].Name
 			u.log("Found existing codespace for %s: %s %s", repo, u.bold(name),
@@ -180,6 +181,13 @@ func startCodespace(u *ui, opts startOptions) int {
 			_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
 			time.Sleep(200 * time.Millisecond)
 		}
+	}
+
+	// --machine only chooses hardware at creation. Resuming or adopting an
+	// existing codespace can't change its VM class, so say so rather than
+	// letting the flag look effective.
+	if opts.machine != "" && !created {
+		u.warn("--machine %s ignored: %s already exists and keeps the class it was created with.", opts.machine, name)
 	}
 
 	// One KB port per stack — other codespaces' forwards keep running;
@@ -351,12 +359,85 @@ func ghCodespaceList(repo string) ([]codespaceInstance, error) {
 	return mine, nil
 }
 
+type codespaceMachine struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	CPUs        int    `json:"cpus"`
+	MemoryBytes int64  `json:"memory_in_bytes"`
+}
+
+// availableMachines: the machine classes GitHub offers THIS user for THIS
+// repo. Verified 2026-07-20: the list is filtered by the devcontainer's
+// `hostRequirements` — a repo declaring 4c/16gb is not offered the 2-core
+// class, while a repo with no devcontainer is. So anything in this list is
+// adequate by the KB's OWN declaration, which is what makes falling back to
+// another class safe rather than reckless (an undersized VM would fail
+// slowly, at the health gate, after minutes of pulls).
+func availableMachines(repo string) ([]codespaceMachine, string, error) {
+	out, err := captureBoth("gh", "api", "/repos/"+repo+"/codespaces/machines")
+	if err != nil {
+		return nil, out, err
+	}
+	var resp struct {
+		Machines []codespaceMachine `json:"machines"`
+	}
+	if json.Unmarshal([]byte(out), &resp) != nil {
+		return nil, out, fmt.Errorf("unexpected response")
+	}
+	return resp.Machines, out, nil
+}
+
+// chooseMachine resolves the VM class for a create. An EXPLICIT request must
+// actually be available — never substitute for something the user asked for
+// by name. Implicitly: premiumLinux when offered (the recipe's verified
+// choice), else the largest available by cores, announced with the reason —
+// premium-then-largest rather than always-largest, so an account with
+// largePremiumLinux isn't silently upgraded to a costlier VM.
+func chooseMachine(u *ui, repo, requested string) (string, int) {
+	machines, raw, err := availableMachines(repo)
+	if err != nil {
+		u.fail("Could not list machine classes for %s: %s", repo, strings.TrimSpace(raw))
+		fmt.Fprintln(os.Stderr, "  Likely causes: the account has no Codespaces access, or an org policy restricts machine types.")
+		return "", 1
+	}
+	if len(machines) == 0 {
+		u.fail("GitHub offers no machine classes for %s.", repo)
+		fmt.Fprintln(os.Stderr, "  Likely causes: an org policy restricts machine types, or the devcontainer's hostRequirements exceed every class available to you.")
+		return "", 1
+	}
+	if requested != "" {
+		for _, m := range machines {
+			if m.Name == requested {
+				return requested, 0
+			}
+		}
+		u.fail("--machine %s is not available to you for %s. Available:", requested, repo)
+		for _, m := range machines {
+			fmt.Fprintf(os.Stderr, "    %-20s %s\n", m.Name, m.DisplayName)
+		}
+		return "", 1
+	}
+	for _, m := range machines {
+		if m.Name == "premiumLinux" {
+			return m.Name, 0
+		}
+	}
+	best := machines[0]
+	for _, m := range machines[1:] {
+		if m.CPUs > best.CPUs || (m.CPUs == best.CPUs && m.MemoryBytes > best.MemoryBytes) {
+			best = m
+		}
+	}
+	u.warn("premiumLinux isn't available to you for %s — using %s (%s).", repo, best.Name, best.DisplayName)
+	return best.Name, 0
+}
+
 // createCodespace with the §1 503-aware backoff: GitHub-side incidents are
 // retried (bounded), everything else fails with the CLI's own words.
 func createCodespace(u *ui, repo string, opts startOptions) (string, int) {
-	machine := opts.machine
-	if machine == "" {
-		machine = "premiumLinux"
+	machine, code := chooseMachine(u, repo, opts.machine)
+	if code != 0 {
+		return "", code
 	}
 	u.log("Creating codespace for %s %s", u.bold(repo), u.dim("(--machine "+machine+"; ~4 min to Available, hooks run minutes past it)"))
 	u.echoCmd("gh", "codespace", "create", "--repo", repo, "--machine", machine)
@@ -440,7 +521,11 @@ func renderCodespacePlan(opts startOptions, repo, recorded string) {
 		fmt.Println("gh codespace list --json name,state,repository   # adopt-or-create decision for " + repo)
 		machine := opts.machine
 		if machine == "" {
-			machine = "premiumLinux"
+			machine = "<machine>"
+			fmt.Println("gh api /repos/" + repo + "/codespaces/machines   # preflight: classes available for this repo (hostRequirements-filtered)")
+			fmt.Println("# <machine> = premiumLinux when available, else the largest offered")
+		} else {
+			fmt.Println("gh api /repos/" + repo + "/codespaces/machines   # preflight: verify --machine " + machine + " is available")
 		}
 		fmt.Println("gh codespace create --repo " + repo + " --machine " + machine + "   # only when none exists (503-aware retry)")
 	}

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -137,7 +137,15 @@ func startCodespace(u *ui, opts startOptions) int {
 		case len(instances) == 0:
 			if !secretOK {
 				u.fail("ANTHROPIC_API_KEY is not a Codespaces user secret selected for %s — the stack would come up with inference dead, silently.", repo)
-				fmt.Fprintln(os.Stderr, "  Fix:  gh secret set ANTHROPIC_API_KEY --user --app codespaces   (then select the repo)")
+				// A codespace can't reach your local provider, so the
+				// value must live in GitHub too. When a source is
+				// registered, name the one command that bridges it.
+				if ref, ok := loadRoots().Secrets["ANTHROPIC_API_KEY"]; ok {
+					fmt.Fprintf(os.Stderr, "  You have a local source registered (%s). Push its current value:\n", refDisplay(ref))
+					fmt.Fprintf(os.Stderr, "    semiont secret push ANTHROPIC_API_KEY --repo %s\n", repo)
+				} else {
+					fmt.Fprintln(os.Stderr, "  Fix:  gh secret set ANTHROPIC_API_KEY --user --app codespaces   (then select the repo)")
+				}
 				fmt.Fprintln(os.Stderr, "  Check:  gh api user/codespaces/secrets/ANTHROPIC_API_KEY/repositories")
 				return 1
 			}

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -20,11 +20,37 @@ import (
 // orchestrates the outside only (create, wait, forward, credentials,
 // lifecycle) by shelling out to `gh`, which owns auth and the tunnel client.
 
-// forwardPorts: the local ports the detached `gh codespace ports forward`
-// binds — browser, backend, and the three sidecar vitals.
-var forwardPorts = []portNeed{
-	{3000, "Frontend"}, {4000, "Backend"},
-	{9090, "Worker"}, {9091, "Smelter"}, {9092, "Weaver"},
+// The KB (backend, remote port 4000) is the ONLY port a codespace stack
+// forwards: the browser's Knowledge Bases panel connects to KBs by
+// host/port, so one browser works N codespace KBs at once — each stack gets
+// its own local port, canonical 4000 when free, else the lowest free above
+// it. Browser, sidecars, and infra stay inside the codespace (compose).
+const kbRemotePort = 4000
+
+// allocateKBPort picks this stack's local KB port: 4000, or the lowest
+// free port above it — skipping every port other recorded stacks claim
+// (local stack's port checks, other codespaces' forwards) and live holders.
+func allocateKBPort(ss *stackSet, repo string) int {
+	used := map[int]bool{}
+	if local := ss.Stacks["local"]; local != nil {
+		for _, p := range local.Ports {
+			used[p] = true
+		}
+	}
+	for _, c := range codespaceStacks(ss) {
+		if c.Repo != repo && c.ForwardPort != 0 {
+			used[c.ForwardPort] = true
+		}
+	}
+	for port := kbRemotePort; ; port++ {
+		if used[port] {
+			continue
+		}
+		if out, err := capture("lsof", "-ti", fmt.Sprintf(":%d", port)); err == nil && out != "" {
+			continue
+		}
+		return port
+	}
 }
 
 var repoSlugRe = regexp.MustCompile(`^[\w.-]+/[\w.-]+$`)
@@ -39,40 +65,50 @@ func startCodespace(u *ui, opts startOptions) int {
 		return 1
 	}
 
-	// A recorded LOCAL stack binds exactly like a recorded runtime mismatch:
-	// proceeding would leave it orphaned behind a codespace record.
-	st := loadState()
-	if st != nil && st.Runtime != "" && st.Runtime != "codespace" {
+	// A recorded LOCAL stack owns the real local ports the forward needs —
+	// that stack must stop first (codespace stacks, by contrast, coexist).
+	ss := loadStackSet()
+	if local := ss.Stacks["local"]; local != nil && local.Runtime != "" {
 		if !opts.dryRun {
-			u.fail("A recorded stack is running under %s (per %s).", st.Runtime, statePath())
-			fmt.Fprintln(os.Stderr, "  Stop it first (semiont stop).")
+			u.fail("The local stack is running under %s (per %s) — it holds the ports the forward needs.", local.Runtime, statePath())
+			fmt.Fprintln(os.Stderr, "  Stop it first (semiont stop --runtime "+local.Runtime+").")
 			return 1
 		}
-		st = nil
 	}
 
-	// Identity ladder: record → --repo → root's origin (create-path
-	// convenience only — a recorded codespace stack never touches root
-	// discovery, so bare resume works from any directory).
-	name, repo := "", ""
-	if st != nil && st.Runtime == "codespace" {
-		name, repo = st.Codespace, st.Repo
-		if opts.repo != "" && opts.repo != repo {
-			u.fail("The recorded codespace stack is for %s (per %s).", repo, statePath())
-			fmt.Fprintln(os.Stderr, "  Stop it first (semiont stop, or semiont stop --delete), then start --repo "+opts.repo+".")
-			return 1
-		}
-	} else {
-		repo = opts.repo
-		if repo == "" {
+	// Identity ladder, repo-first (the repo IS the identity; many codespace
+	// stacks may be recorded at once): --repo → root's origin (create-path
+	// convenience) → the lone recorded codespace stack (bare resume works
+	// from any directory). Several recorded and nothing named → say which.
+	repo := opts.repo
+	cs := codespaceStacks(ss)
+	if repo == "" {
+		if _, _, err := resolveKBRoot(); err == nil || opts.root != "" {
 			var code int
 			if repo, code = repoFromRoot(u, opts); code != 0 {
 				return code
 			}
-		} else if !repoSlugRe.MatchString(repo) {
-			u.fail("--repo must be owner/name, got '%s'.", repo)
+		} else if len(cs) == 1 {
+			repo = cs[0].Repo
+		} else if len(cs) > 1 {
+			u.fail("%d codespace stacks are recorded — say which:", len(cs))
+			for _, c := range cs {
+				fmt.Fprintf(os.Stderr, "    semiont start --runtime codespace --repo %s\n", c.Repo)
+			}
+			return 1
+		} else {
+			u.fail("No KB clone here and no codespace stack recorded.")
+			fmt.Fprintln(os.Stderr, "  Pass --repo <owner>/<name>, or run from a KB clone (its origin supplies the repo).")
 			return 1
 		}
+	} else if !repoSlugRe.MatchString(repo) {
+		u.fail("--repo must be owner/name, got '%s'.", repo)
+		return 1
+	}
+	st := ss.Stacks["codespace:"+repo]
+	name := ""
+	if st != nil {
+		name = st.Codespace
 	}
 
 	if opts.dryRun {
@@ -146,14 +182,14 @@ func startCodespace(u *ui, opts startOptions) int {
 		}
 	}
 
-	// The forward is the only thing binding LOCAL ports; check them like any
-	// other start would (foreign holders fail with names — never killed).
-	for _, p := range forwardPorts {
-		if !requirePortFree(u, p.port, p.label+" (forward)") {
-			return 1
-		}
+	// One KB port per stack — other codespaces' forwards keep running;
+	// concurrency is the point. Allocation dodges every recorded claim and
+	// live holder, so nothing needs displacing.
+	kbPort := allocateKBPort(ss, repo)
+	if !requirePortFree(u, kbPort, "KB (forward)") {
+		return 1
 	}
-	pid, code := spawnForward(u, name)
+	pid, code := spawnForward(u, name, kbPort)
 	if code != 0 {
 		return code
 	}
@@ -161,40 +197,38 @@ func startCodespace(u *ui, opts startOptions) int {
 	// The record binds the stack to its executor before the health gate —
 	// belief, verified by status; a failed wait leaves an honest record.
 	newSt := &stackState{
-		Runtime: "codespace", Codespace: name, Repo: repo, ForwardPID: pid,
+		Runtime: "codespace", Codespace: name, Repo: repo,
+		ForwardPID: pid, ForwardPort: kbPort, Ports: []int{kbPort},
 		Services: map[string]serviceState{},
 	}
-	for _, p := range forwardPorts {
-		newSt.Ports = append(newSt.Ports, p.port)
-	}
-	saveState(newSt)
+	saveStack(newSt)
 
 	// Health, not VM state, is readiness ("Available ≠ hooks finished" —
 	// on a fresh create the devcontainer hooks run minutes past Available).
 	u.log("Waiting for the stack %s", u.dim("(a fresh create runs devcontainer hooks — image and model pulls take minutes)"))
-	d, ok := waitForHTTP(u, "Backend (through the forward)", "http://localhost:4000/api/health", 600)
+	d, ok := waitForHTTP(u, "KB (through the forward)", fmt.Sprintf("http://localhost:%d/api/health", kbPort), 600)
 	if !ok {
 		return 1
 	}
-	u.ok("Backend healthy %s", u.dim("("+took(d)+")"))
+	u.ok("KB healthy %s", u.dim("("+took(d)+")"))
 
 	creds := fetchAdminCreds(u, name)
 
 	fmt.Println()
-	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 Semiont stack is up in codespace "+name), u.dim("("+took(d)+" to healthy)"))
+	fmt.Printf("%s  %s\n", u.wrap(ansiBold+ansiGreen, "🚀 Semiont KB is up in codespace "+name), u.dim("("+took(d)+" to healthy)"))
 	fmt.Println()
-	fmt.Printf("  Semiont Browser    %s\n", u.bold("http://localhost:3000"))
-	fmt.Println("  Semiont KB         http://localhost:4000")
+	fmt.Printf("  Semiont KB         %s %s\n", u.bold(fmt.Sprintf("http://localhost:%d", kbPort)),
+		u.dim("(add Host localhost, Port "+fmt.Sprintf("%d", kbPort)+" in the browser's Knowledge Bases panel)"))
 	fmt.Println()
 	fmt.Printf("  %s\n", u.dim("Runs "+repo+" as pushed — local uncommitted changes don't travel."))
 	if creds != nil {
-		fmt.Printf("  Sign in at http://localhost:3000 as %s / %s %s\n",
+		fmt.Printf("  Connect as %s / %s %s\n",
 			u.bold(creds.Email), u.bold(creds.Password), u.dim("(generated at creation; never stored by the launcher)"))
 	}
 	fmt.Println()
 	fmt.Printf("  Check health:  %s\n", u.bold("semiont status"))
-	fmt.Printf("  Follow logs:   %s\n", u.bold("semiont logs"))
-	fmt.Printf("  Halt billing:  %s %s\n", u.bold("semiont stop"), u.dim("(state persists; semiont stop --delete destroys)"))
+	fmt.Printf("  Follow logs:   %s %s\n", u.bold("semiont logs --repo "+repo), u.dim("(bare logs when unambiguous)"))
+	fmt.Printf("  Halt billing:  %s %s\n", u.bold("semiont stop --repo "+repo), u.dim("(state persists; --delete destroys)"))
 	fmt.Println()
 	return 0
 }
@@ -337,15 +371,13 @@ func createCodespace(u *ui, repo string, opts startOptions) (string, int) {
 	}
 }
 
-// spawnForward starts the detached dev-tunnel forward — a long-lived
-// process the bring-up-and-exit launcher deliberately leaves behind, PID
-// recorded in stack.json (status re-establishes it, stop kills it).
-func spawnForward(u *ui, name string) (int, int) {
-	args := []string{"codespace", "ports", "forward"}
-	for _, p := range forwardPorts {
-		args = append(args, fmt.Sprintf("%d:%d", p.port, p.port))
-	}
-	args = append(args, "-c", name)
+// spawnForward starts the detached dev-tunnel forward for this stack's KB
+// port — a long-lived process the bring-up-and-exit launcher deliberately
+// leaves behind, PID + port recorded (status re-establishes it, stop kills
+// it). Each codespace stack runs its own.
+func spawnForward(u *ui, name string, kbPort int) (int, int) {
+	args := []string{"codespace", "ports", "forward",
+		fmt.Sprintf("%d:%d", kbPort, kbRemotePort), "-c", name}
 	u.echoCmd("gh", args...)
 	cmd := exec.Command("gh", args...)
 	cmd.Stdout, cmd.Stderr = nil, nil
@@ -403,12 +435,8 @@ func renderCodespacePlan(opts startOptions, repo, recorded string) {
 		}
 		fmt.Println("gh codespace create --repo " + repo + " --machine " + machine + "   # only when none exists (503-aware retry)")
 	}
-	fwd := []string{"gh", "codespace", "ports", "forward"}
-	for _, p := range forwardPorts {
-		fwd = append(fwd, fmt.Sprintf("%d:%d", p.port, p.port))
-	}
-	fmt.Println(strings.Join(append(fwd, "-c", "<codespace>"), " ") + "   # detached; pid recorded")
-	fmt.Println("# wait: http://localhost:4000/api/health (600s)")
+	fmt.Println("gh codespace ports forward <kb-port>:4000 -c <codespace>   # detached; pid + port recorded (4000, else lowest free above)")
+	fmt.Println("# wait: http://localhost:<kb-port>/api/health (600s)")
 	fmt.Println("gh codespace ssh -c <codespace> -- cat .devcontainer/admin.json   # credentials (displayed, never stored)")
 }
 
@@ -435,7 +463,10 @@ func stopCodespace(u *ui, st *stackState, service string, del, dryRun bool) int 
 		}
 		return 0
 	}
-	if forwardAlive(st.ForwardPID) {
+	// Verify port release only when THIS stack held the lens — another
+	// codespace's live forward legitimately holds the same local ports.
+	hadLens := forwardAlive(st.ForwardPID)
+	if hadLens {
 		u.log("Stopping the port forward %s", u.dim(fmt.Sprintf("(pid %d)", st.ForwardPID)))
 		_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
 	}
@@ -446,8 +477,10 @@ func stopCodespace(u *ui, st *stackState, service string, del, dryRun bool) int 
 			u.fail("Delete failed: %s", strings.TrimSpace(out))
 			return 1
 		}
-		removeState()
-		verifyPortsReleased(u, st.Ports)
+		forgetStack("codespace:" + st.Repo)
+		if hadLens {
+			verifyPortsReleased(u, st.Ports)
+		}
 		fmt.Println("Codespace deleted — stack, state, and credentials destroyed.")
 		return 0
 	}
@@ -458,8 +491,10 @@ func stopCodespace(u *ui, st *stackState, service string, del, dryRun bool) int 
 		return 1
 	}
 	st.ForwardPID = 0
-	saveState(st)
-	verifyPortsReleased(u, st.Ports)
+	saveStack(st)
+	if hadLens {
+		verifyPortsReleased(u, st.Ports)
+	}
 	fmt.Println("Codespace stopped — billing halted; state and credentials persist.")
 	fmt.Println("  Resume:   semiont start")
 	fmt.Println("  Destroy:  semiont stop --delete")
@@ -497,54 +532,113 @@ func statusCodespace(u *ui, st *stackState) int {
 	}
 
 	if !forwardAlive(st.ForwardPID) {
-		u.log("Recorded port forward is not running — re-establishing")
-		if pid, code := spawnForward(u, st.Codespace); code == 0 {
+		u.log("Recorded KB forward is not running — re-establishing")
+		if st.ForwardPort == 0 {
+			st.ForwardPort = allocateKBPort(loadStackSet(), st.Repo)
+		}
+		if pid, code := spawnForward(u, st.Codespace, st.ForwardPort); code == 0 {
 			st.ForwardPID = pid
-			saveState(st)
+			saveStack(st)
 		}
 	}
 
 	fmt.Println()
-	fmt.Println("  SERVICE     HEALTH (through the forward)")
-	healthy := true
-	for _, p := range []struct{ svc, url string }{
-		{"frontend", "http://localhost:3000"},
-		{"backend", "http://localhost:4000/api/health"},
-		{"worker", "http://localhost:9090/health"},
-		{"smelter", "http://localhost:9091/health"},
-		{"weaver", "http://localhost:9092/health"},
-	} {
-		ok := false
-		for i := 0; i < 10; i++ { // a just-respawned forward needs a beat
-			if httpOK(p.url) {
-				ok = true
-				break
-			}
-			time.Sleep(200 * time.Millisecond)
+	url := fmt.Sprintf("http://localhost:%d/api/health", st.ForwardPort)
+	healthy := false
+	for i := 0; i < 10; i++ { // a just-respawned forward needs a beat
+		if httpOK(url) {
+			healthy = true
+			break
 		}
-		mark := u.wrap(ansiGreen, "healthy")
-		if !ok {
-			mark = u.wrap(ansiRed, "unreachable")
-			healthy = false
-		}
-		fmt.Printf("  %-10s  %s  %s\n", p.svc, mark, u.dim(p.url))
+		time.Sleep(200 * time.Millisecond)
 	}
-	fmt.Printf("  %s\n", u.dim("(infra — database, graph, vectors, inference, traces — runs inside the codespace via compose)"))
+	mark := u.wrap(ansiGreen, "healthy")
+	if !healthy {
+		mark = u.wrap(ansiRed, "unreachable")
+	}
+	fmt.Printf("  KB          %s  %s\n", mark, u.dim(url))
+	fmt.Printf("  %s\n", u.dim("(browser, sidecars, and infra run inside the codespace via compose)"))
 
 	if creds := fetchAdminCreds(u, st.Codespace); creds != nil {
-		fmt.Printf("  Sign in at http://localhost:3000 as %s / %s\n", u.bold(creds.Email), u.bold(creds.Password))
+		fmt.Printf("  Connect (Host localhost, Port %d) as %s / %s\n", st.ForwardPort, u.bold(creds.Email), u.bold(creds.Password))
 	}
 
 	fmt.Println()
 	fmt.Println("  LOCAL")
 	fmt.Printf("  state      %s\n", statePath())
-	fmt.Printf("  forward    pid %d %s\n", st.ForwardPID, u.dim("(ports 3000 4000 9090 9091 9092)"))
+	fmt.Printf("  forward    pid %d %s\n", st.ForwardPID, u.dim(fmt.Sprintf("(KB localhost:%d → codespace:%d)", st.ForwardPort, kbRemotePort)))
 
 	printRoots(u, st)
 	if healthy {
 		return 0
 	}
 	return 1
+}
+
+// forwardedStacks: every codespace stack with a live KB forward — any
+// number may be forwarded at once, each on its own local port.
+func forwardedStacks(cs []*stackState) []*stackState {
+	var out []*stackState
+	for _, c := range cs {
+		if forwardAlive(c.ForwardPID) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// dropCollidingForwards kills codespace forwards squatting on ports a local
+// start is about to claim — and only those; forwards on allocated offset
+// ports keep running (concurrent KBs are the point). A dropped forward is a
+// view, not a stack: nothing stops in the cloud (announced, with the
+// re-attach command — which will re-allocate around the local stack).
+func dropCollidingForwards(u *ui, needs []portNeed) {
+	claimed := map[int]bool{}
+	for _, p := range needs {
+		claimed[p.port] = true
+	}
+	for _, st := range codespaceStacks(loadStackSet()) {
+		if forwardAlive(st.ForwardPID) && claimed[st.ForwardPort] {
+			u.warn("Dropping %s's KB forward on port %d — the local stack needs it; the codespace keeps running (re-attach: semiont start --runtime codespace --repo %s).",
+				st.Repo, st.ForwardPort, st.Repo)
+			_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
+			st.ForwardPID = 0
+			saveStack(st)
+			time.Sleep(200 * time.Millisecond) // let the bind release
+		}
+	}
+}
+
+// printStacksOverview: the fleet view — every recorded stack, its state,
+// and which codespace holds the lens. One gh list serves all of them.
+func printStacksOverview(u *ui, local *stackState, cs []*stackState) {
+	fmt.Println()
+	fmt.Println("  STACKS")
+	states := map[string]string{}
+	if onPath("gh") {
+		if out, err := capture("gh", "codespace", "list", "--json", "name,state,repository"); err == nil {
+			var all []codespaceInstance
+			if json.Unmarshal([]byte(out), &all) == nil {
+				for _, c := range all {
+					states[c.Name] = c.State
+				}
+			}
+		}
+	}
+	if local != nil {
+		fmt.Printf("  local      %s %s\n", local.KBRoot, u.dim("("+local.Runtime+")"))
+	}
+	for _, c := range cs {
+		state := states[c.Codespace]
+		if state == "" {
+			state = "deleted?"
+		}
+		fwd := ""
+		if forwardAlive(c.ForwardPID) {
+			fwd = "  " + u.bold(fmt.Sprintf("KB localhost:%d", c.ForwardPort))
+		}
+		fmt.Printf("  codespace  %s  %s %s%s\n", c.Repo, c.Codespace, u.dim("("+state+")"), fwd)
+	}
 }
 
 // captureBoth: trimmed stdout+stderr combined — gh writes diagnostics (auth

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -3,6 +3,7 @@ package launcher
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -65,16 +66,12 @@ func startCodespace(u *ui, opts startOptions) int {
 		return 1
 	}
 
-	// A recorded LOCAL stack owns the real local ports the forward needs —
-	// that stack must stop first (codespace stacks, by contrast, coexist).
+	// A local stack and codespace stacks COEXIST: the only local resource a
+	// codespace needs is its one KB forward port, and allocateKBPort already
+	// skips the local stack's recorded claims and any live holder. So the
+	// local KB keeps 4000, a codespace KB takes 4001, and one browser works
+	// both from its Knowledge Bases panel — the point of per-stack ports.
 	ss := loadStackSet()
-	if local := ss.Stacks["local"]; local != nil && local.Runtime != "" {
-		if !opts.dryRun {
-			u.fail("The local stack is running under %s (per %s) — it holds the ports the forward needs.", local.Runtime, statePath())
-			fmt.Fprintln(os.Stderr, "  Stop it first (semiont stop --runtime "+local.Runtime+").")
-			return 1
-		}
-	}
 
 	// Identity ladder, repo-first (the repo IS the identity; many codespace
 	// stacks may be recorded at once): --repo → root's origin (create-path
@@ -185,7 +182,7 @@ func startCodespace(u *ui, opts startOptions) int {
 		}
 		// A dead recorded forward is normal here; a live one means the
 		// stack is already reachable and respawning would fail the binds.
-		if forwardAlive(st.ForwardPID) {
+		if forwardProcAlive(st.ForwardPID) { // zombie or healthy, it must go before respawn
 			_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
 			time.Sleep(200 * time.Millisecond)
 		}
@@ -205,9 +202,33 @@ func startCodespace(u *ui, opts startOptions) int {
 	if !requirePortFree(u, kbPort, "KB (forward)") {
 		return 1
 	}
+	// The VM must be Available before a tunnel to it can bind — measured
+	// 2026-07-20: `ports forward` against a stopped codespace TRIGGERS the
+	// wake and then dies, leaving the launcher waiting on a tunnel that
+	// will never exist. So ensure Available first, waking explicitly when
+	// stopped.
+	if code := ensureCodespaceAvailable(u, repo, name); code != 0 {
+		return code
+	}
 	pid, code := spawnForward(u, name, kbPort)
 	if code != 0 {
 		return code
+	}
+	// A forward that never binds is the failure mode that wasted the whole
+	// health budget in testing: gh can exit, or stay up forwarding nothing.
+	// Confirm the port actually answers before gating on the stack.
+	bound := false
+	for i := 0; i < 30; i++ {
+		if forwardAlive(pid, kbPort) {
+			bound = true
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if !bound {
+		u.fail("The port forward did not come up on localhost:%d within 30s.", kbPort)
+		fmt.Fprintf(os.Stderr, "  Try it directly:  gh codespace ports forward %d:%d -c %s\n", kbRemotePort, kbPort, name)
+		return 1
 	}
 
 	// The record binds the stack to its executor before the health gate —
@@ -469,13 +490,71 @@ func createCodespace(u *ui, repo string, opts startOptions) (string, int) {
 	}
 }
 
+// ensureCodespaceAvailable gets the VM to Available before anything tries to
+// tunnel to it. A stopped codespace resumes BECAUSE something connects, so
+// there is a trigger step: `gh codespace ssh -- true` both wakes it and
+// blocks until it is connectable (measured: ~19s), which also proves the
+// ssh path the credentials read needs.
+func ensureCodespaceAvailable(u *ui, repo, name string) int {
+	state := ""
+	if instances, err := ghCodespaceList(repo); err == nil {
+		for _, c := range instances {
+			if c.Name == name {
+				state = c.State
+			}
+		}
+	}
+	if state == "Available" {
+		return 0
+	}
+	if state == "Shutdown" {
+		u.log("Codespace is stopped — waking it %s", u.dim("(connecting is what resumes a codespace; ~20s)"))
+		if err := runSilent("gh", "codespace", "ssh", "-c", name, "--", "true"); err != nil {
+			u.fail("Could not wake codespace %s.", name)
+			fmt.Fprintln(os.Stderr, "  Check it:  gh codespace list")
+			return 1
+		}
+	}
+	return waitCodespaceAvailable(u, repo, name)
+}
+
+// waitCodespaceAvailable polls until GitHub reports the VM Available.
+// Post-CREATE only: a fresh codespace is Provisioning for minutes and
+// forwarding before then cannot bind. Never call it for a stopped
+// codespace — those wake on connection, so this would wait forever.
+func waitCodespaceAvailable(u *ui, repo, name string) int {
+	for i := 0; i < 300; i++ {
+		instances, err := ghCodespaceList(repo)
+		if err == nil {
+			for _, c := range instances {
+				if c.Name == name && c.State == "Available" {
+					return 0
+				}
+			}
+		}
+		if i == 0 {
+			u.log("Waiting for the codespace VM %s", u.dim("(GitHub reports Provisioning until the machine is up)"))
+		}
+		time.Sleep(2 * time.Second)
+	}
+	u.fail("Codespace %s did not reach Available within 10 minutes.", name)
+	fmt.Fprintln(os.Stderr, "  Check it:  gh codespace list")
+	return 1
+}
+
 // spawnForward starts the detached dev-tunnel forward for this stack's KB
 // port — a long-lived process the bring-up-and-exit launcher deliberately
 // leaves behind, PID + port recorded (status re-establishes it, stop kills
 // it). Each codespace stack runs its own.
 func spawnForward(u *ui, name string, kbPort int) (int, int) {
+	// Argument order is <codespacePort>:<localPort> — NOT the reverse.
+	// Getting it backwards forwards a port nothing serves onto a local port
+	// something else may already own: gh then fails to bind but the process
+	// STAYS ALIVE, so it looks healthy while forwarding nothing. The §1
+	// recipe's symmetric 4000:4000 example hides the order; live testing
+	// found it.
 	args := []string{"codespace", "ports", "forward",
-		fmt.Sprintf("%d:%d", kbPort, kbRemotePort), "-c", name}
+		fmt.Sprintf("%d:%d", kbRemotePort, kbPort), "-c", name}
 	u.echoCmd("gh", args...)
 	cmd := exec.Command("gh", args...)
 	cmd.Stdout, cmd.Stderr = nil, nil
@@ -501,11 +580,20 @@ type adminCreds struct {
 // (the pre-sshd-feature gap) degrades with the fix named — never blocks a
 // healthy stack.
 func fetchAdminCreds(u *ui, name string) *adminCreds {
-	u.log("Reading admin credentials %s", u.dim("(gh codespace ssh -c "+name+" -- cat .devcontainer/admin.json — generated at creation, never stored locally)"))
-	out, err := capture("gh", "codespace", "ssh", "-c", name, "--", "cat", ".devcontainer/admin.json")
+	// ABSOLUTE (globbed) path: `gh codespace ssh` lands in /home/vscode, not
+	// the workspace, so the relative form the recipe used silently fails
+	// with "No such file or directory". The glob expands remotely and does
+	// not depend on the workspace directory's name. Found live 2026-07-20.
+	const credPath = "/workspaces/*/.devcontainer/admin.json"
+	u.log("Reading admin credentials %s", u.dim("(gh codespace ssh -c "+name+" -- cat "+credPath+" — generated at creation, never stored locally)"))
+	out, err := capture("gh", "codespace", "ssh", "-c", name, "--", "cat", credPath)
 	if err != nil {
-		u.warn("Could not read credentials over ssh (a codespace created before the devcontainer sshd feature?).")
-		fmt.Println("    Recreate from current main to fix, or read them from the codespace terminal: cat .devcontainer/admin.json")
+		// Two very different causes; naming only the rare one (as this
+		// message used to) misdiagnoses the common case out loud.
+		u.warn("Could not read admin credentials over ssh yet.")
+		fmt.Println("    Usually this means setup is still finishing inside the codespace (sshd comes up with it) —")
+		fmt.Println("    semiont status re-reads them. If it persists, the devcontainer may predate the sshd feature:")
+		fmt.Println("    recreate from current main, or read them in the codespace terminal: cat .devcontainer/admin.json")
 		return nil
 	}
 	var c adminCreds
@@ -537,7 +625,7 @@ func renderCodespacePlan(opts startOptions, repo, recorded string) {
 		}
 		fmt.Println("gh codespace create --repo " + repo + " --machine " + machine + "   # only when none exists (503-aware retry)")
 	}
-	fmt.Println("gh codespace ports forward <kb-port>:4000 -c <codespace>   # detached; pid + port recorded (4000, else lowest free above)")
+	fmt.Println("gh codespace ports forward 4000:<kb-port> -c <codespace>   # <codespacePort>:<localPort>; detached; pid + port recorded")
 	fmt.Println("# wait: http://localhost:<kb-port>/api/health (600s)")
 	fmt.Println("gh codespace ssh -c <codespace> -- cat .devcontainer/admin.json   # credentials (displayed, never stored)")
 }
@@ -567,7 +655,7 @@ func stopCodespace(u *ui, st *stackState, service string, del, dryRun bool) int 
 	}
 	// Verify port release only when THIS stack held the lens — another
 	// codespace's live forward legitimately holds the same local ports.
-	hadLens := forwardAlive(st.ForwardPID)
+	hadLens := forwardProcAlive(st.ForwardPID)
 	if hadLens {
 		u.log("Stopping the port forward %s", u.dim(fmt.Sprintf("(pid %d)", st.ForwardPID)))
 		_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
@@ -626,14 +714,21 @@ func statusCodespace(u *ui, st *stackState) int {
 		printRoots(u, st)
 		return 1
 	case "Available":
-	default:
-		fmt.Printf("  %s\n", u.dim("stopped — state and credentials persist; billing halted"))
+	case "Shutdown":
+		fmt.Printf("  %s\n", u.dim("stopped — state and credentials persist; compute billing halted (storage still bills)"))
 		fmt.Printf("  Resume:   %s\n", u.bold("semiont start"))
+		printRoots(u, st)
+		return 1
+	default:
+		// Queued / Provisioning / Starting / Rebuilding / Failed …: coming
+		// up (and billing) — NOT stopped. Saying "stopped, billing halted"
+		// here would be wrong on both counts.
+		fmt.Printf("  %s\n", u.dim("not ready yet (state: "+state+") — GitHub is still working on it; re-run semiont status"))
 		printRoots(u, st)
 		return 1
 	}
 
-	if !forwardAlive(st.ForwardPID) {
+	if !forwardAlive(st.ForwardPID, st.ForwardPort) {
 		u.log("Recorded KB forward is not running — re-establishing")
 		if st.ForwardPort == 0 {
 			st.ForwardPort = allocateKBPort(loadStackSet(), st.Repo)
@@ -682,7 +777,7 @@ func statusCodespace(u *ui, st *stackState) int {
 func forwardedStacks(cs []*stackState) []*stackState {
 	var out []*stackState
 	for _, c := range cs {
-		if forwardAlive(c.ForwardPID) {
+		if forwardAlive(c.ForwardPID, c.ForwardPort) {
 			out = append(out, c)
 		}
 	}
@@ -700,7 +795,7 @@ func dropCollidingForwards(u *ui, needs []portNeed) {
 		claimed[p.port] = true
 	}
 	for _, st := range codespaceStacks(loadStackSet()) {
-		if forwardAlive(st.ForwardPID) && claimed[st.ForwardPort] {
+		if forwardProcAlive(st.ForwardPID) && claimed[st.ForwardPort] {
 			u.warn("Dropping %s's KB forward on port %d — the local stack needs it; the codespace keeps running (re-attach: semiont start --runtime codespace --repo %s).",
 				st.Repo, st.ForwardPort, st.Repo)
 			_ = syscall.Kill(st.ForwardPID, syscall.SIGTERM)
@@ -736,7 +831,7 @@ func printStacksOverview(u *ui, local *stackState, cs []*stackState) {
 			state = "deleted?"
 		}
 		fwd := ""
-		if forwardAlive(c.ForwardPID) {
+		if forwardAlive(c.ForwardPID, c.ForwardPort) {
 			fwd = "  " + u.bold(fmt.Sprintf("KB localhost:%d", c.ForwardPort))
 		}
 		fmt.Printf("  codespace  %s  %s %s%s\n", c.Repo, c.Codespace, u.dim("("+state+")"), fwd)
@@ -750,14 +845,30 @@ func captureBoth(name string, args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), err
 }
 
-// forwardAlive: is the recorded forward PID still OUR forward? A bare
+// forwardProcAlive: is the recorded PID still OUR forward PROCESS? A bare
 // liveness signal is not enough — PIDs get reused, and trusting (or worse,
 // SIGTERMing) a recycled PID hits an unrelated process. The PID counts only
-// if it is alive AND running gh.
-func forwardAlive(pid int) bool {
+// if it is alive AND running gh. Use this for cleanup decisions.
+func forwardProcAlive(pid int) bool {
 	if pid == 0 || syscall.Kill(pid, 0) != nil {
 		return false
 	}
 	comm, err := capture("ps", "-p", fmt.Sprintf("%d", pid), "-o", "comm=")
 	return err == nil && strings.Contains(comm, "gh")
+}
+
+// forwardAlive: is the forward actually FORWARDING? A live gh process can
+// fail to bind (wrong port order, port taken, codespace not ready) and stay
+// running — a zombie that every pid-only check calls healthy while nothing
+// reaches the KB. Observed live 2026-07-20. So the port must answer too.
+func forwardAlive(pid, port int) bool {
+	if !forwardProcAlive(pid) || port == 0 {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -143,7 +143,7 @@ func (x *liveExec) hostOllamaReachable(addr string, port int) bool {
 
 func (x *liveExec) sweepStaging() {
 	removeStagedConfigs()
-	removeState()
+	forgetStack("local") // codespace stacks' records are not ours to erase
 }
 
 func (x *liveExec) portChecks(ports []portNeed) bool {
@@ -163,7 +163,7 @@ func (x *liveExec) recordPorts(ports []portNeed) {
 		return
 	}
 	if x.st == nil {
-		x.st = loadState()
+		x.st = loadLocalState()
 		if x.st == nil {
 			x.st = &stackState{
 				Runtime: x.rt, KBRoot: x.root, KBDid: loadKBIdentity(x.root).didWeb(),
@@ -181,7 +181,7 @@ func (x *liveExec) recordPorts(ports []portNeed) {
 			have[p.port] = true
 		}
 	}
-	saveState(x.st)
+	saveStack(x.st)
 }
 
 func (x *liveExec) stageDir() (string, bool) {
@@ -322,7 +322,7 @@ func (x *liveExec) ollamaVolume(opts startOptions) string {
 
 func (x *liveExec) record(role, id, image, provided, endpoint, driver string) {
 	if x.st == nil { // --service mode: load, or create with full metadata
-		x.st = loadState()
+		x.st = loadLocalState()
 		if x.st == nil {
 			x.st = &stackState{
 				Runtime: x.rt, KBRoot: x.root, KBDid: loadKBIdentity(x.root).didWeb(),

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -24,9 +24,9 @@ type executor interface {
 	pause()                    // the settle sleep after teardown
 	sweepStaging()             // /tmp/semiont-config.* removal (+ state forget)
 	portChecks(ports []portNeed) bool
-	portCheck(p portNeed) bool     // singular wording in plan mode
-	recordPorts(ports []portNeed)  // note claimed host ports in the belief record
-	stopEcho(name string)          // the echoed best-effort stop (ollama teardown)
+	portCheck(p portNeed) bool    // singular wording in plan mode
+	recordPorts(ports []portNeed) // note claimed host ports in the belief record
+	stopEcho(name string)         // the echoed best-effort stop (ollama teardown)
 	hostOllamaReachable(addr string, port int) bool
 	stageAll(configFile string) (string, bool)           // per-service config copies; returns stage dir
 	stageOne(svc, configFile string) (string, bool)      // one service's fresh private copy

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -346,19 +346,7 @@ func flowOneService(x executor, fc flowCtx) int {
 			x.say(sayLog, "Removed prior %s container", svc)
 			x.pause()
 		}
-		// Port claims follow the plan for config-owned ports (dependency
-		// roles, backend); the static role table covers only the
-		// launcher-fiat ports (sidecars, frontend, traces).
-		ports := roles[svc].ports
-		switch {
-		case svc == "backend" && fc.plan != nil:
-			ports = []portNeed{{fc.plan.BackendPort, "Backend"}}
-		case fc.plan != nil:
-			if rp, ok := fc.plan.Roles[svc]; ok && rp.Obligation == obligationProvided {
-				spec := driverCatalog[svc][rp.Driver]
-				ports = append(append([]portNeed{}, spec.auxPorts...), portNeed{rp.Port, spec.portLabel})
-			}
-		}
+		ports := servicePortNeeds(svc, fc.plan)
 		if !x.portChecks(ports) {
 			return 1
 		}
@@ -466,4 +454,21 @@ func flowOneService(x executor, fc flowCtx) int {
 		x.say(sayOK, "%s healthy %s", svc, x.dim("("+took(d)+")"))
 	}
 	return 0
+}
+
+// servicePortNeeds: one service's must-be-free ports. Claims follow the
+// plan for config-owned ports (dependency roles, backend); the static role
+// table covers only the launcher-fiat ports (sidecars, frontend, traces).
+func servicePortNeeds(svc string, plan *launchPlan) []portNeed {
+	ports := roles[svc].ports
+	switch {
+	case svc == "backend" && plan != nil:
+		ports = []portNeed{{plan.BackendPort, "Backend"}}
+	case plan != nil:
+		if rp, ok := plan.Roles[svc]; ok && rp.Obligation == obligationProvided {
+			spec := driverCatalog[svc][rp.Driver]
+			ports = append(append([]portNeed{}, spec.auxPorts...), portNeed{rp.Port, spec.portLabel})
+		}
+	}
+	return ports
 }

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -132,7 +132,7 @@ func flowFullStart(x executor, fc flowCtx) int {
 
 	// Frontend: a static SPA server — no config mount and no service env.
 	x.banner("Starting Frontend")
-	args := frontendArgs(fc.version)
+	args := frontendArgs(fc.version, 3000)
 	id, ok := x.runDetached(args)
 	if !ok {
 		x.say(sayFail, "Frontend failed to start.")
@@ -346,7 +346,7 @@ func flowOneService(x executor, fc flowCtx) int {
 			x.say(sayLog, "Removed prior %s container", svc)
 			x.pause()
 		}
-		ports := servicePortNeeds(svc, fc.plan)
+		ports := servicePortNeeds(svc, fc.plan, fc.opts)
 		if !x.portChecks(ports) {
 			return 1
 		}
@@ -439,16 +439,20 @@ func flowOneService(x executor, fc flowCtx) int {
 			}
 		}
 	case "frontend":
-		args := frontendArgs(fc.version)
+		bp := browserPort(fc.opts)
+		if bp != 3000 {
+			x.say(sayWarn, "Browser on port %d: backends configured with frontendURL http://localhost:3000 may reject this origin (OAuth redirects / CORS).", bp)
+		}
+		args := frontendArgs(fc.version, bp)
 		id, ok := x.runDetached(args)
 		if !ok {
 			x.say(sayFail, "Frontend failed to start.")
 			return 1
 		}
-		if d, ok = x.waitHTTP("Frontend", "http://localhost:3000", 30); !ok {
+		if d, ok = x.waitHTTP("Frontend", fmt.Sprintf("http://localhost:%d", bp), 30); !ok {
 			return 1
 		}
-		x.record(svc, id, image("frontend", fc.version), providedLauncher, serviceEndpoint(svc, fc.plan), "")
+		x.record(svc, id, image("frontend", fc.version), providedLauncher, fmt.Sprintf("http://localhost:%d", bp), "")
 	}
 	if d > 0 {
 		x.say(sayOK, "%s healthy %s", svc, x.dim("("+took(d)+")"))
@@ -459,9 +463,11 @@ func flowOneService(x executor, fc flowCtx) int {
 // servicePortNeeds: one service's must-be-free ports. Claims follow the
 // plan for config-owned ports (dependency roles, backend); the static role
 // table covers only the launcher-fiat ports (sidecars, frontend, traces).
-func servicePortNeeds(svc string, plan *launchPlan) []portNeed {
+func servicePortNeeds(svc string, plan *launchPlan, opts startOptions) []portNeed {
 	ports := roles[svc].ports
 	switch {
+	case svc == "frontend" && opts.port != 0:
+		ports = []portNeed{{opts.port, "Frontend"}}
 	case svc == "backend" && plan != nil:
 		ports = []portNeed{{plan.BackendPort, "Backend"}}
 	case plan != nil:

--- a/apps/launcher/internal/launcher/logs.go
+++ b/apps/launcher/internal/launcher/logs.go
@@ -11,7 +11,12 @@ import (
 	"syscall"
 )
 
-const logsUsage = `Usage: semiont logs [--service <name>] [--runtime container|docker|podman]
+const logsUsage = `Usage: semiont logs [--service <name>] [--runtime container|docker|podman] [--repo <owner/name>]
+
+A bare invocation follows the lone forwarded codespace stack (when no local
+stack exists), else the local stack, else the lone recorded codespace; with
+several codespace stacks, say which. --repo targets a codespace stack
+explicitly; --runtime targets a local runtime.
 
 Follow the Semiont service logs, one [svc]-prefixed stream per service.
 Ctrl+C stops *following* — it does not stop the stack (that's semiont stop).
@@ -33,6 +38,7 @@ func Logs(args []string) int {
 	u := newUI(false)
 	runtime := ""
 	service := ""
+	repoFlag := ""
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--runtime":
@@ -41,6 +47,13 @@ func Logs(args []string) int {
 				return 1
 			}
 			runtime = args[i+1]
+			i++
+		case "--repo":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --repo")
+				return 1
+			}
+			repoFlag = args[i+1]
 			i++
 		case "--service":
 			if i+1 >= len(args) {
@@ -67,10 +80,24 @@ func Logs(args []string) int {
 	// The record supplies the runtime and container identities; --runtime
 	// overrides, and a record about a different runtime doesn't apply. No
 	// record: the historical name-scan discovery.
-	st := loadState()
+	ss := loadStackSet()
+	cs := codespaceStacks(ss)
+	st := ss.Stacks["local"]
 	rt := ""
 	csName := ""
-	if runtime != "" {
+	if repoFlag != "" {
+		target := ss.Stacks["codespace:"+repoFlag]
+		if target == nil {
+			u.fail("No codespace stack recorded for %s.", repoFlag)
+			return 1
+		}
+		if !onPath("gh") {
+			fmt.Fprintln(os.Stderr, "'gh' is not on PATH.")
+			return 1
+		}
+		csName = target.Codespace
+		st = nil
+	} else if runtime != "" {
 		if !onPath(runtime) {
 			fmt.Fprintf(os.Stderr, "--runtime %s requested, but '%s' is not on PATH.\n", runtime, runtime)
 			return 1
@@ -79,18 +106,33 @@ func Logs(args []string) int {
 		if st != nil && st.Runtime != runtime {
 			st = nil
 		}
-	} else if st != nil && st.Runtime == "codespace" {
-		// Codespace stack: logs ride ssh, by wire-level container name (the
-		// shared contract with compose inside the codespace).
+	} else if fwd := forwardedStacks(cs); len(fwd) == 1 && st == nil {
+		// Read-only commands look at what you're looking at: the lone
+		// forwarded codespace stack wins a bare invocation. Logs ride ssh,
+		// by wire-level container name (the shared contract with compose).
+		if !onPath("gh") {
+			fmt.Fprintln(os.Stderr, "A codespace stack is forwarded but 'gh' is not on PATH.")
+			return 1
+		}
+		csName = fwd[0].Codespace
+		u.log("Using the forwarded codespace stack %s", u.dim("("+csName+" per "+statePath()+")"))
+	} else if st != nil && st.Runtime != "" && onPath(st.Runtime) {
+		rt = st.Runtime
+		u.log("Using recorded stack state %s", u.dim("("+rt+" per "+statePath()+")"))
+	} else if len(cs) == 1 {
 		if !onPath("gh") {
 			fmt.Fprintln(os.Stderr, "A codespace stack is recorded but 'gh' is not on PATH.")
 			return 1
 		}
-		csName = st.Codespace
+		csName = cs[0].Codespace
+		st = nil
 		u.log("Using recorded codespace stack %s", u.dim("("+csName+" per "+statePath()+")"))
-	} else if st != nil && st.Runtime != "" && onPath(st.Runtime) {
-		rt = st.Runtime
-		u.log("Using recorded stack state %s", u.dim("("+rt+" per "+statePath()+")"))
+	} else if len(cs) > 1 {
+		fmt.Fprintln(os.Stderr, "Multiple codespace stacks are recorded — say which:  semiont logs --repo <owner/name>")
+		for _, c := range cs {
+			fmt.Fprintf(os.Stderr, "    recorded: %s\n", c.Repo)
+		}
+		return 1
 	} else {
 		st = nil
 		rt = stackRuntime()

--- a/apps/launcher/internal/launcher/logs.go
+++ b/apps/launcher/internal/launcher/logs.go
@@ -69,6 +69,7 @@ func Logs(args []string) int {
 	// record: the historical name-scan discovery.
 	st := loadState()
 	rt := ""
+	csName := ""
 	if runtime != "" {
 		if !onPath(runtime) {
 			fmt.Fprintf(os.Stderr, "--runtime %s requested, but '%s' is not on PATH.\n", runtime, runtime)
@@ -78,6 +79,15 @@ func Logs(args []string) int {
 		if st != nil && st.Runtime != runtime {
 			st = nil
 		}
+	} else if st != nil && st.Runtime == "codespace" {
+		// Codespace stack: logs ride ssh, by wire-level container name (the
+		// shared contract with compose inside the codespace).
+		if !onPath("gh") {
+			fmt.Fprintln(os.Stderr, "A codespace stack is recorded but 'gh' is not on PATH.")
+			return 1
+		}
+		csName = st.Codespace
+		u.log("Using recorded codespace stack %s", u.dim("("+csName+" per "+statePath()+")"))
 	} else if st != nil && st.Runtime != "" && onPath(st.Runtime) {
 		rt = st.Runtime
 		u.log("Using recorded stack state %s", u.dim("("+rt+" per "+statePath()+")"))
@@ -85,7 +95,7 @@ func Logs(args []string) int {
 		st = nil
 		rt = stackRuntime()
 	}
-	if rt == "" {
+	if rt == "" && csName == "" {
 		fmt.Fprintln(os.Stderr, "No running Semiont stack found in any runtime (container/docker/podman).")
 		fmt.Fprintln(os.Stderr, "Start one with semiont start, or pass --runtime explicitly.")
 		return 1
@@ -121,6 +131,10 @@ func Logs(args []string) int {
 	}
 	targets := make(map[string]string, len(follow)) // svc → handle
 	for _, svc := range follow {
+		if csName != "" { // codespace: wire-level names, no per-service record
+			targets[svc] = roles[svc].container
+			continue
+		}
 		h, ok := handleFor(svc)
 		if !ok {
 			return 1
@@ -137,7 +151,12 @@ func Logs(args []string) int {
 	var wg sync.WaitGroup
 	var cmds []*exec.Cmd
 	for _, svc := range follow {
-		cmd := exec.Command(rt, "logs", "--follow", targets[svc])
+		var cmd *exec.Cmd
+		if csName != "" {
+			cmd = exec.Command("gh", "codespace", "ssh", "-c", csName, "--", "docker", "logs", "--follow", targets[svc])
+		} else {
+			cmd = exec.Command(rt, "logs", "--follow", targets[svc])
+		}
 		stdout, err1 := cmd.StdoutPipe()
 		stderr, err2 := cmd.StderrPipe()
 		if err1 != nil || err2 != nil {

--- a/apps/launcher/internal/launcher/root.go
+++ b/apps/launcher/internal/launcher/root.go
@@ -181,6 +181,9 @@ func saveRoots(reg rootsRegistry) {
 // preference it needs no root: `--service frontend --runtime docker` is a
 // legitimate rootless start and still expresses the choice.
 func recordRuntimePref(rt string) {
+	if rt == "codespace" { // placement, not preference: never sticky (billable VMs)
+		return
+	}
 	reg := loadRoots()
 	if reg.Runtime == rt {
 		return

--- a/apps/launcher/internal/launcher/secrets.go
+++ b/apps/launcher/internal/launcher/secrets.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -109,6 +110,10 @@ Commands:
   set <VAR> [<scheme>://<path>]   Register a source (verified with one read
                                   now). With no source given, an interactive
                                   flow picks the provider and path.
+  push <VAR> --repo <owner/name>  Copy the registered secret's CURRENT value
+                                  into your GitHub Codespaces user secrets and
+                                  select that repo — for codespace stacks,
+                                  which cannot reach your local provider.
   list                            Show registered sources (pointers, never values)
   rm <VAR>                        Forget a source
 
@@ -117,6 +122,7 @@ Providers (the URI scheme picks one):
 Examples:
   semiont secret set ANTHROPIC_API_KEY
   semiont secret set ANTHROPIC_API_KEY op://OSS/Anthropic/credential
+  semiont secret push ANTHROPIC_API_KEY --repo The-AI-Alliance/my-kb
   semiont secret rm ANTHROPIC_API_KEY
 `
 }
@@ -143,6 +149,12 @@ func Secret(args []string) int {
 			u.fail("Usage: semiont secret set <VAR> [<scheme>://<path>]")
 			return 1
 		}
+	case "push":
+		if len(args) != 4 || args[2] != "--repo" {
+			u.fail("Usage: semiont secret push <VAR> --repo <owner/name>")
+			return 1
+		}
+		return secretPush(u, args[1], args[3])
 	case "list":
 		reg := loadRoots()
 		if len(reg.Secrets) == 0 {
@@ -183,6 +195,92 @@ func Secret(args []string) int {
 		fmt.Print(secretUsage())
 		return 1
 	}
+}
+
+// secretPush copies a registered secret's CURRENT value into GitHub's
+// Codespaces user secrets. A codespace runs on GitHub's machine and cannot
+// reach your local provider, so the value has to live there too — this is
+// the one place the launcher moves a secret rather than merely pointing at
+// one. Discipline holds anyway: resolved fresh and announced, handed to `gh`
+// on STDIN (never argv, where ps could read it), encrypted by gh before it
+// leaves the machine, and never written to disk or logs by us.
+//
+// The repo selection is a UNION, never a replacement: pushing for one repo
+// must not silently revoke the secret from every other repo already using it.
+func secretPush(u *ui, name, repo string) int {
+	if !repoSlugRe.MatchString(repo) {
+		u.fail("--repo must be owner/name, got '%s'.", repo)
+		return 1
+	}
+	ref, ok := loadRoots().Secrets[name]
+	if !ok {
+		u.fail("No secret source registered for %s — nothing to push.", name)
+		fmt.Fprintf(os.Stderr, "  Register one first:  semiont secret set %s\n", name)
+		return 1
+	}
+	if !requireProviderBin(u, ref) {
+		return 1
+	}
+	if !onPath("gh") {
+		u.fail("'gh' is not on PATH — needed to write GitHub Codespaces secrets.")
+		fmt.Fprintln(os.Stderr, "  Install it: https://cli.github.com")
+		return 1
+	}
+	p := secretProviders[ref.Provider]
+	u.log("%s: reading from %s (%s) %s", u.bold(name), p.display, refCommand(ref),
+		u.dim("— expect an authorization prompt"))
+	val, err := resolveSecret(ref)
+	if err != nil {
+		u.fail("%s: %v.", name, err)
+		return 1
+	}
+
+	// Union with whatever repos already have access — `gh secret set --repos`
+	// REPLACES the selection, so sending only this repo would revoke every
+	// other one silently.
+	all := currentSecretRepos(name)
+	selected := false
+	for _, r := range all {
+		if strings.EqualFold(r, repo) {
+			selected = true
+			break
+		}
+	}
+	if !selected {
+		all = append(all, repo)
+	}
+	args := []string{"secret", "set", name, "--user", "--app", "codespaces", "--repos", strings.Join(all, ",")}
+	u.echoCmd("gh", args...) // the value is on stdin — nothing here to redact
+	if err := runWithStdin("gh", val, args...); err != nil {
+		u.fail("Could not set the Codespaces user secret (see gh's output above).")
+		fmt.Fprintln(os.Stderr, "  If gh reports a missing scope, grant it and retry.")
+		return 1
+	}
+	u.ok("%s is now a Codespaces user secret, selected for %s %s", u.bold(name), strings.Join(all, ", "),
+		u.dim("(value read fresh from "+refDisplay(ref)+"; never stored locally)"))
+	return 0
+}
+
+// currentSecretRepos: the repos already selected for a Codespaces user
+// secret (empty when the secret does not exist yet).
+func currentSecretRepos(name string) []string {
+	out, err := capture("gh", "api", "user/codespaces/secrets/"+name+"/repositories")
+	if err != nil {
+		return nil
+	}
+	var resp struct {
+		Repositories []struct {
+			FullName string `json:"full_name"`
+		} `json:"repositories"`
+	}
+	if json.Unmarshal([]byte(out), &resp) != nil {
+		return nil
+	}
+	names := make([]string, 0, len(resp.Repositories))
+	for _, r := range resp.Repositories {
+		names = append(names, r.FullName)
+	}
+	return names
 }
 
 func secretSet(u *ui, name, uri string) int {

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -27,18 +27,21 @@ var preflightNames = []string{
 }
 
 type startOptions struct {
-	configName     string
-	configSet      bool // --config given explicitly (drives --service compatibility)
-	listConfigs    bool
-	cleanOllama    bool
-	runtime        string
-	observe        bool
-	noObserveSet   bool // --no-observe given explicitly
-	quiet          bool
-	dryRun         bool
-	ollamaCache    string // "", "host", or "volume"
-	service        string // start just this one service
-	root           string // --root: KB root by path or registered basename
+	configName   string
+	configSet    bool // --config given explicitly (drives --service compatibility)
+	listConfigs  bool
+	cleanOllama  bool
+	runtime      string
+	observe      bool
+	noObserveSet bool // --no-observe given explicitly
+	quiet        bool
+	dryRun       bool
+	ollamaCache  string // "", "host", or "volume"
+	service      string // start just this one service
+	root         string // --root: KB root by path or registered basename
+	repo         string // --repo: owner/name (codespace placement only)
+	csName       string // --codespace: instance disambiguator (codespace placement only)
+	machine      string // --machine: VM class (codespace placement only)
 }
 
 const startUsage = `Usage: semiont start [options]
@@ -65,7 +68,15 @@ Options:
   --runtime <name>      Container runtime: container, docker, or podman
                         (default: the machine's recorded preference — the
                         --runtime a successful start last used, kept in
-                        roots.json — else the first found on PATH)
+                        roots.json — else the first found on PATH). Or
+                        'codespace': run the stack on a GitHub-hosted
+                        machine via gh (never sticky; a recorded codespace
+                        stack resumes on a bare start)
+  --repo <owner/name>   Codespace placement: the GitHub repo (default: the
+                        KB clone's origin remote; the record remembers it)
+  --codespace <name>    Codespace placement: disambiguate when the repo has
+                        several codespaces (the launcher itself makes one)
+  --machine <class>     Codespace placement: VM class (default: premiumLinux)
   --no-observe          Skip the Jaeger sidecar (OTel traces + metrics run by default)
   --ollama-cache <c>    Model cache when starting an Ollama container: 'host'
                         (~/.ollama) or 'volume' (named volume) — skips the prompt
@@ -139,6 +150,27 @@ func Start(args []string) int {
 			}
 			opts.root = v
 			i++
+		case "--repo":
+			v, ok := needVal(i)
+			if !ok {
+				return 1
+			}
+			opts.repo = v
+			i++
+		case "--codespace":
+			v, ok := needVal(i)
+			if !ok {
+				return 1
+			}
+			opts.csName = v
+			i++
+		case "--machine":
+			v, ok := needVal(i)
+			if !ok {
+				return 1
+			}
+			opts.machine = v
+			i++
 		case "--list-configs":
 			opts.listConfigs = true
 		case "--clean-ollama":
@@ -179,6 +211,38 @@ func Start(args []string) int {
 		return 1
 	}
 
+	// Codespace placement: the codespace-only flags are rejected elsewhere,
+	// and the local-only knobs are rejected on a codespace start — nothing
+	// is silently ignored, per the flag-scoping pattern.
+	if opts.runtime == "codespace" {
+		switch {
+		case opts.service != "":
+			u.fail("--service does not apply to --runtime codespace (compose owns the services inside).")
+			return 1
+		case opts.configSet:
+			u.fail("--config does not apply to --runtime codespace (the codespace runs its committed config).")
+			return 1
+		case opts.noObserveSet:
+			u.fail("--no-observe does not apply to --runtime codespace (the observe profile is composed inside).")
+			return 1
+		case opts.ollamaCache != "":
+			u.fail("--ollama-cache does not apply to --runtime codespace.")
+			return 1
+		case opts.cleanOllama:
+			u.fail("--clean-ollama does not apply to --runtime codespace.")
+			return 1
+		case opts.listConfigs:
+			u.fail("--list-configs does not apply to --runtime codespace.")
+			return 1
+		case opts.root != "" && opts.repo != "":
+			u.fail("--root and --repo are contradictory (one derives the repo from a clone, the other bypasses clones).")
+			return 1
+		}
+	} else if opts.repo != "" || opts.csName != "" || opts.machine != "" {
+		u.fail("--repo/--codespace/--machine only apply to --runtime codespace.")
+		return 1
+	}
+
 	// --service compatibility: flags that don't apply to the named service are
 	// rejected rather than silently ignored.
 	if opts.service != "" {
@@ -212,6 +276,25 @@ func Start(args []string) int {
 	u = newUI(opts.quiet || opts.dryRun)
 	if !opts.dryRun {
 		u.stamp("semiont start")
+	}
+
+	// Codespace placement dispatches before anything local: no root
+	// discovery (the record replaces the clone), no config load, no local
+	// preflight. Explicit --runtime codespace, or a recorded codespace stack
+	// binding an implicit start (rejoin what exists, as with any record).
+	if opts.runtime == "codespace" {
+		return startCodespace(u, opts)
+	}
+	if opts.runtime == "" {
+		if recSt := loadState(); recSt != nil && recSt.Runtime == "codespace" {
+			if !onPath("gh") {
+				u.fail("A codespace stack is recorded (per %s) but 'gh' is not on PATH.", statePath())
+				fmt.Fprintln(os.Stderr, "  Install the GitHub CLI, or forget the stack:  semiont stop --delete")
+				return 1
+			}
+			u.log("Using recorded stack's runtime: %s %s", u.bold("codespace"), u.dim("(per "+statePath()+")"))
+			return startCodespace(u, opts)
+		}
 	}
 
 	// Resolve the KB root: SEMIONT_ROOT override (strict), else walk up from
@@ -308,7 +391,9 @@ func Start(args []string) int {
 	// error; a recorded preference that vanished from PATH just falls back.
 	requested, rtSticky := opts.runtime, false
 	if requested == "" {
-		if rec := loadRoots().Runtime; rec != "" {
+		// "codespace" can never be a sticky preference (we never write it);
+		// a hand-edited registry saying so is ignored, not obeyed.
+		if rec := loadRoots().Runtime; rec != "" && rec != "codespace" {
 			if onPath(rec) {
 				requested, rtSticky = rec, true
 			} else if !opts.dryRun { // keep the dry-run seam machine-clean
@@ -344,7 +429,7 @@ func Start(args []string) int {
 	// staged configs out from under its live mounts. A record whose runtime
 	// is no longer installed is stale (that stack cannot be running) and
 	// doesn't bind anything.
-	if recSt := loadState(); recSt != nil && recSt.Runtime != "" && recSt.Runtime != rt && onPath(recSt.Runtime) {
+	if recSt := loadState(); recSt != nil && recSt.Runtime != "" && recSt.Runtime != rt && recordBinds(recSt.Runtime) {
 		if opts.runtime == "" {
 			rt = recSt.Runtime
 			rtFrom = ""

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -80,7 +80,9 @@ Options:
                         KB clone's origin remote; the record remembers it)
   --codespace <name>    Codespace placement: disambiguate when the repo has
                         several codespaces (the launcher itself makes one)
-  --machine <class>     Codespace placement: VM class (default: premiumLinux)
+  --machine <class>     Codespace placement: VM class (default: premiumLinux
+                        when your account can use it for the repo, else the
+                        largest it can; only applies when creating)
   --no-observe          Skip the Jaeger sidecar (OTel traces + metrics run by default)
   --ollama-cache <c>    Model cache when starting an Ollama container: 'host'
                         (~/.ollama) or 'volume' (named volume) — skips the prompt

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -39,6 +39,7 @@ type startOptions struct {
 	ollamaCache  string // "", "host", or "volume"
 	service      string // start just this one service
 	root         string // --root: KB root by path or registered basename
+	port         int    // --port: browser port (--service frontend only; every other port is config-owned)
 	repo         string // --repo: owner/name (codespace placement only)
 	csName       string // --codespace: instance disambiguator (codespace placement only)
 	machine      string // --machine: VM class (codespace placement only)
@@ -64,6 +65,9 @@ Options:
                         frontend, database, graph, vectors, inference, or traces.
                         Rejoins a running stack's worker secret automatically;
                         OTel export is enabled iff traces (Jaeger) is up.
+  --port <n>            Browser port (--service frontend only; default 3000).
+                        The one port a flag may move — every other port
+                        belongs to the KB's config
   --clean-ollama        Remove the Ollama model cache volume and exit
   --runtime <name>      Container runtime: container, docker, or podman
                         (default: the machine's recorded preference — the
@@ -149,6 +153,18 @@ func Start(args []string) int {
 				return 1
 			}
 			opts.root = v
+			i++
+		case "--port":
+			v, ok := needVal(i)
+			if !ok {
+				return 1
+			}
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 || n > 65535 {
+				u.fail("Invalid --port '%s' (expected 1-65535).", v)
+				return 1
+			}
+			opts.port = n
 			i++
 		case "--repo":
 			v, ok := needVal(i)
@@ -240,6 +256,10 @@ func Start(args []string) int {
 		}
 	} else if opts.repo != "" || opts.csName != "" || opts.machine != "" {
 		u.fail("--repo/--codespace/--machine only apply to --runtime codespace.")
+		return 1
+	}
+	if opts.port != 0 && (opts.service != "frontend" || opts.runtime == "codespace") {
+		u.fail("--port only applies to --service frontend — every other port belongs to the KB's config (and a codespace forwards only its KB, on an allocated port).")
 		return 1
 	}
 
@@ -548,7 +568,7 @@ func Start(args []string) int {
 	if !opts.dryRun {
 		var needs []portNeed
 		if opts.service != "" {
-			needs = servicePortNeeds(opts.service, plan) // nil-plan-safe (frontend, traces)
+			needs = servicePortNeeds(opts.service, plan, opts) // nil-plan-safe (frontend, traces)
 		} else {
 			needs = planPortChecks(plan, opts.observe) // full start always has a plan
 		}
@@ -634,9 +654,20 @@ func sidecarArgs(svc, mem string, port int, stage, addr, secret, version string,
 	return append(a, image(svc, version))
 }
 
-func frontendArgs(version string) []string {
+// frontendArgs: the browser publishes on the chosen host port (default
+// 3000; the SPA server always listens on 3000 inside). The ONLY port a flag
+// may move — it's absent from the config and nothing in the stack dials it.
+func frontendArgs(version string, port int) []string {
 	return []string{"run", "-d", "--rm", "--name", "semiont-frontend",
-		"--memory", "1G", "--publish", "3000:3000", image("frontend", version)}
+		"--memory", "1G", "--publish", fmt.Sprintf("%d:3000", port), image("frontend", version)}
+}
+
+// browserPort: the frontend's host port — --port, else 3000.
+func browserPort(opts startOptions) int {
+	if opts.port != 0 {
+		return opts.port
+	}
+	return 3000
 }
 
 func otelArgs(addr string) []string {

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -280,13 +280,24 @@ func Start(args []string) int {
 
 	// Codespace placement dispatches before anything local: no root
 	// discovery (the record replaces the clone), no config load, no local
-	// preflight. Explicit --runtime codespace, or a recorded codespace stack
-	// binding an implicit start (rejoin what exists, as with any record).
+	// preflight. Explicit --runtime codespace; or, implicitly, a bare start
+	// on a machine whose ONLY recorded stack(s) are codespaces — one resumes
+	// (rejoin what exists), several must be named. A local record wins the
+	// bare start (codespace stacks coexist; only the lens contends, dropped
+	// below).
 	if opts.runtime == "codespace" {
 		return startCodespace(u, opts)
 	}
 	if opts.runtime == "" {
-		if recSt := loadState(); recSt != nil && recSt.Runtime == "codespace" {
+		ss := loadStackSet()
+		if cs := codespaceStacks(ss); ss.Stacks["local"] == nil && len(cs) > 0 {
+			if len(cs) > 1 {
+				u.fail("%d codespace stacks are recorded — say which:", len(cs))
+				for _, c := range cs {
+					fmt.Fprintf(os.Stderr, "    semiont start --runtime codespace --repo %s\n", c.Repo)
+				}
+				return 1
+			}
 			if !onPath("gh") {
 				u.fail("A codespace stack is recorded (per %s) but 'gh' is not on PATH.", statePath())
 				fmt.Fprintln(os.Stderr, "  Install the GitHub CLI, or forget the stack:  semiont stop --delete")
@@ -429,7 +440,7 @@ func Start(args []string) int {
 	// staged configs out from under its live mounts. A record whose runtime
 	// is no longer installed is stale (that stack cannot be running) and
 	// doesn't bind anything.
-	if recSt := loadState(); recSt != nil && recSt.Runtime != "" && recSt.Runtime != rt && recordBinds(recSt.Runtime) {
+	if recSt := loadLocalState(); recSt != nil && recSt.Runtime != "" && recSt.Runtime != rt && onPath(recSt.Runtime) {
 		if opts.runtime == "" {
 			rt = recSt.Runtime
 			rtFrom = ""
@@ -530,6 +541,20 @@ func Start(args []string) int {
 		}
 		return 0
 	}
+	// A codespace KB forward may squat on a port this start claims (a
+	// forward is a view, not a stack — dropping one stops nothing in the
+	// cloud). Only colliding forwards drop; concurrent KBs on allocated
+	// ports keep running.
+	if !opts.dryRun {
+		var needs []portNeed
+		if opts.service != "" {
+			needs = servicePortNeeds(opts.service, plan) // nil-plan-safe (frontend, traces)
+		} else {
+			needs = planPortChecks(plan, opts.observe) // full start always has a plan
+		}
+		dropCollidingForwards(u, needs)
+	}
+
 	// Record sticky preferences only when this start SUCCEEDED with the
 	// explicit flag: preferences are "what I actually run", so a typo'd
 	// name or an unlaunchable choice never becomes the default. Implicit

--- a/apps/launcher/internal/launcher/statefile.go
+++ b/apps/launcher/internal/launcher/statefile.go
@@ -5,16 +5,22 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 	"time"
 )
 
-// The launcher records what it believes the current stack IS — which runtime
-// started it, and each service's container name, runtime-reported ID, and
-// image — in stack.json under the XDG state home. stop and status compute
-// their work from these identifiers (falling back to the historical
-// all-runtimes name sweep only when no record exists, e.g. a stack started
-// by an older launcher). The record is belief, not ground truth: status
-// still verifies every claim against the runtime and the health endpoints.
+// The launcher records what it believes each stack IS in stack.json under
+// the XDG state home. Schema 3 is a KEYED COLLECTION: the machine's one
+// LOCAL stack under "local" (fixed ports and container names keep it
+// singleton), plus one entry per codespace stack under "codespace:<repo>" —
+// codespace stacks don't collide in the cloud, so many may run at once,
+// each forwarding its KB on its own local port (4000, else allocated above
+// it); local ports are the only contention point. stop and status compute their
+// work from these identifiers (falling back to the historical all-runtimes
+// name sweep only when no record exists). The record is belief, not ground
+// truth: status still verifies every claim against the runtime, gh, and
+// the health endpoints. Schema 1/2 single-stack files are migrated on read.
 
 // Provided values (schema 2): who provides this role.
 const (
@@ -36,21 +42,21 @@ type serviceState struct {
 }
 
 type stackState struct {
-	Schema     int                     `json:"schema"`
-	UpdatedAt  time.Time               `json:"updatedAt"`
-	Launcher   string                  `json:"launcherVersion"`
-	Runtime    string                  `json:"runtime"`
-	KBRoot     string                  `json:"kbRoot,omitempty"`
-	KBDid      string                  `json:"kbDid,omitempty"` // did:web from .semiont/config
-	Config     string                  `json:"config,omitempty"`
-	Version    string                  `json:"imageVersion,omitempty"`
-	HostAddr   string                  `json:"hostAddr,omitempty"`
-	Stage      string                  `json:"configStage,omitempty"`
-	Ports      []int                   `json:"ports,omitempty"`      // host ports this stack claimed — stop verifies their release
-	Codespace  string                  `json:"codespace,omitempty"`  // runtime "codespace": the instance name (a PID — never user input)
-	Repo       string                  `json:"repo,omitempty"`       // runtime "codespace": owner/name slug (the user-facing identity)
-	ForwardPID int                     `json:"forwardPid,omitempty"` // runtime "codespace": the detached `gh codespace ports forward`
-	Services   map[string]serviceState `json:"services"`
+	Schema      int                     `json:"schema,omitempty"` // legacy single-stack files only (read-compat)
+	UpdatedAt   time.Time               `json:"updatedAt"`
+	Runtime     string                  `json:"runtime"`
+	KBRoot      string                  `json:"kbRoot,omitempty"`
+	KBDid       string                  `json:"kbDid,omitempty"` // did:web from .semiont/config
+	Config      string                  `json:"config,omitempty"`
+	Version     string                  `json:"imageVersion,omitempty"`
+	HostAddr    string                  `json:"hostAddr,omitempty"`
+	Stage       string                  `json:"configStage,omitempty"`
+	Ports       []int                   `json:"ports,omitempty"`       // host ports this stack claimed — stop verifies their release
+	Codespace   string                  `json:"codespace,omitempty"`   // runtime "codespace": the instance name (a PID — never user input)
+	Repo        string                  `json:"repo,omitempty"`        // runtime "codespace": owner/name slug (the user-facing identity)
+	ForwardPID  int                     `json:"forwardPid,omitempty"`  // runtime "codespace": the detached `gh codespace ports forward`
+	ForwardPort int                     `json:"forwardPort,omitempty"` // runtime "codespace": this stack's local KB port (4000, or allocated above)
+	Services    map[string]serviceState `json:"services"`
 }
 
 // stateDir is the launcher's XDG state home: ~/Library/Application Support/
@@ -82,23 +88,57 @@ func statePath() string {
 	return filepath.Join(dir, "stack.json")
 }
 
-// loadState returns the recorded stack state, or nil when none exists (or it
-// is unreadable/corrupt — treated as no record, never as an error).
-func loadState() *stackState {
+// stackSet is the on-disk shape (schema 3): every recorded stack, keyed.
+type stackSet struct {
+	Schema    int                    `json:"schema"`
+	UpdatedAt time.Time              `json:"updatedAt"`
+	Launcher  string                 `json:"launcherVersion"`
+	Stacks    map[string]*stackState `json:"stacks"`
+}
+
+// stackKey: "local" for the machine's one local stack, "codespace:<repo>"
+// per codespace stack (the repo is the user-facing identity there).
+func stackKey(st *stackState) string {
+	if st.Runtime == "codespace" {
+		return "codespace:" + st.Repo
+	}
+	return "local"
+}
+
+// loadStackSet returns every recorded stack (never nil; empty when no file).
+// Schema 1/2 single-stack files migrate in memory — the next save writes
+// schema 3.
+func loadStackSet() *stackSet {
+	ss := &stackSet{Schema: 3, Stacks: map[string]*stackState{}}
 	p := statePath()
 	if p == "" {
-		return nil
+		return ss
 	}
 	b, err := os.ReadFile(p)
 	if err != nil {
-		return nil
+		return ss
 	}
+	var probe struct {
+		Schema int             `json:"schema"`
+		Stacks json.RawMessage `json:"stacks"`
+	}
+	if json.Unmarshal(b, &probe) != nil {
+		return ss
+	}
+	if probe.Stacks != nil {
+		var full stackSet
+		if json.Unmarshal(b, &full) == nil && full.Stacks != nil {
+			full.Schema = 3
+			return &full
+		}
+		return ss
+	}
+	// Legacy single-stack file (schema 1/2).
 	var st stackState
 	if json.Unmarshal(b, &st) != nil || st.Services == nil {
-		return nil
+		return ss
 	}
-	// Schema 1 read-compat: hostReuse was the only non-launcher marker.
-	if st.Schema < 2 {
+	if probe.Schema < 2 { // schema 1: hostReuse was the only non-launcher marker
 		for role, e := range st.Services {
 			if e.Provided == "" {
 				e.Provided = providedLauncher
@@ -109,20 +149,43 @@ func loadState() *stackState {
 			}
 		}
 	}
-	return &st
+	ss.Stacks[stackKey(&st)] = &st
+	return ss
 }
 
-// saveState writes the record atomically (temp + rename). Best-effort: a
-// failure to record belief never fails the command that formed it.
-func saveState(st *stackState) {
+// loadLocalState: the machine's one local stack record, or nil.
+func loadLocalState() *stackState {
+	return loadStackSet().Stacks["local"]
+}
+
+// codespaceStacks: every recorded codespace stack, sorted by repo.
+func codespaceStacks(ss *stackSet) []*stackState {
+	var out []*stackState
+	for k, st := range ss.Stacks {
+		if strings.HasPrefix(k, "codespace:") {
+			out = append(out, st)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Repo < out[j].Repo })
+	return out
+}
+
+// saveStackSet writes the collection atomically (temp + rename); an empty
+// set removes the file — "no record" stays a clean, observable state.
+// Best-effort: a failure to record belief never fails the command.
+func saveStackSet(ss *stackSet) {
 	p := statePath()
 	if p == "" {
 		return
 	}
-	st.UpdatedAt = time.Now().UTC()
-	st.Launcher = BuildVersion
-	st.Schema = 2
-	b, err := json.MarshalIndent(st, "", "  ")
+	if len(ss.Stacks) == 0 {
+		_ = os.Remove(p)
+		return
+	}
+	ss.Schema = 3
+	ss.UpdatedAt = time.Now().UTC()
+	ss.Launcher = BuildVersion
+	b, err := json.MarshalIndent(ss, "", "  ")
 	if err != nil {
 		return
 	}
@@ -136,11 +199,21 @@ func saveState(st *stackState) {
 	_ = os.Rename(tmp, p)
 }
 
-// removeState forgets the stack (full stop).
-func removeState() {
-	if p := statePath(); p != "" {
-		_ = os.Remove(p)
-	}
+// saveStack upserts one stack into the collection.
+func saveStack(st *stackState) {
+	st.UpdatedAt = time.Now().UTC()
+	st.Schema = 0 // schema lives on the set now
+	ss := loadStackSet()
+	ss.Stacks[stackKey(st)] = st
+	saveStackSet(ss)
+}
+
+// forgetStack removes one stack from the collection (full local stop,
+// codespace delete). Other stacks' records survive.
+func forgetStack(key string) {
+	ss := loadStackSet()
+	delete(ss.Stacks, key)
+	saveStackSet(ss)
 }
 
 // recordService updates one service's entry and saves. provided says who
@@ -158,5 +231,5 @@ func (st *stackState) recordService(role, id, image, provided, endpoint, driver 
 		e.Container = roles[role].container
 	}
 	st.Services[role] = e
-	saveState(st)
+	saveStack(st)
 }

--- a/apps/launcher/internal/launcher/statefile.go
+++ b/apps/launcher/internal/launcher/statefile.go
@@ -36,18 +36,21 @@ type serviceState struct {
 }
 
 type stackState struct {
-	Schema    int                     `json:"schema"`
-	UpdatedAt time.Time               `json:"updatedAt"`
-	Launcher  string                  `json:"launcherVersion"`
-	Runtime   string                  `json:"runtime"`
-	KBRoot    string                  `json:"kbRoot,omitempty"`
-	KBDid     string                  `json:"kbDid,omitempty"` // did:web from .semiont/config
-	Config    string                  `json:"config,omitempty"`
-	Version   string                  `json:"imageVersion,omitempty"`
-	HostAddr  string                  `json:"hostAddr,omitempty"`
-	Stage     string                  `json:"configStage,omitempty"`
-	Ports     []int                   `json:"ports,omitempty"` // host ports this stack claimed — stop verifies their release
-	Services  map[string]serviceState `json:"services"`
+	Schema     int                     `json:"schema"`
+	UpdatedAt  time.Time               `json:"updatedAt"`
+	Launcher   string                  `json:"launcherVersion"`
+	Runtime    string                  `json:"runtime"`
+	KBRoot     string                  `json:"kbRoot,omitempty"`
+	KBDid      string                  `json:"kbDid,omitempty"` // did:web from .semiont/config
+	Config     string                  `json:"config,omitempty"`
+	Version    string                  `json:"imageVersion,omitempty"`
+	HostAddr   string                  `json:"hostAddr,omitempty"`
+	Stage      string                  `json:"configStage,omitempty"`
+	Ports      []int                   `json:"ports,omitempty"`      // host ports this stack claimed — stop verifies their release
+	Codespace  string                  `json:"codespace,omitempty"`  // runtime "codespace": the instance name (a PID — never user input)
+	Repo       string                  `json:"repo,omitempty"`       // runtime "codespace": owner/name slug (the user-facing identity)
+	ForwardPID int                     `json:"forwardPid,omitempty"` // runtime "codespace": the detached `gh codespace ports forward`
+	Services   map[string]serviceState `json:"services"`
 }
 
 // stateDir is the launcher's XDG state home: ~/Library/Application Support/

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -99,6 +99,13 @@ func Status(args []string) int {
 	// the runtime reported at start — the record is belief; every claim below
 	// is still verified against the runtime and the health endpoints.
 	st := loadState()
+	if st != nil && st.Runtime == "codespace" && runtime == "" {
+		if service != "" {
+			u.fail("--service does not apply to a codespace stack; semiont status reports it whole.")
+			return 1
+		}
+		return statusCodespace(u, st)
+	}
 	var runtimes []string
 	if runtime != "" {
 		if !onPath(runtime) {

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -11,7 +11,12 @@ import (
 	"unicode/utf8"
 )
 
-const statusUsage = `Usage: semiont status [--service <name>] [--runtime container|docker|podman]
+const statusUsage = `Usage: semiont status [--service <name>] [--runtime container|docker|podman] [--repo <owner/name>]
+
+With codespace stacks recorded, status opens with a STACKS overview (every
+recorded stack, its state, and each forwarded KB's local port), then details
+the lone forwarded stack — or the local one; with several forwarded, the
+overview stands and --repo details a specific codespace stack.
 
 Report each Semiont container's runtime state and application-level health.
 
@@ -63,6 +68,7 @@ func Status(args []string) int {
 	u := newUI(false)
 	runtime := ""
 	service := ""
+	repoFlag := ""
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--runtime":
@@ -71,6 +77,13 @@ func Status(args []string) int {
 				return 1
 			}
 			runtime = args[i+1]
+			i++
+		case "--repo":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --repo")
+				return 1
+			}
+			repoFlag = args[i+1]
 			i++
 		case "--service":
 			if i+1 >= len(args) {
@@ -98,13 +111,49 @@ func Status(args []string) int {
 	// runtime that actually started the stack, and supplies the identifiers
 	// the runtime reported at start — the record is belief; every claim below
 	// is still verified against the runtime and the health endpoints.
-	st := loadState()
-	if st != nil && st.Runtime == "codespace" && runtime == "" {
+	ss := loadStackSet()
+	cs := codespaceStacks(ss)
+	st := ss.Stacks["local"]
+	// Codespace stacks: --repo targets one for detail; otherwise the STACKS
+	// overview shows the fleet, with detail for the lens holder (the stack
+	// localhost currently points at) or the lone codespace when no local
+	// stack exists.
+	if repoFlag != "" {
+		target := ss.Stacks["codespace:"+repoFlag]
+		if target == nil {
+			u.fail("No codespace stack recorded for %s.", repoFlag)
+			return 1
+		}
 		if service != "" {
 			u.fail("--service does not apply to a codespace stack; semiont status reports it whole.")
 			return 1
 		}
-		return statusCodespace(u, st)
+		return statusCodespace(u, target)
+	}
+	if len(cs) > 0 && runtime == "" {
+		printStacksOverview(u, st, cs)
+		fwd := forwardedStacks(cs)
+		var target *stackState
+		switch {
+		case len(fwd) == 1:
+			target = fwd[0]
+		case len(fwd) == 0 && st == nil && len(cs) == 1:
+			target = cs[0]
+		}
+		if target != nil {
+			if service != "" {
+				u.fail("--service does not apply to a codespace stack; semiont status reports it whole.")
+				return 1
+			}
+			return statusCodespace(u, target)
+		}
+		if st == nil {
+			fmt.Println()
+			fmt.Printf("  Details: %s\n", u.bold("semiont status --repo <owner/name>"))
+			return 0
+		}
+		// A local stack exists: detail it below (several forwarded
+		// codespaces stay overview-level — --repo details one).
 	}
 	var runtimes []string
 	if runtime != "" {

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const stopUsage = `Usage: semiont stop [--service <name>] [--runtime container|docker|podman] [--delete] [--dry-run]
+const stopUsage = `Usage: semiont stop [--service <name>] [--runtime container|docker|podman] [--repo <owner/name>] [--delete] [--dry-run]
 
 Stop the whole Semiont stack — services, dependencies, and observability —
 and clean up the staged config copies. Safe to run when nothing is up:
@@ -26,6 +26,9 @@ A CODESPACE stack (started with --runtime codespace) stops with
 'gh codespace stop': billing halts, state and credentials persist, and the
 record is kept — resume with semiont start. --delete destroys the codespace
 (state and all) and forgets the record; it applies only to codespace stacks.
+With several stacks recorded (local + codespaces), a bare stop refuses and
+lists them: --repo <owner/name> targets a codespace stack, --runtime targets
+the local one.
 `
 
 // stopNames sweeps all ten container names in REVERSE start order —
@@ -43,6 +46,7 @@ func Stop(args []string) int {
 	u := newUI(false)
 	runtime := ""
 	service := ""
+	repo := ""
 	dryRun := false
 	del := false
 	for i := 0; i < len(args); i++ {
@@ -60,6 +64,13 @@ func Stop(args []string) int {
 				return 1
 			}
 			service = args[i+1]
+			i++
+		case "--repo":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --repo")
+				return 1
+			}
+			repo = args[i+1]
 			i++
 		case "--delete":
 			del = true
@@ -91,15 +102,37 @@ func Stop(args []string) int {
 	// those instead of a blind every-runtime name sweep. An explicit
 	// --runtime overrides; no record (older launcher, other machine) falls
 	// back to the historical sweep.
-	st := loadState()
+	ss := loadStackSet()
+	cs := codespaceStacks(ss)
+	st := ss.Stacks["local"]
 
-	// A codespace stack dispatches to its own teardown (gh codespace
-	// stop/delete); an explicit --runtime keeps its narrow local meaning —
-	// the existing flow then honestly reports the codespace record as
-	// untouched. --delete means nothing for local stacks (stop+rm already
-	// destroys them).
-	if st != nil && st.Runtime == "codespace" && runtime == "" {
-		return stopCodespace(u, st, service, del, dryRun)
+	// Codespace stacks: --repo targets one; a bare stop resolves only when
+	// unambiguous (destructive commands don't guess among stacks). An
+	// explicit --runtime keeps its narrow local meaning. --delete means
+	// nothing for local stacks (stop+rm already destroys them).
+	if repo != "" {
+		target := ss.Stacks["codespace:"+repo]
+		if target == nil {
+			u.fail("No codespace stack recorded for %s.", repo)
+			for _, c := range cs {
+				fmt.Fprintf(os.Stderr, "    recorded: %s\n", c.Repo)
+			}
+			return 1
+		}
+		return stopCodespace(u, target, service, del, dryRun)
+	}
+	if runtime == "" && len(cs) > 0 {
+		if st == nil && len(cs) == 1 {
+			return stopCodespace(u, cs[0], service, del, dryRun)
+		}
+		u.fail("Multiple stacks are recorded — say which:")
+		if st != nil {
+			fmt.Fprintf(os.Stderr, "    semiont stop --runtime %s   (the local stack)\n", st.Runtime)
+		}
+		for _, c := range cs {
+			fmt.Fprintf(os.Stderr, "    semiont stop --repo %s\n", c.Repo)
+		}
+		return 1
 	}
 	if del {
 		u.fail("--delete only applies to a codespace stack (a local stop already removes the containers).")
@@ -252,7 +285,7 @@ func Stop(args []string) int {
 		// The record forgets this one service; the rest of it stands.
 		if useState {
 			delete(st.Services, service)
-			saveState(st)
+			saveStack(st)
 		}
 		fmt.Printf("%s stopped (staged configs left in place; rest of the stack untouched).\n", service)
 		return 0
@@ -276,7 +309,7 @@ func Stop(args []string) int {
 	if len(staged) > 0 {
 		u.ok("Removed %d staged config dir(s)", len(staged))
 	}
-	removeState()
+	forgetStack("local")
 
 	// Say what actually happened: a stop that found nothing anywhere (the
 	// second stop in a row) is a no-op, not a teardown.

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const stopUsage = `Usage: semiont stop [--service <name>] [--runtime container|docker|podman] [--dry-run]
+const stopUsage = `Usage: semiont stop [--service <name>] [--runtime container|docker|podman] [--delete] [--dry-run]
 
 Stop the whole Semiont stack — services, dependencies, and observability —
 and clean up the staged config copies. Safe to run when nothing is up:
@@ -21,6 +21,11 @@ With --service <name>, stop just that one service (backend, worker, smelter,
 weaver, frontend, database, graph, vectors, inference, or traces). The staged
 config copies are left in place — the rest of the stack is still mounting
 them.
+
+A CODESPACE stack (started with --runtime codespace) stops with
+'gh codespace stop': billing halts, state and credentials persist, and the
+record is kept — resume with semiont start. --delete destroys the codespace
+(state and all) and forgets the record; it applies only to codespace stacks.
 `
 
 // stopNames sweeps all ten container names in REVERSE start order —
@@ -39,6 +44,7 @@ func Stop(args []string) int {
 	runtime := ""
 	service := ""
 	dryRun := false
+	del := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--runtime":
@@ -55,6 +61,8 @@ func Stop(args []string) int {
 			}
 			service = args[i+1]
 			i++
+		case "--delete":
+			del = true
 		case "--dry-run":
 			dryRun = true
 		case "--help", "-h":
@@ -84,6 +92,20 @@ func Stop(args []string) int {
 	// --runtime overrides; no record (older launcher, other machine) falls
 	// back to the historical sweep.
 	st := loadState()
+
+	// A codespace stack dispatches to its own teardown (gh codespace
+	// stop/delete); an explicit --runtime keeps its narrow local meaning —
+	// the existing flow then honestly reports the codespace record as
+	// untouched. --delete means nothing for local stacks (stop+rm already
+	// destroys them).
+	if st != nil && st.Runtime == "codespace" && runtime == "" {
+		return stopCodespace(u, st, service, del, dryRun)
+	}
+	if del {
+		u.fail("--delete only applies to a codespace stack (a local stop already removes the containers).")
+		return 1
+	}
+
 	// The ports this stack claimed, captured before the record may be
 	// discarded below — release verification reads them after the sweep.
 	recordedPorts := []int(nil)

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -172,17 +172,9 @@ func capture(name string, args ...string) (string, error) {
 
 // runtimeOrder is the auto-detect order; on a Mac with several installed,
 // Apple `container` wins. "codespace" is a placement value, never
-// auto-detected and never sticky — it dispatches before selection.
+// auto-detected and never sticky — it dispatches before selection, and its
+// stacks live under their own keys in the record set.
 var runtimeOrder = []string{"container", "docker", "podman"}
-
-// recordBinds: does a recorded runtime still bind subsequent commands? A
-// local runtime binds while its CLI is installed (uninstalled ⇒ that stack
-// cannot be running ⇒ the record is stale). A codespace stack lives on
-// GitHub's machine — it binds regardless of local tooling; erasing its
-// record would orphan knowledge of a possibly-running, billable VM.
-func recordBinds(rt string) bool {
-	return rt == "codespace" || onPath(rt)
-}
 
 func onPath(name string) bool {
 	_, err := exec.LookPath(name)

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -171,8 +171,18 @@ func capture(name string, args ...string) (string, error) {
 // --- Runtime selection ---
 
 // runtimeOrder is the auto-detect order; on a Mac with several installed,
-// Apple `container` wins.
+// Apple `container` wins. "codespace" is a placement value, never
+// auto-detected and never sticky — it dispatches before selection.
 var runtimeOrder = []string{"container", "docker", "podman"}
+
+// recordBinds: does a recorded runtime still bind subsequent commands? A
+// local runtime binds while its CLI is installed (uninstalled ⇒ that stack
+// cannot be running ⇒ the record is stale). A codespace stack lives on
+// GitHub's machine — it binds regardless of local tooling; erasing its
+// record would orphan knowledge of a possibly-running, billable VM.
+func recordBinds(rt string) bool {
+	return rt == "codespace" || onPath(rt)
+}
 
 func onPath(name string) bool {
 	_, err := exec.LookPath(name)

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -159,6 +159,16 @@ func runDetached(name string, args ...string) (string, error) {
 	return strings.TrimSpace(out.String()), err
 }
 
+// runWithStdin feeds input on stdin and shows stderr — for handing a secret
+// value to a subprocess without it ever appearing in argv (where any process
+// on the machine could read it via ps).
+func runWithStdin(name, input string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Stdout, cmd.Stderr = io.Discard, os.Stderr
+	return cmd.Run()
+}
+
 // capture runs a command returning trimmed stdout, stderr discarded.
 func capture(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)

--- a/apps/launcher/internal/launcher/useradd.go
+++ b/apps/launcher/internal/launcher/useradd.go
@@ -57,6 +57,14 @@ func Useradd(args []string) int {
 		return 1
 	}
 
+	// The §1 asymmetry: a codespace stack generated its admin at creation —
+	// the job is to READ those credentials, not mint users from here.
+	if st := loadState(); st != nil && st.Runtime == "codespace" {
+		u.fail("This stack runs in a codespace; its admin credentials were generated at creation.")
+		fmt.Fprintln(os.Stderr, "  semiont status shows them (read from the codespace's .devcontainer/admin.json).")
+		return 1
+	}
+
 	rt, handle := backendHandle()
 	if rt == "" {
 		u.fail("useradd needs a running backend, and none was found under any installed runtime.")

--- a/apps/launcher/internal/launcher/useradd.go
+++ b/apps/launcher/internal/launcher/useradd.go
@@ -58,9 +58,10 @@ func Useradd(args []string) int {
 	}
 
 	// The §1 asymmetry: a codespace stack generated its admin at creation —
-	// the job is to READ those credentials, not mint users from here.
-	if st := loadState(); st != nil && st.Runtime == "codespace" {
-		u.fail("This stack runs in a codespace; its admin credentials were generated at creation.")
+	// the job is to READ those credentials, not mint users from here. With
+	// a LOCAL stack alongside, useradd targets it as usual.
+	if ss := loadStackSet(); ss.Stacks["local"] == nil && len(codespaceStacks(ss)) > 0 {
+		u.fail("The recorded stack(s) run in codespaces; their admin credentials were generated at creation.")
 		fmt.Fprintln(os.Stderr, "  semiont status shows them (read from the codespace's .devcontainer/admin.json).")
 		return 1
 	}
@@ -85,7 +86,7 @@ func Useradd(args []string) int {
 // that runtime is installed), else the name under whichever runtime's
 // listing shows semiont-backend.
 func backendHandle() (rt, handle string) {
-	if st := loadState(); st != nil && st.Runtime != "" && onPath(st.Runtime) {
+	if st := loadLocalState(); st != nil && st.Runtime != "" && onPath(st.Runtime) {
 		if e, ok := st.Services["backend"]; ok && e.Provided == providedLauncher {
 			if e.ID != "" {
 				return st.Runtime, e.ID

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1386,6 +1386,25 @@ func TestCodespaceMachineInertOnResume(t *testing.T) {
 		"--machine largePremiumLinux ignored", "keeps the class it was created with")
 }
 
+func TestCodespaceCredentialFailureShowsGhError(t *testing.T) {
+	// A failed credentials read must report what gh SAID, not guess between
+	// causes in prose — and must not block an otherwise healthy stack.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv, "FAKERT_GH_SSH_FAIL=1")
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("an unreadable admin.json must not fail the start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "stdout", stdout,
+		"Could not read admin credentials over ssh yet",
+		"gh: failed to start SSH server", // gh's own words, surfaced
+		"Usually setup is still finishing",
+		"Semiont KB is up in codespace") // stack still reported up
+	if strings.Contains(stdout, "Connect as ") {
+		t.Errorf("printed credentials it never read:\n%s", stdout)
+	}
+}
+
 func TestCodespaceStopKeepsRecordDeleteForgets(t *testing.T) {
 	s := newCodespaceScenario(t)
 	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -971,7 +971,7 @@ func TestStartSecretProviderMissing(t *testing.T) {
 // --- codespace placement (CODESPACE-KB-LAUNCH.md §2) ---
 
 const csRepo = "pingel-org/foo-kb"
-const csSecretRepos = `{"total_count":1,"repositories":[{"full_name":"pingel-org/foo-kb"}]}`
+const csSecretRepos = `{"total_count":2,"repositories":[{"full_name":"pingel-org/foo-kb"},{"full_name":"other/bar"}]}`
 
 func newCodespaceScenario(t *testing.T) *scenario {
 	s := newScenario(t, "container", "gh")
@@ -997,20 +997,22 @@ func TestCodespaceStartCreates(t *testing.T) {
 		"gh api user/codespaces/secrets/ANTHROPIC_API_KEY/repositories",
 		"gh codespace list --json name,state,repository",
 		"gh codespace create --repo "+csRepo+" --machine premiumLinux",
-		"gh codespace ports forward 3000:3000 4000:4000 9090:9090 9091:9091 9092:9092 -c fake-cs-1",
+		"gh codespace ports forward 4000:4000 -c fake-cs-1",
 		"gh codespace ssh -c fake-cs-1 -- cat .devcontainer/admin.json")
 	mustContain(t, "stdout", stdout,
 		"KB repo: "+csRepo,
 		"uncommitted changes", "as PUSHED",
 		"Creating codespace for "+csRepo,
 		"Reading admin credentials",
-		"Semiont stack is up in codespace fake-cs-1",
+		"Semiont KB is up in codespace fake-cs-1",
+		"Semiont KB         http://localhost:4000",
 		"admin@example.com", "fake-admin-pw",
 		"local uncommitted changes don't travel",
 		"Halt billing:")
 	b, _ := os.ReadFile(statePathFor(s.home))
 	mustContain(t, "stack.json", string(b),
-		`"runtime": "codespace"`, `"codespace": "fake-cs-1"`, `"repo": "pingel-org/foo-kb"`, `"forwardPid"`)
+		`"runtime": "codespace"`, `"codespace": "fake-cs-1"`, `"repo": "pingel-org/foo-kb"`,
+		`"forwardPid"`, `"forwardPort": 4000`)
 	if strings.Contains(string(b), "fake-admin-pw") {
 		t.Fatalf("credentials persisted to stack.json:\n%s", b)
 	}
@@ -1047,13 +1049,27 @@ func TestCodespaceBareResumeRootless(t *testing.T) {
 		t.Errorf("resume attempted root discovery:\n%s", log)
 	}
 
-	// --repo mismatch against the record refuses.
+	// A different --repo is not a mismatch — it's a SECOND stack: codespace
+	// stacks coexist, keyed by repo.
 	s.killServes()
-	_, stderr, code = s.run(t, "start", "--runtime", "codespace", "--repo", "other/bar")
-	if code != 1 {
-		t.Fatalf("repo mismatch: want exit 1, got %d", code)
+	stdout, stderr, code = s.run(t, "start", "--runtime", "codespace", "--repo", "other/bar")
+	if code != 0 {
+		t.Fatalf("second repo: exit %d\nstderr:\n%s", code, stderr)
 	}
-	mustContain(t, "stderr", stderr, "recorded codespace stack is for "+csRepo)
+	b, _ := os.ReadFile(statePathFor(s.home))
+	mustContain(t, "stack.json", string(b), "codespace:"+csRepo, "codespace:other/bar",
+		`"forwardPort": 4001`) // foo's recorded 4000 stays reserved for its re-attach
+
+	// With several codespace stacks and none forwarded, a bare start must
+	// be told which.
+	s.killServes()
+	_, stderr, code = s.run(t, "start")
+	if code != 1 {
+		t.Fatalf("ambiguous bare start: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr,
+		"2 codespace stacks are recorded",
+		"--repo "+csRepo, "--repo other/bar")
 }
 
 func TestCodespaceAdoptAndDisambiguate(t *testing.T) {
@@ -1201,10 +1217,11 @@ func TestCodespaceStatus(t *testing.T) {
 		t.Fatalf("status: exit %d\nstdout:\n%s", code, stdout)
 	}
 	mustContain(t, "status stdout", stdout,
+		"STACKS",
 		"CODESPACE", "fake-cs-1", csRepo, "(state: Available)",
 		"re-establishing",
-		"backend", "healthy",
-		"runs inside the codespace via compose",
+		"KB", "healthy", "http://localhost:4000/api/health",
+		"run inside the codespace via compose",
 		"admin@example.com", "fake-admin-pw",
 		"SEMIONT ROOTS")
 
@@ -1228,19 +1245,21 @@ func TestCodespaceGuardsAndScoping(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("local record + codespace start: want exit 1, got %d", code)
 	}
-	mustContain(t, "stderr", stderr, "A recorded stack is running under container")
+	mustContain(t, "stderr", stderr, "The local stack is running under container")
 
 	s2 := newCodespaceScenario(t)
 	if _, _, code := s2.run(t, "start", "--runtime", "codespace"); code != 0 {
 		t.Fatal("create failed")
 	}
 	s2.killServes()
-	_, stderr, code = s2.run(t, "start", "--runtime", "container")
-	if code != 1 {
-		t.Fatalf("codespace record + local start: want exit 1, got %d", code)
+	// A codespace stack no longer blocks a local start — they coexist (the
+	// dry-run proves the local plan renders; only the lens would contend,
+	// and it's dropped live).
+	stdout, stderr, code := s2.run(t, "start", "--runtime", "container", "--dry-run")
+	if code != 0 {
+		t.Fatalf("codespace record + local dry-run: exit %d\nstderr:\n%s", code, stderr)
 	}
-	mustContain(t, "stderr", stderr,
-		"A recorded stack is running under codespace", "--runtime codespace")
+	mustContain(t, "local plan stdout", stdout, "container run -d --rm --name semiont-backend")
 
 	// useradd refuses: the admin was generated at creation.
 	_, stderr, code = s2.run(t, "useradd", "--email", "a@b.co", "--password", "password123")
@@ -1314,6 +1333,148 @@ func TestCodespaceDryRunAndLogs(t *testing.T) {
 	log, _ := os.ReadFile(s.log)
 	mustContain(t, "argv log", string(log),
 		"gh codespace ssh -c fake-cs-1 -- docker logs --follow semiont-backend")
+}
+
+func TestMultiStackCodespaces(t *testing.T) {
+	// Many codespace stacks run CONCURRENTLY, each forwarding its KB on its
+	// own local port — one browser works them all via the Knowledge Bases
+	// panel. Nothing switches; nothing drops.
+	s := newCodespaceScenario(t)
+	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatalf("foo start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	// foo's forward stays alive; bar allocates the next KB port.
+	s.extraEnv = append(s.extraEnv, "FAKERT_GH_CS_NAME=bar-cs-1")
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace", "--repo", "other/bar")
+	if code != 0 {
+		t.Fatalf("bar start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "bar stdout", stdout, "Semiont KB         http://localhost:4001")
+	if strings.Contains(stdout, "Switching") || strings.Contains(stdout, "Dropping") {
+		t.Errorf("concurrent start disturbed the other stack's forward:\n%s", stdout)
+	}
+	b, _ := os.ReadFile(statePathFor(s.home))
+	mustContain(t, "stack.json", string(b),
+		"codespace:"+csRepo, "codespace:other/bar", `"codespace": "bar-cs-1"`,
+		`"forwardPort": 4000`, `"forwardPort": 4001`)
+	// BOTH KBs are reachable at once — the point of all of this.
+	for _, url := range []string{"http://localhost:4000/api/health", "http://localhost:4001/api/health"} {
+		resp, err := http.Get(url)
+		if err != nil || resp.StatusCode != 200 {
+			t.Fatalf("concurrent KB %s not reachable: %v", url, err)
+		}
+		resp.Body.Close()
+	}
+
+	// Fleet status: overview shows both with their KB ports; with several
+	// forwarded there is no single detail target — the pointer says so.
+	s.extraEnv = append(s.extraEnv,
+		`FAKERT_GH_CS_LIST=[{"name":"fake-cs-1","state":"Available","repository":"pingel-org/foo-kb"},{"name":"bar-cs-1","state":"Available","repository":"other/bar"}]`)
+	stdout, _, code = s.run(t, "status")
+	if code != 0 {
+		t.Fatalf("fleet status: exit %d\n%s", code, stdout)
+	}
+	mustContain(t, "status stdout", stdout,
+		"STACKS",
+		"codespace  "+csRepo+"  fake-cs-1", "KB localhost:4000",
+		"codespace  other/bar  bar-cs-1", "KB localhost:4001",
+		"semiont status --repo <owner/name>")
+
+	// --repo details one stack, probing ITS port.
+	stdout, _, code = s.run(t, "status", "--repo", "other/bar")
+	if code != 0 {
+		t.Fatalf("detail status: exit %d\n%s", code, stdout)
+	}
+	mustContain(t, "detail stdout", stdout,
+		"bar-cs-1  other/bar", "KB", "healthy", "http://localhost:4001/api/health")
+
+	// Bare logs can't guess between two forwarded stacks; --repo can.
+	_, stderr, code = s.run(t, "logs", "--service", "backend")
+	if code != 1 {
+		t.Fatalf("ambiguous logs: want exit 1, got %d", code)
+	}
+	if err := os.Truncate(s.log, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, code := s.run(t, "logs", "--repo", "other/bar", "--service", "backend"); code != 0 {
+		t.Fatal("targeted logs failed")
+	}
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log), "gh codespace ssh -c bar-cs-1")
+
+	// A bare stop refuses to guess among stacks.
+	_, stderr, code = s.run(t, "stop")
+	if code != 1 {
+		t.Fatalf("ambiguous stop: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "Multiple stacks are recorded",
+		"semiont stop --repo "+csRepo, "semiont stop --repo other/bar")
+
+	// stop --repo targets exactly one; the other stack keeps its forward.
+	stdout, stderr, code = s.run(t, "stop", "--repo", csRepo)
+	if code != 0 {
+		t.Fatalf("targeted stop: exit %d\nstderr:\n%s", code, stderr)
+	}
+	log, _ = os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log), "gh codespace stop -c fake-cs-1")
+	if resp, err := http.Get("http://localhost:4001/api/health"); err != nil || resp.StatusCode != 200 {
+		t.Fatalf("bar's forward died with foo's stop: %v", err)
+	} else {
+		resp.Body.Close()
+	}
+	b, _ = os.ReadFile(statePathFor(s.home))
+	mustContain(t, "stack.json", string(b), "codespace:"+csRepo, "codespace:other/bar")
+
+	// stop --repo --delete forgets only that stack.
+	if _, _, code := s.run(t, "stop", "--repo", "other/bar", "--delete"); code != 0 {
+		t.Fatal("targeted delete failed")
+	}
+	b, _ = os.ReadFile(statePathFor(s.home))
+	if strings.Contains(string(b), "other/bar") {
+		t.Errorf("deleted stack still recorded:\n%s", b)
+	}
+	mustContain(t, "stack.json", string(b), "codespace:"+csRepo)
+}
+
+func TestMultiStackLocalPlusCodespace(t *testing.T) {
+	// A local stack and codespace stacks coexist in the record set: verbs
+	// that can't guess refuse with selectors; useradd targets the local
+	// backend; a targeted local stop leaves the codespace records alone.
+	s := newCodespaceScenario(t)
+	set := `{"schema":3,"stacks":{
+	  "local":{"runtime":"container","services":{"backend":{"container":"semiont-backend","id":"fid-semiont-backend","provided":"launcher","startedAt":"2026-07-19T00:00:00Z"}}},
+	  "codespace:pingel-org/foo-kb":{"runtime":"codespace","codespace":"fake-cs-1","repo":"pingel-org/foo-kb","ports":[3000,4000,9090,9091,9092],"services":{}}}}`
+	p := statePathFor(s.home)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(set), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, code := s.run(t, "stop")
+	if code != 1 {
+		t.Fatalf("ambiguous stop: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "Multiple stacks are recorded",
+		"semiont stop --runtime container", "semiont stop --repo "+csRepo)
+
+	// useradd targets the LOCAL backend when one exists.
+	if _, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--password", "password123"); code != 0 {
+		t.Fatalf("useradd: exit %d\nstderr:\n%s", code, stderr)
+	}
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log), "container exec fid-semiont-backend semiont useradd")
+
+	// A targeted local stop consumes the local record only.
+	if _, stderr, code := s.run(t, "stop", "--runtime", "container"); code != 0 {
+		t.Fatalf("local stop: exit %d\nstderr:\n%s", code, stderr)
+	}
+	b, _ := os.ReadFile(statePathFor(s.home))
+	if strings.Contains(string(b), `"local"`) {
+		t.Errorf("local stack survived its targeted stop:\n%s", b)
+	}
+	mustContain(t, "stack.json", string(b), "codespace:"+csRepo)
 }
 
 // --- config-driven boots (LAUNCHER-CONFIG-SYNC P2) ---
@@ -1772,8 +1933,7 @@ func TestStackStateLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stack.json not written: %v", err)
 	}
-	var st struct {
-		Schema   int    `json:"schema"`
+	type recordedStack struct {
 		Runtime  string `json:"runtime"`
 		Services map[string]struct {
 			Container string `json:"container"`
@@ -1783,11 +1943,19 @@ func TestStackStateLifecycle(t *testing.T) {
 			Endpoint  string `json:"endpoint"`
 		} `json:"services"`
 	}
-	if err := json.Unmarshal(b, &st); err != nil {
+	var set struct {
+		Schema int                      `json:"schema"`
+		Stacks map[string]recordedStack `json:"stacks"`
+	}
+	if err := json.Unmarshal(b, &set); err != nil {
 		t.Fatalf("stack.json not valid JSON: %v\n%s", err, b)
 	}
-	if st.Schema != 2 || st.Runtime != "container" {
-		t.Errorf("schema/runtime: got %d/%q", st.Schema, st.Runtime)
+	st, ok := set.Stacks["local"]
+	if !ok {
+		t.Fatalf("no 'local' stack in the record set:\n%s", b)
+	}
+	if set.Schema != 3 || st.Runtime != "container" {
+		t.Errorf("schema/runtime: got %d/%q", set.Schema, st.Runtime)
 	}
 	for _, role := range []string{"traces", "graph", "vectors", "inference", "database", "backend", "worker", "smelter", "weaver", "frontend"} {
 		e, ok := st.Services[role]

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -968,6 +968,354 @@ func TestStartSecretProviderMissing(t *testing.T) {
 		"the environment always wins")
 }
 
+// --- codespace placement (CODESPACE-KB-LAUNCH.md §2) ---
+
+const csRepo = "pingel-org/foo-kb"
+const csSecretRepos = `{"total_count":1,"repositories":[{"full_name":"pingel-org/foo-kb"}]}`
+
+func newCodespaceScenario(t *testing.T) *scenario {
+	s := newScenario(t, "container", "gh")
+	s.extraEnv = append(s.extraEnv,
+		"FAKERT_GIT_ORIGIN=git@github.com:"+csRepo+".git",
+		"FAKERT_GH_SECRET_REPOS="+csSecretRepos,
+	)
+	return s
+}
+
+func TestCodespaceStartCreates(t *testing.T) {
+	// The whole §1 recipe as one command, from a KB clone: preflights,
+	// create, detached forward, health through it, credentials displayed.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv, "FAKERT_GIT_DIRTY=1")
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log),
+		"gh auth status",
+		"gh api user/codespaces/secrets/ANTHROPIC_API_KEY/repositories",
+		"gh codespace list --json name,state,repository",
+		"gh codespace create --repo "+csRepo+" --machine premiumLinux",
+		"gh codespace ports forward 3000:3000 4000:4000 9090:9090 9091:9091 9092:9092 -c fake-cs-1",
+		"gh codespace ssh -c fake-cs-1 -- cat .devcontainer/admin.json")
+	mustContain(t, "stdout", stdout,
+		"KB repo: "+csRepo,
+		"uncommitted changes", "as PUSHED",
+		"Creating codespace for "+csRepo,
+		"Reading admin credentials",
+		"Semiont stack is up in codespace fake-cs-1",
+		"admin@example.com", "fake-admin-pw",
+		"local uncommitted changes don't travel",
+		"Halt billing:")
+	b, _ := os.ReadFile(statePathFor(s.home))
+	mustContain(t, "stack.json", string(b),
+		`"runtime": "codespace"`, `"codespace": "fake-cs-1"`, `"repo": "pingel-org/foo-kb"`, `"forwardPid"`)
+	if strings.Contains(string(b), "fake-admin-pw") {
+		t.Fatalf("credentials persisted to stack.json:\n%s", b)
+	}
+	// Placement is never sticky: no machine-wide runtime preference written.
+	if rb, err := os.ReadFile(rootsPathFor(s.home)); err == nil && strings.Contains(string(rb), `"runtime": "codespace"`) {
+		t.Errorf("codespace recorded as sticky runtime:\n%s", rb)
+	}
+}
+
+func TestCodespaceBareResumeRootless(t *testing.T) {
+	// After a create, a BARE `semiont start` from any directory resumes the
+	// recorded codespace: no --repo, no clone, no root discovery, no create.
+	s := newCodespaceScenario(t)
+	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatalf("create: exit %d\nstderr:\n%s", code, stderr)
+	}
+	s.killServes()
+	if err := os.Truncate(s.log, 0); err != nil {
+		t.Fatal(err)
+	}
+	s.cwd = t.TempDir() // rootless: nothing resembling a KB here
+	stdout, stderr, code := s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("bare resume: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout,
+		"Using recorded stack's runtime: codespace",
+		"Resuming recorded codespace fake-cs-1")
+	log, _ := os.ReadFile(s.log)
+	if strings.Contains(string(log), "codespace create") {
+		t.Errorf("resume created a new codespace:\n%s", log)
+	}
+	if strings.Contains(string(log), "rev-parse") {
+		t.Errorf("resume attempted root discovery:\n%s", log)
+	}
+
+	// --repo mismatch against the record refuses.
+	s.killServes()
+	_, stderr, code = s.run(t, "start", "--runtime", "codespace", "--repo", "other/bar")
+	if code != 1 {
+		t.Fatalf("repo mismatch: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "recorded codespace stack is for "+csRepo)
+}
+
+func TestCodespaceAdoptAndDisambiguate(t *testing.T) {
+	// No record, the repo already has a codespace (another machine, or a
+	// deleted record): adopt it, announced — never create a second.
+	s := newCodespaceScenario(t)
+	s.cwd = t.TempDir() // no clone anywhere in sight
+	s.extraEnv = append(s.extraEnv,
+		`FAKERT_GH_CS_LIST=[{"name":"old-cs","state":"Shutdown","repository":"pingel-org/foo-kb"}]`)
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace", "--repo", csRepo)
+	if code != 0 {
+		t.Fatalf("adopt: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout, "Found existing codespace for "+csRepo+": old-cs", "resuming, not creating")
+	log, _ := os.ReadFile(s.log)
+	if strings.Contains(string(log), "codespace create") {
+		t.Errorf("adopt created:\n%s", log)
+	}
+
+	// Several codespaces: fail listing them; --codespace disambiguates (the
+	// one corner where the name is ever input).
+	s2 := newCodespaceScenario(t)
+	s2.cwd = t.TempDir()
+	s2.extraEnv = append(s2.extraEnv,
+		`FAKERT_GH_CS_LIST=[{"name":"cs-a","state":"Available","repository":"pingel-org/foo-kb"},{"name":"cs-b","state":"Shutdown","repository":"pingel-org/foo-kb"}]`)
+	_, stderr, code = s2.run(t, "start", "--runtime", "codespace", "--repo", csRepo)
+	if code != 1 {
+		t.Fatalf("several: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "has 2 codespaces", "cs-a", "cs-b", "--codespace <name>")
+	stdout, stderr, code = s2.run(t, "start", "--runtime", "codespace", "--repo", csRepo, "--codespace", "cs-b")
+	if code != 0 {
+		t.Fatalf("disambiguated: exit %d\nstderr:\n%s", code, stderr)
+	}
+	b, _ := os.ReadFile(statePathFor(s2.home))
+	mustContain(t, "stack.json", string(b), `"codespace": "cs-b"`)
+}
+
+func TestCodespaceCreate503Retry(t *testing.T) {
+	// §1's GitHub-side incident: 503s are retried with backoff, then the
+	// create proceeds.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv, "FAKERT_GH_CREATE_FAILS=2")
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout, "GitHub returned 503", "retrying")
+	log, _ := os.ReadFile(s.log)
+	if n := strings.Count(string(log), "gh codespace create"); n != 3 {
+		t.Errorf("want 3 create attempts, got %d:\n%s", n, log)
+	}
+}
+
+func TestCodespacePreflights(t *testing.T) {
+	// §1's silent/late failures become first-second failures — each with
+	// the fix spelled out.
+	for _, tc := range []struct {
+		name string
+		env  []string
+		want []string
+	}{
+		{"scope", []string{"FAKERT_GH_SCOPES='repo'"},
+			[]string{"missing the 'codespace' scope", "gh auth refresh -h github.com -s codespace"}},
+		{"auth", []string{"FAKERT_GH_AUTH_FAIL=1"},
+			[]string{"gh is not authenticated", "gh auth login"}},
+		{"secret", []string{"FAKERT_GH_SECRET_404=1"},
+			[]string{"ANTHROPIC_API_KEY is not a Codespaces user secret", "gh secret set ANTHROPIC_API_KEY"}},
+	} {
+		s := newCodespaceScenario(t)
+		s.extraEnv = append(s.extraEnv, tc.env...)
+		_, stderr, code := s.run(t, "start", "--runtime", "codespace")
+		if code != 1 {
+			t.Errorf("%s: want exit 1, got %d", tc.name, code)
+		}
+		mustContain(t, tc.name+" stderr", stderr, tc.want...)
+	}
+	// gh absent entirely: the earliest failure of all.
+	s := newScenario(t, "container")
+	_, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 1 {
+		t.Fatalf("no gh: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "'gh' is not on PATH", "https://cli.github.com")
+}
+
+func TestCodespaceStopKeepsRecordDeleteForgets(t *testing.T) {
+	s := newCodespaceScenario(t)
+	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatalf("create: exit %d\nstderr:\n%s", code, stderr)
+	}
+
+	// stop: gh codespace stop, forward killed, record KEPT (the codespace
+	// still exists — state and credentials persist).
+	stdout, stderr, code := s.run(t, "stop")
+	if code != 0 {
+		t.Fatalf("stop: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "stop stdout", stdout, "billing halted", "state and credentials persist", "semiont stop --delete")
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log), "gh codespace stop -c fake-cs-1")
+	b, err := os.ReadFile(statePathFor(s.home))
+	if err != nil {
+		t.Fatal("stop forgot a codespace record that still mirrors an existing codespace")
+	}
+	mustContain(t, "stack.json after stop", string(b), `"codespace": "fake-cs-1"`)
+	if strings.Contains(string(b), `"forwardPid"`) {
+		t.Errorf("stop left a dead forward pid recorded:\n%s", b)
+	}
+
+	// stop --delete: destroy and forget.
+	stdout, stderr, code = s.run(t, "stop", "--delete")
+	if code != 0 {
+		t.Fatalf("delete: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "delete stdout", stdout, "deleted", "destroyed")
+	log, _ = os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log), "gh codespace delete -c fake-cs-1 --force")
+	if _, err := os.Stat(statePathFor(s.home)); !os.IsNotExist(err) {
+		t.Error("stack.json survived stop --delete")
+	}
+
+	// --delete is codespace-only.
+	writeStackState(t, s, "container")
+	_, stderr, code = s.run(t, "stop", "--delete")
+	if code != 1 {
+		t.Fatalf("--delete on local record: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "--delete only applies to a codespace stack")
+}
+
+func TestCodespaceStatus(t *testing.T) {
+	s := newCodespaceScenario(t)
+	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatalf("create: exit %d\nstderr:\n%s", code, stderr)
+	}
+	s.killServes() // forward dead: status must re-establish it
+
+	// Available: identity line, healthy table through the respawned
+	// forward, credentials read fresh.
+	s.extraEnv = append(s.extraEnv,
+		`FAKERT_GH_CS_LIST=[{"name":"fake-cs-1","state":"Available","repository":"pingel-org/foo-kb"}]`)
+	stdout, _, code := s.run(t, "status")
+	if code != 0 {
+		t.Fatalf("status: exit %d\nstdout:\n%s", code, stdout)
+	}
+	mustContain(t, "status stdout", stdout,
+		"CODESPACE", "fake-cs-1", csRepo, "(state: Available)",
+		"re-establishing",
+		"backend", "healthy",
+		"runs inside the codespace via compose",
+		"admin@example.com", "fake-admin-pw",
+		"SEMIONT ROOTS")
+
+	// Stopped: honest stopped-but-existing, scriptably unhealthy.
+	s.killServes()
+	s.extraEnv = append(s.extraEnv[:len(s.extraEnv)-1],
+		`FAKERT_GH_CS_LIST=[{"name":"fake-cs-1","state":"Shutdown","repository":"pingel-org/foo-kb"}]`)
+	stdout, _, code = s.run(t, "status")
+	if code != 1 {
+		t.Fatalf("stopped status: want exit 1, got %d\n%s", code, stdout)
+	}
+	mustContain(t, "stopped status stdout", stdout,
+		"(state: Shutdown)", "stopped — state and credentials persist", "semiont start")
+}
+
+func TestCodespaceGuardsAndScoping(t *testing.T) {
+	// Cross-placement guards: a recorded stack of either kind binds.
+	s := newCodespaceScenario(t)
+	writeStackState(t, s, "container")
+	_, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 1 {
+		t.Fatalf("local record + codespace start: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "A recorded stack is running under container")
+
+	s2 := newCodespaceScenario(t)
+	if _, _, code := s2.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatal("create failed")
+	}
+	s2.killServes()
+	_, stderr, code = s2.run(t, "start", "--runtime", "container")
+	if code != 1 {
+		t.Fatalf("codespace record + local start: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr,
+		"A recorded stack is running under codespace", "--runtime codespace")
+
+	// useradd refuses: the admin was generated at creation.
+	_, stderr, code = s2.run(t, "useradd", "--email", "a@b.co", "--password", "password123")
+	if code != 1 {
+		t.Fatalf("useradd on codespace: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "generated at creation", "semiont status")
+
+	// status --service and stop --service don't apply.
+	if _, stderr, code := s2.run(t, "status", "--service", "backend"); code != 1 {
+		t.Error("status --service on codespace should fail")
+	} else {
+		mustContain(t, "stderr", stderr, "--service does not apply to a codespace stack")
+	}
+	if _, stderr, code := s2.run(t, "stop", "--service", "worker"); code != 1 {
+		t.Error("stop --service on codespace should fail")
+	} else {
+		mustContain(t, "stderr", stderr, "--service does not apply to a codespace stack")
+	}
+
+	// Flag scoping: codespace-only flags need the placement; contradictions
+	// and local-only knobs are rejected.
+	s3 := newScenario(t, "container")
+	for _, tc := range []struct {
+		args []string
+		want string
+	}{
+		{[]string{"start", "--repo", "a/b"}, "--repo/--codespace/--machine only apply to --runtime codespace"},
+		{[]string{"start", "--machine", "basicLinux"}, "--repo/--codespace/--machine only apply to --runtime codespace"},
+		{[]string{"start", "--runtime", "codespace", "--root", "x", "--repo", "a/b"}, "--root and --repo are contradictory"},
+		{[]string{"start", "--runtime", "codespace", "--service", "worker"}, "--service does not apply to --runtime codespace"},
+		{[]string{"start", "--runtime", "codespace", "--config", "anthropic"}, "--config does not apply to --runtime codespace"},
+	} {
+		_, stderr, code := s3.run(t, tc.args...)
+		if code != 1 {
+			t.Errorf("%v: want exit 1, got %d", tc.args, code)
+		}
+		mustContain(t, fmt.Sprintf("stderr for %v", tc.args), stderr, tc.want)
+	}
+}
+
+func TestCodespaceDryRunAndLogs(t *testing.T) {
+	// Dry-run renders the gh plan and reaches for nothing — no gh calls, no
+	// record, no registry.
+	s := newCodespaceScenario(t)
+	s.cwd = t.TempDir()
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace", "--repo", csRepo, "--dry-run")
+	if code != 0 {
+		t.Fatalf("dry-run: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "dry-run stdout", stdout,
+		"gh codespace create --repo "+csRepo+" --machine premiumLinux",
+		"gh codespace ports forward",
+		"cat .devcontainer/admin.json")
+	if log, _ := os.ReadFile(s.log); strings.Contains(string(log), "gh ") {
+		t.Errorf("dry-run invoked gh:\n%s", log)
+	}
+	if _, err := os.Stat(statePathFor(s.home)); !os.IsNotExist(err) {
+		t.Error("dry-run wrote a stack record")
+	}
+
+	// logs on a codespace record ride ssh, by wire-level container name.
+	if _, _, code := s.run(t, "start", "--runtime", "codespace", "--repo", csRepo); code != 0 {
+		t.Fatal("create failed")
+	}
+	stdout, stderr, code = s.run(t, "logs", "--service", "backend")
+	if code != 0 {
+		t.Fatalf("logs: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "logs stdout", stdout, "[backend] backend out")
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log),
+		"gh codespace ssh -c fake-cs-1 -- docker logs --follow semiont-backend")
+}
+
 // --- config-driven boots (LAUNCHER-CONFIG-SYNC P2) ---
 
 // writeKBConfig drops a variant semiontconfig into the scenario's KB.

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -879,6 +879,123 @@ func TestSecretSetRequiresProviderOnPath(t *testing.T) {
 		"the environment always wins")
 }
 
+func TestSecretPush(t *testing.T) {
+	// A codespace runs on GitHub's machine and can't reach the local
+	// provider, so `secret push` copies the CURRENT value into GitHub's
+	// Codespaces user secrets — resolved fresh, handed over on STDIN (never
+	// argv), and unioned into the existing repo selection.
+	s := newScenario(t, "container", "op", "gh")
+	if _, stderr, code := s.run(t, "secret", "set", "ANTHROPIC_API_KEY", "op://OSS/Anthropic/credential"); code != 0 {
+		t.Fatalf("secret set: exit %d\nstderr:\n%s", code, stderr)
+	}
+
+	// Existing selection must survive: gh's --repos REPLACES the list.
+	s.extraEnv = append(s.extraEnv,
+		`FAKERT_GH_SECRET_REPOS={"total_count":1,"repositories":[{"full_name":"other/already-had-it"}]}`)
+	if err := os.Truncate(s.log, 0); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := s.run(t, "secret", "push", "ANTHROPIC_API_KEY", "--repo", "pingel-org/foo-kb")
+	if code != 0 {
+		t.Fatalf("push: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "push stdout", stdout,
+		"reading from 1Password", "expect an authorization prompt",
+		"is now a Codespaces user secret",
+		"other/already-had-it, pingel-org/foo-kb", // union, not replacement
+		"never stored locally")
+
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log),
+		"gh secret set ANTHROPIC_API_KEY --user --app codespaces --repos other/already-had-it,pingel-org/foo-kb")
+	// The value must NEVER appear in argv (ps-readable) — only on stdin.
+	if strings.Contains(string(log), "fake-op-secret") {
+		t.Fatalf("secret value leaked into argv:\n%s", log)
+	}
+	if strings.Contains(stdout, "fake-op-secret") {
+		t.Errorf("secret value echoed to the terminal:\n%s", stdout)
+	}
+	stdin, err := os.ReadFile(filepath.Join(s.fakertDir, "secret-set-stdin"))
+	if err != nil || strings.TrimSpace(string(stdin)) != "fake-op-secret" {
+		t.Fatalf("value did not reach gh on stdin: %q (%v)", stdin, err)
+	}
+	// Nor into roots.json or the invocation log.
+	if b, _ := os.ReadFile(rootsPathFor(s.home)); strings.Contains(string(b), "fake-op-secret") {
+		t.Error("secret value persisted to roots.json")
+	}
+	if b, _ := os.ReadFile(invLogPath(s.home)); strings.Contains(string(b), "fake-op-secret") {
+		t.Error("secret value reached the invocation log")
+	}
+
+	// Already-selected repo isn't duplicated.
+	s2 := newScenario(t, "container", "op", "gh")
+	if _, _, code := s2.run(t, "secret", "set", "ANTHROPIC_API_KEY", "op://OSS/Anthropic/credential"); code != 0 {
+		t.Fatal("set failed")
+	}
+	s2.extraEnv = append(s2.extraEnv,
+		`FAKERT_GH_SECRET_REPOS={"total_count":1,"repositories":[{"full_name":"pingel-org/foo-kb"}]}`)
+	if err := os.Truncate(s2.log, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, code := s2.run(t, "secret", "push", "ANTHROPIC_API_KEY", "--repo", "pingel-org/foo-kb"); code != 0 {
+		t.Fatal("push failed")
+	}
+	log, _ = os.ReadFile(s2.log)
+	mustContain(t, "argv log", string(log), "--repos pingel-org/foo-kb")
+	if strings.Contains(string(log), "foo-kb,pingel-org/foo-kb") {
+		t.Errorf("repo duplicated in the selection:\n%s", log)
+	}
+
+	// Failure paths: no registered source, bad slug, gh rejecting the write.
+	s3 := newScenario(t, "container", "op", "gh")
+	if _, stderr, code := s3.run(t, "secret", "push", "NOPE_KEY", "--repo", "a/b"); code != 1 {
+		t.Error("push without a source should fail")
+	} else {
+		mustContain(t, "stderr", stderr, "No secret source registered for NOPE_KEY",
+			"semiont secret set NOPE_KEY")
+	}
+	if _, stderr, code := s3.run(t, "secret", "push", "ANTHROPIC_API_KEY", "--repo", "notaslug"); code != 1 {
+		t.Error("bad slug should fail")
+	} else {
+		mustContain(t, "stderr", stderr, "--repo must be owner/name")
+	}
+	if _, _, code := s3.run(t, "secret", "set", "ANTHROPIC_API_KEY", "op://OSS/Anthropic/credential"); code != 0 {
+		t.Fatal("set failed")
+	}
+	s3.extraEnv = append(s3.extraEnv, "FAKERT_GH_SECRET_SET_FAIL=1")
+	if _, stderr, code := s3.run(t, "secret", "push", "ANTHROPIC_API_KEY", "--repo", "a/b"); code != 1 {
+		t.Error("gh failure should fail the push")
+	} else {
+		mustContain(t, "stderr", stderr, "Could not set the Codespaces user secret")
+	}
+}
+
+func TestCodespaceSecretMissingPointsAtPush(t *testing.T) {
+	// The create-path secret preflight names the ONE command that fixes it
+	// when a local source is registered — and the generic gh hint otherwise.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv, "FAKERT_GH_SECRET_404=1")
+	_, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 1 {
+		t.Fatalf("want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr, "gh secret set ANTHROPIC_API_KEY --user --app codespaces")
+
+	s2 := newScenario(t, "container", "op", "gh")
+	if _, _, code := s2.run(t, "secret", "set", "ANTHROPIC_API_KEY", "op://OSS/Anthropic/credential"); code != 0 {
+		t.Fatal("set failed")
+	}
+	s2.extraEnv = append(s2.extraEnv,
+		"FAKERT_GIT_ORIGIN=git@github.com:"+csRepo+".git", "FAKERT_GH_SECRET_404=1")
+	_, stderr, code = s2.run(t, "start", "--runtime", "codespace")
+	if code != 1 {
+		t.Fatalf("want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr,
+		"You have a local source registered (op://OSS/Anthropic/credential)",
+		"semiont secret push ANTHROPIC_API_KEY --repo "+csRepo)
+}
+
 func TestStartResolvesSecret(t *testing.T) {
 	// A registered source feeds start: announced BEFORE the reach, resolved
 	// fresh, injected into the container argv (redacted in echoes). Dry-run

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1436,6 +1436,61 @@ func TestMultiStackCodespaces(t *testing.T) {
 	mustContain(t, "stack.json", string(b), "codespace:"+csRepo)
 }
 
+func TestFrontendPort(t *testing.T) {
+	// --port moves the browser (the one flag-movable port): publish
+	// <p>:3000, warn about frontendURL-configured backends, record the
+	// moved endpoint so status and stop follow it.
+	s := newScenario(t, "container")
+	s.noGitRoot = true // "just the browser" needs no clone
+	stdout, stderr, code := s.run(t, "start", "--service", "frontend", "--port", "3001")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log), "--publish 3001:3000")
+	mustContain(t, "stdout", stdout,
+		"Browser on port 3001", "may reject this origin",
+		"🚀 frontend is up")
+	b, _ := os.ReadFile(statePathFor(s.home))
+	mustContain(t, "stack.json", string(b), `"endpoint": "http://localhost:3001"`)
+
+	// status probes the recorded endpoint, not the static 3000.
+	stdout, _, code = s.run(t, "status", "--service", "frontend")
+	if code != 0 {
+		t.Fatalf("status: exit %d\n%s", code, stdout)
+	}
+	mustContain(t, "status stdout", stdout, "http://localhost:3001")
+
+	// Default port stays 3000, no warning.
+	s.killServes()
+	stdout, _, code = s.run(t, "start", "--service", "frontend")
+	if code != 0 {
+		t.Fatal("default-port frontend failed")
+	}
+	if strings.Contains(stdout, "may reject this origin") {
+		t.Errorf("default port warned:\n%s", stdout)
+	}
+
+	// Scoping: frontend-only, and never with codespace placement.
+	for _, tc := range []struct{ args []string }{
+		{[]string{"start", "--port", "3001"}},
+		{[]string{"start", "--service", "worker", "--port", "3001"}},
+		{[]string{"start", "--runtime", "codespace", "--port", "3001"}},
+	} {
+		if _, stderr, code := s.run(t, tc.args...); code != 1 {
+			t.Errorf("%v: want exit 1, got %d", tc.args, code)
+		} else {
+			mustContain(t, fmt.Sprintf("stderr for %v", tc.args), stderr,
+				"--port only applies to --service frontend")
+		}
+	}
+	if _, stderr, code := s.run(t, "start", "--service", "frontend", "--port", "notaport"); code != 1 {
+		t.Error("bad port value should fail")
+	} else {
+		mustContain(t, "stderr", stderr, "Invalid --port")
+	}
+}
+
 func TestMultiStackLocalPlusCodespace(t *testing.T) {
 	// A local stack and codespace stacks coexist in the record set: verbs
 	// that can't guess refuse with selectors; useradd targets the local

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1114,8 +1114,8 @@ func TestCodespaceStartCreates(t *testing.T) {
 		"gh api user/codespaces/secrets/ANTHROPIC_API_KEY/repositories",
 		"gh codespace list --json name,state,repository",
 		"gh codespace create --repo "+csRepo+" --machine premiumLinux",
-		"gh codespace ports forward 4000:4000 -c fake-cs-1",
-		"gh codespace ssh -c fake-cs-1 -- cat .devcontainer/admin.json")
+		"gh codespace ports forward 4000:4000 -c fake-cs-1", // <codespacePort>:<localPort>
+		"gh codespace ssh -c fake-cs-1 -- cat /workspaces/*/.devcontainer/admin.json")
 	mustContain(t, "stdout", stdout,
 		"KB repo: "+csRepo,
 		"uncommitted changes", "as PUSHED",
@@ -1469,13 +1469,28 @@ func TestCodespaceStatus(t *testing.T) {
 
 func TestCodespaceGuardsAndScoping(t *testing.T) {
 	// Cross-placement guards: a recorded stack of either kind binds.
+	// A LOCAL stack no longer blocks a codespace start: they coexist, and
+	// the codespace KB simply allocates around the local stack's ports.
 	s := newCodespaceScenario(t)
-	writeStackState(t, s, "container")
-	_, stderr, code := s.run(t, "start", "--runtime", "codespace")
-	if code != 1 {
-		t.Fatalf("local record + codespace start: want exit 1, got %d", code)
+	statePath := statePathFor(s.home)
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	mustContain(t, "stderr", stderr, "The local stack is running under container")
+	local := `{"schema":3,"stacks":{"local":{"runtime":"container","ports":[3000,4000,9090],` +
+		`"services":{"backend":{"container":"semiont-backend","id":"fid-semiont-backend","provided":"launcher","startedAt":"2026-07-19T00:00:00Z"}}}}}`
+	if err := os.WriteFile(statePath, []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("local record + codespace start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "coexist stdout", stdout, "Semiont KB         http://localhost:4001")
+	if l, _ := os.ReadFile(s.log); !strings.Contains(string(l), "ports forward 4000:4001") {
+		t.Errorf("forward argv must be <codespacePort>:<localPort> = 4000:4001:\n%s", l)
+	}
+	b, _ := os.ReadFile(statePath)
+	mustContain(t, "stack.json", string(b), `"local"`, "codespace:"+csRepo, `"forwardPort": 4001`)
 
 	s2 := newCodespaceScenario(t)
 	if _, _, code := s2.run(t, "start", "--runtime", "codespace"); code != 0 {
@@ -1485,7 +1500,7 @@ func TestCodespaceGuardsAndScoping(t *testing.T) {
 	// A codespace stack no longer blocks a local start — they coexist (the
 	// dry-run proves the local plan renders; only the lens would contend,
 	// and it's dropped live).
-	stdout, stderr, code := s2.run(t, "start", "--runtime", "container", "--dry-run")
+	stdout, stderr, code = s2.run(t, "start", "--runtime", "container", "--dry-run")
 	if code != 0 {
 		t.Fatalf("codespace record + local dry-run: exit %d\nstderr:\n%s", code, stderr)
 	}

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1006,6 +1006,7 @@ func TestCodespaceStartCreates(t *testing.T) {
 		"Reading admin credentials",
 		"Semiont KB is up in codespace fake-cs-1",
 		"Semiont KB         http://localhost:4000",
+		"Semiont Browser    semiont start --service frontend", // not forwarded — runs locally
 		"admin@example.com", "fake-admin-pw",
 		"local uncommitted changes don't travel",
 		"Halt billing:")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1157,6 +1157,118 @@ func TestCodespacePreflights(t *testing.T) {
 	mustContain(t, "stderr", stderr, "'gh' is not on PATH", "https://cli.github.com")
 }
 
+func TestCodespaceMachinePreflight(t *testing.T) {
+	// The machine list is preflighted on the CREATE path and is
+	// hostRequirements-filtered by GitHub, so anything in it is adequate:
+	// premiumLinux when offered, else the largest — announced. An explicit
+	// --machine must actually be available; we never substitute for it.
+	only := func(names ...string) string {
+		all := map[string]string{
+			"standardLinux32gb": `{"name":"standardLinux32gb","display_name":"4 cores, 16 GB RAM, 32 GB storage","cpus":4,"memory_in_bytes":17179869184}`,
+			"premiumLinux":      `{"name":"premiumLinux","display_name":"8 cores, 32 GB RAM, 64 GB storage","cpus":8,"memory_in_bytes":34359738368}`,
+			"largePremiumLinux": `{"name":"largePremiumLinux","display_name":"16 cores, 64 GB RAM, 128 GB storage","cpus":16,"memory_in_bytes":68719476736}`,
+		}
+		parts := []string{}
+		for _, n := range names {
+			parts = append(parts, all[n])
+		}
+		return "FAKERT_GH_MACHINES={\"machines\":[" + strings.Join(parts, ",") + "]}"
+	}
+
+	// Default: premium is offered, so premium is used — silently.
+	s := newCodespaceScenario(t)
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("default: exit %d\nstderr:\n%s", code, stderr)
+	}
+	log, _ := os.ReadFile(s.log)
+	mustContain(t, "argv log", string(log),
+		"gh api /repos/"+csRepo+"/codespaces/machines",
+		"gh codespace create --repo "+csRepo+" --machine premiumLinux")
+	if strings.Contains(stdout, "isn't available") {
+		t.Errorf("announced a fallback that did not happen:\n%s", stdout)
+	}
+
+	// No premium: fall back to the largest offered, announced with the reason.
+	s2 := newCodespaceScenario(t)
+	s2.extraEnv = append(s2.extraEnv, only("standardLinux32gb"))
+	stdout, stderr, code = s2.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("fallback: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "fallback stdout", stdout,
+		"premiumLinux isn't available to you for "+csRepo,
+		"using standardLinux32gb (4 cores, 16 GB RAM, 32 GB storage)")
+	log, _ = os.ReadFile(s2.log)
+	mustContain(t, "argv log", string(log), "--machine standardLinux32gb")
+
+	// Largest wins the fallback, not merely the first offered.
+	s3 := newCodespaceScenario(t)
+	s3.extraEnv = append(s3.extraEnv, only("standardLinux32gb", "largePremiumLinux"))
+	if _, stderr, code := s3.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatalf("largest: exit %d\nstderr:\n%s", code, stderr)
+	}
+	log, _ = os.ReadFile(s3.log)
+	mustContain(t, "argv log", string(log), "--machine largePremiumLinux")
+
+	// Explicit and available: used, no announcement.
+	s4 := newCodespaceScenario(t)
+	stdout, stderr, code = s4.run(t, "start", "--runtime", "codespace", "--machine", "standardLinux32gb")
+	if code != 0 {
+		t.Fatalf("explicit: exit %d\nstderr:\n%s", code, stderr)
+	}
+	log, _ = os.ReadFile(s4.log)
+	mustContain(t, "argv log", string(log), "--machine standardLinux32gb")
+	if strings.Contains(stdout, "isn't available") {
+		t.Errorf("explicit available should not announce:\n%s", stdout)
+	}
+
+	// Explicit and NOT available: hard fail listing what is, by display name
+	// — never silently substituted.
+	s5 := newCodespaceScenario(t)
+	s5.extraEnv = append(s5.extraEnv, only("standardLinux32gb"))
+	_, stderr, code = s5.run(t, "start", "--runtime", "codespace", "--machine", "largePremiumLinux")
+	if code != 1 {
+		t.Fatalf("explicit unavailable: want exit 1, got %d", code)
+	}
+	mustContain(t, "stderr", stderr,
+		"--machine largePremiumLinux is not available to you for "+csRepo,
+		"standardLinux32gb", "4 cores, 16 GB RAM, 32 GB storage")
+	if l, _ := os.ReadFile(s5.log); strings.Contains(string(l), "codespace create") {
+		t.Errorf("created despite an unavailable machine:\n%s", l)
+	}
+
+	// Empty list and API error both fail with causes, before any create.
+	for _, tc := range []struct{ env, want string }{
+		{`FAKERT_GH_MACHINES={"machines":[]}`, "offers no machine classes"},
+		{"FAKERT_GH_MACHINES=ERROR", "Could not list machine classes"},
+	} {
+		sx := newCodespaceScenario(t)
+		sx.extraEnv = append(sx.extraEnv, tc.env)
+		_, stderr, code := sx.run(t, "start", "--runtime", "codespace")
+		if code != 1 {
+			t.Errorf("%s: want exit 1, got %d", tc.env, code)
+		}
+		mustContain(t, "stderr for "+tc.env, stderr, tc.want)
+	}
+}
+
+func TestCodespaceMachineInertOnResume(t *testing.T) {
+	// --machine chooses hardware at creation only; on a resume it can't
+	// change anything, so it is called out rather than looking effective.
+	s := newCodespaceScenario(t)
+	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatalf("create: exit %d\nstderr:\n%s", code, stderr)
+	}
+	s.killServes()
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace", "--machine", "largePremiumLinux")
+	if code != 0 {
+		t.Fatalf("resume: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "resume stdout", stdout,
+		"--machine largePremiumLinux ignored", "keeps the class it was created with")
+}
+
 func TestCodespaceStopKeepsRecordDeleteForgets(t *testing.T) {
 	s := newCodespaceScenario(t)
 	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {
@@ -1312,7 +1424,8 @@ func TestCodespaceDryRunAndLogs(t *testing.T) {
 		t.Fatalf("dry-run: exit %d\nstderr:\n%s", code, stderr)
 	}
 	mustContain(t, "dry-run stdout", stdout,
-		"gh codespace create --repo "+csRepo+" --machine premiumLinux",
+		"gh api /repos/"+csRepo+"/codespaces/machines",
+		"gh codespace create --repo "+csRepo+" --machine <machine>",
 		"gh codespace ports forward",
 		"cat .devcontainer/admin.json")
 	if log, _ := os.ReadFile(s.log); strings.Contains(string(log), "gh ") {

--- a/docs/KNOWLEDGE-BASES.md
+++ b/docs/KNOWLEDGE-BASES.md
@@ -23,6 +23,23 @@ semiont useradd --email admin@example.com --password <choose-a-password> --admin
 `semiont logs` follows the stack, `semiont status` health-checks it, and
 `semiont stop` tears it down.
 
+**Or run it on GitHub's machine instead of yours.** The same launcher places
+a KB stack in a **GitHub Codespace** — one command creates (or resumes) the
+codespace, waits for the stack to answer, forwards the KB to your machine,
+and prints the admin credentials generated inside it:
+
+```bash
+semiont start --runtime codespace --repo The-AI-Alliance/semiont-template-kb
+semiont start --service frontend    # the browser runs locally
+```
+
+Only the KB is forwarded, each stack on its own local port, so one local
+browser works several cloud KBs at once via its Knowledge Bases panel.
+`semiont status` shows the fleet; `semiont stop --repo <owner/name>` halts
+billing (state persists) and `--delete` destroys the codespace. Prerequisites
+(the `gh` CLI and an `ANTHROPIC_API_KEY` Codespaces user secret) are in each
+KB's README; the raw `gh` recipe is kept there too as the no-launcher path.
+
 See [Local Semiont](system/LOCAL-SEMIONT.md) for the full local-run guide
 (inference configs, running from source with `SEMIONT_VERSION=local`, ports,
 troubleshooting pointers).

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -15,7 +15,10 @@ Where the code lives, how it builds, and how to start working on Semiont itself.
 
 ## Get a workstation
 
-**GitHub Codespaces** (one-click, fastest):
+**GitHub Codespaces** (one-click, fastest) — a workstation for hacking on the
+monorepo itself. (Running a *knowledge base* in a codespace is a different
+thing: see [Knowledge Bases](../KNOWLEDGE-BASES.md) and the launcher's
+`--runtime codespace`.)
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/The-AI-Alliance/semiont)
 

--- a/docs/system/CONTAINER-TOPOLOGY.md
+++ b/docs/system/CONTAINER-TOPOLOGY.md
@@ -151,7 +151,8 @@ The constraint is the **port contracts** — the bus (`/bus/emit`, `/bus/subscri
 
 Two layers, easy to conflate:
 
-- **Operator entry points.** A KB stack is driven by the host-installed [`semiont` launcher](../../apps/launcher/README.md) — `semiont start` / `logs` / `status` / `stop` (runtime-portable, `--runtime` to force one) — or by `docker compose` against `.semiont/compose/backend.yml` (Codespaces uses this). Operators do not invoke the Semiont CLI directly.
+- **Operator entry points.** A KB stack is driven by the host-installed [`semiont` launcher](../../apps/launcher/README.md) — `semiont start` / `logs` / `status` / `stop` (runtime-portable, `--runtime` to force one) — or by `docker compose` against `.semiont/compose/backend.yml`. Operators do not invoke the Semiont CLI directly.
+  In **Codespaces both are true at once**, at different layers: `semiont start --runtime codespace` drives the outside (create/resume the VM, wait for health, forward the KB, read credentials, stop or delete), while *inside* the codespace the devcontainer hooks bring the stack up with `docker compose` exactly as above. The launcher never reaches into the container to manage services.
 - **The CLI inside the containers.** Each published image's entrypoint uses the Semiont CLI to provision and start its own service (e.g. the backend runs `semiont provision --service backend && semiont start --service backend`). Monorepo developers on the POSIX platform can drive the same CLI directly:
 
 ```bash

--- a/docs/system/LOCAL-BACKEND.md
+++ b/docs/system/LOCAL-BACKEND.md
@@ -2,6 +2,8 @@
 
 Run the Semiont backend locally. Both paths below use `~/.semiontconfig` for inference providers, database credentials, graph, and vector store settings — see the **[Configuration Guide](./administration/CONFIGURATION.md)**.
 
+For a stack on GitHub's machine rather than your own, the launcher's codespace placement (`semiont start --runtime codespace`) is covered in **[Knowledge Bases](../KNOWLEDGE-BASES.md)**.
+
 ## Container (no npm required)
 
 Install the [`semiont` launcher](../../apps/launcher/README.md)

--- a/docs/system/LOCAL-SEMIONT.md
+++ b/docs/system/LOCAL-SEMIONT.md
@@ -1,6 +1,8 @@
 # Local Semiont
 
-Run Semiont locally.
+Run Semiont locally. (Don't want the stack on your own machine? The same
+launcher can place it in a GitHub Codespace instead — see
+[Knowledge Bases](../KNOWLEDGE-BASES.md).)
 
 There are two ways to start:
 
@@ -112,3 +114,5 @@ As an alternative to the container image, Semiont ships a native desktop app for
 - [Project Layout](./PROJECT-LAYOUT.md) — Directory structure, XDG paths, and git integration
 - [Configuration Guide](./administration/CONFIGURATION.md) — Full configuration reference
 - [Services Overview](./services/OVERVIEW.md) — Service catalog and runtime layout
+- [Knowledge Bases](../KNOWLEDGE-BASES.md) — KB repos, and running a stack in a GitHub Codespace instead of locally
+- [`semiont` launcher](../../apps/launcher/README.md) — every flag, the stack record, secret sources, codespace placement


### PR DESCRIPTION
## What this does

`semiont start --runtime codespace` runs a KB stack on a GitHub-hosted machine. The launcher orchestrates the **outside** — create/resume, wake, forward, credentials, lifecycle — while the KB's devcontainer and `docker compose` continue to own the **inside**, unchanged (see `.plans/CODESPACE-KB-LAUNCH.md` Non-goals).

**Shape decision:** codespace is a *value on the existing `--runtime` axis*, not a new verb family. `stack.json` already records which executor owns a stack, and `stop` / `status` / `logs` / `useradd` already dispatch off that record — a parallel `semiont codespace <verb>` family would have re-derived what the record unifies for free.

## Identity

The **repo** is the user-facing identity; the codespace **name** is a PID. `--repo owner/name` is needed only at creation (or derived from the KB clone's `origin`); afterwards the record carries it, so a bare `semiont start` resumes from any directory, with no clone at all. At most one codespace per repo — the launcher adopts and resumes what exists rather than creating a second.

## Multi-stack records (schema 3)

`stack.json` becomes a keyed collection: the machine's one local stack (fixed ports and container names keep it singleton) plus one entry per `codespace:<repo>`. Schema 1/2 files migrate on read — verified against a live 10-service local record.

Each codespace stack forwards exactly **one** port, its KB, allocated at 4000 or the lowest free port above. So N codespace KBs run concurrently and a single local browser works all of them from its Knowledge Bases panel. A local start drops only forwards squatting on ports it actually claims.

With several stacks recorded: `status` opens with a STACKS fleet overview; `logs` follows the local stack, else the lone codespace; `stop` refuses to guess (`--repo` targets a codespace stack, `--runtime` the local one). `stop` maps to `gh codespace stop` and **keeps** the record — a stopped codespace still exists — while `--delete` destroys and forgets.

## Also here

- **`--machine` preflight.** GitHub's machine list for a repo is filtered by the devcontainer's `hostRequirements`, so anything offered is adequate by the KB's own declaration: `premiumLinux` when available, else the largest, announced with the reason. An explicit unavailable `--machine` is a hard error listing what *is* available; on a resume the flag is called out as inert.
- **`semiont secret push <VAR> --repo <owner/name>`.** A codespace can't reach your local secret provider, so this copies the registered secret's current value into GitHub Codespaces user secrets. Handed to `gh` on **stdin**, never argv; the repo selection is a **union**, never a replacement (`--repos` replaces, which would silently revoke every other repo's access).
- **`semiont start --service frontend --port <n>`.** Moves the browser — the one port a flag may move, since it's absent from the KB config and nothing in the stack dials it.
- **Docs.** Monorepo cross-references (KNOWLEDGE-BASES, LOCAL-*, CONTAINER-TOPOLOGY's operator layers, dev-README disambiguation of the two meanings of "Codespaces"). Fleet KB READMEs were updated in their own repos.

## Live verification found four bugs the fake harness could not

Tested end to end against a real codespace:

1. **Reversed forward arguments.** `gh codespace ports forward` takes `<codespacePort>:<localPort>`; this had it backwards, binding the wrong local port and leaving a live process forwarding nothing. `fakert` bound the first number too, so the tests happily confirmed the wrong assumption — it now models the real semantics.
2. **Wrong credentials path.** `gh codespace ssh` opens in `/home/vscode`, not the workspace, so the relative `cat .devcontainer/admin.json` always failed. Now an absolute globbed path (the recipe this came from was wrong, and it had propagated to the fleet READMEs).
3. **Wake ordering.** `ports forward` against a stopped codespace *triggers* the wake and then dies. `gh codespace ssh -- true` wakes it and blocks until connectable (~19s), so the launcher now ensures `Available` before forwarding.
4. **Stale local-stack guard** that refused any codespace start while a local stack was recorded — obsolete once per-stack port allocation landed, and it blocked exactly the coexistence this PR advertises.

Plus zombie-forward detection (a live `gh` process forwarding nothing now fails the liveness check), fail-fast when the tunnel doesn't bind within 30s instead of burning the health budget, and gh's own stderr surfaced on a failed credentials read rather than guessing between causes.

## Known open

*(Corrected after re-reading the launcher's own invocation log rather than reconstructing from shell output.)*

- **Resume reliability is unsettled — thinner evidence than first stated.** Launcher log, with its own durations: resumes from `Available` succeeded (05:37:00Z, 18s; 05:41:48Z, 4s); the single launcher resume from `Shutdown` (06:07:02Z) failed after **1346s**; two later ssh-wakes went hang, then clean. Three cold-wake observations, two hanging — and not of one binary, since each ran a different build mid-fix. The backend startup hang (next item) is the leading explanation, but it was never isolated to a specific dependency nor deliberately reproduced.
- **Backend startup connects are unbounded** (Neo4j / embedding / vector store). `restart: on-failure` only rescues a process that *exits*, and `depends_on` governs `compose up`, not daemon-driven restarts — so a codespace wake can reach those connects before the dependencies listen, and the container then sits unhealthy forever. Fix (separate change, ships in the backend **image**): bound each at 60s and name the dependency, turning an unrecoverable hang into a retryable crash.
- **`waitForHTTP`'s last argument is attempts, not seconds** (~3s each), so every "within 600s" message is wrong, local call sites included — the launcher logged **1346s** for one such wait. Not fixed here.

## Testing

~20 new tests covering identity/resume, adopt-and-disambiguate, 503 retry, all preflights, machine selection, multi-stack coexistence, stop/delete isolation, secret push (asserting the value reaches `gh` on stdin and appears in no argv log, terminal output, `roots.json`, or invocation log), and credential-failure reporting. **Every pre-existing argv golden is byte-identical.**

