### PR TITLE
Launcher: the Browser is not a stack member — keep-if-current lifecycle, survives stop, ensured by every start; status leads with BROWSER and merges STATE+HEALTH

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -31,13 +31,21 @@ semiont stop
 
 - `semiont start --help` lists all flags (`--config`, `--runtime`,
   `--no-observe`, `--ollama-cache`, …).
-- `semiont start --service frontend --port <n>` moves the browser — the ONE
-  port a flag may move (it's absent from the KB config and nothing in the
-  stack dials it; every other port belongs to the config, and a codespace
-  forwards only its KB on an allocated port). Move, not multiply: the
-  browser restarts on the chosen port, the record carries the endpoint, and
-  status/stop follow it. A non-3000 port warns that backends configured
-  with `frontendURL http://localhost:3000` may reject the origin.
+- **The Browser is not a stack member** (BROWSER-LIFECYCLE.md): it is the
+  machine-level viewer of every KB, local and codespace, discovery-synced.
+  ANY start ensures it — including a codespace start, when a local container
+  runtime exists — and none churns it: a running Browser is KEPT when its
+  image matches what the start would run (image identity, not tag order),
+  restarted when stale. A bare `semiont stop` leaves it running, announced;
+  `semiont stop --service frontend` is the explicit off-switch. Its record
+  lives beside the stacks (machine-level, with its runtime and image), its
+  port is never among a stack's claims, and `status` opens with a BROWSER
+  section — first because it sits architecturally above everything it views
+  — showing its image tag so browser-vs-stack version skew is visible.
+- `semiont start --service frontend --port <n>` moves the Browser — the ONE
+  port a flag may move — and is also the explicit refresh (it always
+  restarts, bypassing keep-if-current). A non-3000 port warns that backends
+  configured with `frontendURL http://localhost:3000` may reject the origin.
 - **`semiont secret` registers where config secrets come from** — pointers,
   never values. `semiont secret set ANTHROPIC_API_KEY` walks an interactive
   provider-then-path flow (or pass the source directly:

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -475,7 +475,10 @@ func runtimeCmd(base string, args []string) {
 			// docker/podman status form: inspect -f {{.State.Status}} <name>
 			fmt.Println(state)
 		case base == "container":
-			fmt.Printf(`[{"configuration":{"initProcess":{"environment":%s}},"status":%q}]`+"\n", env, state)
+			// FAKERT_IMAGE_<svc> scripts the image reference the container
+			// reports (the Browser's keep-if-current check reads it).
+			img := os.Getenv("FAKERT_IMAGE_" + svc)
+			fmt.Printf(`[{"configuration":{"initProcess":{"environment":%s},"image":{"reference":%q}},"status":%q}]`+"\n", env, img, state)
 		default:
 			// docker/podman full form: inspect <name>
 			fmt.Printf(`[{"Config":{"Env":%s},"State":{"Status":%q}}]`+"\n", env, state)

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -409,16 +409,28 @@ func runtimeCmd(base string, args []string) {
 	}
 	switch args[0] {
 	case "stop":
-		// Exit like real runtimes: 0 only when the container "exists" (a
-		// serve pidfile is our existence marker), else nonzero — the
-		// launcher's preflight counts prior containers from these codes.
-		if !killServe(handleName(args[len(args)-1])) {
+		// Exit like real runtimes: 0 only when the container "exists" — a
+		// serve pidfile (run-created) or a scripted FAKERT_STATE container
+		// that hasn't been rm'd.
+		name := handleName(args[len(args)-1])
+		existed := killServe(name)
+		if scriptedAlive(name) {
+			existed = true
+		}
+		if !existed {
 			fmt.Fprintln(os.Stderr, "Error: no such container")
 			os.Exit(1)
 		}
 	case "rm":
-		fmt.Fprintln(os.Stderr, "Error: no such container")
-		os.Exit(1)
+		// rm releases the NAME: record the removal marker so a later
+		// `run --name` stops conflicting (see the name-holding check in run).
+		name := handleName(args[len(args)-1])
+		existed := killServe(name) || scriptedAlive(name)
+		markRemoved(name)
+		if !existed {
+			fmt.Fprintln(os.Stderr, "Error: no such container")
+			os.Exit(1)
+		}
 	case "pull":
 		pull(args[len(args)-1])
 	case "image":
@@ -528,6 +540,16 @@ func run(args []string) {
 		fmt.Fprintf(os.Stderr, "fakert run: unscripted foreground run %v\n", args)
 		os.Exit(64)
 	}
+	// NAME-HOLDING: real runtimes refuse `run --name X` while a container
+	// named X exists IN ANY STATE — stopped included (no --rm keeps them).
+	// A scripted container (FAKERT_STATE_<svc>) holds its name until an
+	// explicit `rm` records a removal marker. This fidelity gap once let a
+	// stop-without-rm restart path pass hermetically and fail live
+	// (Copilot review, PR #1064).
+	if name != "" && scriptedAlive(name) {
+		fmt.Fprintf(os.Stderr, "Error: the container name %q is already in use\n", name)
+		os.Exit(125)
+	}
 	// FAKERT_SKIP_SERVE: comma-separated host ports to leave unbound even
 	// though the container "runs" — models a container that came up but whose
 	// process crashed before listening, so health gates fail while `logs`
@@ -590,6 +612,29 @@ func createdCodespaces() []string {
 		out = append(out, fmt.Sprintf(`{"name":%q,"state":"Available","repository":%q}`, nameRepo[0], nameRepo[1]))
 	}
 	return out
+}
+
+// removed / markRemoved / scriptedAlive: name-holding bookkeeping for the
+// scripted (FAKERT_STATE_*) containers — env can't be mutated per-invocation,
+// so removal lives in a marker file.
+func removed(name string) bool {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(dir, "removed-"+name))
+	return err == nil
+}
+
+func markRemoved(name string) {
+	if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+		_ = os.WriteFile(filepath.Join(dir, "removed-"+name), nil, 0o644)
+	}
+}
+
+func scriptedAlive(name string) bool {
+	svc := strings.TrimPrefix(name, "semiont-")
+	return os.Getenv("FAKERT_STATE_"+svc) != "" && !removed(name)
 }
 
 // createdCodespaceNames: just the names, for the /user/codespaces facts.

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -272,13 +272,24 @@ func startCodespace(u *ui, opts startOptions) int {
 	fmt.Printf("  Semiont KB         %s %s\n", u.bold(fmt.Sprintf("http://localhost:%d", kbPort)),
 		u.dim("(add Host localhost, Port "+fmt.Sprintf("%d", kbPort)+" in the browser's Knowledge Bases panel)"))
 	// The browser is NOT forwarded — only the KB is. It runs locally and
-	// connects to any number of KBs, cloud or local; without this pointer a
-	// codespace-only user has no browser at all.
+	// views any number of KBs. ANY start ensures it (BROWSER-LIFECYCLE.md
+	// decision 2) — but only when a container runtime exists here: codespace
+	// placement must not gain a hard local-runtime requirement.
+	if rts := installedRuntimes(); len(rts) > 0 {
+		version := os.Getenv("SEMIONT_VERSION")
+		if version == "" {
+			version = "latest"
+		}
+		bx := &liveExec{u: u, rt: rts[0], version: version}
+		// Non-fatal: the KB is up either way; a browser failure already
+		// warned above the summary.
+		_ = flowBrowser(bx, version, 3000, false)
+	}
 	if httpOK("http://localhost:3000") {
-		fmt.Printf("  Semiont Browser    %s %s\n", u.bold("http://localhost:3000"), u.dim("(already running)"))
+		fmt.Printf("  Semiont Browser    %s %s\n", u.bold("http://localhost:3000"), u.dim("(discovery-synced — this KB appears in its panel)"))
 	} else {
 		fmt.Printf("  Semiont Browser    %s %s\n", u.bold("semiont start --service frontend"),
-			u.dim("(runs locally; one browser works any number of KBs)"))
+			u.dim("(no local container runtime found — install one, or browse from another machine)"))
 	}
 	fmt.Println()
 	fmt.Printf("  %s\n", u.dim("Runs "+repo+" as pushed — local uncommitted changes don't travel."))

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -9,6 +9,7 @@ package launcher
 // plan is a plan, not a transcript.
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -44,8 +45,11 @@ type executor interface {
 	workerSecret() (string, bool)          // full start: env or generated
 	ollamaVolume(opts startOptions) string // model-cache choice (prompt is live-only)
 	record(role, id, image, provided, endpoint, driver string)
-	providerOf(role string) string                              // how an already-recorded role was provided
-	noteContainer(role, container string)                       // stamp a launched container on a container-less role
+	providerOf(role string) string        // how an already-recorded role was provided
+	noteContainer(role, container string) // stamp a launched container on a container-less role
+	browserCurrent(desired string) bool   // running AND image identity matches
+	browserRecord() *serviceState         // the machine-level browser record
+	recordBrowser(id, image, version string, port int)
 	dumpLogs(container, svc string)                             // failed health gate: show the crash where it is
 	verifyRemoteModels(role, base, key string, models []string) // record /v1/models metadata; warn on unlisted
 	ensureModels(base string, models []string)                  // pull configured ollama models that are absent
@@ -427,6 +431,60 @@ func (x *liveExec) dumpLogs(container, svc string) {
 	fmt.Fprintf(os.Stderr, "  Full logs:  semiont logs --service %s\n", svc)
 }
 
+// browserCurrent: is semiont-frontend RUNNING on an image identical to the
+// one this start would run? Identity, not tag order: the running container's
+// image reference must match the desired ref, and when both sides expose an
+// image ID those must match too (a moved :latest). Reference match without
+// obtainable IDs KEEPS the browser (restart-on-doubt would negate the
+// feature on runtimes that expose no ID through inspect) — the explicit
+// refresh is `semiont start --service frontend`.
+func (x *liveExec) browserCurrent(desired string) bool {
+	out, err := capture(x.rt, "inspect", "semiont-frontend")
+	if err != nil || out == "" {
+		return false
+	}
+	var entries []map[string]any
+	if json.Unmarshal([]byte(out), &entries) != nil || len(entries) == 0 {
+		return false
+	}
+	e := entries[0]
+	status, _ := digString(e, "status")
+	if status == "" {
+		status, _ = digString(e, "State", "Status")
+	}
+	if status != "running" {
+		return false
+	}
+	ref, _ := digString(e, "configuration", "image", "reference")
+	if ref == "" {
+		ref, _ = digString(e, "Config", "Image")
+	}
+	if ref != desired {
+		return false
+	}
+	runningID, _ := digString(e, "Image")
+	if runningID == "" {
+		return true // reference matches; no ID exposed — keep
+	}
+	idOut, err := capture(x.rt, "image", "inspect", "-f", "{{.Id}}", desired)
+	if err != nil || idOut == "" {
+		return true
+	}
+	return strings.TrimSpace(idOut) == runningID
+}
+
+func (x *liveExec) browserRecord() *serviceState {
+	return loadStackSet().Browser
+}
+
+func (x *liveExec) recordBrowser(id, img, version string, port int) {
+	saveBrowser(&serviceState{
+		Container: "semiont-frontend", ID: id, Image: img, Provided: providedLauncher,
+		Runtime: x.rt, Endpoint: fmt.Sprintf("http://localhost:%d", port),
+		StartedAt: time.Now().UTC(),
+	})
+}
+
 func (x *liveExec) ensureModels(base string, models []string) {
 	ensureOllamaModels(x.u, base, models)
 }
@@ -595,6 +653,12 @@ func (x *planExec) noteContainer(string, string) {}
 
 // --dry-run launches nothing, so nothing can crash.
 func (x *planExec) dumpLogs(string, string) {}
+
+// --dry-run: the keep-or-restart decision is a runtime fact; either() shows
+// both branches, so these answer neutrally.
+func (x *planExec) browserCurrent(string) bool                { return false }
+func (x *planExec) browserRecord() *serviceState              { return nil }
+func (x *planExec) recordBrowser(string, string, string, int) {}
 
 // --dry-run reaches for nothing; name the query a real run would make.
 func (x *planExec) verifyRemoteModels(role, base, _ string, models []string) {

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -27,7 +27,6 @@ type executor interface {
 	portChecks(ports []portNeed) bool
 	portCheck(p portNeed) bool    // singular wording in plan mode
 	recordPorts(ports []portNeed) // note claimed host ports in the belief record
-	stopEcho(name string)         // the echoed best-effort stop (ollama teardown)
 	hostOllamaReachable(addr string, port int) bool
 	stageAll(configFile string) (string, bool)           // per-service config copies; returns stage dir
 	stageOne(svc, configFile string) (string, bool)      // one service's fresh private copy
@@ -119,11 +118,6 @@ func (x *liveExec) pause() { time.Sleep(time.Second) }
 
 func (x *liveExec) portCheck(p portNeed) bool {
 	return requirePortFree(x.u, p.port, p.label)
-}
-
-func (x *liveExec) stopEcho(name string) {
-	x.u.echoCmd(x.rt, "stop", name)
-	runPassthrough(x.rt, "stop", name)
 }
 
 // hostOllamaReachable: a host Ollama is serving — confirm containers can
@@ -589,8 +583,6 @@ func (x *planExec) portCheck(p portNeed) bool {
 }
 
 func (x *planExec) recordPorts([]portNeed) {}
-
-func (x *planExec) stopEcho(name string) { x.p("stop", name) }
 
 func (x *planExec) hostOllamaReachable(string, int) bool { return true }
 

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -140,22 +140,58 @@ func flowFullStart(x executor, fc flowCtx) int {
 		}
 	}
 
-	// Frontend: a static SPA server — no config mount and no service env.
-	x.banner("Starting Frontend")
-	args := frontendArgs(fc.version, 3000)
-	id, ok := x.runDetached(args)
-	if !ok {
-		x.say(sayFail, "Frontend failed to start.")
-		return 1
-	}
-	d, ok := x.waitHTTP("Frontend", "http://localhost:3000", 30)
-	if !ok {
-		x.dumpLogs(roles["frontend"].container, "frontend")
-		return 1
-	}
-	x.say(sayOK, "Frontend on http://localhost:3000 %s", x.dim("("+took(d)+")"))
-	x.record("frontend", id, image("frontend", fc.version), providedLauncher, "http://localhost:3000", "")
-	return 0
+	// The Browser rides every start but belongs to no stack.
+	return flowBrowser(x, fc.version, 3000, false)
+}
+
+// flowBrowser: the Browser is a MACHINE-LEVEL viewer, not a stack member
+// (BROWSER-LIFECYCLE.md). Any start ensures it; none churns it: a running
+// Browser is kept when its image matches what this start would run, and
+// restarted when the image is stale (image identity, not tag order — tags
+// like :latest and :local are mutable) or when the restart is explicit
+// (--service frontend, the port mover).
+func flowBrowser(x executor, version string, port int, forceRestart bool) int {
+	x.banner("Browser")
+	desired := image("frontend", version)
+	x.note("browser: keep if running with image identity matching %s; else stop/rm + pull + run", desired)
+	x.note("(the Browser is not a stack member: stop leaves it running; semiont stop --service frontend stops it)")
+	return x.either(func() bool { return !forceRestart && x.browserCurrent(desired) },
+		func() int {
+			endpoint := "http://localhost:3000"
+			if b := x.browserRecord(); b != nil && b.Endpoint != "" {
+				endpoint = b.Endpoint
+			}
+			x.say(sayOK, "Browser already running on %s %s", endpoint,
+				x.dim("(current image — left alone; semiont stop --service frontend stops it)"))
+			return 0
+		},
+		func() int {
+			if port != 3000 {
+				x.say(sayWarn, "Browser on port %d: backends configured with frontendURL http://localhost:3000 may reject this origin (OAuth redirects / CORS).", port)
+			}
+			x.stopEcho("semiont-frontend")
+			x.pause()
+			if !x.portCheck(portNeed{port, "Frontend"}) {
+				return 1
+			}
+			if version != "local" && !x.pull(desired) {
+				return 1
+			}
+			args := frontendArgs(version, port)
+			id, ok := x.runDetached(args)
+			if !ok {
+				x.say(sayFail, "Browser failed to start.")
+				return 1
+			}
+			d, ok := x.waitHTTP("Browser", fmt.Sprintf("http://localhost:%d", port), 30)
+			if !ok {
+				x.dumpLogs("semiont-frontend", "frontend")
+				return 1
+			}
+			x.say(sayOK, "Browser on http://localhost:%d %s", port, x.dim("("+took(d)+")"))
+			x.recordBrowser(id, desired, version, port)
+			return 0
+		})
 }
 
 // flowDepRole: the uniform dependency-role shape for graph / vectors /
@@ -435,7 +471,11 @@ func flowOneService(x executor, fc flowCtx) int {
 	}
 
 	x.banner("Restarting " + roleTitle(svc))
-	if svc != "inference" {
+	// frontend is handled entirely by flowBrowser (its own stop/port/pull) —
+	// and its port must NEVER enter the STACK's recorded claims: stop
+	// verifies stack-port release while the Browser deliberately keeps
+	// running on its port.
+	if svc != "inference" && svc != "frontend" {
 		if x.stopRm(roles[svc].container) {
 			x.say(sayLog, "Removed prior %s container", svc)
 			x.pause()
@@ -544,21 +584,11 @@ func flowOneService(x executor, fc flowCtx) int {
 			}
 		}
 	case "frontend":
-		bp := browserPort(fc.opts)
-		if bp != 3000 {
-			x.say(sayWarn, "Browser on port %d: backends configured with frontendURL http://localhost:3000 may reject this origin (OAuth redirects / CORS).", bp)
+		// Explicit --service frontend is the one deliberate restart (and the
+		// port mover): forceRestart bypasses keep-if-current.
+		if code := flowBrowser(x, fc.version, browserPort(fc.opts), true); code != 0 {
+			return code
 		}
-		args := frontendArgs(fc.version, bp)
-		id, ok := x.runDetached(args)
-		if !ok {
-			x.say(sayFail, "Frontend failed to start.")
-			return 1
-		}
-		if d, ok = x.waitHTTP("Frontend", fmt.Sprintf("http://localhost:%d", bp), 30); !ok {
-			x.dumpLogs(roles["frontend"].container, "frontend")
-			return 1
-		}
-		x.record(svc, id, image("frontend", fc.version), providedLauncher, fmt.Sprintf("http://localhost:%d", bp), "")
 	}
 	if d > 0 {
 		x.say(sayOK, "%s healthy %s", svc, x.dim("("+took(d)+")"))

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -166,7 +166,15 @@ func flowBrowser(x executor, version string, port int, forceRestart bool) int {
 			return 0
 		},
 		func() int {
+			if port != 3000 {
+				x.say(sayWarn, "Browser on port %d: backends configured with frontendURL http://localhost:3000 may reject this origin (OAuth redirects / CORS).", port)
+			}
+			// stop+rm, not stop: without --rm (kept for crash forensics) a
+			// stopped container HOLDS its name — the next run --name fails
+			// with "already exists" on every runtime (Copilot review, PR
+			// #1064; the same reason stop.go always rm's).
 			x.stopRm("semiont-frontend")
+			x.pause()
 			if !x.portCheck(portNeed{port, "Frontend"}) {
 				return 1
 			}
@@ -372,7 +380,11 @@ func flowOllama(x executor, fc flowCtx, role string, rp rolePlan, addr string) i
 		},
 		func() int {
 			x.say(sayLog, "No host Ollama detected — starting container...")
-			x.stopEcho("semiont-ollama")
+			// Same stop+rm rule as the Browser: --service inference has no
+			// preflight rm ahead of it, so a stopped semiont-ollama would
+			// hold the name (latent since the --rm removal; surfaced by the
+			// same review).
+			x.stopRm("semiont-ollama")
 			x.pause()
 			if !x.portCheck(portNeed{rp.Port, "Ollama"}) {
 				return 1

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -166,11 +166,7 @@ func flowBrowser(x executor, version string, port int, forceRestart bool) int {
 			return 0
 		},
 		func() int {
-			if port != 3000 {
-				x.say(sayWarn, "Browser on port %d: backends configured with frontendURL http://localhost:3000 may reject this origin (OAuth redirects / CORS).", port)
-			}
-			x.stopEcho("semiont-frontend")
-			x.pause()
+			x.stopRm("semiont-frontend")
 			if !x.portCheck(portNeed{port, "Frontend"}) {
 				return 1
 			}

--- a/apps/launcher/internal/launcher/plan.go
+++ b/apps/launcher/internal/launcher/plan.go
@@ -249,7 +249,8 @@ func planPortChecks(plan *launchPlan, observe bool) []portNeed {
 		portNeed{9090, "Worker"},
 		portNeed{9091, "Smelter"},
 		portNeed{9092, "Weaver"},
-		portNeed{3000, "Frontend"},
+		// No browser port here: the Browser is not a stack member — its
+		// port is checked inside flowBrowser, and only when (re)starting.
 	)
 	if observe {
 		checks = append(checks, portNeed{16686, "Jaeger UI"}, portNeed{4318, "Jaeger OTLP"})

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -43,7 +43,9 @@ var roles = map[string]roleSpec{
 	"worker":    {"", "semiont-worker", []portNeed{{9090, "Worker"}}},
 	"smelter":   {"", "semiont-smelter", []portNeed{{9091, "Smelter"}}},
 	"weaver":    {"", "semiont-weaver", []portNeed{{9092, "Weaver"}}},
-	"frontend":  {"", "semiont-frontend", []portNeed{{3000, "Frontend"}}},
+	// frontend: the Browser owns its port inside flowBrowser — an empty
+	// ports list here keeps 3000 out of every stack-level claim and sweep.
+	"frontend": {"", "semiont-frontend", nil},
 }
 
 const roleList = "backend, worker, smelter, weaver, frontend, database, graph, vectors, inference, embedding, or traces"
@@ -108,6 +110,20 @@ func recoverWorkerSecret(rt string) (secret, from, seen string) {
 		}
 	}
 	return "", "", seen
+}
+
+// digString walks a nested inspect entry for a string leaf.
+func digString(m map[string]any, path ...string) (string, bool) {
+	var cur any = m
+	for _, k := range path {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		cur = mm[k]
+	}
+	s, ok := cur.(string)
+	return s, ok
 }
 
 // inspectEnv digs the env list out of one inspect entry, wherever the

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -20,10 +20,13 @@ const (
 // preflightNames is the stop-then-rm sweep order at start; semiont-ollama is
 // deliberately absent — it is handled in the Ollama section, where a host
 // instance may make a container unnecessary.
+// semiont-frontend is deliberately ABSENT: the Browser is not a stack
+// member (BROWSER-LIFECYCLE.md) — its keep-or-refresh lifecycle lives in
+// flowBrowser, and the preflight must not sweep a viewer the user keeps
+// open across stacks.
 var preflightNames = []string{
 	"semiont-jaeger", "semiont-neo4j", "semiont-qdrant", "semiont-postgres",
 	"semiont-backend", "semiont-worker", "semiont-smelter", "semiont-weaver",
-	"semiont-frontend",
 }
 
 type startOptions struct {
@@ -735,7 +738,9 @@ func pullArgs(rt, img string) []string {
 	return []string{"pull", img}
 }
 
-var semiontServices = []string{"backend", "worker", "smelter", "weaver", "frontend"}
+// frontend is absent: the Browser pulls its own image inside flowBrowser,
+// and only when actually (re)starting — a kept Browser costs no pull.
+var semiontServices = []string{"backend", "worker", "smelter", "weaver"}
 
 // sidecarSpecs: the three make-meaning sidecars, in start order.
 type sidecarSpec struct {

--- a/apps/launcher/internal/launcher/statefile.go
+++ b/apps/launcher/internal/launcher/statefile.go
@@ -50,6 +50,7 @@ type serviceState struct {
 	// live only when the key happens to be in its environment.
 	RemoteModels map[string]remoteModelMeta `json:"remoteModels,omitempty"`
 	Endpoint     string                     `json:"endpoint,omitempty"`  // health probe: http(s) URL or tcp:<host>:<port>
+	Runtime      string                     `json:"runtime,omitempty"`   // browser record only: the runtime that runs it (stack services get theirs from the stack)
 	HostReuse    bool                       `json:"hostReuse,omitempty"` // schema 1 (read-compat only; no longer written)
 	StartedAt    time.Time                  `json:"startedAt"`
 }
@@ -107,6 +108,12 @@ type stackSet struct {
 	UpdatedAt time.Time              `json:"updatedAt"`
 	Launcher  string                 `json:"launcherVersion"`
 	Stacks    map[string]*stackState `json:"stacks"`
+	// Browser: the machine-level viewer, deliberately OUTSIDE every stack
+	// (BROWSER-LIFECYCLE.md): it serves any number of KBs, any start ensures
+	// it, and stopping a stack leaves it running. Optional and
+	// read-compatible; pre-separation records carrying a frontend service
+	// entry migrate on read.
+	Browser *serviceState `json:"browser,omitempty"`
 }
 
 // stackKey: "local" for the machine's one local stack, "codespace:<repo>"
@@ -142,6 +149,7 @@ func loadStackSet() *stackSet {
 		var full stackSet
 		if json.Unmarshal(b, &full) == nil && full.Stacks != nil {
 			full.Schema = 3
+			migrateBrowser(&full)
 			return &full
 		}
 		return ss
@@ -163,7 +171,25 @@ func loadStackSet() *stackSet {
 		}
 	}
 	ss.Stacks[stackKey(&st)] = &st
+	migrateBrowser(ss)
 	return ss
+}
+
+// migrateBrowser lifts a pre-separation frontend service entry out of the
+// local stack into the machine-level browser record. Idempotent; the next
+// save persists the lifted shape.
+func migrateBrowser(ss *stackSet) {
+	if ss.Browser != nil {
+		return
+	}
+	st := ss.Stacks["local"]
+	if st == nil {
+		return
+	}
+	if e, ok := st.Services["frontend"]; ok && e.Provided == providedLauncher {
+		ss.Browser = &e
+		delete(st.Services, "frontend")
+	}
 }
 
 // loadLocalState: the machine's one local stack record, or nil.
@@ -191,7 +217,7 @@ func saveStackSet(ss *stackSet) {
 	if p == "" {
 		return
 	}
-	if len(ss.Stacks) == 0 {
+	if len(ss.Stacks) == 0 && ss.Browser == nil {
 		_ = os.Remove(p)
 		writeDiscovery(ss) // empty list, not an absent file
 		return
@@ -230,6 +256,23 @@ func saveStack(st *stackState) {
 func forgetStack(key string) {
 	ss := loadStackSet()
 	delete(ss.Stacks, key)
+	saveStackSet(ss)
+}
+
+// saveBrowser upserts the machine-level browser record.
+func saveBrowser(e *serviceState) {
+	ss := loadStackSet()
+	ss.Browser = e
+	saveStackSet(ss)
+}
+
+// clearBrowser forgets it (the targeted `stop --service frontend`).
+func clearBrowser() {
+	ss := loadStackSet()
+	if ss.Browser == nil {
+		return
+	}
+	ss.Browser = nil
 	saveStackSet(ss)
 }
 

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -8,13 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"unicode/utf8"
 )
 
 const statusUsage = `Usage: semiont status [--root <path|name>] [--repo <owner/name> [--refresh]] [--service <name>] [--runtime container|docker|podman] [--verbose] [--billing]
 
-Reports what this machine knows about, in three layers:
+Reports what this machine knows about:
 
+  BROWSER        the machine-level viewer (not a stack member) — first,
+                 because it sits architecturally above everything it views
   LOCAL STACK    the one stack running here, and the root it belongs to
   LOCAL ROOTS    every KB clone the launcher has used (roots.json)
   REMOTE KNOWLEDGE BASES
@@ -62,7 +63,6 @@ var statusServices = []struct {
 	endpoint string // http(s) URL, or "tcp:<port>"
 	core     bool   // counted toward the exit status
 }{
-	{"frontend", "http://localhost:3000", true},
 	{"backend", "http://localhost:4000/api/health", true},
 	{"database", "tcp:5432", true},
 	{"worker", "http://localhost:9090/health", true},
@@ -145,6 +145,15 @@ func Status(args []string) int {
 			return 1
 		}
 	}
+	// --service frontend asks about the Browser — machine-level, outside
+	// every stack, so it bypasses the stack table entirely.
+	if service == "frontend" && repoFlag == "" {
+		healthy := printBrowser(u, loadStackSet())
+		if healthy {
+			return 0
+		}
+		return 1
+	}
 	if repoFlag != "" && (rootFlag != "" || service != "") {
 		u.fail("--repo names a remote stack; --root/--service name the local one.")
 		return 1
@@ -195,6 +204,9 @@ func Status(args []string) int {
 		}
 	}
 
+	if service == "" {
+		printBrowser(u, ss)
+	}
 	healthy, code := printLocalStack(u, st, runtime, service)
 	if code != 0 {
 		return code
@@ -219,6 +231,57 @@ func Status(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+// printBrowser renders the BROWSER section — FIRST, because the viewer sits
+// architecturally above every stack it views (and is the least interesting
+// line, fine to scroll away). Shows the image tag so browser-vs-stack skew
+// is visible: a kept Browser can legitimately outlive several stacks.
+func printBrowser(u *ui, ss *stackSet) (healthy bool) {
+	u.section("BROWSER")
+	b := ss.Browser
+	endpoint := "http://localhost:3000"
+	handle := "semiont-frontend"
+	if b != nil {
+		if b.Endpoint != "" {
+			endpoint = b.Endpoint
+		}
+		if b.ID != "" {
+			handle = b.ID
+		}
+	}
+	healthy = probeHealth(endpoint)
+	// Query only the runtime the record names — a record must narrow the
+	// sweep, same rule the stack table keeps. No record: all installed.
+	rts := installedRuntimes()
+	if b != nil && b.Runtime != "" && onPath(b.Runtime) {
+		rts = []string{b.Runtime}
+	}
+	state, _ := containerState(rts, handle)
+	word := state
+	if word == "" {
+		word = "absent"
+	}
+	mark := u.wrap(ansiRed, "✗")
+	if healthy {
+		mark = u.wrap(ansiGreen, "✓")
+	}
+	detail := "serves every KB on this machine; discovery-synced"
+	if b != nil && b.Image != "" {
+		if i := strings.LastIndexByte(b.Image, ':'); i > 0 {
+			tag := b.Image[i+1:]
+			detail = "images " + tag + " · " + detail
+			if st := ss.Stacks["local"]; st != nil && st.Version != "" && st.Version != tag {
+				detail += " · STACK RUNS " + st.Version + " — refresh: semiont start --service frontend"
+			}
+		}
+	}
+	if !healthy && state == "" {
+		fmt.Printf("  %s %-12s %s\n", mark, word, u.dim("any semiont start brings it up (or: semiont start --service frontend)"))
+		return healthy
+	}
+	fmt.Printf("  %s %-12s %s  %s\n", mark, word, endpoint, u.dim("("+detail+")"))
+	return healthy
 }
 
 // printLocalStack renders the LOCAL STACK section: the root it belongs to,
@@ -273,7 +336,12 @@ func printLocalStack(u *ui, st *stackState, runtime, service string) (healthy bo
 		fmt.Println()
 	}
 
-	fmt.Printf("  %-22s %-10s %-10s %s\n", "SERVICE", "STATE", "RUNTIME", "HEALTH")
+	// One STATUS cell — mark + word — instead of STATE and HEALTH columns
+	// that said yes twice on every healthy row. The diagnostic divergences
+	// keep distinct words: "✗ running" (up but unhealthy) vs "✗ exited"
+	// (crashed, kept for inspection) vs "✓ host"/"✓ reachable" (provided
+	// elsewhere). The probe endpoint stays, dimmed.
+	fmt.Printf("  %-22s %-10s %s\n", "SERVICE", "RUNTIME", "STATUS")
 	healthy = true
 	// Fetched once, lazily: the inference and embedding model rows both read
 	// it, and a stack with no ollama-served models never asks at all.
@@ -311,7 +379,7 @@ func printLocalStack(u *ui, st *stackState, runtime, service string) (healthy bo
 		}
 
 		if rec != nil && rec.Provided == providedNone {
-			fmt.Printf("  %-22s %-10s %-10s %s\n", label, "—", "—", u.dim("not configured"))
+			fmt.Printf("  %-22s %-10s %s\n", label, "—", u.dim("not configured"))
 			continue
 		}
 
@@ -343,17 +411,23 @@ func printLocalStack(u *ui, st *stackState, runtime, service string) (healthy bo
 			healthy = false
 		}
 
-		stateCol := state
-		switch {
-		case state == "running":
-			stateCol = u.wrap(ansiGreen, state)
-		case state == "":
-			stateCol = u.dim("—")
-		default:
-			stateCol = u.wrap(ansiYellow, state)
+		// The STATUS word: the container state when there is a container
+		// (running / exited), else what the probe can honestly say about a
+		// role provided elsewhere (reachable / unreachable), else "absent".
+		word := state
+		if word == "" {
+			switch {
+			case rt == "external" || rt == "host":
+				word = "unreachable"
+				if isHealthy {
+					word = "reachable"
+				}
+			default:
+				word = "absent"
+			}
 		}
 		if rt == "" {
-			rt = u.dim("—")
+			rt = "—"
 		}
 		probe := endpoint
 		if rest, ok := strings.CutPrefix(probe, "tcp:"); ok {
@@ -363,13 +437,11 @@ func printLocalStack(u *ui, st *stackState, runtime, service string) (healthy bo
 				probe = "tcp://localhost:" + rest
 			}
 		}
-		healthCol := u.wrap(ansiRed, "✗") + " " + u.dim(probe)
+		mark := u.wrap(ansiRed, "✗")
 		if isHealthy {
-			healthCol = u.wrap(ansiGreen, "✓") + " " + u.dim(probe)
+			mark = u.wrap(ansiGreen, "✓")
 		}
-		fmt.Printf("  %-22s %-*s %-*s %s\n",
-			label, 10+utf8.RuneCountInString(stateCol)-visibleLen(stateCol), stateCol,
-			10+utf8.RuneCountInString(rt)-visibleLen(rt), rt, healthCol)
+		fmt.Printf("  %-22s %-10s %s %-12s %s\n", label, rt, mark, word, u.dim(probe))
 
 		// The models this role was started with, indented beneath it.
 		if rec != nil && len(rec.Models) > 0 {
@@ -523,26 +595,6 @@ func printLauncherPaths(u *ui) {
 		p := filepath.Join(home, ".ollama")
 		row("inference", p, presence(p))
 	}
-}
-
-// visibleLen is the printed width of a string minus its ANSI escapes — needed
-// so %-*s column padding lines up whether or not color is on.
-func visibleLen(s string) int {
-	n := 0
-	inEsc := false
-	for _, r := range s {
-		switch {
-		case inEsc:
-			if r == 'm' {
-				inEsc = false
-			}
-		case r == '\033':
-			inEsc = true
-		default:
-			n++
-		}
-	}
-	return n
 }
 
 // containerState asks each runtime for the container's state, first hit wins.

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -238,10 +238,10 @@ func Status(args []string) int {
 // line, fine to scroll away). Shows the image tag so browser-vs-stack skew
 // is visible: a kept Browser can legitimately outlive several stacks.
 func printBrowser(u *ui, ss *stackSet) (healthy bool) {
+	u.section("BROWSER")
 	b := ss.Browser
 	endpoint := "http://localhost:3000"
-	name := "semiont-frontend"
-	handle := name
+	handle := "semiont-frontend"
 	if b != nil {
 		if b.Endpoint != "" {
 			endpoint = b.Endpoint
@@ -258,9 +258,12 @@ func printBrowser(u *ui, ss *stackSet) (healthy bool) {
 		rts = []string{b.Runtime}
 	}
 	state, _ := containerState(rts, handle)
-	if state == "" && handle != name {
-		state, _ = containerState(rts, name)
+	if state == "" && handle != "semiont-frontend" {
+		// A stale recorded ID must not contradict a live endpoint ("absent"
+		// beside ✓): the stable name is the fallback truth (Copilot review).
+		state, _ = containerState(rts, "semiont-frontend")
 	}
+	word := state
 	if word == "" {
 		word = "absent"
 	}

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -238,10 +238,10 @@ func Status(args []string) int {
 // line, fine to scroll away). Shows the image tag so browser-vs-stack skew
 // is visible: a kept Browser can legitimately outlive several stacks.
 func printBrowser(u *ui, ss *stackSet) (healthy bool) {
-	u.section("BROWSER")
 	b := ss.Browser
 	endpoint := "http://localhost:3000"
-	handle := "semiont-frontend"
+	name := "semiont-frontend"
+	handle := name
 	if b != nil {
 		if b.Endpoint != "" {
 			endpoint = b.Endpoint
@@ -258,7 +258,9 @@ func printBrowser(u *ui, ss *stackSet) (healthy bool) {
 		rts = []string{b.Runtime}
 	}
 	state, _ := containerState(rts, handle)
-	word := state
+	if state == "" && handle != name {
+		state, _ = containerState(rts, name)
+	}
 	if word == "" {
 		word = "absent"
 	}

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -100,19 +100,23 @@ func Stop(args []string) int {
 		if b == nil {
 			u.log("No Browser is recorded — sweeping the container name to be sure.")
 		}
-		handle := "semiont-frontend"
+		name := "semiont-frontend"
+		handle := name
 		if b != nil && b.ID != "" {
 			handle = b.ID
 		}
 		if dryRun {
 			fmt.Println("# stop the Browser (machine-level; stacks untouched):")
 			fmt.Printf("<rt> stop %s\n<rt> rm %s\n", handle, handle)
+			if handle != name {
+				fmt.Printf("<rt> stop %s\n<rt> rm %s\n", name, name)
+			}
 			return 0
 		}
 		stopped := false
 		for _, rt := range installedRuntimes() {
-			s1 := runSilent(rt, "stop", handle) == nil
-			s2 := runSilent(rt, "rm", handle) == nil
+			s1 := runSilent(rt, "stop", handle) == nil || (handle != name && runSilent(rt, "stop", name) == nil)
+			s2 := runSilent(rt, "rm", handle) == nil || (handle != name && runSilent(rt, "rm", name) == nil)
 			stopped = stopped || s1 || s2
 		}
 		clearBrowser()

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -100,24 +100,29 @@ func Stop(args []string) int {
 		if b == nil {
 			u.log("No Browser is recorded — sweeping the container name to be sure.")
 		}
-		name := "semiont-frontend"
-		handle := name
+		// Sweep BOTH the recorded ID and the stable name: a stale ID
+		// (container recreated outside this record) would no-op while the
+		// name still runs — an off-switch that doesn't switch off (Copilot
+		// review, PR #1064). Idempotent; the name pass is free when the ID
+		// already got it.
+		handles := []string{"semiont-frontend"}
 		if b != nil && b.ID != "" {
-			handle = b.ID
+			handles = []string{b.ID, "semiont-frontend"}
 		}
 		if dryRun {
 			fmt.Println("# stop the Browser (machine-level; stacks untouched):")
-			fmt.Printf("<rt> stop %s\n<rt> rm %s\n", handle, handle)
-			if handle != name {
-				fmt.Printf("<rt> stop %s\n<rt> rm %s\n", name, name)
+			for _, h := range handles {
+				fmt.Printf("<rt> stop %s\n<rt> rm %s\n", h, h)
 			}
 			return 0
 		}
 		stopped := false
 		for _, rt := range installedRuntimes() {
-			s1 := runSilent(rt, "stop", handle) == nil || (handle != name && runSilent(rt, "stop", name) == nil)
-			s2 := runSilent(rt, "rm", handle) == nil || (handle != name && runSilent(rt, "rm", name) == nil)
-			stopped = stopped || s1 || s2
+			for _, h := range handles {
+				s1 := runSilent(rt, "stop", h) == nil
+				s2 := runSilent(rt, "rm", h) == nil
+				stopped = stopped || s1 || s2
+			}
 		}
 		clearBrowser()
 		if stopped {

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -38,8 +38,11 @@ targets a codespace stack, --runtime targets the local one.
 // dependents before their dependencies, so nothing spends teardown alive
 // with its upstream already gone (start brings up jaeger → neo4j → qdrant →
 // ollama → postgres → backend → worker → smelter → weaver → frontend).
+// semiont-frontend is deliberately ABSENT: the Browser is not a stack
+// member (BROWSER-LIFECYCLE.md) — a bare stop leaves the viewer running
+// (announced), and `stop --service frontend` is its explicit off-switch.
 var stopNames = []string{
-	"semiont-frontend", "semiont-weaver", "semiont-smelter", "semiont-worker",
+	"semiont-weaver", "semiont-smelter", "semiont-worker",
 	"semiont-backend", "semiont-postgres", "semiont-ollama", "semiont-qdrant",
 	"semiont-neo4j", "semiont-jaeger",
 }
@@ -86,6 +89,39 @@ func Stop(args []string) int {
 			u.fail("Unknown argument: %s", args[i])
 			return 1
 		}
+	}
+
+	// --service frontend targets the machine-level Browser, not a stack
+	// member: stop its container (record ID preferred), clear its record,
+	// and never touch stack state.
+	if service == "frontend" && repo == "" {
+		ssPre := loadStackSet()
+		b := ssPre.Browser
+		if b == nil {
+			u.log("No Browser is recorded — sweeping the container name to be sure.")
+		}
+		handle := "semiont-frontend"
+		if b != nil && b.ID != "" {
+			handle = b.ID
+		}
+		if dryRun {
+			fmt.Println("# stop the Browser (machine-level; stacks untouched):")
+			fmt.Printf("<rt> stop %s\n<rt> rm %s\n", handle, handle)
+			return 0
+		}
+		stopped := false
+		for _, rt := range installedRuntimes() {
+			s1 := runSilent(rt, "stop", handle) == nil
+			s2 := runSilent(rt, "rm", handle) == nil
+			stopped = stopped || s1 || s2
+		}
+		clearBrowser()
+		if stopped {
+			u.ok("Browser stopped %s", u.dim("(stacks untouched; any start brings it back)"))
+		} else {
+			u.log("Browser was not running.")
+		}
+		return 0
 	}
 
 	// serviceContainer: the container --service targets. Usually the roles
@@ -375,13 +411,21 @@ func Stop(args []string) int {
 	}
 	verifyPortsReleased(u, ports)
 	fmt.Println("Semiont stack stopped.")
+	// The Browser deliberately survives a stack stop — it is the machine's
+	// viewer, not a stack member. Say so, with the off-switch: silence here
+	// would read as a leak.
+	if b := loadStackSet().Browser; b != nil && b.Endpoint != "" && httpOK(b.Endpoint) {
+		fmt.Printf("Browser still running on %s %s\n", b.Endpoint, u.dim("(not a stack member; stop it with: semiont stop --service frontend)"))
+	}
 	return 0
 }
 
 // fiatPorts: the launcher-owned ports every stack claims regardless of
 // config — the release-verification fallback when no record captured the
-// stack's exact claims (older launcher's record, name-sweep path).
-var fiatPorts = []int{3000, 9090, 9091, 9092, 16686, 4318}
+// stack's exact claims (older launcher's record, name-sweep path). 3000 is
+// absent: the Browser is not a stack member and its port is not the
+// stack's to verify.
+var fiatPorts = []int{9090, 9091, 9092, 16686, 4318}
 
 // verifyPortsReleased: stop's job isn't done until the ports are actually
 // free — runtimes release published ports asynchronously (Apple container's

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -562,7 +562,7 @@ func TestStopSweepsAllRuntimes(t *testing.T) {
 	}
 	checkGolden(t, "stop-all-runtimes.argv", s.argv(t))
 	mustContain(t, "stdout", stdout,
-		"Sweeping 10 container(s) across container, docker, podman",
+		"Sweeping 9 container(s) across container, docker, podman",
 		"container: none found",
 		"docker: none found",
 		"podman: none found",
@@ -643,16 +643,18 @@ func TestStatusMixed(t *testing.T) {
 		t.Errorf("--service names one stack, so it must exit on health; got %d", code)
 	}
 	mustContain(t, "stdout", stdout,
-		"SERVICE", "STATE", "RUNTIME", "HEALTH",
+		"SERVICE", "RUNTIME", "STATUS",
 		"LOCAL STACK", "database (PostgreSQL)", // tech rides in the SERVICE cell now
 		"PostgreSQL", "Neo4j", "Qdrant", "Ollama", "Jaeger",
 		"LOCAL ROOTS",
 		"(discovered from cwd)",
-		"✓ http://localhost:4000/api/health",
-		"✗ http://localhost:9090/health",
-		"✗ tcp://localhost:5432",
-		"exited",
-		"host",
+		// The merged STATUS cell: mark + word, probe dimmed after. The
+		// diagnostic matrix each word pins: running-and-healthy, running-
+		// but-unhealthy, crashed, absent, host-provided.
+		"✓ running", "✗ running", "✗ exited", "✗ absent", "✓ reachable",
+		"http://localhost:4000/api/health",
+		"http://localhost:9090/health",
+		"tcp://localhost:5432",
 	)
 	// LAUNCHER PATHS describes the launcher, not any KB — asked for, not shown.
 	if strings.Contains(stdout, "LAUNCHER PATHS") {
@@ -695,8 +697,10 @@ func TestStatusAllHealthy(t *testing.T) {
 		t.Fatalf("want exit 0 with all core healthy, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 	mustContain(t, "stdout", stdout, "traces")
-	if strings.Contains(stdout, "✗ http://localhost:4000") {
-		t.Errorf("backend reported unhealthy:\n%s", stdout)
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.Contains(line, "backend") && strings.Contains(line, "✗") {
+			t.Errorf("backend reported unhealthy:\n%s", stdout)
+		}
 	}
 }
 
@@ -1188,7 +1192,9 @@ func TestCodespaceStartCreates(t *testing.T) {
 		"Reading admin credentials",
 		"Semiont KB is up in codespace fake-cs-1",
 		"Semiont KB         http://localhost:4000",
-		"Semiont Browser    semiont start --service frontend", // not forwarded — runs locally
+		// Codespace start ENSURES the local Browser (a runtime exists in
+		// this scenario), so the summary names the live endpoint.
+		"Semiont Browser    http://localhost:3000",
 		"admin@example.com", "fake-admin-pw",
 		"local uncommitted changes don't travel",
 		"Halt compute:")
@@ -1724,8 +1730,12 @@ func TestCodespaceStopKeepsRecordDeleteForgets(t *testing.T) {
 	mustContain(t, "delete stdout", stdout, "deleted", "destroyed")
 	log, _ = os.ReadFile(s.log)
 	mustContain(t, "argv log", string(log), "gh codespace delete -c fake-cs-1 --force")
-	if _, err := os.Stat(statePathFor(s.home)); !os.IsNotExist(err) {
-		t.Error("stack.json survived stop --delete")
+	// The codespace record is forgotten — but stack.json itself now
+	// legitimately survives: codespace start ensured the local Browser,
+	// whose machine-level record lives there.
+	b, _ = os.ReadFile(statePathFor(s.home))
+	if strings.Contains(string(b), "codespace:") {
+		t.Errorf("deleted codespace stack still recorded:\n%s", b)
 	}
 
 	// --delete is codespace-only.
@@ -2569,8 +2579,11 @@ func TestStackStateLifecycle(t *testing.T) {
 		} `json:"services"`
 	}
 	var set struct {
-		Schema int                      `json:"schema"`
-		Stacks map[string]recordedStack `json:"stacks"`
+		Schema  int                      `json:"schema"`
+		Stacks  map[string]recordedStack `json:"stacks"`
+		Browser *struct {
+			ID string `json:"id"`
+		} `json:"browser"`
 	}
 	if err := json.Unmarshal(b, &set); err != nil {
 		t.Fatalf("stack.json not valid JSON: %v\n%s", err, b)
@@ -2582,7 +2595,15 @@ func TestStackStateLifecycle(t *testing.T) {
 	if set.Schema != 3 || st.Runtime != "container" {
 		t.Errorf("schema/runtime: got %d/%q", set.Schema, st.Runtime)
 	}
-	for _, role := range []string{"traces", "graph", "vectors", "inference", "database", "backend", "worker", "smelter", "weaver", "frontend"} {
+	// frontend is deliberately ABSENT from the stack's services: the Browser
+	// is machine-level (BROWSER-LIFECYCLE.md), recorded under "browser".
+	if _, ok := st.Services["frontend"]; ok {
+		t.Error("frontend recorded as a stack service — the Browser is machine-level")
+	}
+	if set.Browser == nil || set.Browser.ID != "fid-semiont-frontend" {
+		t.Errorf("browser record missing or wrong: %+v", set.Browser)
+	}
+	for _, role := range []string{"traces", "graph", "vectors", "inference", "database", "backend", "worker", "smelter", "weaver"} {
 		e, ok := st.Services[role]
 		if !ok {
 			t.Errorf("service %q missing from record", role)
@@ -2647,16 +2668,28 @@ func TestStackStateLifecycle(t *testing.T) {
 	mustContain(t, "stdout", stdout, "Using recorded stack state", "Semiont stack stopped.")
 	fullArgv := strings.TrimPrefix(s.argv(t), preFull)
 	mustContain(t, "full stop argv", fullArgv,
-		"container stop fid-semiont-backend", "container rm fid-semiont-frontend",
+		"container stop fid-semiont-backend",
 		"docker stop semiont-backend", "podman stop semiont-backend")
+	// The Browser survives a full stop — never in the sweep.
+	if strings.Contains(fullArgv, "semiont-frontend") {
+		t.Errorf("full stop touched the Browser:\n%s", fullArgv)
+	}
 	for _, bad := range []string{"docker stop fid-", "podman stop fid-"} {
 		if strings.Contains(fullArgv, bad) {
 			t.Errorf("stray sweep used the recorded runtime's IDs: %q", bad)
 		}
 	}
-	if _, err := os.Stat(statePathFor(s.home)); !os.IsNotExist(err) {
-		t.Error("stack.json survived a full stop")
+	// stack.json now legitimately survives a full stop: the browser record
+	// lives there and the Browser keeps running. The LOCAL STACK entry must
+	// be gone, the browser entry present.
+	b2, err := os.ReadFile(statePathFor(s.home))
+	if err != nil {
+		t.Fatalf("stack.json should survive (browser record): %v", err)
 	}
+	if strings.Contains(string(b2), `"local"`) {
+		t.Errorf("local stack record survived its stop:\n%s", b2)
+	}
+	mustContain(t, "browser record survives", string(b2), `"browser"`)
 }
 
 func TestStopTwiceIsHonest(t *testing.T) {
@@ -2751,7 +2784,8 @@ func TestStopRuntimeMismatchKeepsRecordAndStaging(t *testing.T) {
 		t.Error("stack.json erased by a mismatched-runtime stop")
 	}
 	argv := s.argv(t)
-	mustContain(t, "argv", argv, "docker stop semiont-frontend")
+	// The sweep excludes the Browser now; weaver is the first stack member.
+	mustContain(t, "argv", argv, "docker stop semiont-weaver")
 	if strings.Contains(argv, "container stop") {
 		t.Errorf("mismatched stop touched the recorded runtime:\n%s", argv)
 	}
@@ -3684,6 +3718,89 @@ func TestDiscoveryFileTracksStacks(t *testing.T) {
 	mustContain(t, "empty view", disc(), `"kbs": []`)
 }
 
+func TestBrowserOutlivesTheStack(t *testing.T) {
+	// BROWSER-LIFECYCLE P2: the Browser is a machine-level viewer, not a
+	// stack member. Start ensures it; a second start with a current image
+	// KEEPS it; bare stop leaves it running (announced); a stale image is
+	// restarted; --service frontend is the explicit off-switch.
+	s := newScenario(t, "container")
+	if _, stderr, code := s.run(t, "start"); code != 0 {
+		t.Fatalf("start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	// The record is machine-level, not a stack service.
+	rec, _ := os.ReadFile(statePathFor(s.home))
+	mustContain(t, "stack.json", string(rec), `"browser"`)
+	if strings.Contains(string(rec), `"frontend"`) {
+		t.Errorf("frontend still recorded as a stack service:\n%s", rec)
+	}
+	// The stack's port claims must NOT include the Browser's 3000 — stop
+	// verifies release of stack ports, and the Browser keeps running.
+	if strings.Contains(string(rec), "3000") && strings.Contains(strings.Split(string(rec), `"browser"`)[0], "3000") {
+		t.Errorf("browser port recorded among the stack's claims:\n%s", rec)
+	}
+
+	// Bare stop: stack down, Browser untouched and announced. Slice the
+	// argv to THIS command — start's own restart branch legitimately
+	// stop/rm's a stale browser earlier in the log.
+	preStop := s.mustLog(t)
+	stdout, stderr, code := s.run(t, "stop", "--runtime", "container")
+	if code != 0 {
+		t.Fatalf("stop: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "stop stdout", stdout, "Browser still running", "semiont stop --service frontend")
+	if stopArgv := strings.TrimPrefix(string(s.mustLog(t)), string(preStop)); strings.Contains(stopArgv, "semiont-frontend") {
+		t.Errorf("bare stop touched the Browser:\n%s", stopArgv)
+	}
+	rec, _ = os.ReadFile(statePathFor(s.home))
+	mustContain(t, "browser record survives the stack record", string(rec), `"browser"`)
+
+	// Second start with the SAME image running: keep, don't churn. The fake
+	// runtime reports the reference the launcher would run.
+	s.extraEnv = append(s.extraEnv,
+		"FAKERT_STATE_frontend=running",
+		"FAKERT_IMAGE_frontend=ghcr.io/the-ai-alliance/semiont-frontend:latest")
+	before := s.mustLog(t)
+	stdout, stderr, code = s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("second start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	fresh := strings.TrimPrefix(string(s.mustLog(t)), string(before))
+	mustContain(t, "keep message", stdout+stderr, "Browser already running")
+	if strings.Contains(fresh, "run -d --name semiont-frontend") {
+		t.Errorf("current Browser was churned:\n%s", fresh)
+	}
+
+	// Stale image (reference differs): restart.
+	for i, e := range s.extraEnv {
+		if strings.HasPrefix(e, "FAKERT_IMAGE_frontend=") {
+			s.extraEnv[i] = "FAKERT_IMAGE_frontend=ghcr.io/the-ai-alliance/semiont-frontend:old"
+		}
+	}
+	if _, _, code := s.run(t, "stop", "--runtime", "container"); code != 0 {
+		t.Fatal("interim stop")
+	}
+	before = s.mustLog(t)
+	stdout, stderr, code = s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("stale-image start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	fresh = strings.TrimPrefix(string(s.mustLog(t)), string(before))
+	if !strings.Contains(fresh, "run -d --name semiont-frontend") {
+		t.Errorf("stale Browser was not restarted:\n%s", fresh)
+	}
+
+	// The explicit off-switch stops it and clears the record.
+	stdout, _, code = s.run(t, "stop", "--service", "frontend")
+	if code != 0 {
+		t.Fatalf("stop --service frontend: exit %d", code)
+	}
+	mustContain(t, "off-switch", stdout, "Browser stopped")
+	rec, _ = os.ReadFile(statePathFor(s.home))
+	if strings.Contains(string(rec), `"browser"`) {
+		t.Errorf("browser record survived its explicit stop:\n%s", rec)
+	}
+}
+
 func TestStatusService(t *testing.T) {
 	s := newScenario(t, "container")
 	s.extraEnv = append(s.extraEnv, "FAKERT_STATE_backend=running")
@@ -3692,7 +3809,7 @@ func TestStatusService(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("healthy backend: want exit 0, got %d\nstdout:\n%s", code, stdout)
 	}
-	mustContain(t, "stdout", stdout, "backend", "running", "✓ http://localhost:4000/api/health")
+	mustContain(t, "stdout", stdout, "backend", "✓ running", "http://localhost:4000/api/health")
 	for _, absent := range []string{"LOCAL ROOTS", "worker", "traces"} {
 		if strings.Contains(stdout, absent) {
 			t.Errorf("filtered status leaked %q:\n%s", absent, stdout)

--- a/apps/launcher/testdata/golden/start-default-boot.argv
+++ b/apps/launcher/testdata/golden/start-default-boot.argv
@@ -66,6 +66,7 @@ container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 container stop semiont-ollama
+container rm semiont-ollama
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -77,6 +78,7 @@ container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 container inspect semiont-frontend
 container stop semiont-frontend
+container rm semiont-frontend
 lsof -ti :3000
 container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-default-boot.argv
+++ b/apps/launcher/testdata/golden/start-default-boot.argv
@@ -16,8 +16,6 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 docker stop semiont-jaeger
 docker rm semiont-jaeger
 docker stop semiont-neo4j
@@ -34,8 +32,6 @@ docker stop semiont-smelter
 docker rm semiont-smelter
 docker stop semiont-weaver
 docker rm semiont-weaver
-docker stop semiont-frontend
-docker rm semiont-frontend
 podman stop semiont-jaeger
 podman rm semiont-jaeger
 podman stop semiont-neo4j
@@ -52,8 +48,6 @@ podman stop semiont-smelter
 podman rm semiont-smelter
 podman stop semiont-weaver
 podman rm semiont-weaver
-podman stop semiont-frontend
-podman rm semiont-frontend
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -62,14 +56,12 @@ lsof -ti :4000
 lsof -ti :9090
 lsof -ti :9091
 lsof -ti :9092
-lsof -ti :3000
 lsof -ti :16686
 lsof -ti :4318
 container image pull ghcr.io/the-ai-alliance/semiont-backend:latest
 container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
-container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
@@ -83,4 +75,8 @@ container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api
 container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume <config-stage>/worker.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-worker:latest
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
+container inspect semiont-frontend
+container stop semiont-frontend
+lsof -ti :3000
+container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-docker-boot.argv
+++ b/apps/launcher/testdata/golden/start-docker-boot.argv
@@ -16,8 +16,6 @@ docker stop semiont-smelter
 docker rm semiont-smelter
 docker stop semiont-weaver
 docker rm semiont-weaver
-docker stop semiont-frontend
-docker rm semiont-frontend
 container stop semiont-jaeger
 container rm semiont-jaeger
 container stop semiont-neo4j
@@ -34,8 +32,6 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 podman stop semiont-jaeger
 podman rm semiont-jaeger
 podman stop semiont-neo4j
@@ -52,8 +48,6 @@ podman stop semiont-smelter
 podman rm semiont-smelter
 podman stop semiont-weaver
 podman rm semiont-weaver
-podman stop semiont-frontend
-podman rm semiont-frontend
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -62,14 +56,12 @@ lsof -ti :4000
 lsof -ti :9090
 lsof -ti :9091
 lsof -ti :9092
-lsof -ti :3000
 lsof -ti :16686
 lsof -ti :4318
 docker pull ghcr.io/the-ai-alliance/semiont-backend:latest
 docker pull ghcr.io/the-ai-alliance/semiont-worker:latest
 docker pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 docker pull ghcr.io/the-ai-alliance/semiont-weaver:latest
-docker pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 docker run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 docker run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 docker run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
@@ -83,4 +75,8 @@ docker run --rm busybox:1.38.0 sh -c wget -q -O- http://host.docker.internal:400
 docker run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume <config-stage>/worker.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4318 --env BACKEND_HOST=host.docker.internal --env OLLAMA_HOST=host.docker.internal --env NEO4J_HOST=host.docker.internal --env QDRANT_HOST=host.docker.internal --env POSTGRES_HOST=host.docker.internal --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-worker:latest
 docker run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4318 --env BACKEND_HOST=host.docker.internal --env OLLAMA_HOST=host.docker.internal --env NEO4J_HOST=host.docker.internal --env QDRANT_HOST=host.docker.internal --env POSTGRES_HOST=host.docker.internal --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 docker run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4318 --env BACKEND_HOST=host.docker.internal --env OLLAMA_HOST=host.docker.internal --env NEO4J_HOST=host.docker.internal --env QDRANT_HOST=host.docker.internal --env POSTGRES_HOST=host.docker.internal --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
+docker inspect semiont-frontend
+docker stop semiont-frontend
+lsof -ti :3000
+docker pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 docker run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-docker-boot.argv
+++ b/apps/launcher/testdata/golden/start-docker-boot.argv
@@ -66,6 +66,7 @@ docker run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/al
 docker run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 docker run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 docker stop semiont-ollama
+docker rm semiont-ollama
 lsof -ti :11434
 docker run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 docker run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -77,6 +78,7 @@ docker run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <c
 docker run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4318 --env BACKEND_HOST=host.docker.internal --env OLLAMA_HOST=host.docker.internal --env NEO4J_HOST=host.docker.internal --env QDRANT_HOST=host.docker.internal --env POSTGRES_HOST=host.docker.internal --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 docker inspect semiont-frontend
 docker stop semiont-frontend
+docker rm semiont-frontend
 lsof -ti :3000
 docker pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 docker run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-dryrun-default.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-default.txt
@@ -69,6 +69,7 @@ container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 # ensure ollama models present at http://localhost:11434 (pull each missing one): gemma4:26b, gemma4:e2b, nomic-embed-text
 # else:
 container stop semiont-ollama
+container rm semiont-ollama
 # require free port: 11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v <ollama-volume>:/root/.ollama ollama/ollama
 # wait: http://localhost:11434/api/version (30s)
@@ -90,6 +91,7 @@ container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume 
 # (the Browser is not a stack member: stop leaves it running; semiont stop --service frontend stops it)
 # else:
 container stop semiont-frontend
+container rm semiont-frontend
 # require free port: 3000
 container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-dryrun-default.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-default.txt
@@ -17,8 +17,6 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 # sweep stray Semiont containers under docker:
 docker stop semiont-jaeger
 docker rm semiont-jaeger
@@ -36,8 +34,6 @@ docker stop semiont-smelter
 docker rm semiont-smelter
 docker stop semiont-weaver
 docker rm semiont-weaver
-docker stop semiont-frontend
-docker rm semiont-frontend
 # sweep stray Semiont containers under podman:
 podman stop semiont-jaeger
 podman rm semiont-jaeger
@@ -55,16 +51,13 @@ podman stop semiont-smelter
 podman rm semiont-smelter
 podman stop semiont-weaver
 podman rm semiont-weaver
-podman stop semiont-frontend
-podman rm semiont-frontend
 # remove staged config copies: /tmp/semiont-config.*
-# require free ports: 7474 7687 6333 5432 4000 9090 9091 9092 3000 16686 4318
+# require free ports: 7474 7687 6333 5432 4000 9090 9091 9092 16686 4318
 # stage per-service config copies under <config-stage>: backend.toml worker.toml smelter.toml weaver.toml
 container image pull ghcr.io/the-ai-alliance/semiont-backend:latest
 container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
-container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 # wait: http://localhost:16686 (30s)
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
@@ -93,5 +86,11 @@ container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume
 # wait: http://localhost:9091/health (30s)
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://<host-addr>:4318 --env BACKEND_HOST=<host-addr> --env OLLAMA_HOST=<host-addr> --env NEO4J_HOST=<host-addr> --env QDRANT_HOST=<host-addr> --env POSTGRES_HOST=<host-addr> --env SEMIONT_WORKER_SECRET=<worker-secret> ghcr.io/the-ai-alliance/semiont-weaver:latest
 # wait: http://localhost:9092/health (30s)
+# browser: keep if running with image identity matching ghcr.io/the-ai-alliance/semiont-frontend:latest; else stop/rm + pull + run
+# (the Browser is not a stack member: stop leaves it running; semiont stop --service frontend stops it)
+# else:
+container stop semiont-frontend
+# require free port: 3000
+container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest
 # wait: http://localhost:3000 (30s)

--- a/apps/launcher/testdata/golden/start-dryrun-local.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-local.txt
@@ -17,10 +17,8 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 # remove staged config copies: /tmp/semiont-config.*
-# require free ports: 7474 7687 6333 5432 4000 9090 9091 9092 3000 16686 4318
+# require free ports: 7474 7687 6333 5432 4000 9090 9091 9092 16686 4318
 # stage per-service config copies under <config-stage>: backend.toml worker.toml smelter.toml weaver.toml
 # SEMIONT_VERSION=local — using locally-built :local images (no pull)
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
@@ -51,5 +49,10 @@ container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume
 # wait: http://localhost:9091/health (30s)
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://<host-addr>:4318 --env BACKEND_HOST=<host-addr> --env OLLAMA_HOST=<host-addr> --env NEO4J_HOST=<host-addr> --env QDRANT_HOST=<host-addr> --env POSTGRES_HOST=<host-addr> --env SEMIONT_WORKER_SECRET=<worker-secret> ghcr.io/the-ai-alliance/semiont-weaver:local
 # wait: http://localhost:9092/health (30s)
+# browser: keep if running with image identity matching ghcr.io/the-ai-alliance/semiont-frontend:local; else stop/rm + pull + run
+# (the Browser is not a stack member: stop leaves it running; semiont stop --service frontend stops it)
+# else:
+container stop semiont-frontend
+# require free port: 3000
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:local
 # wait: http://localhost:3000 (30s)

--- a/apps/launcher/testdata/golden/start-dryrun-local.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-local.txt
@@ -32,6 +32,7 @@ container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 # ensure ollama models present at http://localhost:11434 (pull each missing one): gemma4:26b, gemma4:e2b, nomic-embed-text
 # else:
 container stop semiont-ollama
+container rm semiont-ollama
 # require free port: 11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v <ollama-volume>:/root/.ollama ollama/ollama
 # wait: http://localhost:11434/api/version (30s)
@@ -53,6 +54,7 @@ container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume 
 # (the Browser is not a stack member: stop leaves it running; semiont stop --service frontend stops it)
 # else:
 container stop semiont-frontend
+container rm semiont-frontend
 # require free port: 3000
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:local
 # wait: http://localhost:3000 (30s)

--- a/apps/launcher/testdata/golden/start-host-ollama-boot.argv
+++ b/apps/launcher/testdata/golden/start-host-ollama-boot.argv
@@ -16,8 +16,6 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -26,14 +24,12 @@ lsof -ti :4000
 lsof -ti :9090
 lsof -ti :9091
 lsof -ti :9092
-lsof -ti :3000
 lsof -ti :16686
 lsof -ti :4318
 container image pull ghcr.io/the-ai-alliance/semiont-backend:latest
 container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
-container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
@@ -45,4 +41,8 @@ container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api
 container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume <config-stage>/worker.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-worker:latest
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
+container inspect semiont-frontend
+container stop semiont-frontend
+lsof -ti :3000
+container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-host-ollama-boot.argv
+++ b/apps/launcher/testdata/golden/start-host-ollama-boot.argv
@@ -43,6 +43,7 @@ container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 container inspect semiont-frontend
 container stop semiont-frontend
+container rm semiont-frontend
 lsof -ti :3000
 container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-local-version-boot.argv
+++ b/apps/launcher/testdata/golden/start-local-version-boot.argv
@@ -30,6 +30,7 @@ container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 container stop semiont-ollama
+container rm semiont-ollama
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -41,5 +42,6 @@ container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:local
 container inspect semiont-frontend
 container stop semiont-frontend
+container rm semiont-frontend
 lsof -ti :3000
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:local

--- a/apps/launcher/testdata/golden/start-local-version-boot.argv
+++ b/apps/launcher/testdata/golden/start-local-version-boot.argv
@@ -16,8 +16,6 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -26,7 +24,6 @@ lsof -ti :4000
 lsof -ti :9090
 lsof -ti :9091
 lsof -ti :9092
-lsof -ti :3000
 lsof -ti :16686
 lsof -ti :4318
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
@@ -42,4 +39,7 @@ container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api
 container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume <config-stage>/worker.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-worker:local
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:local
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:local
+container inspect semiont-frontend
+container stop semiont-frontend
+lsof -ti :3000
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:local

--- a/apps/launcher/testdata/golden/start-no-observe-boot.argv
+++ b/apps/launcher/testdata/golden/start-no-observe-boot.argv
@@ -16,8 +16,6 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -26,12 +24,10 @@ lsof -ti :4000
 lsof -ti :9090
 lsof -ti :9091
 lsof -ti :9092
-lsof -ti :3000
 container image pull ghcr.io/the-ai-alliance/semiont-backend:latest
 container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
-container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 container stop semiont-ollama
@@ -44,4 +40,8 @@ container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api
 container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume <config-stage>/worker.toml:/home/semiont/.semiontconfig:ro --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-worker:latest
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
+container inspect semiont-frontend
+container stop semiont-frontend
+lsof -ti :3000
+container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-no-observe-boot.argv
+++ b/apps/launcher/testdata/golden/start-no-observe-boot.argv
@@ -31,6 +31,7 @@ container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 container stop semiont-ollama
+container rm semiont-ollama
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -42,6 +43,7 @@ container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 container inspect semiont-frontend
 container stop semiont-frontend
+container rm semiont-frontend
 lsof -ti :3000
 container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-port-conflict.argv
+++ b/apps/launcher/testdata/golden/start-port-conflict.argv
@@ -16,7 +16,5 @@ container stop semiont-smelter
 container rm semiont-smelter
 container stop semiont-weaver
 container rm semiont-weaver
-container stop semiont-frontend
-container rm semiont-frontend
 lsof -ti :7474
 ps -p 12345 -o comm=

--- a/apps/launcher/testdata/golden/stop-all-runtimes.argv
+++ b/apps/launcher/testdata/golden/stop-all-runtimes.argv
@@ -1,5 +1,3 @@
-container stop semiont-frontend
-container rm semiont-frontend
 container stop semiont-weaver
 container rm semiont-weaver
 container stop semiont-smelter
@@ -18,8 +16,6 @@ container stop semiont-neo4j
 container rm semiont-neo4j
 container stop semiont-jaeger
 container rm semiont-jaeger
-docker stop semiont-frontend
-docker rm semiont-frontend
 docker stop semiont-weaver
 docker rm semiont-weaver
 docker stop semiont-smelter
@@ -38,8 +34,6 @@ docker stop semiont-neo4j
 docker rm semiont-neo4j
 docker stop semiont-jaeger
 docker rm semiont-jaeger
-podman stop semiont-frontend
-podman rm semiont-frontend
 podman stop semiont-weaver
 podman rm semiont-weaver
 podman stop semiont-smelter
@@ -58,7 +52,6 @@ podman stop semiont-neo4j
 podman rm semiont-neo4j
 podman stop semiont-jaeger
 podman rm semiont-jaeger
-lsof -ti :3000
 lsof -ti :9090
 lsof -ti :9091
 lsof -ti :9092

--- a/apps/launcher/testdata/golden/stop-docker-only.argv
+++ b/apps/launcher/testdata/golden/stop-docker-only.argv
@@ -1,5 +1,3 @@
-docker stop semiont-frontend
-docker rm semiont-frontend
 docker stop semiont-weaver
 docker rm semiont-weaver
 docker stop semiont-smelter

--- a/apps/launcher/testdata/golden/stop-dryrun.txt
+++ b/apps/launcher/testdata/golden/stop-dryrun.txt
@@ -1,7 +1,5 @@
 # semiont stop --dry-run — the exact runtime commands a real run would
 # execute, in order.
-container stop semiont-frontend
-container rm semiont-frontend
 container stop semiont-weaver
 container rm semiont-weaver
 container stop semiont-smelter
@@ -20,8 +18,6 @@ container stop semiont-neo4j
 container rm semiont-neo4j
 container stop semiont-jaeger
 container rm semiont-jaeger
-docker stop semiont-frontend
-docker rm semiont-frontend
 docker stop semiont-weaver
 docker rm semiont-weaver
 docker stop semiont-smelter
@@ -40,8 +36,6 @@ docker stop semiont-neo4j
 docker rm semiont-neo4j
 docker stop semiont-jaeger
 docker rm semiont-jaeger
-podman stop semiont-frontend
-podman rm semiont-frontend
 podman stop semiont-weaver
 podman rm semiont-weaver
 podman stop semiont-smelter


### PR DESCRIPTION
## Summary

The Browser (frontend container) is no longer a member of the local stack: it is the machine-level viewer of every KB — local and codespace, discovery-synced — and its lifecycle now matches that role. Design record: `.plans/BROWSER-LIFECYCLE.md` (untracked); companion to BROWSER-KB-DISCOVERY. Live-verified against a running stack (including migration of a pre-separation record, no restart required).

## Lifecycle: any start ensures it, none churns it, no stop takes it down by accident

- **Keep-if-current**: a full start keeps a running Browser when its image matches what this start would run — image *identity*, not tag order (`:latest`/`:local` are mutable). When stale, or on the explicit `semiont start --service frontend` (which is also the `--port` mover), it stop/rm + pulls + restarts. A kept Browser costs no pull.
  - One recorded deviation from the ratified design: reference-match with *unobtainable* image IDs KEEPS rather than restarts — Apple `container` exposes no ID through inspect, and restart-on-doubt would have negated keep-if-running on that runtime entirely. The explicit refresh is `--service frontend`.
- **Bare `semiont stop` leaves it running**, announced with the off-switch (`semiont stop --service frontend`, which stops the container and clears its record). Port 3000 left *every* stack-level table — preflight sweep, stop sweep, fiat ports, roles ports, plan port checks — because a stack's port-release verification must not wait on a viewer that deliberately keeps running.
- **Codespace starts ensure the local Browser too** (when a container runtime exists locally — codespace placement gains no new hard requirement), completing the discovery story: start a codespace anywhere, the panel is already open and the new KB appears in it.

## Record

The Browser's record moves out of the local stack's services into a machine-level `browser` entry in `stack.json` (schema 3 unchanged; optional field), carrying its runtime, image, and endpoint. Pre-separation records migrate on read. `stack.json` now legitimately survives a full stop while the Browser runs.

## Status

- **BROWSER section first** — architecturally above everything it views (and least interesting, fine to scroll away) — with its image tag, so Browser-vs-stack version skew is visible rather than mysterious (`images local · …` plus an explicit `STACK RUNS <v> — refresh: …` when they diverge).
- **STATE + HEALTH merged into one STATUS column**: the old pair said yes twice on every healthy row. One cell — mark + word — keeps every diagnostic divergence expressible and now *asserted by word* in the tests: `✓ running`, `✗ running` (up but unhealthy), `✗ exited` (crashed, kept for inspection), `✗ absent`, `✓ reachable` (provided elsewhere).

## Verification

Full suite green; the browser lifecycle test covers keep / stale-restart / bare-stop-survival / explicit-off-switch end to end, and the keep logic is RED-verified (disabling it fires the no-churn assertion). Golden churn is the adjudicated shape: preflight and stop sweep 9 names instead of 10, the frontend run line moved from the stack sequence to the Browser flow, dry-run carries the keep-or-restart plan.

## Behavior changes

- Bare `stop` no longer stops the Browser (announced; `stop --service frontend` does).
- Repeated `start`s stop churning a current Browser; a stale one is refreshed automatically.
- Codespace starts bring up the local Browser.
- `status`: new BROWSER section on top; the service table's STATE/HEALTH columns are now one STATUS column — table parsers will notice.
