### PR TITLE
Launcher: semiont init — birth a KB (identity at birth, config built-validated-vetted or copied from the template)

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -19,16 +19,40 @@ no language runtime bleeds onto your host. Besides the launcher you need only
 
 ## Use
 
-Run from inside a KB clone (or birth one first with `semiont init` — it
-assigns the KB's permanent did:web identity at birth, from --domain, the git
-origin, or a prompt; interactive with full flag parity, and --yes refuses
-rather than guessing where no safe default exists. `--inference anthropic|ollama --model <id>
---embedding ollama:<model>` builds a full semiontconfig from the launcher's
-own knowledge — nothing copied, nothing mastered, the three-name binding
-roster (per-worker refinement is your edit) — and every generated config is
-vetted by the plan deriver before it is written, so a generator bug is a
-refusal, never a KB that cannot start. Live model pickers and template-copy
-paths are landing next: .plans/LAUNCHER-BIRTH.md):
+Run from inside a KB clone — or birth one first with **`semiont init`**
+(design record: .plans/LAUNCHER-BIRTH.md). Interactive with full flag
+parity; `--yes` refuses rather than guessing where no safe default exists.
+What init does:
+
+- **Identity at birth**: the permanent did:web domain from `--domain`, the
+  git origin (`<owner_lc>.github.io:<name>` — the same rule the template's
+  post-fork action applies), or a prompt that says plainly this is the
+  identity stamped into the committed event log.
+- **A config built, not copied**: `--inference anthropic|ollama --model <id>
+  --embedding ollama:<model>` synthesizes a full semiontconfig from the
+  launcher's own knowledge — the three-name binding roster
+  (gatherer/matcher/workers.default; per-worker refinement is your edit).
+  NOTHING is mastered anywhere.
+- **Choices validated live**: with a key, Anthropic models validate against
+  `/v1/models` (an unlisted id is a refusal printing what exists; no
+  `--model` picks the newest capable, announced); Ollama models pass as
+  installed or registry-verified ("pulled at start"), refuse on the
+  registry's 404, and degrade to accept-with-warning when sources are
+  unreachable — unknown is not missing.
+- **Or copy from the template, explicitly**: `--from-template [url|dir]`
+  shallow-clones and copies its semiontconfigs — each vetted, all-or-nothing
+  — and `--devcontainer` copies the codespace set with the display name
+  rewritten to yours, making a locally-born KB `--runtime codespace`
+  eligible. Identity is NEVER copied.
+- **Every config write — generated or copied — passes the plan deriver
+  first**: a bug or a version-skewed template is a pre-write refusal
+  carrying the parser's own error, never a KB that cannot start.
+
+```sh
+semiont init --yes --inference anthropic --embedding ollama:nomic-embed-text
+```
+
+births a startable KB in one command (identity from your git origin). Then:
 
 ```sh
 semiont start

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -22,8 +22,13 @@ no language runtime bleeds onto your host. Besides the launcher you need only
 Run from inside a KB clone (or birth one first with `semiont init` — it
 assigns the KB's permanent did:web identity at birth, from --domain, the git
 origin, or a prompt; interactive with full flag parity, and --yes refuses
-rather than guessing where no safe default exists. The config builder and
-template-copy paths are landing next: .plans/LAUNCHER-BIRTH.md):
+rather than guessing where no safe default exists. `--inference anthropic|ollama --model <id>
+--embedding ollama:<model>` builds a full semiontconfig from the launcher's
+own knowledge — nothing copied, nothing mastered, the three-name binding
+roster (per-worker refinement is your edit) — and every generated config is
+vetted by the plan deriver before it is written, so a generator bug is a
+refusal, never a KB that cannot start. Live model pickers and template-copy
+paths are landing next: .plans/LAUNCHER-BIRTH.md):
 
 ```sh
 semiont start

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -19,7 +19,11 @@ no language runtime bleeds onto your host. Besides the launcher you need only
 
 ## Use
 
-Run from inside a KB clone:
+Run from inside a KB clone (or birth one first with `semiont init` — it
+assigns the KB's permanent did:web identity at birth, from --domain, the git
+origin, or a prompt; interactive with full flag parity, and --yes refuses
+rather than guessing where no safe default exists. The config builder and
+template-copy paths are landing next: .plans/LAUNCHER-BIRTH.md):
 
 ```sh
 semiont start

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -102,6 +102,11 @@ func git(args []string) {
 		fmt.Fprintln(os.Stderr, "error: No such remote 'origin'")
 		os.Exit(2)
 	}
+	if len(args) >= 1 && (args[0] == "init" || args[0] == "add") {
+		// The birth flow (semiont init): idempotent no-ops here — the argv
+		// log is the observable.
+		return
+	}
 	if len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
 		if os.Getenv("FAKERT_GIT_DIRTY") != "" {
 			fmt.Println(" M .semiont/semiontconfig/anthropic.toml")

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -102,6 +102,21 @@ func git(args []string) {
 		fmt.Fprintln(os.Stderr, "error: No such remote 'origin'")
 		os.Exit(2)
 	}
+	if len(args) >= 1 && args[0] == "clone" {
+		// The template-copy URL path: materialize FAKERT_TEMPLATE_DIR at the
+		// destination, standing in for a shallow clone.
+		dst := args[len(args)-1]
+		srcDir := os.Getenv("FAKERT_TEMPLATE_DIR")
+		if srcDir == "" {
+			fmt.Fprintln(os.Stderr, "fakert git clone: FAKERT_TEMPLATE_DIR not set")
+			os.Exit(1)
+		}
+		if err := copyTree(srcDir, dst); err != nil {
+			fmt.Fprintln(os.Stderr, "fakert git clone:", err)
+			os.Exit(1)
+		}
+		return
+	}
 	if len(args) >= 1 && (args[0] == "init" || args[0] == "add") {
 		// The birth flow (semiont init): idempotent no-ops here — the argv
 		// log is the observable.
@@ -844,4 +859,23 @@ func serve(ports []string) {
 		}()
 	}
 	<-done // parked until killed
+}
+
+// copyTree: minimal recursive copy for the fake clone.
+func copyTree(src, dst string) error {
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, p)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, b, info.Mode())
+	})
 }

--- a/apps/launcher/internal/launcher/confgen.go
+++ b/apps/launcher/internal/launcher/confgen.go
@@ -20,10 +20,11 @@ import (
 )
 
 type genParams struct {
-	Inference      string // "anthropic" | "ollama"
-	Model          string // heavy: gatherer, matcher, workers.default
-	ModelLight     string // optional: emitted as a commented example only
-	EmbeddingModel string // ollama-served embedding model
+	Inference         string // "anthropic" | "ollama"
+	Model             string // heavy: gatherer, matcher, workers.default
+	ModelLight        string // optional: emitted as a commented example only
+	EmbeddingModel    string // ollama-served embedding model
+	AnthropicEndpoint string // honored in the generated config; "" → the default
 }
 
 func generateSemiontconfig(p genParams) string {
@@ -68,9 +69,16 @@ func generateSemiontconfig(p genParams) string {
 	w(``)
 	switch p.Inference {
 	case "anthropic":
+		// Honor --anthropic-endpoint: validating against a proxy but writing
+		// the default endpoint would be a silent mismatch (Copilot review,
+		// PR #1065).
+		endpoint := p.AnthropicEndpoint
+		if endpoint == "" {
+			endpoint = "https://api.anthropic.com"
+		}
 		w(`[environments.local.inference.anthropic]`)
 		w(`platform = "external"`)
-		w(`endpoint = "https://api.anthropic.com"`)
+		w(`endpoint = %q`, endpoint)
 		w(`apiKey = "${ANTHROPIC_API_KEY}"`)
 	case "ollama":
 		w(`[environments.local.inference.ollama]`)
@@ -112,29 +120,45 @@ func generateSemiontconfig(p genParams) string {
 // place. The same gate template copies pass through (P4): no path may write
 // a config this launcher cannot start.
 func writeVettedConfig(u *ui, root, name, content string) bool {
+	// name becomes a filename and (via --config-name) is user-controlled — a
+	// separator or ".." would escape .semiont/semiontconfig. Require a plain
+	// stem (Copilot review, PR #1065).
+	if name == "" || name == "." || name == ".." ||
+		strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		u.fail("Config name %q must be a simple file stem (no path separators).", name)
+		return false
+	}
+	// Vet in a SYSTEM temp file: loadConfig+derivePlan judge the content
+	// without touching .semiont, so a rejected config never leaves a partial
+	// tree behind.
+	vf, err := os.CreateTemp("", "semiont-vet-*.toml")
+	if err != nil {
+		u.fail("Vetting config: %v", err)
+		return false
+	}
+	vetPath := vf.Name()
+	defer os.Remove(vetPath)
+	if _, err := vf.WriteString(content); err != nil {
+		vf.Close()
+		u.fail("Vetting config: %v", err)
+		return false
+	}
+	vf.Close()
+	env, envName, _, err := loadConfig(vetPath)
+	if err == nil {
+		_, err = derivePlan(env, envName, vetPath)
+	}
+	if err != nil {
+		u.fail("The config did not pass the launcher's own deriver — refusing to write it: %v", err)
+		return false
+	}
 	dir := filepath.Join(root, ".semiont", "semiontconfig")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		u.fail("Creating %s: %v", dir, err)
 		return false
 	}
-	tmp := filepath.Join(dir, "."+name+".toml.vetting")
-	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644); err != nil {
 		u.fail("Writing config: %v", err)
-		return false
-	}
-	env, envName, _, err := loadConfig(tmp)
-	if err == nil {
-		_, err = derivePlan(env, envName, tmp)
-	}
-	if err != nil {
-		_ = os.Remove(tmp)
-		u.fail("The config did not pass the launcher's own deriver — refusing to write it: %v", err)
-		return false
-	}
-	final := filepath.Join(dir, name+".toml")
-	if err := os.Rename(tmp, final); err != nil {
-		_ = os.Remove(tmp)
-		u.fail("Placing config: %v", err)
 		return false
 	}
 	u.ok(".semiont/semiontconfig/%s.toml written %s", name, u.dim("(vetted by the plan deriver)"))

--- a/apps/launcher/internal/launcher/confgen.go
+++ b/apps/launcher/internal/launcher/confgen.go
@@ -128,7 +128,7 @@ func writeVettedConfig(u *ui, root, name, content string) bool {
 	}
 	if err != nil {
 		_ = os.Remove(tmp)
-		u.fail("The generated config did not pass the launcher's own deriver — refusing to write it: %v", err)
+		u.fail("The config did not pass the launcher's own deriver — refusing to write it: %v", err)
 		return false
 	}
 	final := filepath.Join(dir, name+".toml")

--- a/apps/launcher/internal/launcher/confgen.go
+++ b/apps/launcher/internal/launcher/confgen.go
@@ -1,0 +1,142 @@
+package launcher
+
+// confgen.go — LAUNCHER-BIRTH P2: the generative semiontconfig builder.
+// NOTHING IS MASTERED (decision 2/3): the config is synthesized from the
+// launcher's own knowledge — the same injected-var and driver shapes
+// derivePlan parses — plus the user's model choices. Bindings are exactly
+// the three-name roster (actors.gatherer, actors.matcher, workers.default;
+// resolveWorkerInference falls back to default — verified 2026-07-22);
+// per-worker refinement is the user's edit, as it always really was.
+//
+// Every generated config passes through the SAME vet as a template copy:
+// loadConfig + derivePlan on a temp file before the real name exists. A
+// generator bug is a refusal, never a KB that cannot start.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type genParams struct {
+	Inference      string // "anthropic" | "ollama"
+	Model          string // heavy: gatherer, matcher, workers.default
+	ModelLight     string // optional: emitted as a commented example only
+	EmbeddingModel string // ollama-served embedding model
+}
+
+func generateSemiontconfig(p genParams) string {
+	var b strings.Builder
+	w := func(format string, a ...any) { fmt.Fprintf(&b, format+"\n", a...) }
+
+	w(`[user]`)
+	w(`name = ""`)
+	w(`email = ""`)
+	w(``)
+	w(`[defaults]`)
+	w(`environment = "local"`)
+	w(``)
+	w(`[environments.local.backend]`)
+	w(`platform = "posix"`)
+	w(`port = 4000`)
+	w(`publicURL = "http://${BACKEND_HOST:-localhost}:4000"`)
+	w(``)
+	w(`[environments.local.graph]`)
+	w(`platform = "external"`)
+	w(`type = "neo4j"`)
+	w(`name = "neo4j"`)
+	w(`uri = "bolt://${NEO4J_HOST}:7687"`)
+	w(`username = "neo4j"`)
+	w(`password = "localpass"`)
+	w(`database = "neo4j"`)
+	w(``)
+	w(`[environments.local.vectors]`)
+	w(`type = "qdrant"`)
+	w(`host = "${QDRANT_HOST}"`)
+	w(`port = 6333`)
+	w(``)
+	w(`[environments.local.embedding]`)
+	w(`platform = "external"`)
+	w(`type = "ollama"`)
+	w(`model = %q`, p.EmbeddingModel)
+	w(`baseURL = "http://${OLLAMA_HOST}:11434"`)
+	w(``)
+	w(`[environments.local.embedding.chunking]`)
+	w(`chunkSize = 512`)
+	w(`overlap = 64`)
+	w(``)
+	switch p.Inference {
+	case "anthropic":
+		w(`[environments.local.inference.anthropic]`)
+		w(`platform = "external"`)
+		w(`endpoint = "https://api.anthropic.com"`)
+		w(`apiKey = "${ANTHROPIC_API_KEY}"`)
+	case "ollama":
+		w(`[environments.local.inference.ollama]`)
+		w(`platform = "posix"`)
+		w(`baseURL = "http://${OLLAMA_HOST}:11434"`)
+	}
+	w(``)
+	for _, binding := range []string{
+		"actors.gatherer.inference",
+		"actors.matcher.inference",
+		"workers.default.inference",
+	} {
+		w(`[environments.local.%s]`, binding)
+		w(`type = %q`, p.Inference)
+		w(`model = %q`, p.Model)
+		w(``)
+	}
+	if p.ModelLight != "" {
+		w(`# Per-worker refinement is yours to make. For example, a lighter`)
+		w(`# model for the high-volume annotation workers:`)
+		w(`# [environments.local.workers.tag-annotation.inference]`)
+		w(`# type = %q`, p.Inference)
+		w(`# model = %q`, p.ModelLight)
+		w(``)
+	}
+	w(`[environments.local.database]`)
+	w(`platform = "external"`)
+	w(`host = "${POSTGRES_HOST}"`)
+	w(`port = 5432`)
+	w(`name = "semiont"`)
+	w(`user = "postgres"`)
+	w(`password = "localpass"`)
+	return b.String()
+}
+
+// writeVettedConfig writes content to .semiont/semiontconfig/<name>.toml —
+// but only after the REAL deriver accepts it: the content lands in a temp
+// file, loadConfig + derivePlan judge it, and only success renames it into
+// place. The same gate template copies pass through (P4): no path may write
+// a config this launcher cannot start.
+func writeVettedConfig(u *ui, root, name, content string) bool {
+	dir := filepath.Join(root, ".semiont", "semiontconfig")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		u.fail("Creating %s: %v", dir, err)
+		return false
+	}
+	tmp := filepath.Join(dir, "."+name+".toml.vetting")
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		u.fail("Writing config: %v", err)
+		return false
+	}
+	env, envName, _, err := loadConfig(tmp)
+	if err == nil {
+		_, err = derivePlan(env, envName, tmp)
+	}
+	if err != nil {
+		_ = os.Remove(tmp)
+		u.fail("The generated config did not pass the launcher's own deriver — refusing to write it: %v", err)
+		return false
+	}
+	final := filepath.Join(dir, name+".toml")
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		u.fail("Placing config: %v", err)
+		return false
+	}
+	u.ok(".semiont/semiontconfig/%s.toml written %s", name, u.dim("(vetted by the plan deriver)"))
+	return true
+}

