### PR TITLE
Launcher: codespace cost visibility and control — Tier 1 facts, explicit idle/retention levers, opt-in billing report

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -109,6 +109,25 @@ semiont stop
   announced with the reason; an explicit `--machine` that isn't available is
   a hard error listing what is (never a silent substitution), and on a
   resume the flag is called out as inert rather than looking effective.
+  `semiont status --billing` (opt-in, needs gh's
+  `user` scope — it prints the one-line grant command if missing) shows
+  GitHub's own monthly usage report: compute/storage quantities, gross,
+  plan-quota discounts, and the NET actually paid — their numbers verbatim,
+  attributed per repository as GitHub reports it.
+  Status states the burn in FACTS, never invented dollars
+  (rates live on GitHub's pricing page, not in any API): an Available
+  codespace shows its machine and uptime (`Available · premiumLinux 8c/32GB
+  · up 3h20m`), a stopped one shows when storage billing ends by deletion
+  (`storage still bills; auto-deletes 2026-08-19, state and all`), and the
+  up-summary names the machine and its auto-stop.
+  Every create sets the cost levers EXPLICITLY: `--idle-timeout 60m` (auto-
+  stop; looser than GitHub's 30m for long pulls) and `--retention-period
+  720h` (30 days — GitHub's maximum — after which a STOPPED codespace is
+  auto-deleted, state and all; explicit so a tighter account default cannot
+  silently shorten a KB codespace's life). Both are overridable flags on
+  `semiont start`, create-time only: on a resume they are called out as
+  inert, and outside codespace placement they are refused. The create
+  announces both, because a default that deletes user state is never silent.
   Codespace placement is never sticky — every codespace start says
   `--runtime codespace` (or rides an existing record).
 - `semiont useradd` creates or updates users in the RUNNING stack: the

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -163,6 +163,10 @@ func ghCmd(args []string) {
 		}
 		fmt.Println(body)
 	case len(args) >= 3 && args[0] == "api" && args[1] == "user" && args[2] == "--jq":
+		if os.Getenv("FAKERT_GH_UNAUTH") != "" {
+			fmt.Fprintln(os.Stderr, "gh: To get started with GitHub CLI, please run:  gh auth login")
+			os.Exit(4)
+		}
 		fmt.Println("fakeuser")
 	case len(args) >= 2 && args[0] == "api" && strings.Contains(args[1], "/settings/billing/usage"):
 		// The Tier 2 payload, shaped exactly like the 2026-07-20 capture:

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -36,6 +36,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func main() {
@@ -161,6 +162,38 @@ func ghCmd(args []string) {
 				`{"name":"largePremiumLinux","display_name":"16 cores, 64 GB RAM, 128 GB storage","cpus":16,"memory_in_bytes":68719476736}],"total_count":3}`
 		}
 		fmt.Println(body)
+	case len(args) >= 3 && args[0] == "api" && args[1] == "user" && args[2] == "--jq":
+		fmt.Println("fakeuser")
+	case len(args) >= 2 && args[0] == "api" && strings.Contains(args[1], "/settings/billing/usage"):
+		// The Tier 2 payload, shaped exactly like the 2026-07-20 capture:
+		// month buckets, per-repo (bare name), quota-as-discount, and a
+		// non-codespaces product that must be filtered out.
+		if os.Getenv("FAKERT_GH_BILLING_NOSCOPE") != "" {
+			fmt.Fprintln(os.Stderr, "gh: This API operation needs the \"user\" scope (HTTP 403)")
+			os.Exit(1)
+		}
+		body := os.Getenv("FAKERT_GH_BILLING")
+		if body == "" {
+			body = `{"usageItems":[` +
+				`{"date":"2026-01-01T00:00:00Z","product":"codespaces","sku":"Codespaces compute 8-core","quantity":44.29,"unitType":"Hours","grossAmount":31.89,"discountAmount":16.2,"netAmount":15.69,"repositoryName":"semiont"},` +
+				`{"date":"2026-01-01T00:00:00Z","product":"codespaces","sku":"Codespaces storage","quantity":7.71,"unitType":"GigabyteHours","grossAmount":0.54,"discountAmount":0.54,"netAmount":0.0,"repositoryName":"semiont"},` +
+				`{"date":"2026-07-01T00:00:00Z","product":"codespaces","sku":"Codespaces compute 8-core","quantity":4.03,"unitType":"Hours","grossAmount":2.90,"discountAmount":2.90,"netAmount":0.0,"repositoryName":"semiont-template-kb"},` +
+				`{"date":"2026-07-01T00:00:00Z","product":"copilot","sku":"Copilot Cloud Agent","quantity":18.0,"unitType":"Requests","grossAmount":0.72,"discountAmount":0.72,"netAmount":0.0,"repositoryName":""}]}`
+		}
+		fmt.Println(body)
+	case len(args) >= 2 && args[0] == "api" && args[1] == "/user/codespaces":
+		// The cost-facts endpoint (CODESPACE-COSTS Tier 1): machine size,
+		// last_used_at (= when last STARTED; verified 2026-07-20),
+		// retention expiry, idle timeout. Every fake codespace reports the
+		// same premiumLinux shape; last_used_at is now-2h30s so "up 2h"
+		// renders deterministically (the 30s absorbs test runtime).
+		var entries []string
+		for _, cs := range createdCodespaceNames() {
+			entries = append(entries, `{"name":"`+cs+`","machine":{"name":"premiumLinux","cpus":8,"memory_in_bytes":34359738368},`+
+				`"last_used_at":"`+time.Now().UTC().Add(-2*time.Hour-30*time.Second).Format(time.RFC3339)+`",`+
+				`"retention_expires_at":"2026-08-19T14:59:00Z","idle_timeout_minutes":60}`)
+		}
+		fmt.Println(`{"codespaces":[` + strings.Join(entries, ",") + `]}`)
 	case len(args) >= 2 && args[0] == "api" && strings.Contains(args[1], "/codespaces/secrets/"):
 		if os.Getenv("FAKERT_GH_SECRET_404") != "" {
 			fmt.Fprintln(os.Stderr, "gh: Not Found (HTTP 404)")
@@ -548,6 +581,25 @@ func createdCodespaces() []string {
 			continue
 		}
 		out = append(out, fmt.Sprintf(`{"name":%q,"state":"Available","repository":%q}`, nameRepo[0], nameRepo[1]))
+	}
+	return out
+}
+
+// createdCodespaceNames: just the names, for the /user/codespaces facts.
+func createdCodespaceNames() []string {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return nil
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "created-codespaces"))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		if f := strings.Fields(line); len(f) >= 1 {
+			out = append(out, f[0])
+		}
 	}
 	return out
 }

--- a/apps/launcher/internal/launcher/billing.go
+++ b/apps/launcher/internal/launcher/billing.go
@@ -30,13 +30,21 @@ type usageItem struct {
 // statusBilling renders the report, or — without the scope — exactly the fix
 // and nothing else. Exit codes: 0 shown, 1 not.
 func statusBilling(u *ui) int {
-	if !onPath("gh") {
-		u.fail("--billing reads GitHub's usage report via gh, which is not on PATH.")
+	if !requireGh(u, "--billing (GitHub's usage report)") {
 		return 1
 	}
-	login, err := capture("gh", "api", "user", "--jq", ".login")
+	// captureBoth, not capture: an unauthenticated gh explains itself on
+	// stderr ("please run: gh auth login") — discarding that showed a bare
+	// "cannot resolve login" with no way forward.
+	login, err := captureBoth("gh", "api", "user", "--jq", ".login")
 	if err != nil {
-		u.fail("Cannot resolve the GitHub login: %s", strings.TrimSpace(login))
+		u.fail("Cannot resolve the GitHub login — is gh authenticated?")
+		if msg := strings.TrimSpace(login); msg != "" {
+			for _, line := range strings.Split(msg, "\n") {
+				fmt.Fprintln(os.Stderr, "    gh: "+line)
+			}
+		}
+		fmt.Fprintln(os.Stderr, "  First-time setup:  gh auth login")
 		return 1
 	}
 	out, err := captureBoth("gh", "api", "/users/"+strings.TrimSpace(login)+"/settings/billing/usage")

--- a/apps/launcher/internal/launcher/billing.go
+++ b/apps/launcher/internal/launcher/billing.go
@@ -1,0 +1,125 @@
+package launcher
+
+// billing.go — `semiont status --billing`, Tier 2 of CODESPACE-COSTS.md:
+// ACTUAL money, from GitHub's own usage report, opt-in behind the `user`
+// scope. Everything shown is GitHub's number — quantities, rates, discounts,
+// net — never a launcher estimate; the included-quota story is theirs too
+// (it arrives as discountAmount). Attribution is per REPOSITORY (bare name,
+// no owner — the payload's shape, verified 2026-07-20), never per codespace.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+type usageItem struct {
+	Date           string  `json:"date"` // month bucket, RFC3339
+	Product        string  `json:"product"`
+	SKU            string  `json:"sku"`
+	Quantity       float64 `json:"quantity"`
+	UnitType       string  `json:"unitType"`
+	GrossAmount    float64 `json:"grossAmount"`
+	DiscountAmount float64 `json:"discountAmount"`
+	NetAmount      float64 `json:"netAmount"`
+	RepositoryName string  `json:"repositoryName"`
+}
+
+// statusBilling renders the report, or — without the scope — exactly the fix
+// and nothing else. Exit codes: 0 shown, 1 not.
+func statusBilling(u *ui) int {
+	if !onPath("gh") {
+		u.fail("--billing reads GitHub's usage report via gh, which is not on PATH.")
+		return 1
+	}
+	login, err := capture("gh", "api", "user", "--jq", ".login")
+	if err != nil {
+		u.fail("Cannot resolve the GitHub login: %s", strings.TrimSpace(login))
+		return 1
+	}
+	out, err := captureBoth("gh", "api", "/users/"+strings.TrimSpace(login)+"/settings/billing/usage")
+	if err != nil {
+		// The one expected failure is the missing scope; per the plan, print
+		// exactly the fix and nothing else.
+		if strings.Contains(out, "user") && strings.Contains(out, "scope") {
+			u.fail("The billing report needs the `user` scope on gh's token.")
+			fmt.Fprintln(os.Stderr, "  Grant it once:  gh auth refresh -h github.com -s user")
+			return 1
+		}
+		u.fail("Usage report failed: %s", strings.TrimSpace(out))
+		return 1
+	}
+	var body struct {
+		UsageItems []usageItem `json:"usageItems"`
+	}
+	if json.Unmarshal([]byte(out), &body) != nil {
+		u.fail("Unexpected usage-report shape — GitHub may have changed the endpoint.")
+		return 1
+	}
+
+	// Aggregate the codespaces lines per month: compute hours, storage, and
+	// the three money columns. Repos noted per month (bare names — the
+	// payload has no owner, and inventing one would be a guess).
+	type monthAgg struct {
+		computeH, storageGBh, gross, discount, net float64
+		repos                                      map[string]bool
+	}
+	months := map[string]*monthAgg{}
+	for _, it := range body.UsageItems {
+		if it.Product != "codespaces" {
+			continue
+		}
+		key := it.Date
+		if len(key) >= 7 {
+			key = key[:7]
+		}
+		m := months[key]
+		if m == nil {
+			m = &monthAgg{repos: map[string]bool{}}
+			months[key] = m
+		}
+		switch {
+		case strings.HasPrefix(it.SKU, "Codespaces compute"):
+			m.computeH += it.Quantity
+		case it.SKU == "Codespaces storage":
+			m.storageGBh += it.Quantity
+		}
+		m.gross += it.GrossAmount
+		m.discount += it.DiscountAmount
+		m.net += it.NetAmount
+		if it.RepositoryName != "" {
+			m.repos[it.RepositoryName] = true
+		}
+	}
+
+	u.section("CODESPACES BILLING")
+	if len(months) == 0 {
+		fmt.Printf("  %s\n", u.dim("(no codespaces usage in GitHub's report)"))
+		return 0
+	}
+	fmt.Printf("  %s\n", u.dim("GitHub's own usage report (gh api /users/"+strings.TrimSpace(login)+"/settings/billing/usage) — monthly buckets;"))
+	fmt.Printf("  %s\n", u.dim("\"included\" is plan quota GitHub applied as a discount. NET is what you pay."))
+	fmt.Println()
+	keys := make([]string, 0, len(months))
+	for k := range months {
+		keys = append(keys, k)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+	for _, k := range keys {
+		m := months[k]
+		repos := make([]string, 0, len(m.repos))
+		for r := range m.repos {
+			repos = append(repos, r)
+		}
+		sort.Strings(repos)
+		net := fmt.Sprintf("net $%.2f", m.net)
+		if m.net > 0 {
+			net = u.bold(net) // the months that actually cost money must pop
+		}
+		fmt.Printf("  %s  %5.1f compute-hrs · %5.1f GB-hrs storage   gross $%6.2f   included $%6.2f   %s  %s\n",
+			k, m.computeH, m.storageGBh, m.gross, m.discount, net, u.dim("("+strings.Join(repos, ", ")+")"))
+	}
+	return 0
+}

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -196,6 +196,9 @@ func startCodespace(u *ui, opts startOptions) int {
 	if opts.machine != "" && !created {
 		u.warn("--machine %s ignored: %s already exists and keeps the class it was created with.", opts.machine, name)
 	}
+	if (opts.idleTimeout != "" || opts.retention != "") && !created {
+		u.warn("--idle-timeout/--retention-period ignored: %s already exists and keeps its create-time settings.", name)
+	}
 
 	// One KB port per stack — other codespaces' forwards keep running;
 	// concurrency is the point. Allocation dodges every recorded claim and
@@ -279,6 +282,15 @@ func startCodespace(u *ui, opts startOptions) int {
 	}
 	fmt.Println()
 	fmt.Printf("  %s\n", u.dim("Runs "+repo+" as pushed — local uncommitted changes don't travel."))
+	// The hardware burning and its auto-stop — the summary is where a fresh
+	// VM's cost begins (CODESPACE-COSTS.md P0 q1).
+	if f, ok := fetchCodespaceFacts()[name]; ok && f.Machine != "" {
+		line := "Machine " + f.Machine
+		if f.IdleMin > 0 {
+			line += fmt.Sprintf(" · auto-stops after %dm idle", f.IdleMin)
+		}
+		fmt.Printf("  %s\n", u.dim(line))
+	}
 	if creds != nil {
 		fmt.Printf("  Connect as %s / %s %s\n",
 			u.bold(creds.Email), u.bold(creds.Password), u.dim("(generated at creation; never stored by the launcher)"))
@@ -286,7 +298,9 @@ func startCodespace(u *ui, opts startOptions) int {
 	fmt.Println()
 	fmt.Printf("  Check health:  %s\n", u.bold("semiont status"))
 	fmt.Printf("  Follow logs:   %s %s\n", u.bold("semiont logs --repo "+repo), u.dim("(bare logs when unambiguous)"))
-	fmt.Printf("  Halt billing:  %s %s\n", u.bold("semiont stop --repo "+repo), u.dim("(state persists; --delete destroys)"))
+	// "Halt billing" overpromised: stopping halts COMPUTE billing; storage
+	// bills until retention auto-deletes the codespace (CODESPACE-COSTS.md).
+	fmt.Printf("  Halt compute:  %s %s\n", u.bold("semiont stop --repo "+repo), u.dim("(storage bills until auto-delete; --delete destroys now)"))
 	fmt.Println()
 	return 0
 }
@@ -522,10 +536,27 @@ func createCodespace(u *ui, repo string, opts startOptions) (string, int) {
 	if code != 0 {
 		return "", code
 	}
+	// Cost levers, set EXPLICITLY at create (adjudicated 2026-07-20,
+	// CODESPACE-COSTS.md P0 q3/q4): idle-timeout 60m — looser than GitHub's
+	// 30m, headroom for long image/model pulls; retention 720h (30 days,
+	// GitHub's maximum) — explicit so a tighter account-level default cannot
+	// silently shorten a KB codespace's life. Retention is when a STOPPED
+	// codespace is auto-deleted, state and all; announced because a default
+	// that deletes user state must never be silent.
+	idle, retention := opts.idleTimeout, opts.retention
+	if idle == "" {
+		idle = "60m"
+	}
+	if retention == "" {
+		retention = "720h"
+	}
 	u.log("Creating codespace for %s %s", u.bold(repo), u.dim("(--machine "+machine+"; ~4 min to Available, hooks run minutes past it)"))
-	u.echoCmd("gh", "codespace", "create", "--repo", repo, "--machine", machine)
+	u.log("Cost levers: %s", u.dim("auto-stop after "+idle+" idle; kept "+retention+" after stopping, then AUTO-DELETED (state and all)"))
+	args := []string{"codespace", "create", "--repo", repo, "--machine", machine,
+		"--idle-timeout", idle, "--retention-period", retention}
+	u.echoCmd("gh", args...)
 	for attempt := 1; ; attempt++ {
-		out, err := captureBoth("gh", "codespace", "create", "--repo", repo, "--machine", machine)
+		out, err := captureBoth("gh", args...)
 		if err == nil {
 			lines := strings.Fields(out)
 			if len(lines) == 0 {
@@ -743,7 +774,7 @@ func renderCodespacePlan(opts startOptions, repo, recorded string) {
 		} else {
 			fmt.Println("gh api /repos/" + repo + "/codespaces/machines   # preflight: verify --machine " + machine + " is available")
 		}
-		fmt.Println("gh codespace create --repo " + repo + " --machine " + machine + "   # only when none exists (503-aware retry)")
+		fmt.Println("gh codespace create --repo " + repo + " --machine " + machine + " --idle-timeout 60m --retention-period 720h   # only when none exists (503-aware retry; 60m/720h are launcher defaults, flags override)")
 	}
 	fmt.Println("gh codespace ports forward 4000:<kb-port> -c <codespace>   # <codespacePort>:<localPort>; detached; pid + port recorded")
 	fmt.Println("# wait: http://localhost:<kb-port>/api/health (600s)")
@@ -836,7 +867,22 @@ func statusCodespace(u *ui, st *stackState, refresh bool) int {
 			}
 		}
 	}
-	fmt.Printf("  %s  %s %s\n", u.bold(st.Codespace), st.Repo, u.dim("(state: "+state+")"))
+	stateDetail := "state: " + state
+	if f, ok := fetchCodespaceFacts()[st.Codespace]; ok {
+		if f.Machine != "" {
+			stateDetail += " · " + f.Machine
+		}
+		if state == "Available" && !f.StartedAt.IsZero() {
+			stateDetail += " · up " + formatUptime(time.Since(f.StartedAt))
+		}
+		if state == "Shutdown" && f.AutoDel != "" {
+			stateDetail += " · auto-deletes " + f.AutoDel
+		}
+		if f.IdleMin > 0 {
+			stateDetail += fmt.Sprintf(" · idle-stop %dm", f.IdleMin)
+		}
+	}
+	fmt.Printf("  %s  %s %s\n", u.bold(st.Codespace), st.Repo, u.dim("("+stateDetail+")"))
 	// --refresh needs an ssh, and an ssh to a stopped codespace WAKES it —
 	// resuming compute billing from a command the user ran to look, not to
 	// launch. Say so and skip rather than do it quietly.
@@ -949,6 +995,75 @@ func dropCollidingForwards(u *ui, needs []portNeed) {
 	}
 }
 
+// codespaceFacts: the cost-relevant facts for one codespace, from
+// `gh api /user/codespaces` — retention expiry, idle timeout, machine class
+// and size, and when it was last STARTED. lastUsedAt is "billing since" for
+// an Available codespace: verified 2026-07-20 by observation (the field
+// moved to the exact minute a resume started it; createdAt stayed put).
+// Everything here is DISPLAY — best-effort, absent facts render as nothing.
+type codespaceFacts struct {
+	Machine   string // class + size, e.g. "premiumLinux 8c/32GB"
+	StartedAt time.Time
+	AutoDel   string // yyyy-mm-dd a STOPPED codespace is deleted, state and all
+	IdleMin   int
+}
+
+func fetchCodespaceFacts() map[string]codespaceFacts {
+	out, err := capture("gh", "api", "/user/codespaces")
+	if err != nil {
+		return nil
+	}
+	var body struct {
+		Codespaces []struct {
+			Name    string `json:"name"`
+			Machine struct {
+				Name   string `json:"name"`
+				CPUs   int    `json:"cpus"`
+				Memory int64  `json:"memory_in_bytes"`
+			} `json:"machine"`
+			LastUsedAt         string `json:"last_used_at"`
+			RetentionExpiresAt string `json:"retention_expires_at"`
+			IdleTimeoutMinutes int    `json:"idle_timeout_minutes"`
+		} `json:"codespaces"`
+	}
+	if json.Unmarshal([]byte(out), &body) != nil {
+		return nil
+	}
+	facts := make(map[string]codespaceFacts, len(body.Codespaces))
+	for _, c := range body.Codespaces {
+		f := codespaceFacts{IdleMin: c.IdleTimeoutMinutes}
+		if c.Machine.Name != "" {
+			f.Machine = c.Machine.Name
+			if c.Machine.CPUs > 0 && c.Machine.Memory > 0 {
+				f.Machine += fmt.Sprintf(" %dc/%dGB", c.Machine.CPUs, c.Machine.Memory>>30)
+			}
+		}
+		if t, err := time.Parse(time.RFC3339, c.LastUsedAt); err == nil {
+			f.StartedAt = t
+		}
+		if len(c.RetentionExpiresAt) >= 10 {
+			f.AutoDel = c.RetentionExpiresAt[:10]
+		}
+		facts[c.Name] = f
+	}
+	return facts
+}
+
+// formatUptime: coarse on purpose — this is a cost cue, not a stopwatch.
+func formatUptime(d time.Duration) string {
+	if d < time.Minute {
+		return "<1m"
+	}
+	h, m := int(d.Hours()), int(d.Minutes())%60
+	switch {
+	case h == 0:
+		return fmt.Sprintf("%dm", m)
+	case m == 0:
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh%dm", h, m)
+}
+
 // printRemoteKBs: the REMOTE KNOWLEDGE BASES section — codespace-hosted KBs this
 // machine knows about. A repo is the durable thing (the identity); the
 // codespace instance and its state are status layered on it, which is why
@@ -960,8 +1075,10 @@ func printRemoteKBs(u *ui, cs []*stackState) {
 		return
 	}
 	states := map[string]string{}
+	var facts map[string]codespaceFacts
 	ghQueried := false
 	if onPath("gh") {
+		facts = fetchCodespaceFacts()
 		if out, err := capture("gh", "codespace", "list", "--json", "name,state,repository"); err == nil {
 			ghQueried = true
 			var all []codespaceInstance
@@ -989,7 +1106,21 @@ func printRemoteKBs(u *ui, cs []*stackState) {
 		case state == "":
 			state = "not listed by GitHub"
 		}
-		fmt.Printf("    %s %s\n", u.dim("codespace "+c.Codespace), u.dim("("+state+")"))
+		// Cost facts ride the state parens: an Available codespace names the
+		// hardware burning and since when — the safety tax the concurrent-KB
+		// feature owes (CODESPACE-COSTS.md Tier 1).
+		detail := state
+		if f, ok := facts[c.Codespace]; ok {
+			if state == "Available" {
+				if f.Machine != "" {
+					detail += " · " + f.Machine
+				}
+				if !f.StartedAt.IsZero() {
+					detail += " · up " + formatUptime(time.Since(f.StartedAt))
+				}
+			}
+		}
+		fmt.Printf("    %s %s\n", u.dim("codespace "+c.Codespace), u.dim("("+detail+")"))
 		// Status layered on top: where its KB is reachable, or what to run.
 		switch {
 		case forwardAlive(c.ForwardPID, c.ForwardPort):
@@ -1001,7 +1132,11 @@ func printRemoteKBs(u *ui, cs []*stackState) {
 		case state == "Available":
 			fmt.Printf("    %s\n", u.dim("not forwarded — semiont start --runtime codespace --repo "+c.Repo))
 		case state == "Shutdown":
-			fmt.Printf("    %s\n", u.dim("stopped (storage still bills) — resume: semiont start --runtime codespace --repo "+c.Repo))
+			bill := "stopped (storage still bills"
+			if f, ok := facts[c.Codespace]; ok && f.AutoDel != "" {
+				bill += "; auto-deletes " + f.AutoDel + ", state and all"
+			}
+			fmt.Printf("    %s\n", u.dim(bill+") — resume: semiont start --runtime codespace --repo "+c.Repo))
 		default:
 			fmt.Printf("    %s\n", u.dim("details: semiont status --repo "+c.Repo))
 		}

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -43,6 +43,8 @@ type startOptions struct {
 	repo         string // --repo: owner/name (codespace placement only)
 	csName       string // --codespace: instance disambiguator (codespace placement only)
 	machine      string // --machine: VM class (codespace placement only)
+	idleTimeout  string // --idle-timeout: create-time only (codespace placement)
+	retention    string // --retention-period: create-time only (codespace placement)
 }
 
 const startUsage = `Usage: semiont start [options]
