### PR TITLE
launcher: persist local-stack state per root (postgres/qdrant/neo4j) + semiont clean

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -401,6 +401,14 @@ rebuild, never a refusal. (The Neo4j subdirs are host-side mode 777: its
 entrypoint refuses to boot unless its `test -w` gate passes, and Apple
 container's virtiofs won't let it chown a mount root.)
 
+`semiont clean` is the one way this state dies: it removes the current
+root's state directory (`--store database|vectors|graph` scopes to one
+store; `--dry-run` shows what would go, with sizes; `--root <path|name|key>`
+targets another root — a literal key is how you remove *orphaned* state
+whose KB directory no longer exists). It refuses while a recorded stack is
+using the state — stop first. `stop` itself never touches state; stopping
+and restarting is exactly the round trip persistence exists for.
+
 ## Development
 
 Go module with no external dependencies. Build and test (hermetically — no Go

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -376,6 +376,23 @@ semiont stop
 - `SEMIONT_VERSION` selects the service image tag (default `latest`; the
   sentinel `local` uses locally-built `:local` images and skips pulls).
 
+### Where state lives
+
+Local-stack databases persist across restarts. Each local semiont root gets
+its own directory under the launcher's data home — `~/Library/Application
+Support/semiont/roots/<key>` on macOS, `$XDG_DATA_HOME/semiont/roots/<key>`
+(default `~/.local/share/...`) on Linux — keyed by the KB's did:web when
+`.semiont/config` declares one (identity travels with the KB, so a moved
+clone keeps its state), else by a hash of the root path. `start`
+bind-mounts each store's subdir into its container: PostgreSQL rows —
+including users, which the event log does **not** record — survive `stop`
+and restart. A `meta.json` stamp records which image wrote each store; a
+start whose config names a *different* database image over existing data
+refuses with a fix-it line rather than risk it (Postgres data is never
+auto-deleted). The backend applies its schema with `prisma migrate deploy`,
+which only applies not-yet-applied migrations — a populated database
+no-ops on restart.
+
 ## Development
 
 Go module with no external dependencies. Build and test (hermetically — no Go

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -393,6 +393,14 @@ auto-deleted). The backend applies its schema with `prisma migrate deploy`,
 which only applies not-yet-applied migrations — a populated database
 no-ops on restart.
 
+Qdrant (`qdrant/`) and Neo4j (`neo4j/`) state persists the same way, with
+the opposite mismatch rule: they are *projections* of the event log, so a
+start whose config names a different image announces it is clearing the
+stale store and lets the normal rebuild repopulate it — freshness by
+rebuild, never a refusal. (The Neo4j subdirs are host-side mode 777: its
+entrypoint refuses to boot unless its `test -w` gate passes, and Apple
+container's virtiofs won't let it chown a mount root.)
+
 ## Development
 
 Go module with no external dependencies. Build and test (hermetically — no Go

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -193,8 +193,12 @@ semiont stop
   running here, headed by the root it belongs to and its did:web), LOCAL
   ROOTS, REMOTE KNOWLEDGE BASES (codespace-hosted KBs, their state, and each
   KB's local port). `--verbose` adds LAUNCHER PATHS — the launcher's own
-  config, cache, log, state, staging and model-cache paths, which describe the
-  tool rather than any KB. Roots and KBs are the durable
+  config, cache, log, state, staging and model-cache paths, plus the
+  persistent per-root stack state with its disk consumption: a `data` row
+  for the current root (per-store breakdown — postgres, qdrant, neo4j) and
+  an `all roots` row totaling every root, with orphaned state (its KB
+  directory no longer exists) called out alongside the `semiont clean
+  --root <key>` that removes it. Roots and KBs are the durable
   things; a stack is status layered on one of them. Per service it
   shows the container STATE as the runtime sees it plus a host-side health
   probe, with the concrete product in the service cell (`database

--- a/apps/launcher/internal/launcher/clean.go
+++ b/apps/launcher/internal/launcher/clean.go
@@ -79,40 +79,53 @@ func Clean(args []string) int {
 		return 1
 	}
 
-	type target struct{ label, path string }
+	type target struct {
+		label, path string
+		size        int64
+	}
 	var targets []target
 	if store != "" {
-		targets = append(targets, target{store, filepath.Join(dir, stateStores[store].dir)})
+		targets = append(targets, target{store, filepath.Join(dir, stateStores[store].dir), 0})
 	} else {
-		targets = append(targets, target{"all stores (" + key + ")", dir})
+		targets = append(targets, target{"all stores (" + key + ")", dir, 0})
 	}
 
-	var total int64
-	found := false
+	var kept []target
 	for _, tg := range targets {
 		sz, exists := dirSize(tg.path)
 		if !exists {
 			continue
 		}
-		found = true
-		total += sz
+		tg.size = sz
+		kept = append(kept, tg)
 		if dryRun {
 			u.log("would remove %s — %s (%s)", tg.path, humanBytes(sz), tg.label)
 		}
 	}
-	if !found {
-		u.log("Nothing to remove: no state at %s", dir)
+	if len(kept) == 0 {
+		if store != "" {
+			u.log("Nothing to remove: no %s state under %s", store, dir)
+		} else {
+			u.log("Nothing to remove: no state at %s", dir)
+		}
 		return 0
 	}
 	if dryRun {
+		var total int64
+		for _, tg := range kept {
+			total += tg.size
+		}
 		u.log("Total: %s %s", humanBytes(total), u.dim("(dry-run; nothing removed)"))
 		return 0
 	}
-	for _, tg := range targets {
+	for _, tg := range kept {
 		if err := os.RemoveAll(tg.path); err != nil {
 			u.fail("cannot remove %s: %v", tg.path, err)
 			return 1
 		}
+		// Name what was actually removed — a scoped clean removes ONE
+		// store's dir, never the root's.
+		u.ok("Removed %s — %s freed.", tg.path, humanBytes(tg.size))
 	}
 	// A scoped clean drops that store's stamp too, so the next start sees
 	// first-use, not a mismatch against thin air. A full clean removed
@@ -122,7 +135,6 @@ func Clean(args []string) int {
 		delete(meta.Stores, store)
 		saveRootMeta(dir, meta)
 	}
-	u.ok("Removed %s — %s freed.", dir, humanBytes(total))
 	return 0
 }
 
@@ -151,9 +163,13 @@ func cleanTarget(u *ui, rootArg string) (key, dir string, code int) {
 			key = rootKey(root)
 			break
 		}
-		if fi, statErr := os.Stat(filepath.Join(d, "roots", rootArg)); statErr == nil && fi.IsDir() {
-			key = rootArg
-			break
+		// A literal key must be a plain basename — anything else (".."; a
+		// path) would let RemoveAll reach outside roots/.
+		if rootArg == filepath.Base(rootArg) && rootArg != "." && rootArg != ".." {
+			if fi, statErr := os.Stat(filepath.Join(d, "roots", rootArg)); statErr == nil && fi.IsDir() {
+				key = rootArg
+				break
+			}
 		}
 		u.fail("%v", err)
 		fmt.Fprintf(os.Stderr, "  (and no state key %q under %s)\n", rootArg, filepath.Join(d, "roots"))

--- a/apps/launcher/internal/launcher/clean.go
+++ b/apps/launcher/internal/launcher/clean.go
@@ -1,0 +1,163 @@
+package launcher
+
+// clean.go — `semiont clean`: remove one root's persistent local-stack
+// state (LAUNCHER-STATE.md). start persists postgres/qdrant/neo4j under
+// <dataDir>/roots/<key>; this command is the only way that data dies —
+// stop deliberately leaves it, and start's database image-mismatch refusal
+// names this command as the way out.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const cleanUsage = `Usage: semiont clean [options]
+
+Remove the persistent local-stack state (PostgreSQL, Qdrant, Neo4j data)
+for one local semiont root. The stack must be stopped first — state is
+never removed while a recorded stack may be mounting it.
+
+Options:
+  --store <role>   Remove one store only: database, vectors, or graph
+  --root <value>   Another root: a path, a registered basename, or a state
+                   key as listed by status --verbose (how orphaned state,
+                   whose KB directory no longer exists, is named)
+  --dry-run        Show what would be removed and its size; remove nothing
+  --help           Show this help
+`
+
+func Clean(args []string) int {
+	u := newUI(false)
+	store := ""
+	rootArg := ""
+	dryRun := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--store":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --store")
+				return 1
+			}
+			store = args[i+1]
+			i++
+		case "--root":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --root")
+				return 1
+			}
+			rootArg = args[i+1]
+			i++
+		case "--dry-run":
+			dryRun = true
+		case "--help", "-h":
+			fmt.Print(cleanUsage)
+			return 0
+		default:
+			u.fail("Unknown argument: %s", args[i])
+			return 1
+		}
+	}
+	if store != "" {
+		if _, ok := stateStores[store]; !ok {
+			u.fail("Unknown store %q (stores with persistent state: database, graph, vectors)", store)
+			return 1
+		}
+	}
+
+	key, dir, code := cleanTarget(u, rootArg)
+	if code != 0 {
+		return code
+	}
+
+	// Never sweep state out from under a stack that may be mounting it.
+	// stack.json is belief, but the asymmetry decides: a stale "running"
+	// costs the user one `semiont stop`; removing mounted dirs corrupts.
+	if st := loadLocalState(); st != nil && stateKeyFor(st.KBDid, st.KBRoot) == key {
+		u.fail("A recorded local stack is using this state (per %s).", statePath())
+		fmt.Fprintln(os.Stderr, "  Stop it first: semiont stop")
+		return 1
+	}
+
+	type target struct{ label, path string }
+	var targets []target
+	if store != "" {
+		targets = append(targets, target{store, filepath.Join(dir, stateStores[store].dir)})
+	} else {
+		targets = append(targets, target{"all stores (" + key + ")", dir})
+	}
+
+	var total int64
+	found := false
+	for _, tg := range targets {
+		sz, exists := dirSize(tg.path)
+		if !exists {
+			continue
+		}
+		found = true
+		total += sz
+		if dryRun {
+			u.log("would remove %s — %s (%s)", tg.path, humanBytes(sz), tg.label)
+		}
+	}
+	if !found {
+		u.log("Nothing to remove: no state at %s", dir)
+		return 0
+	}
+	if dryRun {
+		u.log("Total: %s %s", humanBytes(total), u.dim("(dry-run; nothing removed)"))
+		return 0
+	}
+	for _, tg := range targets {
+		if err := os.RemoveAll(tg.path); err != nil {
+			u.fail("cannot remove %s: %v", tg.path, err)
+			return 1
+		}
+	}
+	// A scoped clean drops that store's stamp too, so the next start sees
+	// first-use, not a mismatch against thin air. A full clean removed
+	// meta.json with the dir.
+	if store != "" {
+		meta := loadRootMeta(dir)
+		delete(meta.Stores, store)
+		saveRootMeta(dir, meta)
+	}
+	u.ok("Removed %s — %s freed.", dir, humanBytes(total))
+	return 0
+}
+
+// cleanTarget resolves which root's state to clean. No --root: the same
+// cwd ladder start uses. --root: a path or registered basename first
+// (resolveRootArg), else a literal key with a dir under roots/ — the form
+// status prints for orphans, whose KB no longer resolves any other way.
+func cleanTarget(u *ui, rootArg string) (key, dir string, code int) {
+	d := dataDir()
+	if d == "" {
+		u.fail("No home directory resolvable; nowhere for state to live.")
+		return "", "", 1
+	}
+	switch {
+	case rootArg == "":
+		root, _, err := resolveKBRoot()
+		if err != nil {
+			u.fail("%v", err)
+			fmt.Fprintln(os.Stderr, "  Run inside a KB, or name one: semiont clean --root <path|name|key>")
+			return "", "", 1
+		}
+		key = rootKey(root)
+	default:
+		root, err := resolveRootArg(rootArg)
+		if err == nil {
+			key = rootKey(root)
+			break
+		}
+		if fi, statErr := os.Stat(filepath.Join(d, "roots", rootArg)); statErr == nil && fi.IsDir() {
+			key = rootArg
+			break
+		}
+		u.fail("%v", err)
+		fmt.Fprintf(os.Stderr, "  (and no state key %q under %s)\n", rootArg, filepath.Join(d, "roots"))
+		return "", "", 1
+	}
+	return key, filepath.Join(d, "roots", key), 0
+}

--- a/apps/launcher/internal/launcher/dryrun.go
+++ b/apps/launcher/internal/launcher/dryrun.go
@@ -17,10 +17,13 @@ func renderCmd(rt string, args ...string) string {
 
 // renderStartPlan is the --dry-run output: the same full-start flow walked
 // in plan mode. This is the legibility replacement for reading the old bash —
-// and the extraction seam for the stack-parity gate.
-func renderStartPlan(rt, version string, opts startOptions, userEnv []string, plan *launchPlan) {
+// and the extraction seam for the stack-parity gate. It takes the REAL kb
+// root: paths derivable at plan time (the per-root state dir) print as
+// truth; the kb mount still renders "<kb-root>" via val(), the seam for
+// values the flow treats as runtime-scoped.
+func renderStartPlan(rt, version, root string, opts startOptions, userEnv []string, plan *launchPlan) {
 	x := &planExec{rt: rt}
 	x.c("semiont start --dry-run — the exact runtime commands a real run would")
 	x.c("execute, in order. Values known only at runtime appear as <placeholders>.")
-	flowFullStart(x, flowCtx{plan: plan, opts: opts, version: version, root: "<kb-root>", configFile: opts.configName, userEnv: userEnv})
+	flowFullStart(x, flowCtx{plan: plan, opts: opts, version: version, root: root, configFile: opts.configName, userEnv: userEnv})
 }

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -528,6 +528,16 @@ func (x *liveExec) stateMounts(role, image, root string) ([]string, bool) {
 			}
 		}
 	}
+	if spec.mode != 0 {
+		// The mount dirs carry a permissive mode for the container's own
+		// gate — clamp their UNMOUNTED parent to owner-only so other local
+		// users can't traverse to them. The container never sees the
+		// parent; only the mount dirs cross the boundary.
+		if err := os.Chmod(sd, 0o700); err != nil {
+			x.u.fail("cannot chmod state dir %s: %v", sd, err)
+			return nil, false
+		}
+	}
 	meta.KBRoot = root
 	meta.Did = loadKBIdentity(root).didWeb()
 	meta.Stores[role] = storeMeta{Image: image}

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -485,10 +485,9 @@ func (x *liveExec) ensureModels(base string, models []string) {
 }
 
 // stateMounts prepares a role's persistent state dir and returns the run
-// args that mount it (LAUNCHER-STATE.md). !ok is the DATABASE refusal:
-// existing data written by a different image is user rows — never
-// auto-deleted; the fix-it names the clean command. Projections (P2) will
-// auto-clean here instead.
+// args that mount it (LAUNCHER-STATE.md). The image-mismatch split lives
+// here: database data is user rows — refuse, fix-it names the clean
+// command; projections (vectors/graph) auto-clean and rebuild.
 func (x *liveExec) stateMounts(role, image, root string) ([]string, bool) {
 	args := stateMountArgs(role, root)
 	if len(args) == 0 {
@@ -496,16 +495,38 @@ func (x *liveExec) stateMounts(role, image, root string) ([]string, bool) {
 	}
 	spec := stateStores[role]
 	dir := stateRootDir(root)
-	sub := filepath.Join(dir, spec.sub)
+	sd := spec.storeDir(root)
 	meta := loadRootMeta(dir)
-	if prev := meta.Stores[role].Image; prev != "" && prev != image && storeDirNonEmpty(sub) {
-		x.u.fail("%s state at %s was written by %s; this config launches %s.", role, sub, prev, image)
-		fmt.Fprintln(os.Stderr, "  That data is not auto-deleted. Remove it first: semiont clean --store "+role)
-		return nil, false
+	if prev := meta.Stores[role].Image; prev != "" && prev != image && storeDirNonEmpty(sd) {
+		if spec.projection {
+			// A projection of the event log: staleness is rebuildable, so a
+			// mismatch clears rather than refuses.
+			x.u.log("%s state at %s was written by %s; this config launches %s — projections rebuild, so clearing it.",
+				role, sd, prev, image)
+			if err := os.RemoveAll(sd); err != nil {
+				x.u.fail("cannot clear %s state %s: %v", role, sd, err)
+				return nil, false
+			}
+		} else {
+			x.u.fail("%s state at %s was written by %s; this config launches %s.", role, sd, prev, image)
+			fmt.Fprintln(os.Stderr, "  That data is not auto-deleted. Remove it first: semiont clean --store "+role)
+			return nil, false
+		}
 	}
-	if err := os.MkdirAll(sub, 0o755); err != nil {
-		x.u.fail("cannot create state dir %s: %v", sub, err)
-		return nil, false
+	for _, m := range spec.mounts {
+		mp := filepath.Join(sd, m.sub)
+		if err := os.MkdirAll(mp, 0o755); err != nil {
+			x.u.fail("cannot create state dir %s: %v", mp, err)
+			return nil, false
+		}
+		if spec.mode != 0 {
+			// MkdirAll perms pass through the umask; the virtiofs gate needs
+			// the literal mode, so stamp it explicitly.
+			if err := os.Chmod(mp, spec.mode); err != nil {
+				x.u.fail("cannot chmod state dir %s: %v", mp, err)
+				return nil, false
+			}
+		}
 	}
 	meta.KBRoot = root
 	meta.Did = loadKBIdentity(root).didWeb()
@@ -705,7 +726,7 @@ func (x *planExec) stateMounts(role, _, root string) ([]string, bool) {
 	args := stateMountArgs(role, root)
 	if len(args) > 0 {
 		x.c("%s state: %s (created if absent; reused across restarts)",
-			role, filepath.Join(stateRootDir(root), stateStores[role].sub))
+			role, stateStores[role].storeDir(root))
 	}
 	return args, true
 }

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -52,6 +52,7 @@ type executor interface {
 	dumpLogs(container, svc string)                             // failed health gate: show the crash where it is
 	verifyRemoteModels(role, base, key string, models []string) // record /v1/models metadata; warn on unlisted
 	ensureModels(base string, models []string)                  // pull configured ollama models that are absent
+	stateMounts(role, image, root string) ([]string, bool)      // persistent-state run args; !ok = refuse (data written by another image)
 	val(live, plan string) string                               // mode-scoped value (kb root, admin password)
 	rtName() string
 
@@ -483,6 +484,36 @@ func (x *liveExec) ensureModels(base string, models []string) {
 	ensureOllamaModels(x.u, base, models)
 }
 
+// stateMounts prepares a role's persistent state dir and returns the run
+// args that mount it (LAUNCHER-STATE.md). !ok is the DATABASE refusal:
+// existing data written by a different image is user rows — never
+// auto-deleted; the fix-it names the clean command. Projections (P2) will
+// auto-clean here instead.
+func (x *liveExec) stateMounts(role, image, root string) ([]string, bool) {
+	args := stateMountArgs(role, root)
+	if len(args) == 0 {
+		return nil, true
+	}
+	spec := stateStores[role]
+	dir := stateRootDir(root)
+	sub := filepath.Join(dir, spec.sub)
+	meta := loadRootMeta(dir)
+	if prev := meta.Stores[role].Image; prev != "" && prev != image && storeDirNonEmpty(sub) {
+		x.u.fail("%s state at %s was written by %s; this config launches %s.", role, sub, prev, image)
+		fmt.Fprintln(os.Stderr, "  That data is not auto-deleted. Remove it first: semiont clean --store "+role)
+		return nil, false
+	}
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		x.u.fail("cannot create state dir %s: %v", sub, err)
+		return nil, false
+	}
+	meta.KBRoot = root
+	meta.Did = loadKBIdentity(root).didWeb()
+	meta.Stores[role] = storeMeta{Image: image}
+	saveRootMeta(dir, meta)
+	return args, true
+}
+
 func (x *liveExec) val(live, _ string) string { return live }
 func (x *liveExec) rtName() string            { return x.rt }
 func (x *liveExec) dim(s string) string       { return x.u.dim(s) }
@@ -665,6 +696,18 @@ func (x *planExec) ensureModels(base string, models []string) {
 	if len(models) > 0 {
 		x.c("ensure ollama models present at %s (pull each missing one): %s", base, strings.Join(models, ", "))
 	}
+}
+
+// --dry-run computes the real state path (it is derivation, not effect) but
+// creates nothing and never refuses — the image-mismatch check reads disk,
+// a runtime fact the plan only names.
+func (x *planExec) stateMounts(role, _, root string) ([]string, bool) {
+	args := stateMountArgs(role, root)
+	if len(args) > 0 {
+		x.c("%s state: %s (created if absent; reused across restarts)",
+			role, filepath.Join(stateRootDir(root), stateStores[role].sub))
+	}
+	return args, true
 }
 
 func (x *planExec) val(_, plan string) string { return plan }

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -212,7 +212,14 @@ func flowDepRole(x executor, role string, fc flowCtx, addr string) int {
 	x.banner(depRoleTitles[role] + " (" + disp + ")")
 	switch rp.Obligation {
 	case obligationProvided:
-		args := providedRunArgs(role, rp)
+		// Persistent state rides the run argv (LAUNCHER-STATE.md): roles in
+		// stateStores mount their per-root dir; a database refusal (data
+		// written by another image) stops the start here.
+		extra, ok := x.stateMounts(role, rp.Image, fc.root)
+		if !ok {
+			return 1
+		}
+		args := providedRunArgs(role, rp, extra...)
 		id, ok := x.runDetached(args)
 		if !ok {
 			x.say(sayFail, "%s (%s) failed to start.", role, disp)

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -551,7 +551,14 @@ func flowOneService(x executor, fc flowCtx) int {
 	case "graph", "vectors", "database":
 		rp := fc.plan.Roles[svc]
 		disp := driverDisplay(svc, rp.Driver)
-		args := providedRunArgs(svc, rp)
+		// The same persistence rules as a full start (LAUNCHER-STATE.md): a
+		// lone database restart that skipped its mount would write rows into
+		// a container that dies with it.
+		extra, ok := x.stateMounts(svc, rp.Image, fc.root)
+		if !ok {
+			return 1
+		}
+		args := providedRunArgs(svc, rp, extra...)
 		id, ok := x.runDetached(args)
 		if !ok {
 			x.say(sayFail, "%s (%s) failed to start.", svc, disp)

--- a/apps/launcher/internal/launcher/rootstate.go
+++ b/apps/launcher/internal/launcher/rootstate.go
@@ -75,21 +75,54 @@ func stateRootDir(root string) string {
 
 // stateStoreSpec: how one infra role's container consumes its state subdir.
 type stateStoreSpec struct {
-	sub    string   // subdir under the root's state dir
-	target string   // container path it mounts at
-	env    []string // extra env the mount shape requires
+	dir    string       // the store's subdir under the root's state dir
+	mounts []stateMount // bind mounts within it
+	env    []string     // extra env the mount shape requires
+	mode   os.FileMode  // non-zero: host-side perms on the mount dirs (virtiofs test -w gate)
+	// projection: this store derives from the event log — an image mismatch
+	// auto-cleans and rebuilds instead of refusing. False = system of
+	// record (database): existing data is never auto-deleted.
+	projection bool
 }
 
-// stateStores: the roles whose containers persist state. P1: database only;
-// P2 adds vectors and graph.
+// stateMount: one -v within a store. sub "" mounts the store dir itself.
+type stateMount struct{ sub, target string }
+
+// stateStores: the roles whose containers persist state, with the mount
+// shapes the Phase 0 spikes measured (LAUNCHER-STATE.md Decision).
 var stateStores = map[string]stateStoreSpec{
 	// The entrypoint chmods $PGDATA only — a created-inside subdir — never
 	// the mount root (which virtiofs refuses; Phase 0, 7/7).
 	"database": {
-		sub:    "postgres",
-		target: "/var/lib/postgresql/data",
+		dir:    "postgres",
+		mounts: []stateMount{{"", "/var/lib/postgresql/data"}},
 		env:    []string{"PGDATA=/var/lib/postgresql/data/pgdata"},
 	},
+	// Qdrant just writes files; a plain mount works (Phase 0, 7/7).
+	"vectors": {
+		dir:        "qdrant",
+		mounts:     []stateMount{{"", "/qdrant/storage"}},
+		projection: true,
+	},
+	// Neo4j's entrypoint gates on `test -w` of /data and /logs and insists
+	// on chowning an unwritable mount root — refused on virtiofs, and
+	// in-mount chown silently no-ops. Host-side 0777 satisfies the gate so
+	// the chown is never attempted (Phase 0, 8/8).
+	"graph": {
+		dir:        "neo4j",
+		mounts:     []stateMount{{"data", "/data"}, {"logs", "/logs"}},
+		mode:       0o777,
+		projection: true,
+	},
+}
+
+// storeDir: the store's directory under a root's state dir.
+func (spec stateStoreSpec) storeDir(root string) string {
+	dir := stateRootDir(root)
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, spec.dir)
 }
 
 // stateMountArgs renders the -v/-e run args for a role's persistent state.
@@ -100,11 +133,14 @@ func stateMountArgs(role, root string) []string {
 	if !ok {
 		return nil
 	}
-	dir := stateRootDir(root)
-	if dir == "" {
+	sd := spec.storeDir(root)
+	if sd == "" {
 		return nil
 	}
-	args := []string{"-v", filepath.Join(dir, spec.sub) + ":" + spec.target}
+	var args []string
+	for _, m := range spec.mounts {
+		args = append(args, "-v", filepath.Join(sd, m.sub)+":"+m.target)
+	}
 	for _, e := range spec.env {
 		args = append(args, "-e", e)
 	}

--- a/apps/launcher/internal/launcher/rootstate.go
+++ b/apps/launcher/internal/launcher/rootstate.go
@@ -1,0 +1,178 @@
+package launcher
+
+// rootstate.go — persistent per-root local-stack state (LAUNCHER-STATE.md).
+// Each local semiont root gets its own directory under the launcher's data
+// home; infra containers bind-mount their store subdirs from it, so postgres
+// rows (which include users the event log does NOT record) survive restarts,
+// and the qdrant/neo4j projections skip their rebuild. The mount shapes are
+// the ones the Phase 0 spikes measured on Apple container's virtiofs:
+// chmod/chown of a mount root is refused and in-mount chown silently no-ops,
+// but host-side mode bits pass through and created-inside writes land — so
+// postgres points PGDATA at a subdir the entrypoint creates inside the
+// mount, and (P2) neo4j's dirs get host-side 0777 to satisfy its `test -w`
+// boot gate.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"time"
+)
+
+// dataDir is the launcher's data home: the same ~/Library/Application
+// Support/semiont bucket the state file uses on macOS (Apple keeps one home
+// for both), $XDG_DATA_HOME/semiont (default ~/.local/share/semiont)
+// elsewhere — DB contents are XDG data, not XDG state. "" when no home is
+// resolvable.
+func dataDir() string {
+	if runtime.GOOS == "darwin" {
+		dir, err := os.UserConfigDir()
+		if err != nil {
+			return ""
+		}
+		return filepath.Join(dir, "semiont")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	if s := os.Getenv("XDG_DATA_HOME"); s != "" {
+		return filepath.Join(s, "semiont")
+	}
+	return filepath.Join(home, ".local", "share", "semiont")
+}
+
+var keyUnsafe = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+// rootKey names a root's state directory. The KB's did:web domain when
+// declared — identity travels with the KB, so a moved clone keeps its state
+// — else "path-" + a stable hash of the absolute root path. meta.json keeps
+// the unsanitized truth so status and clean can always name the root.
+func rootKey(root string) string {
+	if ident := loadKBIdentity(root); ident != nil && ident.Domain != "" {
+		return keyUnsafe.ReplaceAllString(ident.Domain, "-")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		abs = root
+	}
+	sum := sha256.Sum256([]byte(abs))
+	return "path-" + hex.EncodeToString(sum[:])[:12]
+}
+
+// stateRootDir: <dataDir>/roots/<key> for this KB root; "" when homeless.
+func stateRootDir(root string) string {
+	d := dataDir()
+	if d == "" {
+		return ""
+	}
+	return filepath.Join(d, "roots", rootKey(root))
+}
+
+// stateStoreSpec: how one infra role's container consumes its state subdir.
+type stateStoreSpec struct {
+	sub    string   // subdir under the root's state dir
+	target string   // container path it mounts at
+	env    []string // extra env the mount shape requires
+}
+
+// stateStores: the roles whose containers persist state. P1: database only;
+// P2 adds vectors and graph.
+var stateStores = map[string]stateStoreSpec{
+	// The entrypoint chmods $PGDATA only — a created-inside subdir — never
+	// the mount root (which virtiofs refuses; Phase 0, 7/7).
+	"database": {
+		sub:    "postgres",
+		target: "/var/lib/postgresql/data",
+		env:    []string{"PGDATA=/var/lib/postgresql/data/pgdata"},
+	},
+}
+
+// stateMountArgs renders the -v/-e run args for a role's persistent state.
+// nil for roles without a store, or when no data home resolves — the stack
+// still boots, just ephemeral, as before this feature.
+func stateMountArgs(role, root string) []string {
+	spec, ok := stateStores[role]
+	if !ok {
+		return nil
+	}
+	dir := stateRootDir(root)
+	if dir == "" {
+		return nil
+	}
+	args := []string{"-v", filepath.Join(dir, spec.sub) + ":" + spec.target}
+	for _, e := range spec.env {
+		args = append(args, "-e", e)
+	}
+	return args
+}
+
+// rootMeta is <stateRootDir>/meta.json: which root this state belongs to
+// and which image wrote each store — the stamp the freshness/safety split
+// reads (database mismatch refuses; projections auto-clean, P2).
+type rootMeta struct {
+	KBRoot    string               `json:"kbRoot"`
+	Did       string               `json:"did,omitempty"`
+	CreatedAt time.Time            `json:"createdAt"`
+	Stores    map[string]storeMeta `json:"stores"`
+}
+
+type storeMeta struct {
+	Image string `json:"image"`
+}
+
+// loadRootMeta: the dir's meta.json, or a zero-valued meta (never nil).
+func loadRootMeta(dir string) *rootMeta {
+	m := &rootMeta{Stores: map[string]storeMeta{}}
+	if dir == "" {
+		return m
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		return m
+	}
+	var read rootMeta
+	if json.Unmarshal(b, &read) != nil {
+		return m
+	}
+	if read.Stores == nil {
+		read.Stores = map[string]storeMeta{}
+	}
+	return &read
+}
+
+// saveRootMeta writes the stamp atomically (temp + rename). Best-effort by
+// design: the stamp protects FUTURE starts; failing THIS boot over it would
+// punish the user for a full disk twice.
+func saveRootMeta(dir string, m *rootMeta) {
+	if dir == "" {
+		return
+	}
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = time.Now().UTC()
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	tmp := filepath.Join(dir, "meta.json.tmp")
+	if err := os.WriteFile(tmp, append(b, '\n'), 0o644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, filepath.Join(dir, "meta.json"))
+}
+
+// storeDirNonEmpty: whether a store subdir already holds anything — the
+// difference between first use (mount and go) and existing data (the
+// image-mismatch check applies).
+func storeDirNonEmpty(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) > 0
+}

--- a/apps/launcher/internal/launcher/rootstate.go
+++ b/apps/launcher/internal/launcher/rootstate.go
@@ -16,10 +16,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -53,8 +56,16 @@ var keyUnsafe = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
 // — else "path-" + a stable hash of the absolute root path. meta.json keeps
 // the unsanitized truth so status and clean can always name the root.
 func rootKey(root string) string {
-	if ident := loadKBIdentity(root); ident != nil && ident.Domain != "" {
-		return keyUnsafe.ReplaceAllString(ident.Domain, "-")
+	return stateKeyFor(loadKBIdentity(root).didWeb(), root)
+}
+
+// stateKeyFor derives the key from an already-known identity — the form
+// clean and status use against RECORDS (stack.json's kbDid/kbRoot), where
+// re-reading .semiont/config would answer for the wrong tree (or none, for
+// an orphan).
+func stateKeyFor(did, root string) string {
+	if d, ok := strings.CutPrefix(did, "did:web:"); ok && d != "" {
+		return keyUnsafe.ReplaceAllString(d, "-")
 	}
 	abs, err := filepath.Abs(root)
 	if err != nil {
@@ -211,4 +222,41 @@ func saveRootMeta(dir string, m *rootMeta) {
 func storeDirNonEmpty(dir string) bool {
 	entries, err := os.ReadDir(dir)
 	return err == nil && len(entries) > 0
+}
+
+// dirSize: total bytes of regular files under path, and whether the path
+// exists at all — absent must stay distinguishable from empty ("unknown is
+// not missing"). Go-native walk; unreadable entries are skipped, not fatal.
+func dirSize(path string) (int64, bool) {
+	if _, err := os.Stat(path); err != nil {
+		return 0, false
+	}
+	var total int64
+	_ = filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.Type().IsRegular() {
+			if info, e := d.Info(); e == nil {
+				total += info.Size()
+			}
+		}
+		return nil
+	})
+	return total, true
+}
+
+// humanBytes: one rounding for every size the launcher prints.
+func humanBytes(n int64) string {
+	const k = 1024
+	switch {
+	case n >= k*k*k:
+		return fmt.Sprintf("%.1f GB", float64(n)/(k*k*k))
+	case n >= k*k:
+		return fmt.Sprintf("%.1f MB", float64(n)/(k*k))
+	case n >= k:
+		return fmt.Sprintf("%.1f KB", float64(n)/k)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }

--- a/apps/launcher/internal/launcher/service.go
+++ b/apps/launcher/internal/launcher/service.go
@@ -218,11 +218,13 @@ func runStartService(u *ui, rt, version, root, configFile string, opts startOpti
 }
 
 // renderServicePlan is --dry-run for --service: the same flow, plan mode.
-func renderServicePlan(rt, version string, opts startOptions, userEnv []string, plan *launchPlan) {
+// Real root for the same reason as renderStartPlan: the state path is
+// plan-time truth; the kb mount keeps its placeholder via val().
+func renderServicePlan(rt, version, root string, opts startOptions, userEnv []string, plan *launchPlan) {
 	x := &planExec{rt: rt}
 	x.c("semiont start --service %s --dry-run — the exact runtime commands a real", opts.service)
 	x.c("run would execute, in order. Values known only at runtime appear as <placeholders>.")
-	flowOneService(x, flowCtx{plan: plan, opts: opts, version: version, root: "<kb-root>", configFile: opts.configName, userEnv: userEnv})
+	flowOneService(x, flowCtx{plan: plan, opts: opts, version: version, root: root, configFile: opts.configName, userEnv: userEnv})
 }
 
 // serviceEndpoint: the health endpoint status should probe for a service the

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -602,9 +602,9 @@ func Start(args []string) int {
 
 	if opts.dryRun {
 		if opts.service != "" {
-			renderServicePlan(rt, version, opts, userEnv, plan)
+			renderServicePlan(rt, version, root, opts, userEnv, plan)
 		} else {
-			renderStartPlan(rt, version, opts, userEnv, plan)
+			renderStartPlan(rt, version, root, opts, userEnv, plan)
 		}
 		return 0
 	}

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -2,7 +2,9 @@ package launcher
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -630,10 +632,12 @@ func printLauncherPaths(u *ui) {
 			roots++
 			sz, _ := dirSize(filepath.Join(rootsDir, e.Name()))
 			total += sz
-			// Orphan = the stamped kb path no longer exists. A dir without a
-			// readable stamp is counted but never accused.
+			// Orphan = the stamped kb path DOES NOT EXIST — only that.
+			// Permission or IO errors are unknowns, and unknown is not
+			// missing; a dir without a readable stamp is counted, never
+			// accused.
 			if m := loadRootMeta(filepath.Join(rootsDir, e.Name())); m.KBRoot != "" {
-				if _, statErr := os.Stat(m.KBRoot); statErr != nil {
+				if _, statErr := os.Stat(m.KBRoot); errors.Is(statErr, fs.ErrNotExist) {
 					orphanKeys = append(orphanKeys, e.Name())
 				}
 			}

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -643,15 +643,15 @@ func printLauncherPaths(u *ui) {
 		row("all roots", rootsDir, "no persistent state")
 		return
 	}
-	note := fmt.Sprintf("%d roots, %s total", roots, humanBytes(total))
+	rootsNote := fmt.Sprintf("%d roots, %s total", roots, humanBytes(total))
 	if roots == 1 {
-		note = fmt.Sprintf("1 root, %s total", humanBytes(total))
+		rootsNote = fmt.Sprintf("1 root, %s total", humanBytes(total))
 	}
 	if n := len(orphanKeys); n > 0 {
-		note += fmt.Sprintf("; %d orphaned — kb path no longer exists; semiont clean --root %s",
+		rootsNote += fmt.Sprintf("; %d orphaned — kb path no longer exists; semiont clean --root %s",
 			n, strings.Join(orphanKeys, ", "))
 	}
-	row("all roots", rootsDir, note)
+	row("all roots", rootsDir, rootsNote)
 }
 
 // storeSizes: one root's per-store disk breakdown, fixed display order,

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -22,9 +22,10 @@ Reports what this machine knows about:
                  codespace-hosted KBs, their state, and their KB port
 
 --verbose adds LAUNCHER PATHS: the launcher's own config, cache, log, state,
-staging and model-cache paths on this host. They describe the tool, not any
-KB, and change only when the launcher itself does — so they are asked for
-rather than shown.
+staging and model-cache paths on this host, plus the persistent per-root
+stack state and its disk consumption — the active root's stores, and the
+total across all roots (orphaned state is called out with the clean
+command that removes it).
 
 For every local service: the container state as the runtime reports it
 (running / exited / absent — across all installed runtimes unless --runtime
@@ -556,15 +557,16 @@ func printRoots(u *ui, st *stackState) {
 }
 
 // printLauncherPaths reports the host-side paths the stack touches, under
-// --verbose only: they describe the LAUNCHER, not any KB, and change only
-// when the launcher itself does — so the everyday report leads with roots
-// and stacks instead. (Paths, not
-// "directories" — the state entry is a file.) They are: the
-// launcher's XDG-resolved config/cache homes (reserved by design — see
-// GO-LAUNCHER.md host need #1; Go maps them to XDG_* on Linux and
+// --verbose only — the everyday report leads with roots and stacks
+// instead. (Paths, not "directories" — the state entry is a file.) They
+// are: the launcher's XDG-resolved config/cache homes (reserved by design
+// — see GO-LAUNCHER.md host need #1; Go maps them to XDG_* on Linux and
 // ~/Library/... on macOS), the live config staging under /tmp (never
-// $TMPDIR — Apple container cannot sustain mounts from /var/folders), and
-// the Ollama model cache a container run may share.
+// $TMPDIR — Apple container cannot sustain mounts from /var/folders), the
+// Ollama model cache a container run may share, and the persistent
+// per-root stack state with its disk consumption (LAUNCHER-STATE.md):
+// the active root's stores, then the total across every root, orphans
+// called out with the clean command that removes them.
 func printLauncherPaths(u *ui) {
 	u.section("LAUNCHER PATHS")
 	row := func(label, path, note string) {
@@ -600,6 +602,72 @@ func printLauncherPaths(u *ui) {
 		p := filepath.Join(home, ".ollama")
 		row("inference", p, presence(p))
 	}
+
+	// Persistent per-root stack state (LAUNCHER-STATE.md requirement 5):
+	// the active root's stores and the all-roots total.
+	d := dataDir()
+	if d == "" {
+		return
+	}
+	rootsDir := filepath.Join(d, "roots")
+	if root, _, err := resolveKBRoot(); err == nil {
+		dir := filepath.Join(rootsDir, rootKey(root))
+		note := "absent"
+		if parts, total, any := storeSizes(dir); any {
+			note = humanBytes(total) + ": " + strings.Join(parts, ", ")
+		}
+		row("data", dir, note)
+	}
+	entries, err := os.ReadDir(rootsDir)
+	roots := 0
+	var total int64
+	var orphanKeys []string
+	if err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			roots++
+			sz, _ := dirSize(filepath.Join(rootsDir, e.Name()))
+			total += sz
+			// Orphan = the stamped kb path no longer exists. A dir without a
+			// readable stamp is counted but never accused.
+			if m := loadRootMeta(filepath.Join(rootsDir, e.Name())); m.KBRoot != "" {
+				if _, statErr := os.Stat(m.KBRoot); statErr != nil {
+					orphanKeys = append(orphanKeys, e.Name())
+				}
+			}
+		}
+	}
+	if roots == 0 {
+		row("all roots", rootsDir, "no persistent state")
+		return
+	}
+	note := fmt.Sprintf("%d roots, %s total", roots, humanBytes(total))
+	if roots == 1 {
+		note = fmt.Sprintf("1 root, %s total", humanBytes(total))
+	}
+	if n := len(orphanKeys); n > 0 {
+		note += fmt.Sprintf("; %d orphaned — kb path no longer exists; semiont clean --root %s",
+			n, strings.Join(orphanKeys, ", "))
+	}
+	row("all roots", rootsDir, note)
+}
+
+// storeSizes: one root's per-store disk breakdown, fixed display order,
+// present stores only — absent is absent, not 0 B.
+func storeSizes(dir string) (parts []string, total int64, any bool) {
+	for _, role := range []string{"database", "vectors", "graph"} {
+		spec := stateStores[role]
+		sz, ok := dirSize(filepath.Join(dir, spec.dir))
+		if !ok {
+			continue
+		}
+		any = true
+		total += sz
+		parts = append(parts, spec.dir+" "+humanBytes(sz))
+	}
+	return
 }
 
 // containerState asks each runtime for the container's state, first hit wins.

--- a/apps/launcher/internal/launcher/stop.go
+++ b/apps/launcher/internal/launcher/stop.go
@@ -12,7 +12,9 @@ const stopUsage = `Usage: semiont stop [--service <name>] [--runtime container|d
 
 Stop the whole Semiont stack — services, dependencies, and observability —
 and clean up the staged config copies. Safe to run when nothing is up:
-every step is a no-op then.
+every step is a no-op then. Persistent stack state (PostgreSQL, Qdrant,
+Neo4j data) is deliberately LEFT: the next start reuses it. Removing it is
+its own explicit command: semiont clean.
 
 With no --runtime, EVERY installed runtime is swept — stopping via the wrong
 runtime is a silent no-op that leaves the real stack running.

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -547,6 +547,91 @@ func TestStartDryRunLocalVersion(t *testing.T) {
 	checkGolden(t, "start-dryrun-local.txt", s.norm(stdout))
 }
 
+// --- local-stack state persistence (LAUNCHER-STATE.md) ---
+
+// stateRootFor mirrors the launcher's per-root state dir for the scenario's
+// fake HOME (tests run on linux, so the XDG data home).
+func stateRootFor(home, key string) string {
+	return filepath.Join(home, ".local", "share", "semiont", "roots", key)
+}
+
+// testKBKey: the slug of the test KB's did:web (testdata/kb/.semiont/config).
+const testKBKey = "example.github.io-test-kb"
+
+func TestStatePersistsAcrossStarts(t *testing.T) {
+	s := newScenario(t, "container")
+	_, stderr, code := s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("first start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	dir := stateRootFor(s.home, testKBKey)
+	meta, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatalf("meta.json after start: %v", err)
+	}
+	mustContain(t, "meta.json", string(meta), "postgres:15.18-alpine", s.kb)
+	if _, err := os.Stat(filepath.Join(dir, "postgres")); err != nil {
+		t.Fatalf("postgres state dir after start: %v", err)
+	}
+	// A second start must REUSE the same dir — that is the whole feature:
+	// the mount appears in both boots' argv, same path both times.
+	s.killServes()
+	_, stderr, code = s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("second start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	mount := dir + "/postgres:/var/lib/postgresql/data"
+	if got := strings.Count(string(s.mustLog(t)), mount); got != 2 {
+		t.Errorf("state mount should appear in both boots (want 2, got %d)", got)
+	}
+}
+
+func TestStateImageMismatchRefuses(t *testing.T) {
+	s := newScenario(t, "container")
+	// Existing postgres data written by a DIFFERENT image version: the
+	// launcher must refuse — user rows are not a projection it may delete.
+	dir := stateRootFor(s.home, testKBKey)
+	pg := filepath.Join(dir, "postgres", "pgdata")
+	if err := os.MkdirAll(pg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pg, "PG_VERSION"), []byte("14\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"kbRoot":"` + s.kb + `","stores":{"database":{"image":"postgres:14.9-alpine"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := s.run(t, "start")
+	if code == 0 {
+		t.Fatalf("start over another image's data must refuse\nstdout:\n%s", stdout)
+	}
+	mustContain(t, "refusal", stdout+stderr,
+		"postgres:14.9-alpine",  // what wrote the data
+		"postgres:15.18-alpine", // what the plan wants
+		"semiont clean --store database") // the way out
+	if _, err := os.Stat(filepath.Join(pg, "PG_VERSION")); err != nil {
+		t.Error("a refusal must not touch the data dir")
+	}
+}
+
+func TestStatePathHashKeyWithoutDid(t *testing.T) {
+	s := newScenario(t, "container")
+	// A KB with no [site] domain has no did:web — the state key falls back
+	// to a stable hash of the root path.
+	if err := os.WriteFile(filepath.Join(s.kb, ".semiont", "config"),
+		[]byte("[project]\nname = \"No Did KB\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := s.run(t, "start", "--dry-run")
+	if code != 0 {
+		t.Fatalf("exit %d\nstderr:\n%s", code, stderr)
+	}
+	if !regexp.MustCompile(`roots/path-[0-9a-f]{12}/postgres`).MatchString(stdout) {
+		t.Errorf("dry-run must show a path-hash state key; stdout:\n%s", stdout)
+	}
+}
+
 // --- stop ---
 
 func TestStopSweepsAllRuntimes(t *testing.T) {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -549,9 +549,13 @@ func TestStartDryRunLocalVersion(t *testing.T) {
 
 // --- local-stack state persistence (LAUNCHER-STATE.md) ---
 
-// stateRootFor mirrors the launcher's per-root state dir for the scenario's
-// fake HOME (tests run on linux, so the XDG data home).
+// stateRootFor mirrors the launcher's per-root state dir (dataDir) for the
+// scenario's fake HOME — GOOS-aware like statePathFor, though the suite's
+// home is the linux golang container in practice.
 func stateRootFor(home, key string) string {
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Application Support", "semiont", "roots", key)
+	}
 	return filepath.Join(home, ".local", "share", "semiont", "roots", key)
 }
 
@@ -657,6 +661,13 @@ func TestStateProjectionAutoCleans(t *testing.T) {
 			t.Errorf("neo4j %s dir mode = %o, want 777 (neo4j's entrypoint gates on test -w)", sub, perm)
 		}
 	}
+	// ...while their UNMOUNTED parent is clamped owner-only, so the 0777
+	// leaves nothing traversable by other local users.
+	if fi, err := os.Stat(filepath.Join(dir, "neo4j")); err != nil {
+		t.Fatalf("neo4j store dir: %v", err)
+	} else if perm := fi.Mode().Perm(); perm != 0o700 {
+		t.Errorf("neo4j store dir mode = %o, want 700 (owner-only parent clamp)", perm)
+	}
 }
 
 func TestStatePathHashKeyWithoutDid(t *testing.T) {
@@ -735,9 +746,15 @@ func TestCleanRemovesRootState(t *testing.T) {
 func TestCleanStoreScopes(t *testing.T) {
 	s := newScenario(t)
 	dir := seedStateDir(t, s)
-	_, stderr, code := s.run(t, "clean", "--store", "vectors")
+	stdout, stderr, code := s.run(t, "clean", "--store", "vectors")
 	if code != 0 {
 		t.Fatalf("exit %d\nstderr:\n%s", code, stderr)
+	}
+	// The success message names the STORE dir it removed, not the root —
+	// a scoped clean must not claim it wiped everything.
+	mustContain(t, "scoped message", stdout, filepath.Join(dir, "qdrant"))
+	if strings.Contains(stdout, "Removed "+dir+" ") {
+		t.Errorf("scoped clean claimed to remove the whole root:\n%s", stdout)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "qdrant")); !os.IsNotExist(err) {
 		t.Error("--store vectors left the qdrant dir")
@@ -797,6 +814,33 @@ func TestCleanOrphanKeyTarget(t *testing.T) {
 	}
 	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
 		t.Error("orphan state survived clean --root <key>")
+	}
+}
+
+func TestStartServiceDatabaseMountsState(t *testing.T) {
+	s := newScenario(t, "container")
+	// --service must apply the SAME persistence rules as a full start: a
+	// database restarted alone that silently skipped its mount would write
+	// rows into a container that dies with it.
+	_, stderr, code := s.run(t, "start", "--service", "database")
+	if code != 0 {
+		t.Fatalf("exit %d\nstderr:\n%s", code, stderr)
+	}
+	mount := filepath.Join(stateRootFor(s.home, testKBKey), "postgres") + ":/var/lib/postgresql/data"
+	mustContain(t, "service-mode state mount", string(s.mustLog(t)), mount)
+}
+
+func TestCleanRejectsTraversalKey(t *testing.T) {
+	s := newScenario(t)
+	dir := seedStateDir(t, s)
+	// A --root value that is not a plain key must never reach RemoveAll:
+	// "roots/.." is the data dir itself.
+	stdout, _, code := s.run(t, "clean", "--root", "..")
+	if code == 0 {
+		t.Fatalf("traversal --root value accepted\nstdout:\n%s", stdout)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("traversal --root removed state outside roots/: %v", err)
 	}
 }
 

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -615,6 +615,50 @@ func TestStateImageMismatchRefuses(t *testing.T) {
 	}
 }
 
+func TestStateProjectionAutoCleans(t *testing.T) {
+	s := newScenario(t, "container")
+	// Graph/vectors are PROJECTIONS of the event log: data written by a
+	// different image is auto-cleaned (announced), never a refusal — the
+	// rebuild is the freshness guarantee. Contrast: the database refusal
+	// in TestStateImageMismatchRefuses.
+	dir := stateRootFor(s.home, testKBKey)
+	stale := filepath.Join(dir, "neo4j", "data", "databases")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stale, "stale.db"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"kbRoot":"` + s.kb + `","stores":{"graph":{"image":"neo4j:5.20.0-community"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("projection mismatch must not refuse: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "auto-clean announcement", stdout, "neo4j:5.20.0-community", "clearing")
+	if _, err := os.Stat(filepath.Join(stale, "stale.db")); err == nil {
+		t.Error("stale projection data survived the auto-clean")
+	}
+	newMeta, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatalf("meta.json after start: %v", err)
+	}
+	mustContain(t, "meta.json restamp", string(newMeta), "neo4j:5.26.28-community")
+	// The neo4j mount dirs must exist again (and 0777 for the virtiofs
+	// test -w gate its entrypoint runs).
+	for _, sub := range []string{"data", "logs"} {
+		fi, err := os.Stat(filepath.Join(dir, "neo4j", sub))
+		if err != nil {
+			t.Fatalf("neo4j %s dir after start: %v", sub, err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o777 {
+			t.Errorf("neo4j %s dir mode = %o, want 777 (neo4j's entrypoint gates on test -w)", sub, perm)
+		}
+	}
+}
+
 func TestStatePathHashKeyWithoutDid(t *testing.T) {
 	s := newScenario(t, "container")
 	// A KB with no [site] domain has no did:web — the state key falls back

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -676,6 +676,176 @@ func TestStatePathHashKeyWithoutDid(t *testing.T) {
 	}
 }
 
+// --- clean ---
+
+// seedStateDir fabricates a populated per-root state dir with all three
+// stores and a fully-stamped meta.json.
+func seedStateDir(t *testing.T, s *scenario) string {
+	t.Helper()
+	dir := stateRootFor(s.home, testKBKey)
+	for sub, content := range map[string]string{
+		"postgres/pgdata/PG_VERSION": "15\n",
+		"qdrant/collections/spike":   strings.Repeat("q", 2048),
+		"neo4j/data/databases/x":     strings.Repeat("n", 1024),
+	} {
+		p := filepath.Join(dir, sub)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	meta := `{"kbRoot":"` + s.kb + `","did":"did:web:example.github.io:test-kb","stores":{` +
+		`"database":{"image":"postgres:15.18-alpine"},` +
+		`"vectors":{"image":"qdrant/qdrant:v1.18.3"},` +
+		`"graph":{"image":"neo4j:5.26.28-community"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestCleanDryRunListsAndKeeps(t *testing.T) {
+	s := newScenario(t)
+	dir := seedStateDir(t, s)
+	stdout, stderr, code := s.run(t, "clean", "--dry-run")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "dry-run", stdout, "would remove", "dry-run")
+	if _, err := os.Stat(filepath.Join(dir, "postgres", "pgdata", "PG_VERSION")); err != nil {
+		t.Error("--dry-run removed data")
+	}
+}
+
+func TestCleanRemovesRootState(t *testing.T) {
+	s := newScenario(t)
+	dir := seedStateDir(t, s)
+	stdout, stderr, code := s.run(t, "clean")
+	if code != 0 {
+		t.Fatalf("exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "clean", stdout, "Removed")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("state dir survived clean: %v", err)
+	}
+}
+
+func TestCleanStoreScopes(t *testing.T) {
+	s := newScenario(t)
+	dir := seedStateDir(t, s)
+	_, stderr, code := s.run(t, "clean", "--store", "vectors")
+	if code != 0 {
+		t.Fatalf("exit %d\nstderr:\n%s", code, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "qdrant")); !os.IsNotExist(err) {
+		t.Error("--store vectors left the qdrant dir")
+	}
+	for _, keep := range []string{"postgres", "neo4j"} {
+		if _, err := os.Stat(filepath.Join(dir, keep)); err != nil {
+			t.Errorf("--store vectors touched %s: %v", keep, err)
+		}
+	}
+	meta, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatalf("meta.json after scoped clean: %v", err)
+	}
+	if strings.Contains(string(meta), `"vectors"`) {
+		t.Error("vectors stamp survived its store's clean")
+	}
+	mustContain(t, "meta.json keeps other stamps", string(meta), `"database"`, `"graph"`)
+}
+
+func TestCleanRefusesRunningStack(t *testing.T) {
+	s := newScenario(t)
+	seedStateDir(t, s)
+	// A recorded local stack on this root: clean must refuse — those dirs
+	// may be mounted right now.
+	stack := `{"schema":3,"stacks":{"local":{"runtime":"container","kbRoot":"` + s.kb +
+		`","kbDid":"did:web:example.github.io:test-kb","services":{}}}}`
+	if err := os.MkdirAll(filepath.Dir(statePathFor(s.home)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePathFor(s.home), []byte(stack), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := s.run(t, "clean")
+	if code == 0 {
+		t.Fatalf("clean under a recorded stack must refuse\nstdout:\n%s", stdout)
+	}
+	mustContain(t, "refusal", stdout+stderr, "semiont stop")
+	if _, err := os.Stat(stateRootFor(s.home, testKBKey)); err != nil {
+		t.Error("refusal must not remove anything")
+	}
+}
+
+func TestCleanOrphanKeyTarget(t *testing.T) {
+	s := newScenario(t)
+	// State whose KB no longer exists anywhere: targetable by its literal
+	// key, exactly as status names it.
+	orphan := stateRootFor(s.home, "gone.example.org-old-kb")
+	if err := os.MkdirAll(filepath.Join(orphan, "qdrant"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "qdrant", "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, code := s.run(t, "clean", "--root", "gone.example.org-old-kb")
+	if code != 0 {
+		t.Fatalf("exit %d\nstderr:\n%s", code, stderr)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Error("orphan state survived clean --root <key>")
+	}
+}
+
+func TestCleanNothingToRemove(t *testing.T) {
+	s := newScenario(t)
+	stdout, stderr, code := s.run(t, "clean")
+	if code != 0 {
+		t.Fatalf("exit %d\nstderr:\n%s", code, stderr)
+	}
+	mustContain(t, "no-op clean", stdout, "Nothing to remove")
+}
+
+func TestStatusVerboseDiskUsage(t *testing.T) {
+	s := newScenario(t, "container")
+	seedStateDir(t, s) // postgres 3 B, qdrant 2048 B, neo4j 1024 B
+	// A second, ORPHANED root: stamped kbRoot no longer exists.
+	orphan := stateRootFor(s.home, "gone.example.org-old-kb")
+	if err := os.MkdirAll(filepath.Join(orphan, "qdrant"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "qdrant", "f"), []byte("xxxx"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "meta.json"),
+		[]byte(`{"kbRoot":"/nowhere/does/not/exist","stores":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := s.run(t, "status", "--verbose")
+	_ = code // status exit reflects health; the paths section prints regardless
+	_ = stderr
+	mustContain(t, "active-root data row", stdout,
+		"roots/"+testKBKey,
+		"postgres 3 B", "qdrant 2.0 KB", "neo4j 1.0 KB")
+	mustContain(t, "all-roots row", stdout,
+		"2 roots", "1 orphaned", "semiont clean --root gone.example.org-old-kb")
+}
+
+func TestStatusVerboseNoState(t *testing.T) {
+	s := newScenario(t, "container")
+	stdout, _, _ := s.run(t, "status", "--verbose")
+	// No state anywhere: the data row says so honestly — absent, not a
+	// zero-byte fiction.
+	mustContain(t, "data row absent", stdout, "data")
+	if strings.Contains(stdout, "0 B:") {
+		t.Errorf("absent state must read as absent, not zero bytes:\n%s", stdout)
+	}
+	mustContain(t, "no roots", stdout, "no persistent state")
+}
+
 // --- stop ---
 
 func TestStopSweepsAllRuntimes(t *testing.T) {

--- a/apps/launcher/main.go
+++ b/apps/launcher/main.go
@@ -27,6 +27,7 @@ Commands:
   status    Report container state and application health per service
   logs      Follow the running stack's service logs
   stop      Stop the stack across all installed runtimes
+  clean     Remove a root's persistent stack state (PostgreSQL/Qdrant/Neo4j)
   about     What Semiont is, project links, and detected runtimes
   version   Print the launcher version
 
@@ -58,6 +59,8 @@ func main() {
 		code = launcher.Logs(rest)
 	case "stop":
 		code = launcher.Stop(rest)
+	case "clean":
+		code = launcher.Clean(rest)
 	case "about":
 		code = launcher.About(rest)
 	case "version", "--version":

--- a/apps/launcher/testdata/golden/start-default-boot.argv
+++ b/apps/launcher/testdata/golden/start-default-boot.argv
@@ -63,8 +63,8 @@ container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
-container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
-container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
+container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
+container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
 container stop semiont-ollama
 container rm semiont-ollama
 lsof -ti :11434

--- a/apps/launcher/testdata/golden/start-default-boot.argv
+++ b/apps/launcher/testdata/golden/start-default-boot.argv
@@ -69,7 +69,7 @@ container stop semiont-ollama
 container rm semiont-ollama
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
-container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
+container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 container run --rm busybox:1.38.0 nc -z -w 2 192.168.64.1 5432
 container run -d --name semiont-backend --publish 4000:4000 --memory 8G --volume <kb-root>:/kb --volume <config-stage>/backend.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env POSTGRES_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-backend:latest
 container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api/health

--- a/apps/launcher/testdata/golden/start-docker-boot.argv
+++ b/apps/launcher/testdata/golden/start-docker-boot.argv
@@ -63,8 +63,8 @@ docker pull ghcr.io/the-ai-alliance/semiont-worker:latest
 docker pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 docker pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 docker run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
-docker run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
-docker run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
+docker run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
+docker run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
 docker stop semiont-ollama
 docker rm semiont-ollama
 lsof -ti :11434

--- a/apps/launcher/testdata/golden/start-docker-boot.argv
+++ b/apps/launcher/testdata/golden/start-docker-boot.argv
@@ -69,7 +69,7 @@ docker stop semiont-ollama
 docker rm semiont-ollama
 lsof -ti :11434
 docker run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
-docker run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
+docker run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 docker run --rm busybox:1.38.0 nc -z -w 2 host.docker.internal 5432
 docker run -d --name semiont-backend --publish 4000:4000 --memory 8G --volume <kb-root>:/kb --volume <config-stage>/backend.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4318 --env POSTGRES_HOST=host.docker.internal --env NEO4J_HOST=host.docker.internal --env QDRANT_HOST=host.docker.internal --env OLLAMA_HOST=host.docker.internal --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-backend:latest
 docker run --rm busybox:1.38.0 sh -c wget -q -O- http://host.docker.internal:4000/api/health

--- a/apps/launcher/testdata/golden/start-dryrun-default.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-default.txt
@@ -75,7 +75,8 @@ container run -d --name semiont-ollama -p 11434:11434 -m 24G -v <ollama-volume>:
 # wait: http://localhost:11434/api/version (30s)
 # ensure ollama models present at http://localhost:11434 (pull each missing one): gemma4:26b, gemma4:e2b, nomic-embed-text
 # embedding: externally provided at localhost:11434 — verify reachability, launch nothing
-container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
+# database state: <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres (created if absent; reused across restarts)
+container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 # wait: tcp localhost:5432 (20s)
 # probe: container run --rm busybox:1.38.0 nc -z -w 2 <host-addr> 5432
 container run -d --name semiont-backend --publish 4000:4000 --memory 8G --volume <kb-root>:/kb --volume <config-stage>/backend.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://<host-addr>:4318 --env POSTGRES_HOST=<host-addr> --env NEO4J_HOST=<host-addr> --env QDRANT_HOST=<host-addr> --env OLLAMA_HOST=<host-addr> --env SEMIONT_WORKER_SECRET=<worker-secret> ghcr.io/the-ai-alliance/semiont-backend:latest

--- a/apps/launcher/testdata/golden/start-dryrun-default.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-default.txt
@@ -60,9 +60,11 @@ container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 # wait: http://localhost:16686 (30s)
-container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
+# graph state: <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j (created if absent; reused across restarts)
+container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 # wait: http://localhost:7474 (30s)
-container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
+# vectors state: <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant (created if absent; reused across restarts)
+container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
 # wait: http://localhost:6333/readyz (15s)
 # probe: host Ollama at http://localhost:11434/api/version
 # if present — probe: container run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:11434/api/version" — and use it

--- a/apps/launcher/testdata/golden/start-dryrun-local.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-local.txt
@@ -23,9 +23,11 @@ container rm semiont-weaver
 # SEMIONT_VERSION=local — using locally-built :local images (no pull)
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 # wait: http://localhost:16686 (30s)
-container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
+# graph state: <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j (created if absent; reused across restarts)
+container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 # wait: http://localhost:7474 (30s)
-container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
+# vectors state: <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant (created if absent; reused across restarts)
+container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
 # wait: http://localhost:6333/readyz (15s)
 # probe: host Ollama at http://localhost:11434/api/version
 # if present — probe: container run --rm busybox:1.38.0 sh -c "wget -q -O- http://<host-addr>:11434/api/version" — and use it

--- a/apps/launcher/testdata/golden/start-dryrun-local.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-local.txt
@@ -38,7 +38,8 @@ container run -d --name semiont-ollama -p 11434:11434 -m 24G -v <ollama-volume>:
 # wait: http://localhost:11434/api/version (30s)
 # ensure ollama models present at http://localhost:11434 (pull each missing one): gemma4:26b, gemma4:e2b, nomic-embed-text
 # embedding: externally provided at localhost:11434 — verify reachability, launch nothing
-container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
+# database state: <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres (created if absent; reused across restarts)
+container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 # wait: tcp localhost:5432 (20s)
 # probe: container run --rm busybox:1.38.0 nc -z -w 2 <host-addr> 5432
 container run -d --name semiont-backend --publish 4000:4000 --memory 8G --volume <kb-root>:/kb --volume <config-stage>/backend.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://<host-addr>:4318 --env POSTGRES_HOST=<host-addr> --env NEO4J_HOST=<host-addr> --env QDRANT_HOST=<host-addr> --env OLLAMA_HOST=<host-addr> --env SEMIONT_WORKER_SECRET=<worker-secret> ghcr.io/the-ai-alliance/semiont-backend:local

--- a/apps/launcher/testdata/golden/start-host-ollama-boot.argv
+++ b/apps/launcher/testdata/golden/start-host-ollama-boot.argv
@@ -34,7 +34,7 @@ container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
 container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:11434/api/version
-container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
+container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 container run --rm busybox:1.38.0 nc -z -w 2 192.168.64.1 5432
 container run -d --name semiont-backend --publish 4000:4000 --memory 8G --volume <kb-root>:/kb --volume <config-stage>/backend.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env POSTGRES_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-backend:latest
 container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api/health

--- a/apps/launcher/testdata/golden/start-host-ollama-boot.argv
+++ b/apps/launcher/testdata/golden/start-host-ollama-boot.argv
@@ -31,8 +31,8 @@ container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
-container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
-container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
+container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
+container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
 container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:11434/api/version
 container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 container run --rm busybox:1.38.0 nc -z -w 2 192.168.64.1 5432

--- a/apps/launcher/testdata/golden/start-local-version-boot.argv
+++ b/apps/launcher/testdata/golden/start-local-version-boot.argv
@@ -27,8 +27,8 @@ lsof -ti :9092
 lsof -ti :16686
 lsof -ti :4318
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
-container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
-container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
+container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
+container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
 container stop semiont-ollama
 container rm semiont-ollama
 lsof -ti :11434

--- a/apps/launcher/testdata/golden/start-local-version-boot.argv
+++ b/apps/launcher/testdata/golden/start-local-version-boot.argv
@@ -33,7 +33,7 @@ container stop semiont-ollama
 container rm semiont-ollama
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
-container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
+container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 container run --rm busybox:1.38.0 nc -z -w 2 192.168.64.1 5432
 container run -d --name semiont-backend --publish 4000:4000 --memory 8G --volume <kb-root>:/kb --volume <config-stage>/backend.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env POSTGRES_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-backend:local
 container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api/health

--- a/apps/launcher/testdata/golden/start-no-observe-boot.argv
+++ b/apps/launcher/testdata/golden/start-no-observe-boot.argv
@@ -28,8 +28,8 @@ container image pull ghcr.io/the-ai-alliance/semiont-backend:latest
 container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
-container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
-container run -d --name semiont-qdrant -p 6333:6333 qdrant/qdrant:v1.18.3
+container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
+container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
 container stop semiont-ollama
 container rm semiont-ollama
 lsof -ti :11434

--- a/apps/launcher/testdata/golden/start-no-observe-boot.argv
+++ b/apps/launcher/testdata/golden/start-no-observe-boot.argv
@@ -34,7 +34,7 @@ container stop semiont-ollama
 container rm semiont-ollama
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
-container run -d --name semiont-postgres -p 5432:5432 -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
+container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
 container run --rm busybox:1.38.0 nc -z -w 2 192.168.64.1 5432
 container run -d --name semiont-backend --publish 4000:4000 --memory 8G --volume <kb-root>:/kb --volume <config-stage>/backend.toml:/home/semiont/.semiontconfig:ro --env POSTGRES_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-backend:latest
 container run --rm busybox:1.38.0 sh -c wget -q -O- http://192.168.64.1:4000/api/health


### PR DESCRIPTION
Local stacks now keep their database state across restarts, per KB root, with an explicit `semiont clean` to remove it and disk accounting in `status --verbose`. Design and execution log: `.plans/LAUNCHER-STATE.md`.

## Why

Every `stop`/`start` rebuilt postgres, qdrant, and neo4j from nothing. For qdrant/neo4j that was wasted work — they are projections of the event log. For postgres it was **data loss**: `useradd` rows are not in the event log, so every user created on a stack died with it.

## What

**Per-root state under the launcher's data home** — `~/Library/Application Support/semiont/roots/<key>` (macOS) / `$XDG_DATA_HOME/semiont/roots/<key>` (Linux), keyed by the KB's did:web when declared (identity travels with the KB; a moved clone keeps its state), else a hash of the root path. A `meta.json` stamps which image wrote each store.

**Measured mount shapes, not guessed** — scripted Phase 0 spikes on Apple `container` 0.11.0 established the virtiofs semantics: chmod/chown of a mount *root* → EPERM; chown *inside* a mount → silent no-op; host-side mode bits pass through; writes from any container uid land host-owned. Hence:

| store | shape | spike |
|---|---|---|
| postgres | mount at `/var/lib/postgresql/data`, `PGDATA` in a created-inside subdir | 7/7 |
| qdrant | plain mount at `/qdrant/storage` | 7/7 |
| neo4j | `data/`+`logs/` subdirs, host-side mode 777 (its entrypoint gates on `test -w`) | 8/8 |

**The mismatch split** — existing data written by a *different* image: database **refuses** with a fix-it line (user rows are never auto-deleted); qdrant/neo4j **auto-clean and rebuild** (announced) — freshness by rebuild is what projections are for. Startup idempotency is verified at the source: the backend image runs `prisma migrate deploy` (apps/cli `backend-start.ts:177`) against the versioned history in `apps/backend/prisma/migrations/` — a populated volume no-ops.

**`semiont clean`** — the one way state dies. Same root ladder as `start`; `--store database|vectors|graph` scopes to one store (and drops its meta stamp); `--dry-run` lists sizes; `--root <path|name|key>` targets another root, a literal key being how *orphaned* state (KB directory gone) is removed. Refuses while a recorded stack is using the state.

**`status --verbose` disk accounting** — LAUNCHER PATHS gains a `data` row (active root, per-store breakdown, present stores only — absent is absent, never 0 B) and an `all roots` row (count, total, orphans called out with the exact `clean --root <key>` fix-it).

**`stop` is unchanged** and its `--help` now says so: persistent state is deliberately left; stop→start is the round trip persistence exists for.

## Testing

TDD throughout (goldens are the spec): every phase's RED was observed before (or bite-checked after) its GREEN — including a mutation check that flipping `projection:false` fails the auto-clean test, and a dispatch mutation that fails all six `TestClean*` with the exact pre-implementation error. New tests: persist-across-starts, image-mismatch refusal, path-hash keying, projection auto-clean (wipe + restamp + 0777 asserted), six `clean` behaviors, two `status --verbose` accounting cases. All 7 boot/dry-run goldens updated. Gates: gofmt + vet + full launcher suite in golang:1.25, 0 FAIL at each phase; en route this fixed a real dry-run bug (both renderers passed the literal `"<kb-root>"` placeholder as the flow root, deriving state paths from a constant hash).

## Copilot review round

8 comments, 6 valid, all fixed RED-first. Two were real bugs: `start --service database|vectors|graph` bypassed the state mounts entirely (ephemeral container, no mismatch rules), and `clean --root ..` could traverse out of `roots/` into `os.RemoveAll` — literal keys must now be plain basenames. Also: scoped-clean messages name exactly what was removed, the neo4j 0777 mount dirs sit under an owner-only (0700) unmounted parent, and orphan detection accuses only on `fs.ErrNotExist`. One comment was stale (the `clean` command it flagged as missing lands in this PR) and one test-helper note was addressed by making `stateRootFor` GOOS-aware.