--- a/apps/launcher/internal/launcher/initcmd.go
+++ b/apps/launcher/internal/launcher/initcmd.go
@@ -33,6 +33,11 @@ With --yes and neither source, init refuses rather than guessing.
   --domain <d>        did:web domain (colon-path form, e.g. owner.github.io:repo)
   --site-name <s>     Human-readable site name (default: the project name)
   --admin-email <e>   Admin email recorded in the site config
+  --inference <p>     Build a config: anthropic or ollama
+  --model <id>        The heavy model (gatherer, matcher, workers.default)
+  --model-light <id>  Emitted as a commented per-worker example, not a binding
+  --embedding <e>     ollama:<model> (voyage: not yet — no established key var)
+  --config-name <n>   Config file name (default: the provider name)
   --no-git            Skip git init/add; sets git.sync = false (stated consequences)
   --force             Re-initialize over an existing .semiont/
   --yes               Accept defaults; never prompt (refuses where no safe default exists)
@@ -44,6 +49,7 @@ With --yes and neither source, init refuses rather than guessing.
 func Init(args []string) int {
 	u := newUI(false)
 	var name, domain, siteName, adminEmail string
+	var inference, model, modelLight, embedding, configName string
 	var noGit, yes, force, dryRun bool
 	for i := 0; i < len(args); i++ {
 		need := func() (string, bool) {
@@ -82,6 +88,41 @@ func Init(args []string) int {
 			}
 			adminEmail = v
 			i++
+		case "--inference":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			inference = v
+			i++
+		case "--model":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			model = v
+			i++
+		case "--model-light":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			modelLight = v
+			i++
+		case "--embedding":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			embedding = v
+			i++
+		case "--config-name":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			configName = v
+			i++
 		case "--no-git":
 			noGit = true
 		case "--yes":
@@ -97,6 +138,36 @@ func Init(args []string) int {
 			u.fail("Unknown argument: %s", args[i])
 			return 1
 		}
+	}
+
+	// Config-builder inputs validate BEFORE anything touches disk.
+	if inference != "" && inference != "anthropic" && inference != "ollama" {
+		u.fail("--inference must be anthropic or ollama, got %q.", inference)
+		return 1
+	}
+	embModel := ""
+	if embedding != "" {
+		kind, m, _ := strings.Cut(embedding, ":")
+		switch kind {
+		case "ollama":
+			if m == "" {
+				u.fail("--embedding ollama:<model> needs a model name.")
+				return 1
+			}
+			embModel = m
+		case "voyage":
+			// No established key variable exists for voyage, and the
+			// launcher never invents environment variables. Deferred.
+			u.fail("voyage embedding is not supported yet (no established key variable) — use --embedding ollama:<model>.")
+			return 1
+		default:
+			u.fail("--embedding must be ollama:<model>, got %q.", embedding)
+			return 1
+		}
+	}
+	if inference != "" && model == "" {
+		u.fail("--inference %s needs --model <id> (the heavy model: gatherer, matcher, workers.default).", inference)
+		return 1
 	}
 
 	dir, err := os.Getwd()
@@ -188,6 +259,13 @@ adminEmail = %q
 			fmt.Println("git init")
 			fmt.Println("git add .semiont")
 		}
+		if inference != "" {
+			cn := configName
+			if cn == "" {
+				cn = inference
+			}
+			fmt.Printf("# .semiont/semiontconfig/%s.toml — generated (%s inference, %s embedding), vetted by derivePlan before writing\n", cn, inference, embModel)
+		}
 		fmt.Println("# register root in " + rootsPath())
 		return 0
 	}
@@ -222,6 +300,52 @@ adminEmail = %q
 		}
 	}
 
+	// The config builder (P2): flags first; interactively, prompts fill the
+	// gaps (typed entry — the live pickers are P3); --yes with no
+	// --inference skips generation rather than guessing a provider.
+	if inference == "" && !yes {
+		fmt.Println("Configure inference now? The config is built from the launcher's own")
+		fmt.Println("knowledge — nothing is copied, and the file is yours from its first byte.")
+		inference = prompt("Inference provider (anthropic / ollama / skip)", "skip")
+		if inference == "skip" || inference == "" {
+			inference = ""
+		} else if inference != "anthropic" && inference != "ollama" {
+			u.fail("Provider must be anthropic or ollama, got %q.", inference)
+			return 1
+		}
+		if inference != "" && model == "" {
+			model = prompt("Model id (heavy: gatherer, matcher, default worker)", "")
+			if model == "" {
+				u.fail("A model id is required.")
+				return 1
+			}
+		}
+		if inference != "" && embModel == "" {
+			embModel = prompt("Embedding model (served by Ollama)", "nomic-embed-text")
+		}
+	}
+	if inference != "" {
+		if embModel == "" {
+			embModel = "nomic-embed-text"
+		}
+		cn := configName
+		if cn == "" {
+			cn = inference
+		}
+		content := generateSemiontconfig(genParams{
+			Inference: inference, Model: model, ModelLight: modelLight, EmbeddingModel: embModel,
+		})
+		if !writeVettedConfig(u, dir, cn, content) {
+			return 1
+		}
+		if !noGit && onPath("git") {
+			if out, err := captureBoth("git", "-C", dir, "add", ".semiont"); err != nil {
+				u.fail("git add .semiont: %s", strings.TrimSpace(out))
+				return 1
+			}
+		}
+	}
+
 	registerRootUse(dir, false, "")
 	warnICloudRoot(u, dir)
 
@@ -229,8 +353,15 @@ adminEmail = %q
 	fmt.Printf("%s\n", u.wrap(ansiBold+ansiGreen, "🌱 "+name+" is born"))
 	fmt.Println()
 	fmt.Println("  Next steps:")
-	fmt.Printf("    1. %s %s\n", u.bold("semiont init is not yet a config builder"), u.dim("(LAUNCHER-BIRTH P2) — add .semiont/semiontconfig/<name>.toml before starting"))
-	fmt.Printf("    2. %s\n", u.bold("semiont secret set ANTHROPIC_API_KEY"))
-	fmt.Printf("    3. %s\n", u.bold("semiont start"))
+	step := 1
+	if inference == "" {
+		fmt.Printf("    %d. %s %s\n", step, u.bold("add a config"), u.dim("(rerun with --inference, or write .semiont/semiontconfig/<name>.toml)"))
+		step++
+	}
+	if inference == "anthropic" {
+		fmt.Printf("    %d. %s\n", step, u.bold("semiont secret set ANTHROPIC_API_KEY"))
+		step++
+	}
+	fmt.Printf("    %d. %s\n", step, u.bold("semiont start"))
 	return 0
 }

--- a/apps/launcher/internal/launcher/initcmd.go
+++ b/apps/launcher/internal/launcher/initcmd.go
@@ -1,11 +1,11 @@
 package launcher
 
-// initcmd.go — `semiont init`, LAUNCHER-BIRTH.md P1: birth a KB locally with
+// initcmd.go — `semiont init`, LAUNCHER-BIRTH.md: birth a KB locally with
 // correct identity AT birth (the template path assigns identity by post-fork
-// rewrite — a workaround this command exists to not need). P1 is the
-// scaffold: identity + .semiont/config + git + roots registration. The
-// config BUILDER (semiontconfig generation, live model registries, template
-// copy) lands in later phases of the plan.
+// rewrite — a workaround this command exists to not need). Identity +
+// .semiont/config + git + roots (P1), the generative semiontconfig builder
+// with a derivePlan vet (P2), live model validation (P3), and the explicit
+// template-copy paths (P4) all land here.
 
 import (
 	"bufio"
@@ -25,8 +25,9 @@ Interactive by design — every prompt has a flag twin, so callers can run it
 prompt-free; --yes accepts defaults where a safe default exists. The one
 thing with NO safe default is the did:web domain: it is the KB's PERMANENT
 identity, stamped into the committed event log. It comes from --domain, or
-is derived from this directory's git origin (<owner_lc>.github.io:<name> —
-the same rule the template's post-fork action applies), or is prompted for.
+is derived from this directory's git origin (<owner_lc>.github.io:<repo>,
+from the origin slug — the same rule the template's post-fork action
+applies), or is prompted for.
 With --yes and neither source, init refuses rather than guessing.
 
   --name <n>          Project name (default: directory basename)