@@ -80,6 +82,13 @@ Options:
                         KB clone's origin remote; the record remembers it)
   --codespace <name>    Codespace placement: disambiguate when the repo has
                         several codespaces (the launcher itself makes one)
+  --idle-timeout <d>    Codespace placement, create-time: inactivity before
+                        auto-stop (launcher default 60m — GitHub's own is 30m)
+  --retention-period <d>  Codespace placement, create-time: how long a stopped
+                        codespace is kept before AUTO-DELETION, state and all
+                        (launcher default 720h = 30 days, GitHub's maximum;
+                        passed explicitly so a tighter account default cannot
+                        silently shorten a KB codespace's life)
   --machine <class>     Codespace placement: VM class (default: premiumLinux
                         when your account can use it for the repo, else the
                         largest it can; only applies when creating)
@@ -189,6 +198,20 @@ func Start(args []string) int {
 			}
 			opts.machine = v
 			i++
+		case "--idle-timeout":
+			v, ok := needVal(i)
+			if !ok {
+				return 1
+			}
+			opts.idleTimeout = v
+			i++
+		case "--retention-period":
+			v, ok := needVal(i)
+			if !ok {
+				return 1
+			}
+			opts.retention = v
+			i++
 		case "--list-configs":
 			opts.listConfigs = true
 		case "--clean-ollama":
@@ -256,8 +279,8 @@ func Start(args []string) int {
 			u.fail("--root and --repo are contradictory (one derives the repo from a clone, the other bypasses clones).")
 			return 1
 		}
-	} else if opts.repo != "" || opts.csName != "" || opts.machine != "" {
-		u.fail("--repo/--codespace/--machine only apply to --runtime codespace.")
+	} else if opts.repo != "" || opts.csName != "" || opts.machine != "" || opts.idleTimeout != "" || opts.retention != "" {
+		u.fail("--repo/--codespace/--machine/--idle-timeout/--retention-period only apply to --runtime codespace.")
 		return 1
 	}
 	if opts.port != 0 && (opts.service != "frontend" || opts.runtime == "codespace") {

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -11,7 +11,7 @@ import (
 	"unicode/utf8"
 )
 
-const statusUsage = `Usage: semiont status [--root <path|name>] [--repo <owner/name> [--refresh]] [--service <name>] [--runtime container|docker|podman] [--verbose]
+const statusUsage = `Usage: semiont status [--root <path|name>] [--repo <owner/name> [--refresh]] [--service <name>] [--runtime container|docker|podman] [--verbose] [--billing]
 
 Reports what this machine knows about, in three layers:
 
@@ -40,6 +40,11 @@ health, name ONE stack:
   semiont status --service backend     && echo backend-up
 
 Those forms exit 0 only when the named stack (or service) is healthy.
+
+--billing (standalone) shows GitHub's own codespaces usage report — monthly
+compute/storage quantities, gross, plan-quota discounts, and the NET you
+actually pay. Their numbers, never launcher estimates. Needs the "user"
+scope: grant once with  gh auth refresh -h github.com -s user
 
 status never wakes a stopped codespace. --refresh (with --repo) re-reads that
 KB's did:web identity over ssh to confirm the recorded one — it is skipped,
@@ -82,6 +87,7 @@ func Status(args []string) int {
 	runtime, service, repoFlag, rootFlag := "", "", "", ""
 	refresh := false
 	verbose := false
+	billing := false
 	for i := 0; i < len(args); i++ {
 		need := func() (string, bool) {
 			if i+1 >= len(args) {
@@ -123,6 +129,8 @@ func Status(args []string) int {
 			refresh = true
 		case "--verbose", "-v":
 			verbose = true
+		case "--billing":
+			billing = true
 		case "--help", "-h":
 			fmt.Print(statusUsage)
 			return 0
@@ -140,6 +148,13 @@ func Status(args []string) int {
 	if repoFlag != "" && (rootFlag != "" || service != "") {
 		u.fail("--repo names a remote stack; --root/--service name the local one.")
 		return 1
+	}
+	if billing {
+		if repoFlag != "" || rootFlag != "" || service != "" || refresh {
+			u.fail("--billing is a standalone report (GitHub bills per month and repo, not per stack).")
+			return 1
+		}
+		return statusBilling(u)
 	}
 	if refresh && repoFlag == "" {
 		u.fail("--refresh re-reads ONE remote KB's identity over ssh — name it with --repo <owner/name>.")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -3607,6 +3607,16 @@ func TestStatusBilling(t *testing.T) {
 		t.Errorf("scope-less billing printed money:\n%s\n%s", stdout, stderr)
 	}
 
+	// Unauthenticated gh: its own guidance must reach the user, plus ours —
+	// capture-stdout-only used to swallow gh's "please run gh auth login".
+	s3 := newScenario(t, "container", "gh")
+	s3.extraEnv = append(s3.extraEnv, "FAKERT_GH_UNAUTH=1")
+	stdout, stderr, code = s3.run(t, "status", "--billing")
+	if code != 1 {
+		t.Fatalf("unauthenticated --billing: want exit 1, got %d", code)
+	}
+	mustContain(t, "unauth guidance", stdout+stderr, "gh auth login", "is gh authenticated?")
+
 	// --billing is standalone: GitHub bills per month/repo, not per stack.
 	if _, stderr, code := s.run(t, "status", "--billing", "--repo", "a/b"); code != 1 {
 		t.Fatal("billing+repo should refuse")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1166,6 +1166,10 @@ func TestCodespaceStartCreates(t *testing.T) {
 		"gh auth status",
 		"gh api user/codespaces/secrets/ANTHROPIC_API_KEY/repositories",
 		"gh codespace list --json name,state,repository",
+		// Cost levers ride every create, explicitly (CODESPACE-COSTS.md P0
+		// q3/q4): 60m idle, 30-day retention — GitHub's max, stated so a
+		// tighter account default cannot silently shorten the KB's life.
+		"--idle-timeout 60m --retention-period 720h",
 		"gh codespace create --repo "+csRepo+" --machine premiumLinux",
 		"gh codespace ports forward 4000:4000 -c fake-cs-1", // <codespacePort>:<localPort>
 		"gh codespace ssh -c fake-cs-1 -- cat /workspaces/*/.devcontainer/admin.json")
@@ -1179,7 +1183,7 @@ func TestCodespaceStartCreates(t *testing.T) {
 		"Semiont Browser    semiont start --service frontend", // not forwarded — runs locally
 		"admin@example.com", "fake-admin-pw",
 		"local uncommitted changes don't travel",
-		"Halt billing:")
+		"Halt compute:")
 	b, _ := os.ReadFile(statePathFor(s.home))
 	mustContain(t, "stack.json", string(b),
 		`"runtime": "codespace"`, `"codespace": "fake-cs-1"`, `"repo": "pingel-org/foo-kb"`,
@@ -1750,7 +1754,7 @@ func TestCodespaceStatus(t *testing.T) {
 		t.Fatalf("status --repo: exit %d\nstdout:\n%s", code, stdout)
 	}
 	mustContain(t, "status --repo stdout", stdout,
-		"CODESPACE", "fake-cs-1", csRepo, "(state: Available)",
+		"CODESPACE", "fake-cs-1", csRepo, "state: Available",
 		"re-establishing",
 		"KB", "healthy", "http://localhost:4000/api/health",
 		"run inside the codespace via compose",
@@ -1765,7 +1769,7 @@ func TestCodespaceStatus(t *testing.T) {
 		t.Fatalf("stopped status --repo: want exit 1, got %d\n%s", code, stdout)
 	}
 	mustContain(t, "stopped status stdout", stdout,
-		"(state: Shutdown)", "stopped — state and credentials persist", "semiont start")
+		"state: Shutdown", "stopped — state and credentials persist", "semiont start")
 }
 
 func TestCodespaceGuardsAndScoping(t *testing.T) {
@@ -1834,8 +1838,8 @@ func TestCodespaceGuardsAndScoping(t *testing.T) {
 		args []string
 		want string
 	}{
-		{[]string{"start", "--repo", "a/b"}, "--repo/--codespace/--machine only apply to --runtime codespace"},
-		{[]string{"start", "--machine", "basicLinux"}, "--repo/--codespace/--machine only apply to --runtime codespace"},
+		{[]string{"start", "--repo", "a/b"}, "--repo/--codespace/--machine/--idle-timeout/--retention-period only apply to --runtime codespace"},
+		{[]string{"start", "--machine", "basicLinux"}, "--repo/--codespace/--machine/--idle-timeout/--retention-period only apply to --runtime codespace"},
 		{[]string{"start", "--runtime", "codespace", "--root", "x", "--repo", "a/b"}, "--root and --repo are contradictory"},
 		{[]string{"start", "--runtime", "codespace", "--service", "worker"}, "--service does not apply to --runtime codespace"},
 		{[]string{"start", "--runtime", "codespace", "--config", "anthropic"}, "--config does not apply to --runtime codespace"},
@@ -3515,6 +3519,99 @@ func TestCrashedContainerStaysInspectable(t *testing.T) {
 		if strings.Contains(line, "busybox") && !strings.Contains(line, "--rm") {
 			t.Errorf("busybox probe lost its --rm: %q", line)
 		}
+	}
+}
+
+func TestCodespaceCostLevers(t *testing.T) {
+	// Explicit flags override the launcher defaults at create; on a resume
+	// they are inert and say so (settings are create-time), like --machine.
+	s := newCodespaceScenario(t)
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace",
+		"--idle-timeout", "15m", "--retention-period", "48h")
+	if code != 0 {
+		t.Fatalf("create: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "argv", s.argv(t), "--idle-timeout 15m --retention-period 48h")
+	mustContain(t, "announcement", stdout+stderr, "auto-stop after 15m idle", "48h", "AUTO-DELETED")
+
+	// Resume: the flags cannot apply and must be called out, not look effective.
+	stdout, stderr, _ = s.run(t, "start", "--runtime", "codespace", "--idle-timeout", "5m")
+	mustContain(t, "inert warning", stdout+stderr, "--idle-timeout/--retention-period ignored")
+
+	// And outside codespace placement they are refused, like --repo.
+	if _, stderr, code := s.run(t, "start", "--runtime", "container", "--idle-timeout", "5m"); code != 1 {
+		t.Fatalf("local start with codespace flag: want exit 1")
+	} else {
+		mustContain(t, "refusal", stderr, "only apply to --runtime codespace")
+	}
+}
+
+func TestCodespaceCostFacts(t *testing.T) {
+	// Tier 1 of CODESPACE-COSTS: status states the hardware burning and
+	// since when — facts only, never invented dollars. Available shows
+	// machine + uptime; Shutdown shows when storage billing ENDS by
+	// auto-deletion; the up-summary names the machine and its auto-stop.
+	s := newCodespaceScenario(t)
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("create: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "up-summary", stdout+stderr, "Machine premiumLinux 8c/32GB", "auto-stops after 60m idle")
+
+	stdout, _, _ = s.run(t, "status")
+	mustContain(t, "overview (Available)", stdout,
+		"Available · premiumLinux 8c/32GB · up 2h")
+
+	if _, _, code := s.run(t, "stop"); code != 0 {
+		t.Fatal("stop")
+	}
+	stdout, _, _ = s.run(t, "status")
+	mustContain(t, "overview (Shutdown)", stdout,
+		"storage still bills; auto-deletes 2026-08-19, state and all")
+	if strings.Contains(stdout, "up 2h") {
+		t.Errorf("a stopped codespace claimed uptime:\n%s", stdout)
+	}
+	// And no dollar figure is ever invented.
+	if strings.Contains(stdout, "$") {
+		t.Errorf("status printed a dollar figure it cannot know:\n%s", stdout)
+	}
+}
+
+func TestStatusBilling(t *testing.T) {
+	// Tier 2 (CODESPACE-COSTS): GitHub's OWN usage report, opt-in. Their
+	// numbers verbatim — quantities, gross, quota-as-discount, net — never a
+	// launcher estimate; non-codespaces products filtered out; the month
+	// that actually cost money shows its net.
+	s := newScenario(t, "container", "gh")
+	stdout, stderr, code := s.run(t, "status", "--billing")
+	if code != 0 {
+		t.Fatalf("--billing: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "billing", stdout,
+		"CODESPACES BILLING",
+		"2026-01", "44.3 compute-hrs", "net $15.69",
+		"2026-07", "net $0.00", "semiont-template-kb")
+	if strings.Contains(stdout, "Copilot") || strings.Contains(stdout, "copilot") {
+		t.Errorf("a non-codespaces product leaked into the codespaces report:\n%s", stdout)
+	}
+
+	// Without the scope: exactly the fix, nothing invented.
+	s2 := newScenario(t, "container", "gh")
+	s2.extraEnv = append(s2.extraEnv, "FAKERT_GH_BILLING_NOSCOPE=1")
+	stdout, stderr, code = s2.run(t, "status", "--billing")
+	if code != 1 {
+		t.Fatalf("scope-less --billing: want exit 1, got %d", code)
+	}
+	mustContain(t, "scope fix", stdout+stderr, "gh auth refresh -h github.com -s user")
+	if strings.Contains(stdout+stderr, "$") {
+		t.Errorf("scope-less billing printed money:\n%s\n%s", stdout, stderr)
+	}
+
+	// --billing is standalone: GitHub bills per month/repo, not per stack.
+	if _, stderr, code := s.run(t, "status", "--billing", "--repo", "a/b"); code != 1 {
+		t.Fatal("billing+repo should refuse")
+	} else {
+		mustContain(t, "refusal", stderr, "standalone")
 	}
 }
 


### PR DESCRIPTION
## Summary

Codespace cost visibility and control — the full CODESPACE-COSTS arc (design record in the untracked `.plans/CODESPACE-COSTS.md`, proposed / verified / built the same day). The launcher already made it easy to run several billable VMs at once; this makes the burn legible and bounded. Guiding constraint throughout: **every dollar on screen is GitHub's own number — the launcher never invents an estimate** (pinned by a test that fails on any `$` the report path didn't produce).

## Tier 1 — the cost-relevant facts (no scope, no rates)

- REMOTE KNOWLEDGE BASES entries state the hardware burning and since when: `(Available · premiumLinux 8c/32GB · up 3h20m)`; a stopped codespace states when storage billing ends and at what price: `stopped (storage still bills; auto-deletes 2026-08-19, state and all)`.
- The `status --repo` view adds the idle-stop setting; the post-start summary names the machine and its auto-stop — the cost begins where the VM does.
- All from **one best-effort `gh api /user/codespaces` call**, already covered by the `codespace` scope. If it fails, the display degrades to state-only rather than guessing.
- "Halt billing" retired for **"Halt compute: … (storage bills until auto-delete)"** — the old wording overpromised.
- "billing since" = `last_used_at`, ratified by observation: the field moved to the exact minute of a real resume while `created_at` stayed at creation.

## Prevention — cost levers set explicitly at create

Every `gh codespace create` now passes `--idle-timeout 60m` (looser than GitHub's 30m — headroom for long image/model pulls) and `--retention-period 720h` (30 days, GitHub's maximum, passed explicitly so a tighter account default cannot silently shorten a KB codespace's life). Both are overridable flags on `semiont start`, create-time only: inert-with-a-warning on resume (the `--machine` pattern), refused outside codespace placement. The create announces both — a default that auto-deletes user state is never silent.

## Tier 2 — actual money, opt-in: `semiont status --billing`

GitHub's own monthly usage report, rendered newest-first: compute-hours, storage GB-hours, gross, **included** (plan quota, which the payload represents as `discountAmount`), and **net** — bold only when nonzero, so the months that actually cost money pop. Attribution is per repository exactly as GitHub reports it (bare name, no owner — the payload has none and the launcher won't guess). Non-codespaces products (actions, copilot) share the endpoint and are filtered out, pinned by a test.

Scope handling is a clean ladder: gh missing → install link + `gh auth login`; gh unauthenticated → gh's own guidance relayed (previously swallowed by a stdout-only capture) plus `First-time setup: gh auth login`; missing `user` scope → exactly `gh auth refresh -h github.com -s user` and nothing else — no money invented on any failure path.

## Invariant preserved

`gh` is never executed unless a codespace stack is requested or recorded, or the command's whole purpose is GitHub (`--billing`, `secret push`) — audited across all 26 invocation sites; a purely local user never runs it. Default `status` with zero codespace records makes zero gh calls.

## Test surface

fakert gains `gh api user`, `/user/codespaces` (machine/uptime/retention facts), and the billing endpoint with the captured payload's exact shape, plus unauthenticated and scope-missing personas. New tests cover the facts rendering (Available vs Shutdown), the levers (defaults, overrides, inert-on-resume, refusal outside codespaces), and the billing report (quota-as-discount rendering, product filtering, both auth failure modes).