@@ -239,9 +240,20 @@ func Init(args []string) int {
 	if name == "" {
 		name = filepath.Base(dir)
 	}
-	if _, err := os.Stat(filepath.Join(dir, ".semiont")); err == nil && !force {
-		u.fail(".semiont/ already exists here — this KB is already born. Re-initialize with --force.")
-		return 1
+	semiontDir := filepath.Join(dir, ".semiont")
+	if _, err := os.Stat(semiontDir); err == nil {
+		if !force {
+			u.fail(".semiont/ already exists here — this KB is already born. Re-initialize with --force.")
+			return 1
+		}
+		// --force is a fresh birth, not a merge: remove the old tree so no
+		// stale semiontconfig/*.toml survives beside the new identity
+		// (Copilot review, PR #1065). This is destructive by request.
+		if err := os.RemoveAll(semiontDir); err != nil {
+			u.fail("--force: could not remove the existing .semiont/: %v", err)
+			return 1
+		}
+		u.warn("--force: removed the existing .semiont/ — re-initializing from scratch.")
 	}
 
 	in := bufio.NewReader(os.Stdin)
@@ -275,7 +287,7 @@ func Init(args []string) int {
 	if domain == "" {
 		if yes {
 			u.fail("No did:web domain: it is the KB's permanent identity (stamped into the committed event log) and has no safe default.")
-			fmt.Fprintln(os.Stderr, "  Pass --domain <owner_lc>.github.io:<name>, or run from a clone whose git origin can supply it.")
+			fmt.Fprintln(os.Stderr, "  Pass --domain <owner_lc>.github.io:<repo>, or run from a clone whose git origin can supply it.")
 			return 1
 		}
 		fmt.Println("The did:web domain is this KB's permanent identity — it is stamped")
@@ -325,7 +337,11 @@ adminEmail = %q
 			if cn == "" {
 				cn = inference
 			}
-			fmt.Printf("# .semiont/semiontconfig/%s.toml — generated (%s inference, %s embedding), vetted by derivePlan before writing\n", cn, inference, embModel)
+			em := embModel
+			if em == "" {
+				em = "nomic-embed-text" // the same default a real run applies
+			}
+			fmt.Printf("# .semiont/semiontconfig/%s.toml — generated (%s inference, %s embedding), vetted by derivePlan before writing\n", cn, inference, em)
 		}
 		if fromTemplate != "" {
 			fmt.Printf("# copy semiontconfig tomls from %s (ref %s) — each vetted by derivePlan pre-write; identity NEVER copied\n", fromTemplate, templateRef)
@@ -337,40 +353,11 @@ adminEmail = %q
 		return 0
 	}
 
-	if noGit {
-		u.warn("--no-git: git init is skipped, git.sync = false, and .semiont/ is not staged — the backend versions the event log via git, so this KB cannot run the full stack until it becomes a clone.")
-	}
-	if err := os.MkdirAll(filepath.Join(dir, ".semiont"), 0o755); err != nil {
-		u.fail("Creating .semiont/: %v", err)
-		return 1
-	}
-	if err := os.WriteFile(filepath.Join(dir, ".semiont", "config"), []byte(cfg), 0o644); err != nil {
-		u.fail("Writing .semiont/config: %v", err)
-		return 1
-	}
-	u.ok(".semiont/config written %s", u.dim("("+domain+")"))
-
-	if !noGit {
-		if !onPath("git") {
-			u.warn("git is not on PATH — skipping git init/add; the full stack needs this KB to be a clone.")
-		} else {
-			if out, err := captureBoth("git", "-C", dir, "init"); err != nil {
-				u.fail("git init: %s", strings.TrimSpace(out))
-				return 1
-			}
-			u.ok("git init")
-			if out, err := captureBoth("git", "-C", dir, "add", ".semiont"); err != nil {
-				u.fail("git add .semiont: %s", strings.TrimSpace(out))
-				return 1
-			}
-			u.ok("git add .semiont")
-		}
-	}
-
-	// The config builder (P2): flags first; interactively, prompts fill the
-	// gaps (typed entry — the live pickers are P3); --yes with no
-	// --inference skips generation rather than guessing a provider.
-	if inference == "" && !yes {
+	// ── Decide everything BEFORE touching disk (Copilot review, PR #1065:
+	// init must be transactional). Interactive prompts, model validation,
+	// and config generation all happen here; the writes come after, guarded
+	// by a rollback so a failure never leaves a half-born .semiont/.
+	if inference == "" && !yes && fromTemplate == "" {
 		fmt.Println("Configure inference now? The config is built from the launcher's own")
 		fmt.Println("knowledge — nothing is copied, and the file is yours from its first byte.")
 		inference = prompt("Inference provider (anthropic / ollama / skip)", "skip")
@@ -391,12 +378,12 @@ adminEmail = %q
 			embModel = prompt("Embedding model (served by Ollama)", "nomic-embed-text")
 		}
 	}
+
+	genContent, genName := "", ""
 	if inference != "" {
 		if embModel == "" {
 			embModel = "nomic-embed-text"
 		}
-		// Live validation (P3): the choices are checked against the sources
-		// that will have to serve them — refusals now, not failed jobs later.
 		switch inference {
 		case "anthropic":
 			m, ok := resolveAnthropicModel(u, anthropicEndpoint, os.Getenv("ANTHROPIC_API_KEY"), model)
@@ -412,58 +399,98 @@ adminEmail = %q
 		if !validateOllamaModel(u, ollamaBase, ollamaRegistry, embModel) {
 			return 1
 		}
-		cn := configName
-		if cn == "" {
-			cn = inference
+		genName = configName
+		if genName == "" {
+			genName = inference
 		}
-		content := generateSemiontconfig(genParams{
-			Inference: inference, Model: model, ModelLight: modelLight, EmbeddingModel: embModel,
+		genContent = generateSemiontconfig(genParams{
+			Inference: inference, Model: model, ModelLight: modelLight,
+			EmbeddingModel: embModel, AnthropicEndpoint: anthropicEndpoint,
 		})
-		if !writeVettedConfig(u, dir, cn, content) {
-			return 1
-		}
-		if !noGit && onPath("git") {
-			if out, err := captureBoth("git", "-C", dir, "add", ".semiont"); err != nil {
-				u.fail("git add .semiont: %s", strings.TrimSpace(out))
-				return 1
-			}
-		}
 	}
 
+	// Template materialization is a reach that can fail — do it before the
+	// first .semiont write too.
+	var tplDir string
 	if fromTemplate != "" || devcontainer {
 		src := fromTemplate
 		if src == "" {
 			src = defaultTemplateRepo // --devcontainer alone still needs the tree
 		}
-		tplDir, cleanup, ok := materializeTemplate(u, src, templateRef)
+		d, cleanup, ok := materializeTemplate(u, src, templateRef)
 		if !ok {
 			return 1
 		}
 		defer cleanup()
-		if fromTemplate != "" {
-			if !copyTemplateConfigs(u, dir, tplDir) {
-				return 1
+		tplDir = d
+	}
+
+	// ── Write phase. Rollback removes anything init created this run if any
+	// step below fails, so a rerun sees a clean directory (no stale --force).
+	var startedWriting, success bool
+	defer func() {
+		if startedWriting && !success {
+			_ = os.RemoveAll(semiontDir)
+			if devcontainer {
+				_ = os.RemoveAll(filepath.Join(dir, ".devcontainer"))
 			}
 		}
-		if devcontainer {
-			if !copyDevcontainer(u, dir, tplDir, name) {
-				return 1
-			}
+	}()
+	fail := func(format string, a ...any) int {
+		u.fail(format, a...)
+		return 1
+	}
+
+	if noGit {
+		u.warn("--no-git: git init is skipped, git.sync = false, and .semiont/ is not staged — the backend versions the event log via git, so this KB cannot run the full stack until it becomes a clone.")
+	}
+	startedWriting = true
+	if err := os.MkdirAll(semiontDir, 0o755); err != nil {
+		return fail("Creating .semiont/: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(semiontDir, "config"), []byte(cfg), 0o644); err != nil {
+		return fail("Writing .semiont/config: %v", err)
+	}
+	u.ok(".semiont/config written %s", u.dim("("+domain+")"))
+
+	if genContent != "" {
+		if !writeVettedConfig(u, dir, genName, genContent) {
+			return 1
 		}
-		if !noGit && onPath("git") {
+	}
+	if tplDir != "" && fromTemplate != "" {
+		if !copyTemplateConfigs(u, dir, tplDir) {
+			return 1
+		}
+	}
+	if tplDir != "" && devcontainer {
+		if !copyDevcontainer(u, dir, tplDir, name) {
+			return 1
+		}
+	}
+
+	if !noGit {
+		if !onPath("git") {
+			u.warn("git is not on PATH — skipping git init/add; the full stack needs this KB to be a clone.")
+		} else {
+			if out, err := captureBoth("git", "-C", dir, "init"); err != nil {
+				return fail("git init: %s", strings.TrimSpace(out))
+			}
+			u.ok("git init")
 			addArgs := []string{"-C", dir, "add", ".semiont"}
 			if devcontainer {
 				addArgs = append(addArgs, ".devcontainer")
 			}
 			if out, err := captureBoth("git", addArgs...); err != nil {
-				u.fail("git add: %s", strings.TrimSpace(out))
-				return 1
+				return fail("git add: %s", strings.TrimSpace(out))
 			}
+			u.ok("git add")
 		}
 	}
 
 	registerRootUse(dir, false, "")
 	warnICloudRoot(u, dir)
+	success = true
 
 	fmt.Println()
 	fmt.Printf("%s\n", u.wrap(ansiBold+ansiGreen, "🌱 "+name+" is born"))

--- a/apps/launcher/internal/launcher/initcmd.go
+++ b/apps/launcher/internal/launcher/initcmd.go
@@ -38,6 +38,12 @@ With --yes and neither source, init refuses rather than guessing.
   --model-light <id>  Emitted as a commented per-worker example, not a binding
   --embedding <e>     ollama:<model> (voyage: not yet — no established key var)
   --config-name <n>   Config file name (default: the provider name)
+  --from-template [s] Copy semiontconfig from the template instead of building
+                      (s: URL or local dir; default the canonical template repo;
+                      every copy is vetted by the plan deriver pre-write)
+  --template-ref <r>  Git ref for a URL template source (default main)
+  --devcontainer      Also copy .devcontainer (display name rewritten) — makes
+                      this KB codespace-capable
   --anthropic-endpoint <u>  Anthropic API base (proxy knob; default https://api.anthropic.com)
   --ollama-base <u>         Local Ollama base (default http://localhost:11434)
   --ollama-registry <u>     Ollama registry base (default https://registry.ollama.ai)
@@ -53,6 +59,8 @@ func Init(args []string) int {
 	u := newUI(false)
 	var name, domain, siteName, adminEmail string
 	var inference, model, modelLight, embedding, configName string
+	var fromTemplate, templateRef string
+	var devcontainer bool
 	anthropicEndpoint := "https://api.anthropic.com"
 	ollamaBase := "http://localhost:11434"
 	ollamaRegistry := "https://registry.ollama.ai"
@@ -129,6 +137,24 @@ func Init(args []string) int {
 			}
 			configName = v
 			i++
+		case "--from-template":
+			// Optional value: a URL or local directory; bare flag = the
+			// canonical template repo.
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				fromTemplate = args[i+1]
+				i++
+			} else {
+				fromTemplate = defaultTemplateRepo
+			}
+		case "--template-ref":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			templateRef = v
+			i++
+		case "--devcontainer":
+			devcontainer = true
 		case "--anthropic-endpoint":
 			v, ok := need()
 			if !ok {
@@ -168,6 +194,13 @@ func Init(args []string) int {
 	}
 
 	// Config-builder inputs validate BEFORE anything touches disk.
+	if fromTemplate != "" && inference != "" {
+		u.fail("--from-template and --inference are two sources for the same configs — pick one.")
+		return 1
+	}
+	if templateRef == "" {
+		templateRef = "main"
+	}
 	if inference != "" && inference != "anthropic" && inference != "ollama" {
 		u.fail("--inference must be anthropic or ollama, got %q.", inference)
 		return 1
@@ -294,6 +327,12 @@ adminEmail = %q
 			}
 			fmt.Printf("# .semiont/semiontconfig/%s.toml — generated (%s inference, %s embedding), vetted by derivePlan before writing\n", cn, inference, embModel)
 		}
+		if fromTemplate != "" {
+			fmt.Printf("# copy semiontconfig tomls from %s (ref %s) — each vetted by derivePlan pre-write; identity NEVER copied\n", fromTemplate, templateRef)
+		}
+		if devcontainer {
+			fmt.Println("# copy .devcontainer from the template, display name rewritten to the KB's")
+		}
 		fmt.Println("# register root in " + rootsPath())
 		return 0
 	}
@@ -386,6 +425,38 @@ adminEmail = %q
 		if !noGit && onPath("git") {
 			if out, err := captureBoth("git", "-C", dir, "add", ".semiont"); err != nil {
 				u.fail("git add .semiont: %s", strings.TrimSpace(out))
+				return 1
+			}
+		}
+	}
+
+	if fromTemplate != "" || devcontainer {
+		src := fromTemplate
+		if src == "" {
+			src = defaultTemplateRepo // --devcontainer alone still needs the tree
+		}
+		tplDir, cleanup, ok := materializeTemplate(u, src, templateRef)
+		if !ok {
+			return 1
+		}
+		defer cleanup()
+		if fromTemplate != "" {
+			if !copyTemplateConfigs(u, dir, tplDir) {
+				return 1
+			}
+		}
+		if devcontainer {
+			if !copyDevcontainer(u, dir, tplDir, name) {
+				return 1
+			}
+		}
+		if !noGit && onPath("git") {
+			addArgs := []string{"-C", dir, "add", ".semiont"}
+			if devcontainer {
+				addArgs = append(addArgs, ".devcontainer")
+			}
+			if out, err := captureBoth("git", addArgs...); err != nil {
+				u.fail("git add: %s", strings.TrimSpace(out))
 				return 1
 			}
 		}

--- a/apps/launcher/internal/launcher/initcmd.go
+++ b/apps/launcher/internal/launcher/initcmd.go
@@ -1,0 +1,236 @@
+package launcher
+
+// initcmd.go — `semiont init`, LAUNCHER-BIRTH.md P1: birth a KB locally with
+// correct identity AT birth (the template path assigns identity by post-fork
+// rewrite — a workaround this command exists to not need). P1 is the
+// scaffold: identity + .semiont/config + git + roots registration. The
+// config BUILDER (semiontconfig generation, live model registries, template
+// copy) lands in later phases of the plan.
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const initUsage = `Usage: semiont init [options]
+
+Create a new Semiont KB in the current directory: its permanent identity
+(.semiont/config), a git repository (the /kb mount requires a clone), and a
+registration in the launcher's roots.
+
+Interactive by design — every prompt has a flag twin, so callers can run it
+prompt-free; --yes accepts defaults where a safe default exists. The one
+thing with NO safe default is the did:web domain: it is the KB's PERMANENT
+identity, stamped into the committed event log. It comes from --domain, or
+is derived from this directory's git origin (<owner_lc>.github.io:<name> —
+the same rule the template's post-fork action applies), or is prompted for.
+With --yes and neither source, init refuses rather than guessing.
+
+  --name <n>          Project name (default: directory basename)
+  --domain <d>        did:web domain (colon-path form, e.g. owner.github.io:repo)
+  --site-name <s>     Human-readable site name (default: the project name)
+  --admin-email <e>   Admin email recorded in the site config
+  --no-git            Skip git init/add; sets git.sync = false (stated consequences)
+  --force             Re-initialize over an existing .semiont/
+  --yes               Accept defaults; never prompt (refuses where no safe default exists)
+  --dry-run           Print what would be created; write and execute nothing
+  --help, -h          Show this help
+`
+
+// Init implements `semiont init`.
+func Init(args []string) int {
+	u := newUI(false)
+	var name, domain, siteName, adminEmail string
+	var noGit, yes, force, dryRun bool
+	for i := 0; i < len(args); i++ {
+		need := func() (string, bool) {
+			if i+1 >= len(args) {
+				u.fail("Missing value for %s", args[i])
+				return "", false
+			}
+			return args[i+1], true
+		}
+		switch args[i] {
+		case "--name":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			name = v
+			i++
+		case "--domain":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			domain = v
+			i++
+		case "--site-name":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			siteName = v
+			i++
+		case "--admin-email":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			adminEmail = v
+			i++
+		case "--no-git":
+			noGit = true
+		case "--yes":
+			yes = true
+		case "--force":
+			force = true
+		case "--dry-run":
+			dryRun = true
+		case "--help", "-h":
+			fmt.Print(initUsage)
+			return 0
+		default:
+			u.fail("Unknown argument: %s", args[i])
+			return 1
+		}
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		u.fail("Cannot determine the current directory: %v", err)
+		return 1
+	}
+	if name == "" {
+		name = filepath.Base(dir)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".semiont")); err == nil && !force {
+		u.fail(".semiont/ already exists here — this KB is already born. Re-initialize with --force.")
+		return 1
+	}
+
+	in := bufio.NewReader(os.Stdin)
+	prompt := func(question, def string) string {
+		if def != "" {
+			fmt.Printf("  %s [%s]: ", question, def)
+		} else {
+			fmt.Printf("  %s: ", question)
+		}
+		line, _ := in.ReadString('\n')
+		line = strings.TrimSpace(line)
+		if line == "" {
+			return def
+		}
+		return line
+	}
+
+	// The did:web ladder (LAUNCHER-BIRTH decision 6): flag → derived from
+	// the git origin by the SAME rule as the template's post-fork action
+	// (<owner_lc>.github.io:<repo>) → prompt. Permanent identity has no
+	// safe default, so --yes with neither source REFUSES.
+	if domain == "" {
+		if origin, err := capture("git", "-C", dir, "remote", "get-url", "origin"); err == nil && origin != "" {
+			if slug, ok := parseGitHubSlug(origin); ok {
+				owner, repo, _ := strings.Cut(slug, "/")
+				domain = strings.ToLower(owner) + ".github.io:" + repo
+				u.log("did:web domain derived from the git origin: %s", u.bold(domain))
+			}
+		}
+	}
+	if domain == "" {
+		if yes {
+			u.fail("No did:web domain: it is the KB's permanent identity (stamped into the committed event log) and has no safe default.")
+			fmt.Fprintln(os.Stderr, "  Pass --domain <owner_lc>.github.io:<name>, or run from a clone whose git origin can supply it.")
+			return 1
+		}
+		fmt.Println("The did:web domain is this KB's permanent identity — it is stamped")
+		fmt.Println("into the committed event log and should never change.")
+		domain = prompt("did:web domain (e.g. owner.github.io:repo)", "")
+		if domain == "" {
+			u.fail("A did:web domain is required.")
+			return 1
+		}
+	}
+	if siteName == "" {
+		if yes {
+			siteName = name
+		} else {
+			siteName = prompt("Site name", name)
+		}
+	}
+	if adminEmail == "" && !yes {
+		adminEmail = prompt("Admin email", "")
+	}
+
+	cfg := fmt.Sprintf(`[project]
+name = %q
+version = "0.1.0"
+
+[git]
+sync = %t
+
+[site]
+domain = %q
+siteName = %q
+adminEmail = %q
+`, name, !noGit, domain, siteName, adminEmail)
+
+	if dryRun {
+		fmt.Println("# semiont init --dry-run — what a real run would create. Nothing is written.")
+		fmt.Println("# .semiont/config:")
+		for _, l := range strings.Split(strings.TrimRight(cfg, "\n"), "\n") {
+			fmt.Println("#   " + l)
+		}
+		if !noGit {
+			fmt.Println("git init")
+			fmt.Println("git add .semiont")
+		}
+		fmt.Println("# register root in " + rootsPath())
+		return 0
+	}
+
+	if noGit {
+		u.warn("--no-git: git init is skipped, git.sync = false, and .semiont/ is not staged — the backend versions the event log via git, so this KB cannot run the full stack until it becomes a clone.")
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".semiont"), 0o755); err != nil {
+		u.fail("Creating .semiont/: %v", err)
+		return 1
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".semiont", "config"), []byte(cfg), 0o644); err != nil {
+		u.fail("Writing .semiont/config: %v", err)
+		return 1
+	}
+	u.ok(".semiont/config written %s", u.dim("("+domain+")"))
+
+	if !noGit {
+		if !onPath("git") {
+			u.warn("git is not on PATH — skipping git init/add; the full stack needs this KB to be a clone.")
+		} else {
+			if out, err := captureBoth("git", "-C", dir, "init"); err != nil {
+				u.fail("git init: %s", strings.TrimSpace(out))
+				return 1
+			}
+			u.ok("git init")
+			if out, err := captureBoth("git", "-C", dir, "add", ".semiont"); err != nil {
+				u.fail("git add .semiont: %s", strings.TrimSpace(out))
+				return 1
+			}
+			u.ok("git add .semiont")
+		}
+	}
+
+	registerRootUse(dir, false, "")
+	warnICloudRoot(u, dir)
+
+	fmt.Println()
+	fmt.Printf("%s\n", u.wrap(ansiBold+ansiGreen, "🌱 "+name+" is born"))
+	fmt.Println()
+	fmt.Println("  Next steps:")
+	fmt.Printf("    1. %s %s\n", u.bold("semiont init is not yet a config builder"), u.dim("(LAUNCHER-BIRTH P2) — add .semiont/semiontconfig/<name>.toml before starting"))
+	fmt.Printf("    2. %s\n", u.bold("semiont secret set ANTHROPIC_API_KEY"))
+	fmt.Printf("    3. %s\n", u.bold("semiont start"))
+	return 0
+}

--- a/apps/launcher/internal/launcher/initcmd.go
+++ b/apps/launcher/internal/launcher/initcmd.go
@@ -38,6 +38,9 @@ With --yes and neither source, init refuses rather than guessing.
   --model-light <id>  Emitted as a commented per-worker example, not a binding
   --embedding <e>     ollama:<model> (voyage: not yet — no established key var)
   --config-name <n>   Config file name (default: the provider name)
+  --anthropic-endpoint <u>  Anthropic API base (proxy knob; default https://api.anthropic.com)
+  --ollama-base <u>         Local Ollama base (default http://localhost:11434)
+  --ollama-registry <u>     Ollama registry base (default https://registry.ollama.ai)
   --no-git            Skip git init/add; sets git.sync = false (stated consequences)
   --force             Re-initialize over an existing .semiont/
   --yes               Accept defaults; never prompt (refuses where no safe default exists)
@@ -50,6 +53,9 @@ func Init(args []string) int {
 	u := newUI(false)
 	var name, domain, siteName, adminEmail string
 	var inference, model, modelLight, embedding, configName string
+	anthropicEndpoint := "https://api.anthropic.com"
+	ollamaBase := "http://localhost:11434"
+	ollamaRegistry := "https://registry.ollama.ai"
 	var noGit, yes, force, dryRun bool
 	for i := 0; i < len(args); i++ {
 		need := func() (string, bool) {
@@ -123,6 +129,27 @@ func Init(args []string) int {
 			}
 			configName = v
 			i++
+		case "--anthropic-endpoint":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			anthropicEndpoint = v
+			i++
+		case "--ollama-base":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			ollamaBase = v
+			i++
+		case "--ollama-registry":
+			v, ok := need()
+			if !ok {
+				return 1
+			}
+			ollamaRegistry = v
+			i++
 		case "--no-git":
 			noGit = true
 		case "--yes":
@@ -165,8 +192,9 @@ func Init(args []string) int {
 			return 1
 		}
 	}
-	if inference != "" && model == "" {
-		u.fail("--inference %s needs --model <id> (the heavy model: gatherer, matcher, workers.default).", inference)
+	if inference == "ollama" && model == "" && yes {
+		// No registry listing exists to derive an ollama default from.
+		u.fail("--inference ollama needs --model <id> (no list-all registry API exists to pick a default from).")
 		return 1
 	}
 
@@ -327,6 +355,23 @@ adminEmail = %q
 	if inference != "" {
 		if embModel == "" {
 			embModel = "nomic-embed-text"
+		}
+		// Live validation (P3): the choices are checked against the sources
+		// that will have to serve them — refusals now, not failed jobs later.
+		switch inference {
+		case "anthropic":
+			m, ok := resolveAnthropicModel(u, anthropicEndpoint, os.Getenv("ANTHROPIC_API_KEY"), model)
+			if !ok {
+				return 1
+			}
+			model = m
+		case "ollama":
+			if !validateOllamaModel(u, ollamaBase, ollamaRegistry, model) {
+				return 1
+			}
+		}
+		if !validateOllamaModel(u, ollamaBase, ollamaRegistry, embModel) {
+			return 1
 		}
 		cn := configName
 		if cn == "" {

--- a/apps/launcher/internal/launcher/initmodels.go
+++ b/apps/launcher/internal/launcher/initmodels.go
@@ -1,0 +1,142 @@
+package launcher
+
+// initmodels.go — LAUNCHER-BIRTH P3: live model validation at birth.
+// Anthropic choices validate against /v1/models when a key is in hand — a
+// withdrawn or typo'd id becomes a refusal naming what exists, not a KB
+// whose jobs fail later. Ollama choices validate against the local daemon
+// (installed) and the ollama registry's per-name manifest probe (pullable;
+// there is NO list-all API — probing a typed name is the whole surface).
+// Both keep the status ladder's honesty rule: unreachable sources degrade
+// to accept-with-warning — unknown is not missing.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// resolveAnthropicModel validates (key in hand) or passes through with a
+// warning (keyless). model=="" with a key picks the ONE editorial default:
+// the newest capable model — the API lists newest first; prefer the first
+// sonnet-class id, else the newest of all (decision 7).
+func resolveAnthropicModel(u *ui, base, key, model string) (string, bool) {
+	if key == "" {
+		if model == "" {
+			u.fail("No ANTHROPIC_API_KEY in the environment and no --model: with no key the list cannot be fetched, and a permanent default cannot be guessed.")
+			return "", false
+		}
+		u.warn("ANTHROPIC_API_KEY is not set — %s is recorded unvalidated (the live list needs a key; a typo surfaces only when a job runs).", model)
+		return model, true
+	}
+	list, ok := anthropicModelList(base, key)
+	if !ok || len(list) == 0 {
+		if model == "" {
+			u.fail("Could not fetch the model list from %s — pass --model explicitly.", base)
+			return "", false
+		}
+		u.warn("Could not fetch the model list from %s — %s is recorded unvalidated.", base, model)
+		return model, true
+	}
+	if model != "" {
+		for _, m := range list {
+			if m.ID == model {
+				u.ok("Model %s validated against the live list %s", model, u.dim("("+base+")"))
+				return model, true
+			}
+		}
+		u.fail("Model %q is not listed for this API key (withdrawn, or a typo?).", model)
+		fmt.Fprintln(os.Stderr, "  Available:")
+		for _, m := range list {
+			fmt.Fprintf(os.Stderr, "    %-32s %s\n", m.ID, m.DisplayName)
+		}
+		return "", false
+	}
+	pick := list[0]
+	for _, m := range list {
+		if strings.Contains(m.ID, "sonnet") {
+			pick = m
+			break
+		}
+	}
+	u.ok("Model %s %s", u.bold(pick.ID), u.dim("(newest capable per the live list — override with --model)"))
+	return pick.ID, true
+}
+
+type anthropicModel struct {
+	ID          string
+	DisplayName string
+}
+
+// anthropicModelList: /v1/models preserving the API's newest-first ORDER
+// (fetchAnthropicModels returns a map for status's lookups; the picker
+// needs the ordering).
+func anthropicModelList(base, key string) ([]anthropicModel, bool) {
+	req, err := http.NewRequest("GET", base+"/v1/models?limit=1000", nil)
+	if err != nil {
+		return nil, false
+	}
+	req.Header.Set("x-api-key", key)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	resp, err := (&http.Client{Timeout: 3 * time.Second}).Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, false
+	}
+	var body struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	b, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil || json.Unmarshal(b, &body) != nil {
+		return nil, false
+	}
+	out := make([]anthropicModel, 0, len(body.Data))
+	for _, m := range body.Data {
+		out = append(out, anthropicModel{ID: m.ID, DisplayName: m.DisplayName})
+	}
+	return out, true
+}
+
+// validateOllamaModel: installed → ok; pullable per the registry probe →
+// ok (start pulls it); registry 404 → refusal; sources unreachable →
+// accept-with-warning.
+func validateOllamaModel(u *ui, ollamaBase, registryBase, model string) bool {
+	facts := fetchModelFacts(ollamaBase)
+	if facts.found {
+		if _, ok := facts.installed[normalizeModel(model)]; ok {
+			u.ok("Model %s is installed %s", model, u.dim("("+ollamaBase+")"))
+			return true
+		}
+	}
+	name, tag, hasTag := strings.Cut(model, ":")
+	if !hasTag {
+		tag = "latest"
+	}
+	url := fmt.Sprintf("%s/v2/library/%s/manifests/%s", registryBase, name, tag)
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Get(url)
+	if err != nil {
+		u.warn("Model %s could not be verified (registry unreachable) — recorded as typed; start will attempt the pull.", model)
+		return true
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case 200:
+		u.ok("Model %s exists in the ollama registry %s", model, u.dim("(not installed yet — pulled at start)"))
+		return true
+	case 404:
+		u.fail("Model %q is not in the ollama registry (404) — a typo?", model)
+		return false
+	default:
+		u.warn("Model %s could not be verified (registry answered %d) — recorded as typed.", model, resp.StatusCode)
+		return true
+	}
+}

--- a/apps/launcher/internal/launcher/initmodels.go
+++ b/apps/launcher/internal/launcher/initmodels.go
@@ -133,7 +133,16 @@ func validateOllamaModel(u *ui, ollamaBase, registryBase, model string) bool {
 		u.ok("Model %s exists in the ollama registry %s", model, u.dim("(not installed yet — pulled at start)"))
 		return true
 	case 404:
-		u.fail("Model %q is not in the ollama registry (404) — a typo?", model)
+		// A registry 404 is a refusal ONLY when the local Ollama could be
+		// consulted and did not have it — then it is a genuine typo. If
+		// Ollama itself is unreachable, the model may be installed there (or
+		// be a custom/local-only model) and we simply cannot know: unknown
+		// is not missing (Copilot review, PR #1065).
+		if !facts.found {
+			u.warn("Model %s is not in the ollama registry, and the local Ollama (%s) is unreachable — recorded as typed; verify it is installed before start.", model, ollamaBase)
+			return true
+		}
+		u.fail("Model %q is not in the ollama registry (404) and is not installed locally — a typo?", model)
 		return false
 	default:
 		u.warn("Model %s could not be verified (registry answered %d) — recorded as typed.", model, resp.StatusCode)

--- a/apps/launcher/internal/launcher/inittemplate.go
+++ b/apps/launcher/internal/launcher/inittemplate.go
@@ -1,0 +1,146 @@
+package launcher
+
+// inittemplate.go — LAUNCHER-BIRTH P4: the explicit template-copy paths.
+// The mechanism is a shallow `git clone` (git is already a launcher
+// requirement; there is no listing API over raw fetches, and a clone is an
+// atomic ref) — or a local directory used directly, which is also the
+// hermetic test seam. Two hard rules, both from the ratified decisions:
+// identity (.semiont/config) is NEVER copied — init's own is already
+// written — and every copied semiontconfig passes the SAME derivePlan vet
+// as generated ones, with the WHOLE init refusing pre-write on the first
+// failure (no partial trees).
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const defaultTemplateRepo = "https://github.com/The-AI-Alliance/semiont-template-kb"
+
+// materializeTemplate returns a local directory holding the template tree:
+// the source itself when it is a directory, else a shallow clone in a temp
+// dir (caller cleans up via the returned func).
+func materializeTemplate(u *ui, src, ref string) (dir string, cleanup func(), ok bool) {
+	if fi, err := os.Stat(src); err == nil && fi.IsDir() {
+		return src, func() {}, true
+	}
+	tmp, err := os.MkdirTemp("", "semiont-template-*")
+	if err != nil {
+		u.fail("Creating a temp dir for the template clone: %v", err)
+		return "", nil, false
+	}
+	args := []string{"clone", "--depth", "1", "--branch", ref, src, tmp}
+	u.log("Fetching template %s", u.dim("(git "+strings.Join(args, " ")+")"))
+	if out, err := captureBoth("git", args...); err != nil {
+		_ = os.RemoveAll(tmp)
+		u.fail("Template clone failed: %s", strings.TrimSpace(out))
+		return "", nil, false
+	}
+	return tmp, func() { _ = os.RemoveAll(tmp) }, true
+}
+
+// copyTemplateConfigs vets and copies every semiontconfig toml. All-or-
+// nothing: the first vet failure removes everything this call wrote.
+func copyTemplateConfigs(u *ui, root, tplDir string) bool {
+	src := filepath.Join(tplDir, ".semiont", "semiontconfig")
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		u.fail("The template has no .semiont/semiontconfig: %v", err)
+		return false
+	}
+	written := []string{}
+	rollback := func() {
+		for _, p := range written {
+			_ = os.Remove(p)
+		}
+		_ = os.Remove(filepath.Join(root, ".semiont", "semiontconfig")) // rmdir if empty
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			rollback()
+			u.fail("Reading template config %s: %v", e.Name(), err)
+			return false
+		}
+		name := strings.TrimSuffix(e.Name(), ".toml")
+		if !writeVettedConfig(u, root, name, string(b)) {
+			rollback()
+			return false
+		}
+		written = append(written, filepath.Join(root, ".semiont", "semiontconfig", name+".toml"))
+	}
+	if len(written) == 0 {
+		u.fail("The template carried no semiontconfig tomls.")
+		return false
+	}
+	return true
+}
+
+// copyDevcontainer copies the template's .devcontainer set verbatim EXCEPT
+// the display name in devcontainer.json, which becomes the newborn's — each
+// KB's codespace must self-identify (template-init.yml step 5). This is
+// what makes a locally-born KB eligible for --runtime codespace.
+func copyDevcontainer(u *ui, root, tplDir, kbName string) bool {
+	src := filepath.Join(tplDir, ".devcontainer")
+	if _, err := os.Stat(src); err != nil {
+		u.fail("The template has no .devcontainer: %v", err)
+		return false
+	}
+	dst := filepath.Join(root, ".devcontainer")
+	err := filepath.WalkDir(src, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, p)
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if d.Name() == "devcontainer.json" {
+			b = rewriteDevcontainerName(b, kbName)
+		}
+		info, _ := d.Info()
+		mode := fs.FileMode(0o644)
+		if info != nil && info.Mode()&0o111 != 0 {
+			mode = 0o755 // scripts keep their executability
+		}
+		return os.WriteFile(target, b, mode)
+	})
+	if err != nil {
+		u.fail("Copying .devcontainer: %v", err)
+		return false
+	}
+	u.ok(".devcontainer copied %s", u.dim("(display name → "+kbName+"; this KB is codespace-capable)"))
+	return true
+}
+
+// rewriteDevcontainerName replaces the "name" value. Targeted string
+// surgery, not a JSON round-trip: devcontainer.json is JSONC in the wild,
+// and a reserialize would destroy comments and ordering.
+func rewriteDevcontainerName(b []byte, kbName string) []byte {
+	s := string(b)
+	const marker = `"name":`
+	i := strings.Index(s, marker)
+	if i < 0 {
+		return b
+	}
+	rest := s[i+len(marker):]
+	open := strings.IndexByte(rest, '"')
+	if open < 0 {
+		return b
+	}
+	close := strings.IndexByte(rest[open+1:], '"')
+	if close < 0 {
+		return b
+	}
+	return []byte(s[:i] + marker + rest[:open+1] + kbName + rest[open+1+close:])
+}

--- a/apps/launcher/internal/launcher/inittemplate.go
+++ b/apps/launcher/internal/launcher/inittemplate.go
@@ -11,9 +11,11 @@ package launcher
 // failure (no partial trees).
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -31,7 +33,9 @@ func materializeTemplate(u *ui, src, ref string) (dir string, cleanup func(), ok
 		u.fail("Creating a temp dir for the template clone: %v", err)
 		return "", nil, false
 	}
-	args := []string{"clone", "--depth", "1", "--branch", ref, src, tmp}
+	// `--` before positionals: a src beginning with "-" would otherwise be
+	// read as a git option (option injection) — Copilot review, PR #1065.
+	args := []string{"clone", "--depth", "1", "--branch", ref, "--", src, tmp}
 	u.log("Fetching template %s", u.dim("(git "+strings.Join(args, " ")+")"))
 	if out, err := captureBoth("git", args...); err != nil {
 		_ = os.RemoveAll(tmp)
@@ -60,6 +64,14 @@ func copyTemplateConfigs(u *ui, root, tplDir string) bool {
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
 			continue
+		}
+		// Refuse symlinks: a template (or local dir) could symlink a .toml
+		// at an arbitrary local path, reading it into the newborn KB
+		// (Copilot review, PR #1065).
+		if e.Type()&os.ModeSymlink != 0 {
+			rollback()
+			u.fail("Template config %s is a symlink — refusing (a symlinked config could read arbitrary local files).", e.Name())
+			return false
 		}
 		b, err := os.ReadFile(filepath.Join(src, e.Name()))
 		if err != nil {
@@ -95,6 +107,9 @@ func copyDevcontainer(u *ui, root, tplDir, kbName string) bool {
 	err := filepath.WalkDir(src, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink — refusing (a symlinked file could copy arbitrary local paths into the KB)", p)
 		}
 		rel, _ := filepath.Rel(src, p)
 		target := filepath.Join(dst, rel)
@@ -142,5 +157,11 @@ func rewriteDevcontainerName(b []byte, kbName string) []byte {
 	if close < 0 {
 		return b
 	}
-	return []byte(s[:i] + marker + rest[:open+1] + kbName + rest[open+1+close:])
+	// JSON-escape: a --name (or dir basename) with a quote or backslash would
+	// otherwise produce invalid JSON/JSONC (Copilot review, PR #1065).
+	// strconv.Quote yields a full quoted string, so drop the surrounding
+	// quotes we already have in the splice.
+	escaped := strconv.Quote(kbName)
+	escaped = escaped[1 : len(escaped)-1]
+	return []byte(s[:i] + marker + rest[:open+1] + escaped + rest[open+1+close:])
 }

--- a/apps/launcher/internal/launcher/models_test.go
+++ b/apps/launcher/internal/launcher/models_test.go
@@ -1,6 +1,10 @@
 package launcher
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // Ollama reports an untagged model as ":latest". A config naming it without
 // a tag must still read as installed — getting this wrong turns every
@@ -81,5 +85,31 @@ func TestICloudZone(t *testing.T) {
 	}
 	if got := icloudZone("/Users/x/Desktop/kb", ""); got != "" {
 		t.Errorf("empty home must classify nothing, got %q", got)
+	}
+}
+
+// The vet gate is the whole safety story of config generation and template
+// copying alike: NOTHING may write a semiontconfig this launcher's own
+// deriver rejects. A refusal must also leave no file behind.
+func TestWriteVettedConfigRefusesUnstartable(t *testing.T) {
+	root := t.TempDir()
+	u := newUI(true)
+	bad := "[environments.local.graph]\ntype = \"janusgraph\"\nuri = \"bolt://${NEO4J_HOST}:7687\"\n"
+	if writeVettedConfig(u, root, "bad", bad) {
+		t.Fatal("an unknown driver type passed the vet")
+	}
+	dir := filepath.Join(root, ".semiont", "semiontconfig")
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		t.Errorf("refusal left a file behind: %s", e.Name())
+	}
+
+	// And the generator's real output passes — the same gate, both verdicts.
+	good := generateSemiontconfig(genParams{Inference: "anthropic", Model: "m", EmbeddingModel: "nomic-embed-text"})
+	if !writeVettedConfig(u, root, "good", good) {
+		t.Fatal("the generator's own output failed the vet")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "good.toml")); err != nil {
+		t.Fatalf("vetted config not placed: %v", err)
 	}
 }

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -4116,6 +4116,160 @@ func TestInitOllamaModelsValidatedByRegistry(t *testing.T) {
 	mustContain(t, "offline warning", stdout+stderr, "could not be verified")
 }
 
+// templateFixture builds a fake semiont-template-kb tree: real fixture
+// configs (the same files the parser tests trust) plus a devcontainer set
+// with the template's display name.
+func templateFixture(t *testing.T, includeBad bool) string {
+	t.Helper()
+	root := t.TempDir()
+	sc := filepath.Join(root, ".semiont", "semiontconfig")
+	if err := os.MkdirAll(sc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"anthropic.toml", "ollama-gemma.toml"} {
+		b, err := os.ReadFile(filepath.Join("testdata", "kb", ".semiont", "semiontconfig", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sc, name), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if includeBad {
+		bad := "[defaults]\nenvironment = \"local\"\n\n[environments.local.graph]\ntype = \"janusgraph\"\nuri = \"bolt://${NEO4J_HOST}:7687\"\n"
+		if err := os.WriteFile(filepath.Join(sc, "broken.toml"), []byte(bad), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dc := filepath.Join(root, ".devcontainer")
+	if err := os.MkdirAll(dc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"devcontainer.json":  `{"name": "Semiont Template KB", "dockerComposeFile": "docker-compose.yml"}`,
+		"docker-compose.yml": "services:\n  backend:\n    image: x\n",
+		"post-create.sh":     "#!/bin/sh\necho hi\n",
+	}
+	for n, c := range files {
+		if err := os.WriteFile(filepath.Join(dc, n), []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Template identity — must NEVER reach the newborn.
+	if err := os.WriteFile(filepath.Join(root, ".semiont", "config"),
+		[]byte("[site]\ndomain = \"the-ai-alliance.github.io:semiont-template-kb\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestInitFromTemplateCopiesAndVets(t *testing.T) {
+	// LAUNCHER-BIRTH P4: the explicit template-copy path. Every fetched toml
+	// passes the SAME derivePlan vet as generated ones; identity is always
+	// init's own, never the template's; and the copied config round-trips
+	// through the real deriver.
+	tpl := templateFixture(t, false)
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	s.extraEnv = append(s.extraEnv, "FAKERT_GIT_ROOT="+s.cwd)
+	_, stderr, code := s.run(t, "init", "--name", "kb", "--domain", "d.io:kb", "--yes",
+		"--from-template", tpl)
+	if code != 0 {
+		t.Fatalf("from-template: exit %d\nstderr:\n%s", code, stderr)
+	}
+	for _, n := range []string{"anthropic.toml", "ollama-gemma.toml"} {
+		if _, err := os.Stat(filepath.Join(s.cwd, ".semiont", "semiontconfig", n)); err != nil {
+			t.Errorf("%s not copied: %v", n, err)
+		}
+	}
+	cfg, _ := os.ReadFile(filepath.Join(s.cwd, ".semiont", "config"))
+	mustContain(t, "identity is init's own", string(cfg), `domain = "d.io:kb"`)
+	if strings.Contains(string(cfg), "semiont-template-kb") {
+		t.Errorf("template identity leaked into the newborn:\n%s", cfg)
+	}
+	if _, _, code := s.run(t, "start", "--config", "anthropic", "--dry-run"); code != 0 {
+		t.Fatal("copied config failed the real deriver")
+	}
+
+	// A template carrying an unstartable config: the WHOLE init refuses,
+	// pre-write, with the parser's own complaint — no partial tree.
+	tplBad := templateFixture(t, true)
+	s2 := newScenario(t, "container")
+	s2.cwd = t.TempDir()
+	_, stderr, code = s2.run(t, "init", "--name", "kb2", "--domain", "d.io:kb2", "--yes",
+		"--from-template", tplBad)
+	if code != 1 {
+		t.Fatalf("bad template: want refusal, got %d", code)
+	}
+	mustContain(t, "parser's own error", stderr, "janusgraph")
+	if _, err := os.Stat(filepath.Join(s2.cwd, ".semiont", "semiontconfig")); !os.IsNotExist(err) {
+		t.Error("refusal left a partial semiontconfig tree")
+	}
+
+	// Two config sources are contradictory.
+	s3 := newScenario(t, "container")
+	s3.cwd = t.TempDir()
+	_, stderr, code = s3.run(t, "init", "--name", "kb3", "--domain", "d.io:kb3", "--yes",
+		"--from-template", tpl, "--inference", "anthropic", "--model", "m")
+	if code != 1 {
+		t.Fatalf("both sources: want refusal, got %d", code)
+	}
+	mustContain(t, "contradiction", stderr, "--from-template", "--inference")
+}
+
+func TestInitDevcontainerCopy(t *testing.T) {
+	// The separate devcontainer offer: the set copies verbatim EXCEPT the
+	// display name, which becomes the newborn's (template-init.yml step 5 —
+	// each KB's codespace self-identifies). This is what makes a local-born
+	// KB codespace-capable.
+	tpl := templateFixture(t, false)
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	_, stderr, code := s.run(t, "init", "--name", "myk", "--domain", "d.io:myk", "--yes",
+		"--from-template", tpl, "--devcontainer")
+	if code != 0 {
+		t.Fatalf("devcontainer copy: exit %d\nstderr:\n%s", code, stderr)
+	}
+	dj, err := os.ReadFile(filepath.Join(s.cwd, ".devcontainer", "devcontainer.json"))
+	if err != nil {
+		t.Fatalf("devcontainer.json not copied: %v", err)
+	}
+	mustContain(t, "renamed", string(dj), `"name": "myk"`)
+	if strings.Contains(string(dj), "Semiont Template KB") {
+		t.Errorf("template display name survived:\n%s", dj)
+	}
+	for _, n := range []string{"docker-compose.yml", "post-create.sh"} {
+		got, err := os.ReadFile(filepath.Join(s.cwd, ".devcontainer", n))
+		if err != nil {
+			t.Errorf("%s not copied: %v", n, err)
+			continue
+		}
+		want, _ := os.ReadFile(filepath.Join(tpl, ".devcontainer", n))
+		if string(got) != string(want) {
+			t.Errorf("%s not byte-identical", n)
+		}
+	}
+}
+
+func TestInitFromTemplateURLClones(t *testing.T) {
+	// A URL source shallow-clones via git (already a launcher requirement —
+	// no gh, no listing APIs, atomic ref). fakert's clone persona materializes
+	// FAKERT_TEMPLATE_DIR at the destination.
+	tpl := templateFixture(t, false)
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	s.extraEnv = append(s.extraEnv, "FAKERT_TEMPLATE_DIR="+tpl)
+	_, stderr, code := s.run(t, "init", "--name", "kb", "--domain", "d.io:kb", "--yes",
+		"--from-template", "https://github.com/The-AI-Alliance/semiont-template-kb")
+	if code != 0 {
+		t.Fatalf("url template: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "argv", s.argv(t), "clone --depth 1")
+	if _, err := os.Stat(filepath.Join(s.cwd, ".semiont", "semiontconfig", "anthropic.toml")); err != nil {
+		t.Errorf("cloned config missing: %v", err)
+	}
+}
+
 func TestStatusService(t *testing.T) {
 	s := newScenario(t, "container")
 	s.extraEnv = append(s.extraEnv, "FAKERT_STATE_backend=running")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -3801,6 +3801,120 @@ func TestBrowserOutlivesTheStack(t *testing.T) {
 	}
 }
 
+// --- semiont init (LAUNCHER-BIRTH P1) ---
+
+func TestInitBirthsIdentity(t *testing.T) {
+	// Flag-driven birth, prompt-free: .semiont/config carries the exact
+	// identity, git init + stage happen, the root registers, and a second
+	// init refuses without --force.
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	stdout, stderr, code := s.run(t, "init",
+		"--name", "family-kb", "--domain", "pingel-org.github.io:family-kb",
+		"--site-name", "Family KB", "--admin-email", "a@b.co", "--yes")
+	if code != 0 {
+		t.Fatalf("init: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	cfg, err := os.ReadFile(filepath.Join(s.cwd, ".semiont", "config"))
+	if err != nil {
+		t.Fatalf(".semiont/config not written: %v", err)
+	}
+	mustContain(t, ".semiont/config", string(cfg),
+		`name = "family-kb"`,
+		`domain = "pingel-org.github.io:family-kb"`,
+		`siteName = "Family KB"`,
+		`adminEmail = "a@b.co"`,
+		`sync = true`)
+	// The launcher runs git with -C <dir>; assert the subcommands.
+	mustContain(t, "argv", s.argv(t), " init", " add .semiont")
+	roots, _ := os.ReadFile(filepath.Join(s.home, ".local", "state", "semiont", "roots.json"))
+	mustContain(t, "roots.json", string(roots), "family-kb")
+
+	// Refuse a second birth without --force — .semiont/ is not overwritable
+	// by accident.
+	_, stderr, code = s.run(t, "init", "--name", "x", "--domain", "d:x", "--yes")
+	if code != 1 {
+		t.Fatalf("re-init without --force: want exit 1, got %d", code)
+	}
+	mustContain(t, "refusal", stderr, "--force")
+}
+
+func TestInitIdentityLadderAndRefusals(t *testing.T) {
+	// The did:web ladder: --domain wins; else derived from the git origin by
+	// THE SAME RULE as template-init.yml step 6 (<owner_lc>.github.io:<name>);
+	// else --yes REFUSES — permanent identity has no safe default.
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	s.extraEnv = append(s.extraEnv, "FAKERT_GIT_ORIGIN=git@github.com:Pingel-Org/family-kb.git")
+	stdout, stderr, code := s.run(t, "init", "--name", "family-kb", "--yes")
+	if code != 0 {
+		t.Fatalf("origin-derived init: exit %d\nstderr:\n%s", code, stderr)
+	}
+	cfg, _ := os.ReadFile(filepath.Join(s.cwd, ".semiont", "config"))
+	// Owner lowercased (Pages hosts are lowercase); repo name kept as-is.
+	mustContain(t, "derived did", string(cfg), `domain = "pingel-org.github.io:family-kb"`)
+	mustContain(t, "derivation announced", stdout+stderr, "pingel-org.github.io:family-kb")
+
+	// No --domain, no origin, --yes: refuse and say why.
+	s2 := newScenario(t, "container")
+	s2.cwd = t.TempDir()
+	_, stderr, code = s2.run(t, "init", "--name", "x", "--yes")
+	if code != 1 {
+		t.Fatalf("identity-less --yes: want exit 1, got %d", code)
+	}
+	mustContain(t, "identity refusal", stderr, "permanent", "--domain")
+}
+
+func TestInitNoGitAndDryRun(t *testing.T) {
+	// --no-git: sync=false, consequences stated, no git in the argv.
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	stdout, stderr, code := s.run(t, "init", "--name", "x", "--domain", "d.io:x", "--yes", "--no-git")
+	if code != 0 {
+		t.Fatalf("init --no-git: exit %d\nstderr:\n%s", code, stderr)
+	}
+	cfg, _ := os.ReadFile(filepath.Join(s.cwd, ".semiont", "config"))
+	mustContain(t, "config", string(cfg), `sync = false`)
+	mustContain(t, "consequences", stdout+stderr, "--no-git")
+	for _, line := range strings.Split(s.argv(t), "\n") {
+		if strings.HasPrefix(line, "git ") && (strings.Contains(line, " init") || strings.Contains(line, " add")) {
+			t.Errorf("--no-git ran git: %q", line)
+		}
+	}
+
+	// --dry-run: says what it would write, writes NOTHING, reaches for
+	// nothing (start's plan discipline).
+	s3 := newScenario(t, "container")
+	s3.cwd = t.TempDir()
+	stdout, stderr, code = s3.run(t, "init", "--name", "y", "--domain", "d.io:y", "--yes", "--dry-run")
+	if code != 0 {
+		t.Fatalf("init --dry-run: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "plan", stdout, ".semiont/config", "git init")
+	if _, err := os.Stat(filepath.Join(s3.cwd, ".semiont")); !os.IsNotExist(err) {
+		t.Error("--dry-run wrote .semiont/")
+	}
+	if got := s3.argv(t); strings.Contains(got, " init") || strings.Contains(got, " add") {
+		t.Errorf("--dry-run executed git:\n%s", got)
+	}
+}
+
+func TestInitInteractivePrompts(t *testing.T) {
+	// The interactive path: prompts fill what flags did not — here the
+	// domain (with the permanent-identity warning) and site name.
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	s.stdin = "d.example.org:kb\nMy KB\n"
+	stdout, stderr, code := s.run(t, "init", "--name", "kb", "--admin-email", "a@b.co")
+	if code != 0 {
+		t.Fatalf("interactive init: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "identity warning shown", stdout, "permanent")
+	cfg, _ := os.ReadFile(filepath.Join(s.cwd, ".semiont", "config"))
+	mustContain(t, "prompted values", string(cfg),
+		`domain = "d.example.org:kb"`, `siteName = "My KB"`)
+}
+
 func TestStatusService(t *testing.T) {
 	s := newScenario(t, "container")
 	s.extraEnv = append(s.extraEnv, "FAKERT_STATE_backend=running")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -4270,6 +4270,94 @@ func TestInitFromTemplateURLClones(t *testing.T) {
 	}
 }
 
+func TestInitCopilotHardening(t *testing.T) {
+	// The PR #1065 review fixes, pinned so they cannot silently regress.
+
+	// (1) --config-name path traversal is refused, no file escapes.
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	_, stderr, code := s.run(t, "init", "--name", "kb", "--domain", "d.io:kb", "--yes",
+		"--inference", "anthropic", "--model", "m", "--config-name", "../escape",
+		"--anthropic-endpoint", "http://127.0.0.1:1")
+	if code != 1 {
+		t.Fatalf("traversal config-name: want refusal, got %d", code)
+	}
+	mustContain(t, "traversal refused", stderr, "simple file stem")
+	if _, err := os.Stat(filepath.Join(s.cwd, "..", "escape.toml")); err == nil {
+		t.Error("traversal wrote outside the KB")
+	}
+
+	// (2) Transactional: a failure after .semiont/config leaves NOTHING —
+	// a bogus model is rejected, and the dir is rolled back so a rerun does
+	// not need --force.
+	s2 := newScenario(t, "container")
+	s2.cwd = t.TempDir()
+	serveOllamaFixtures(t, 41451, nil, nil) // registry knows nothing
+	_, _, code = s2.run(t, "init", "--name", "kb", "--domain", "d.io:kb", "--yes",
+		"--inference", "ollama", "--model", "totally-fake:9b", "--embedding", "ollama:nomic-embed-text",
+		"--ollama-base", "http://localhost:41451", "--ollama-registry", "http://localhost:41451")
+	if code != 1 {
+		t.Fatalf("bad model: want refusal, got %d", code)
+	}
+	if _, err := os.Stat(filepath.Join(s2.cwd, ".semiont")); !os.IsNotExist(err) {
+		t.Error("a failed init left a partial .semiont/ (not rolled back)")
+	}
+
+	// (3) --force removes the old tree — no stale config survives.
+	s3 := newScenario(t, "container")
+	s3.cwd = t.TempDir()
+	scdir := filepath.Join(s3.cwd, ".semiont", "semiontconfig")
+	if err := os.MkdirAll(scdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(scdir, "stale.toml"), []byte("junk"), 0o644)
+	if _, _, code := s3.run(t, "init", "--name", "kb", "--domain", "d.io:kb", "--yes", "--force"); code != 0 {
+		t.Fatalf("--force init failed: %d", code)
+	}
+	if _, err := os.Stat(filepath.Join(scdir, "stale.toml")); err == nil {
+		t.Error("--force left a stale config beside the new identity")
+	}
+
+	// (4) devcontainer name with a quote stays valid JSON.
+	tpl := templateFixture(t, false)
+	s4 := newScenario(t, "container")
+	s4.cwd = t.TempDir()
+	if _, _, code := s4.run(t, "init", "--name", `weird"name`, "--domain", "d.io:w", "--yes",
+		"--from-template", tpl, "--devcontainer"); code != 0 {
+		t.Fatalf("quoted-name init failed: %d", code)
+	}
+	dj, _ := os.ReadFile(filepath.Join(s4.cwd, ".devcontainer", "devcontainer.json"))
+	var parsed map[string]any
+	if err := json.Unmarshal(dj, &parsed); err != nil {
+		t.Errorf("devcontainer.json is invalid JSON after a quoted name: %v\n%s", err, dj)
+	}
+
+	// (5) a symlinked template config is refused.
+	tpl2 := templateFixture(t, false)
+	_ = os.Symlink("/etc/hosts", filepath.Join(tpl2, ".semiont", "semiontconfig", "evil.toml"))
+	s5 := newScenario(t, "container")
+	s5.cwd = t.TempDir()
+	_, stderr, code = s5.run(t, "init", "--name", "kb", "--domain", "d.io:kb", "--yes", "--from-template", tpl2)
+	if code != 1 {
+		t.Fatalf("symlinked config: want refusal, got %d", code)
+	}
+	mustContain(t, "symlink refused", stderr, "symlink")
+
+	// (6) the generated anthropic config honors --anthropic-endpoint.
+	s6 := newScenario(t, "container")
+	s6.cwd = t.TempDir()
+	serveAnthropicModels(t, 41452, "m")
+	s6.extraEnv = append(s6.extraEnv, "ANTHROPIC_API_KEY=k")
+	if _, stderr, code := s6.run(t, "init", "--name", "kb", "--domain", "d.io:kb", "--yes",
+		"--inference", "anthropic", "--model", "m", "--embedding", "ollama:nomic-embed-text",
+		"--anthropic-endpoint", "http://localhost:41452",
+		"--ollama-base", "http://127.0.0.1:1", "--ollama-registry", "http://127.0.0.1:1"); code != 0 {
+		t.Fatalf("endpoint init: %d\n%s", code, stderr)
+	}
+	cfg, _ := os.ReadFile(filepath.Join(s6.cwd, ".semiont", "semiontconfig", "anthropic.toml"))
+	mustContain(t, "endpoint honored", string(cfg), `endpoint = "http://localhost:41452"`)
+}
+
 func TestStatusService(t *testing.T) {
 	s := newScenario(t, "container")
 	s.extraEnv = append(s.extraEnv, "FAKERT_STATE_backend=running")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -3924,10 +3924,13 @@ func TestInitGeneratesStartableConfig(t *testing.T) {
 	s := newScenario(t, "container")
 	s.cwd = t.TempDir()
 	s.extraEnv = append(s.extraEnv, "FAKERT_GIT_ROOT="+s.cwd)
+	// Seam flags at a dead port: hermetic — validation degrades to the
+	// warn path, which is itself part of the P3 contract.
 	_, stderr, code := s.run(t, "init",
 		"--name", "kb", "--domain", "d.io:kb", "--yes",
 		"--inference", "anthropic", "--model", "claude-sonnet-4-5-20250929",
-		"--embedding", "ollama:nomic-embed-text", "--config-name", "anthropic")
+		"--embedding", "ollama:nomic-embed-text", "--config-name", "anthropic",
+		"--ollama-base", "http://127.0.0.1:1", "--ollama-registry", "http://127.0.0.1:1")
 	if code != 0 {
 		t.Fatalf("init: exit %d\nstderr:\n%s", code, stderr)
 	}
@@ -3961,7 +3964,8 @@ func TestInitGeneratesStartableConfig(t *testing.T) {
 	if _, stderr, code := s2.run(t, "init",
 		"--name", "kb2", "--domain", "d.io:kb2", "--yes",
 		"--inference", "ollama", "--model", "gemma4:26b",
-		"--embedding", "ollama:nomic-embed-text"); code != 0 {
+		"--embedding", "ollama:nomic-embed-text",
+		"--ollama-base", "http://127.0.0.1:1", "--ollama-registry", "http://127.0.0.1:1"); code != 0 {
 		t.Fatalf("ollama init: exit %d\nstderr:\n%s", code, stderr)
 	}
 	stdout, stderr, code = s2.run(t, "start", "--config", "ollama", "--dry-run")
@@ -3980,6 +3984,136 @@ func TestInitGeneratesStartableConfig(t *testing.T) {
 		t.Fatalf("voyage: want refusal, got %d", code)
 	}
 	mustContain(t, "voyage refusal", stderr, "voyage", "ollama")
+}
+
+// serveOllamaFixtures: a local stand-in for BOTH the local Ollama daemon
+// (/api/tags — what is installed) and the ollama registry
+// (/v2/library/<m>/manifests/<t> — what exists to pull). init reaches them
+// through --ollama-base / --ollama-registry, the proxy knobs that double as
+// test seams.
+func serveOllamaFixtures(t *testing.T, port int, installed []string, pullable []string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("port %d unavailable: %v", port, err)
+	}
+	known := map[string]bool{}
+	for _, m := range pullable {
+		known[m] = true
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/tags":
+			type m struct {
+				Name string `json:"name"`
+				Size int64  `json:"size"`
+			}
+			var ms []m
+			for _, n := range installed {
+				ms = append(ms, m{Name: n, Size: 1 << 30})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"models": ms})
+		case strings.HasPrefix(r.URL.Path, "/v2/library/"):
+			rest := strings.TrimPrefix(r.URL.Path, "/v2/library/")
+			name, tag, _ := strings.Cut(rest, "/manifests/")
+			if known[name+":"+tag] {
+				w.WriteHeader(200)
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+}
+
+func TestInitAnthropicPickerValidatesAgainstLiveList(t *testing.T) {
+	// With a key in hand, the model choice is validated against /v1/models —
+	// a withdrawn or typo'd id is a REFUSAL naming what exists, not a KB
+	// whose jobs fail later (the claude-fable-5 lesson). Without --model,
+	// the ONE editorial default picks the newest capable model and says so.
+	serveAnthropicModels(t, 41436, "claude-sonnet-4-9", "claude-haiku-4-5")
+	base := []string{"init", "--domain", "d.io:kb", "--yes",
+		"--inference", "anthropic", "--embedding", "ollama:nomic-embed-text",
+		"--anthropic-endpoint", "http://localhost:41436", "--ollama-registry", "http://localhost:41437"}
+	serveOllamaFixtures(t, 41437, nil, []string{"nomic-embed-text:latest"})
+
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	s.extraEnv = append(s.extraEnv, "ANTHROPIC_API_KEY=test-key")
+	_, stderr, code := s.run(t, append(base, "--name", "kb", "--model", "claude-fable-5")...)
+	if code != 1 {
+		t.Fatalf("unlisted model: want refusal, got %d", code)
+	}
+	mustContain(t, "refusal names the live list", stderr, "claude-fable-5", "claude-sonnet-4-9")
+
+	s2 := newScenario(t, "container")
+	s2.cwd = t.TempDir()
+	s2.extraEnv = append(s2.extraEnv, "ANTHROPIC_API_KEY=test-key")
+	stdout, stderr, code := s2.run(t, append(base, "--name", "kb2")...)
+	if code != 0 {
+		t.Fatalf("default pick: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "default announced", stdout+stderr, "claude-sonnet-4-9")
+	cfg, _ := os.ReadFile(filepath.Join(s2.cwd, ".semiont", "semiontconfig", "anthropic.toml"))
+	mustContain(t, "config", string(cfg), `model = "claude-sonnet-4-9"`)
+
+	// Keyless: typed model accepted, plainly marked unvalidated.
+	s3 := newScenario(t, "container")
+	s3.cwd = t.TempDir()
+	stdout, stderr, code = s3.run(t, append(base, "--name", "kb3", "--model", "claude-anything")...)
+	if code != 0 {
+		t.Fatalf("keyless: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "unvalidated warning", stdout+stderr, "unvalidated")
+}
+
+func TestInitOllamaModelsValidatedByRegistry(t *testing.T) {
+	// Ollama models: installed passes; not-installed-but-pullable passes
+	// (start's pull machinery finishes the job); bogus is REFUSED with the
+	// registry's own 404; an unreachable registry degrades to
+	// accept-with-warning — unknown is not missing, init edition.
+	serveOllamaFixtures(t, 41438, []string{"gemma4:26b"}, []string{"gemma4:e2b:latest", "gemma4:e2b", "nomic-embed-text:latest"})
+	base := []string{"init", "--domain", "d.io:kb", "--yes", "--inference", "ollama",
+		"--embedding", "ollama:nomic-embed-text",
+		"--ollama-base", "http://localhost:41438", "--ollama-registry", "http://localhost:41438"}
+
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	stdout, stderr, code := s.run(t, append(base, "--name", "a", "--model", "gemma4:26b")...)
+	if code != 0 {
+		t.Fatalf("installed model: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "installed", stdout+stderr, "installed")
+
+	s2 := newScenario(t, "container")
+	s2.cwd = t.TempDir()
+	stdout, stderr, code = s2.run(t, append(base, "--name", "b", "--model", "gemma4:e2b")...)
+	if code != 0 {
+		t.Fatalf("pullable model: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "pull promise", stdout+stderr, "pulled at start")
+
+	s3 := newScenario(t, "container")
+	s3.cwd = t.TempDir()
+	_, stderr, code = s3.run(t, append(base, "--name", "c", "--model", "gemma9:nope")...)
+	if code != 1 {
+		t.Fatalf("bogus model: want refusal, got %d", code)
+	}
+	mustContain(t, "registry refusal", stderr, "gemma9:nope", "registry")
+
+	// Registry unreachable AND not installed: accept, warned.
+	s4 := newScenario(t, "container")
+	s4.cwd = t.TempDir()
+	stdout, stderr, code = s4.run(t, "init", "--domain", "d.io:kb", "--yes", "--name", "d",
+		"--inference", "ollama", "--model", "gemma4:26b", "--embedding", "ollama:nomic-embed-text",
+		"--ollama-base", "http://127.0.0.1:1", "--ollama-registry", "http://127.0.0.1:1")
+	if code != 0 {
+		t.Fatalf("offline: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "offline warning", stdout+stderr, "could not be verified")
 }
 
 func TestStatusService(t *testing.T) {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -3915,6 +3915,73 @@ func TestInitInteractivePrompts(t *testing.T) {
 		`domain = "d.example.org:kb"`, `siteName = "My KB"`)
 }
 
+func TestInitGeneratesStartableConfig(t *testing.T) {
+	// LAUNCHER-BIRTH P2: the generative builder. The strongest possible
+	// assertion is the round trip — the generated config must pass the REAL
+	// deriver: `start --dry-run --config <name>` succeeds from the newborn
+	// KB. Bindings are exactly the three-name roster; per-worker refinement
+	// is the user's edit, not ours.
+	s := newScenario(t, "container")
+	s.cwd = t.TempDir()
+	s.extraEnv = append(s.extraEnv, "FAKERT_GIT_ROOT="+s.cwd)
+	_, stderr, code := s.run(t, "init",
+		"--name", "kb", "--domain", "d.io:kb", "--yes",
+		"--inference", "anthropic", "--model", "claude-sonnet-4-5-20250929",
+		"--embedding", "ollama:nomic-embed-text", "--config-name", "anthropic")
+	if code != 0 {
+		t.Fatalf("init: exit %d\nstderr:\n%s", code, stderr)
+	}
+	cfg, err := os.ReadFile(filepath.Join(s.cwd, ".semiont", "semiontconfig", "anthropic.toml"))
+	if err != nil {
+		t.Fatalf("generated config missing: %v", err)
+	}
+	mustContain(t, "config", string(cfg),
+		"[environments.local.actors.gatherer.inference]",
+		"[environments.local.actors.matcher.inference]",
+		"[environments.local.workers.default.inference]",
+		`model = "claude-sonnet-4-5-20250929"`,
+		`model = "nomic-embed-text"`,
+		"${ANTHROPIC_API_KEY}")
+	if strings.Contains(string(cfg), "reference-annotation") {
+		t.Errorf("generator emitted per-worker refinements — those are the user's edits:\n%s", cfg)
+	}
+	stdout, stderr, code := s.run(t, "start", "--config", "anthropic", "--dry-run")
+	if code != 0 {
+		t.Fatalf("the generated config failed the real deriver: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	// The anthropic shape: external SaaS inference; the Ollama that exists
+	// solely for the embedding, pulling exactly the embedding model.
+	mustContain(t, "plan", stdout, "remote SaaS",
+		"pull each missing one): nomic-embed-text")
+
+	// The ollama variant round-trips too, in the local-Ollama shape.
+	s2 := newScenario(t, "container")
+	s2.cwd = t.TempDir()
+	s2.extraEnv = append(s2.extraEnv, "FAKERT_GIT_ROOT="+s2.cwd)
+	if _, stderr, code := s2.run(t, "init",
+		"--name", "kb2", "--domain", "d.io:kb2", "--yes",
+		"--inference", "ollama", "--model", "gemma4:26b",
+		"--embedding", "ollama:nomic-embed-text"); code != 0 {
+		t.Fatalf("ollama init: exit %d\nstderr:\n%s", code, stderr)
+	}
+	stdout, stderr, code = s2.run(t, "start", "--config", "ollama", "--dry-run")
+	if code != 0 {
+		t.Fatalf("ollama config failed the deriver: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "ollama plan", stdout, "host Ollama", "gemma4:26b, nomic-embed-text")
+
+	// voyage embedding refuses: no established key variable exists, and the
+	// launcher never invents environment variables.
+	s3 := newScenario(t, "container")
+	s3.cwd = t.TempDir()
+	_, stderr, code = s3.run(t, "init", "--name", "kb3", "--domain", "d.io:kb3", "--yes",
+		"--inference", "anthropic", "--model", "m", "--embedding", "voyage:voyage-3")
+	if code != 1 {
+		t.Fatalf("voyage: want refusal, got %d", code)
+	}
+	mustContain(t, "voyage refusal", stderr, "voyage", "ollama")
+}
+
 func TestStatusService(t *testing.T) {
 	s := newScenario(t, "container")
 	s.extraEnv = append(s.extraEnv, "FAKERT_STATE_backend=running")

--- a/apps/launcher/main.go
+++ b/apps/launcher/main.go
@@ -20,6 +20,7 @@ Local Semiont stack launcher — drives your container runtime
 (Apple container, Docker, or Podman) directly.
 
 Commands:
+  init      Birth a new KB here: permanent identity, git repo, registration
   start     Start the local Semiont stack
   useradd   Create or update a user in the running stack
   secret    Register where config secrets come from (pointers, never values)
@@ -43,6 +44,8 @@ func main() {
 	cmd, rest := os.Args[1], os.Args[2:]
 	code := 0
 	switch cmd {
+	case "init":
+		code = launcher.Init(rest)
 	case "start":
 		code = launcher.Start(rest)
 	case "useradd":


### PR DESCRIPTION
## Summary

`semiont init` — the launcher can now birth a KB, not just run one. Design record: `.plans/LAUNCHER-BIRTH.md` (untracked). Five phases, one session, each RED-first; live-verified end to end including a real clone of the template repo. The guiding principle: **nothing is mastered** — the config is built from the schema, the launcher's own driver catalog, live model registries, and the user's answers, with an explicit opt-in to copy from the template instead.

## Identity at birth

`.semiont/config` gets its permanent did:web at creation — from `--domain`, else derived from the git origin (`<owner_lc>.github.io:<repo>` — the same rule the template's post-fork action applies), else prompted with a plain warning that this is the identity stamped into the committed event log. `--yes` refuses rather than guess where no safe default exists. This replaces the template path's assign-then-rewrite dance: the KB is born with its own name.

## A config built, validated, and vetted

- **Built** (`--inference anthropic|ollama --model <id> --embedding ollama:<model>`): the full semiontconfig synthesized from launcher knowledge — the three-name binding roster (gatherer/matcher/workers.default; per-worker refinement is the user's edit, emitted only as a commented example).
- **Validated live**: with a key, Anthropic models validate against `/v1/models` (unlisted → refusal printing what exists; no `--model` → newest-capable pick, announced); Ollama models pass as installed or registry-verified, refuse on a genuine 404, and degrade to accept-with-warning when sources are unreachable — unknown is not missing.
- **Vetted**: every config write — generated or copied — passes through the real `derivePlan` before landing. A generator bug or a version-skewed template is a pre-write refusal carrying the parser's own error, never a KB that cannot start.

## Or copy from the template, explicitly

`--from-template [url|dir]` shallow-clones (git is already a requirement; atomic ref, no listing API needed) and copies its semiontconfigs — each vetted, all-or-nothing with rollback. `--devcontainer` copies the codespace set with the display name rewritten to the new KB's, making a locally-born KB `--runtime codespace` eligible. Identity is never copied.

## Interactive with full flag parity

Every prompt has a flag twin; all-flags (or `--yes`) runs prompt-free. `--dry-run` renders every file it would write and every reach it would make, touching nothing. The endpoint seams (`--anthropic-endpoint`, `--ollama-base`, `--ollama-registry`) are user-facing proxy knobs that double as the hermetic test seams — no invented env vars.

## Not in scope

`~/.semiontconfig` (the container CLI's world), repo creation, README/badge scaffolding (template-path concern). The template survives as the zero-install browser-birth path and this command's optional copy source — master of nothing.
