### PR TITLE
launcher: narrate codespace waits (VM state + creation-log tail) and fail fast when the forward dies

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -115,7 +115,12 @@ semiont stop
   codespace *name* is a PID, shown by status, input only via `--codespace`
   when raw `gh` left several). `semiont stop` maps to `gh codespace stop` —
   billing halts, state and credentials persist, the record is kept; `semiont
-  stop --delete` destroys and forgets.
+  stop --delete` destroys and forgets. The two long waits narrate
+  themselves: the VM wait redraws the polled state with elapsed time, and a
+  fresh create's health wait tails the devcontainer creation log (`gh
+  codespace logs --follow`) as a sliding window of its last few lines —
+  cleared once healthy; piped output gets 30-second heartbeat lines
+  instead.
 - **Many codespace stacks run concurrently — each forwards its KB on its
   own local port.** The record store (`stack.json`, schema 3) is a keyed
   collection: the machine's one local stack (fixed ports and container

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -307,6 +307,13 @@ func ghCodespace(args []string, joined string) {
 				[]byte(strconv.Itoa(os.Getpid())), 0o644)
 		}
 		serve(ports)
+	case "logs":
+		// The creation-log follower the health wait tails. A few plausible
+		// lines, then exit — a tailer that ends early is legal (the launcher
+		// treats the stream as decoration, never a gate).
+		fmt.Println("2026-01-01 00:00:00.000Z: Running onCreateCommand...")
+		fmt.Println("2026-01-01 00:00:01.000Z: Pulling semiont-backend:latest")
+		fmt.Println("2026-01-01 00:00:02.000Z: postCreateCommand done")
 	case "stop", "delete":
 		// argv log is the observable, but state must follow too: a stopped
 		// codespace reports Shutdown until something wakes it, exactly as

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -292,6 +292,25 @@ func ghCodespace(args []string, joined string) {
 		// Real gh takes <codespacePort>:<localPort> and listens on the
 		// LOCAL one. Modelling this correctly is what would have caught the
 		// reversed-argument bug found live on 2026-07-20.
+		//
+		// FAKERT_GH_FORWARD_SICK: the tunnel is bound but the stack behind
+		// it answers 503 (backend still warming). FAKERT_GH_FORWARD_DIES_
+		// AFTER_MS: the forward process exits after that delay — the
+		// mid-wait death observed live on 2026-07-23 (pid went defunct
+		// while the KB was healthy in the codespace).
+		if ms := os.Getenv("FAKERT_GH_FORWARD_DIES_AFTER_MS"); ms != "" {
+			if n, err := strconv.Atoi(ms); err == nil {
+				go func() {
+					time.Sleep(time.Duration(n) * time.Millisecond)
+					os.Exit(1)
+				}()
+			}
+		}
+		if os.Getenv("FAKERT_GH_FORWARD_SICK") != "" {
+			// Scoped to THIS process: __serve children of `run -d` never
+			// see it, so container health fakes stay healthy.
+			os.Setenv("FAKERT_SERVE_SICK", "1")
+		}
 		var ports []string
 		for _, a := range args {
 			if pair := strings.SplitN(a, ":", 2); len(pair) == 2 {
@@ -845,6 +864,12 @@ func serve(ports []string) {
 		}
 		go func() {
 			_ = http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// A sick serve answers but is never ready (see the forward
+				// case) — bound ≠ healthy, exactly like a warming backend.
+				if os.Getenv("FAKERT_SERVE_SICK") != "" {
+					http.Error(w, "warming", http.StatusServiceUnavailable)
+					return
+				}
 				// A fake Ollama, so model checks and pulls are exercisable.
 				// FAKERT_OLLAMA_TAGS lists the models it already has (comma
 				// separated); every pull is appended to a log the test reads.

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -218,7 +218,7 @@ func startCodespace(u *ui, opts startOptions) int {
 	if code := ensureCodespaceAvailable(u, repo, name); code != 0 {
 		return code
 	}
-	pid, code := spawnForward(u, name, kbPort)
+	pid, fwdDead, code := spawnForward(u, name, kbPort)
 	if code != 0 {
 		return code
 	}
@@ -269,7 +269,22 @@ func startCodespace(u *ui, opts startOptions) int {
 	if created {
 		tail = startCreationLogTail(u, name)
 	}
-	d, ok := waitForHTTPTick(u, "KB (through the forward)", fmt.Sprintf("http://localhost:%d/api/health", kbPort), 600, tail.tick)
+	// Each tick renders the window AND takes the forward's pulse: a tunnel
+	// that dies mid-wait must fail in seconds with the true diagnosis, not
+	// burn the whole budget blaming a KB that may be healthy (observed
+	// live 2026-07-23 — 600s spent polling a defunct forward).
+	tick := func(elapsed time.Duration) bool {
+		tail.tick(elapsed)
+		select {
+		case <-fwdDead:
+			u.fail("The port forward (pid %d) died after %s — the stack may be fine.", pid, took(elapsed))
+			fmt.Fprintln(os.Stderr, "  Rerun to respawn it:  semiont start --runtime codespace --repo "+repo)
+			return false
+		default:
+			return true
+		}
+	}
+	d, ok := waitForHTTPTick(u, "KB (through the forward)", fmt.Sprintf("http://localhost:%d/api/health", kbPort), 600, tick)
 	tail.stop()
 	if !ok {
 		return 1
@@ -813,8 +828,10 @@ func (lt *creationLogTail) stop() {
 // spawnForward starts the detached dev-tunnel forward for this stack's KB
 // port — a long-lived process the bring-up-and-exit launcher deliberately
 // leaves behind, PID + port recorded (status re-establishes it, stop kills
-// it). Each codespace stack runs its own.
-func spawnForward(u *ui, name string, kbPort int) (int, int) {
+// it). Each codespace stack runs its own. The returned channel closes if
+// the forward dies while THIS launcher still runs — the health gate's
+// fail-fast signal.
+func spawnForward(u *ui, name string, kbPort int) (int, <-chan struct{}, int) {
 	// Argument order is <codespacePort>:<localPort> — NOT the reverse.
 	// Getting it backwards forwards a port nothing serves onto a local port
 	// something else may already own: gh then fails to bind but the process
@@ -828,12 +845,21 @@ func spawnForward(u *ui, name string, kbPort int) (int, int) {
 	cmd.Stdout, cmd.Stderr = nil, nil
 	if err := cmd.Start(); err != nil {
 		u.fail("Could not start the port forward: %v", err)
-		return 0, 1
+		return 0, nil, 1
 	}
 	pid := cmd.Process.Pid
-	_ = cmd.Process.Release()
+	// A reaping Wait (not Release): the observed mid-wait death left a
+	// ZOMBIE, and a zombie still passes kill-0 aliveness — only Wait both
+	// reaps it and yields a truthful death signal for the health gate.
+	// The child still outlives a normally-exiting launcher: Wait blocks in
+	// a goroutine that dies with the process, killing nothing.
+	dead := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(dead)
+	}()
 	u.log("Port forward running %s", u.dim(fmt.Sprintf("(detached, pid %d — recorded; semiont stop ends it)", pid)))
-	return pid, 0
+	return pid, dead, 0
 }
 
 type adminCreds struct {
@@ -1103,7 +1129,7 @@ func statusCodespace(u *ui, st *stackState, refresh bool) int {
 		if st.ForwardPort == 0 {
 			st.ForwardPort = allocateKBPort(loadStackSet(), st.Repo)
 		}
-		if pid, code := spawnForward(u, st.Codespace, st.ForwardPort); code == 0 {
+		if pid, _, code := spawnForward(u, st.Codespace, st.ForwardPort); code == 0 {
 			st.ForwardPID = pid
 			saveStack(st)
 		}

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -8,6 +9,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -254,7 +256,14 @@ func startCodespace(u *ui, opts startOptions) int {
 	// Health, not VM state, is readiness ("Available ≠ hooks finished" —
 	// on a fresh create the devcontainer hooks run minutes past Available).
 	u.log("Waiting for the stack %s", u.dim("(a fresh create runs devcontainer hooks — image and model pulls take minutes)"))
-	d, ok := waitForHTTP(u, "KB (through the forward)", fmt.Sprintf("http://localhost:%d/api/health", kbPort), 600)
+	// A fresh create narrates its hooks: tail the creation log while the
+	// health gate waits. Resume tails nothing — its creation log is old.
+	var tail *creationLogTail
+	if created {
+		tail = startCreationLogTail(u, name)
+	}
+	d, ok := waitForHTTPTick(u, "KB (through the forward)", fmt.Sprintf("http://localhost:%d/api/health", kbPort), 600, tail.tick)
+	tail.stop()
 	if !ok {
 		return 1
 	}
@@ -618,12 +627,25 @@ func ensureCodespaceAvailable(u *ui, repo, name string) int {
 // Post-CREATE only: a fresh codespace is Provisioning for minutes and
 // forwarding before then cannot bind. Never call it for a stopped
 // codespace — those wake on connection, so this would wait forever.
+// Liveness during the minutes-long wait: on a terminal, one redrawn line
+// carrying the polled state and elapsed time; piped, a 30s heartbeat —
+// silence and a spinner are different claims, and this wait had neither.
 func waitCodespaceAvailable(u *ui, repo, name string) int {
+	t0 := time.Now()
+	lastBeat := t0
+	state := "Provisioning"
 	for i := 0; i < 300; i++ {
 		instances, err := ghCodespaceList(repo)
 		if err == nil {
 			for _, c := range instances {
-				if c.Name == name && c.State == "Available" {
+				if c.Name != name {
+					continue
+				}
+				state = c.State
+				if state == "Available" {
+					if u.color {
+						fmt.Print("\r\033[K")
+					}
 					return 0
 				}
 			}
@@ -631,11 +653,121 @@ func waitCodespaceAvailable(u *ui, repo, name string) int {
 		if i == 0 {
 			u.log("Waiting for the codespace VM %s", u.dim("(GitHub reports Provisioning until the machine is up)"))
 		}
+		if u.color {
+			fmt.Printf("\r  %s\033[K", u.dim(state+"… ("+took(time.Since(t0))+")"))
+		} else if time.Since(lastBeat) >= 30*time.Second {
+			lastBeat = time.Now()
+			u.log("Still waiting for the VM — %s (%s elapsed)", state, took(time.Since(t0)))
+		}
 		time.Sleep(2 * time.Second)
+	}
+	if u.color {
+		fmt.Print("\r\033[K")
 	}
 	u.fail("Codespace %s did not reach Available within 10 minutes.", name)
 	fmt.Fprintln(os.Stderr, "  Check it:  gh codespace list")
 	return 1
+}
+
+// creationLogTail streams `gh codespace logs --follow` (the devcontainer
+// creation log — compose pulls, hook output) alongside the health wait. On
+// a terminal the last few lines render as a dimmed sliding window, redrawn
+// in place and cleared when the wait ends; piped, a 30s heartbeat carries
+// the newest line instead. Decoration, never a gate: if gh cannot stream
+// (briefly true right at Available), the window simply stays empty.
+type creationLogTail struct {
+	u        *ui
+	cmd      *exec.Cmd
+	mu       sync.Mutex
+	lines    []string // ring: the newest creationLogWindow lines
+	rendered int      // lines currently drawn on the terminal
+	lastBeat time.Time
+}
+
+const creationLogWindow = 6
+
+// startCreationLogTail spawns the follower. CREATE path only: a resumed
+// codespace's creation log is stale history and tailing it would narrate
+// the wrong boot.
+func startCreationLogTail(u *ui, name string) *creationLogTail {
+	args := []string{"codespace", "logs", "--follow", "-c", name}
+	u.echoCmd("gh", args...)
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil
+	}
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return nil
+	}
+	lt := &creationLogTail{u: u, cmd: cmd, lastBeat: time.Now()}
+	go func() {
+		sc := bufio.NewScanner(out)
+		for sc.Scan() {
+			line := strings.TrimRight(sc.Text(), " \t")
+			if line == "" {
+				continue
+			}
+			lt.mu.Lock()
+			lt.lines = append(lt.lines, line)
+			if len(lt.lines) > creationLogWindow {
+				lt.lines = lt.lines[len(lt.lines)-creationLogWindow:]
+			}
+			lt.mu.Unlock()
+		}
+	}()
+	return lt
+}
+
+// tick renders the window (terminal) or the heartbeat (piped). Wired into
+// the health wait's loop via waitForHTTPTick.
+func (lt *creationLogTail) tick(elapsed time.Duration) {
+	if lt == nil {
+		return
+	}
+	lt.mu.Lock()
+	lines := append([]string(nil), lt.lines...)
+	lt.mu.Unlock()
+	if !lt.u.color {
+		if time.Since(lt.lastBeat) >= 30*time.Second {
+			lt.lastBeat = time.Now()
+			if n := len(lines); n > 0 {
+				lt.u.log("Still waiting (%s elapsed) — %s", took(elapsed), lines[n-1])
+			} else {
+				lt.u.log("Still waiting (%s elapsed)", took(elapsed))
+			}
+		}
+		return
+	}
+	if lt.rendered > 0 {
+		fmt.Printf("\033[%dA", lt.rendered)
+	}
+	for _, ln := range lines {
+		// Hard truncation keeps every window line to one terminal row —
+		// a wrapped line would break the cursor-up arithmetic.
+		if len(ln) > 100 {
+			ln = ln[:100] + "…"
+		}
+		fmt.Printf("\033[K  %s\n", lt.u.dim(ln))
+	}
+	lt.rendered = len(lines)
+}
+
+// stop kills the follower and, on a terminal, collapses the window so the
+// final transcript keeps only the launcher's own lines.
+func (lt *creationLogTail) stop() {
+	if lt == nil {
+		return
+	}
+	if lt.cmd.Process != nil {
+		_ = lt.cmd.Process.Kill()
+	}
+	_ = lt.cmd.Wait()
+	if lt.u.color && lt.rendered > 0 {
+		fmt.Printf("\033[%dA\033[J", lt.rendered)
+		lt.rendered = 0
+	}
 }
 
 // spawnForward starts the detached dev-tunnel forward for this stack's KB

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -255,7 +256,13 @@ func startCodespace(u *ui, opts startOptions) int {
 
 	// Health, not VM state, is readiness ("Available ≠ hooks finished" —
 	// on a fresh create the devcontainer hooks run minutes past Available).
-	u.log("Waiting for the stack %s", u.dim("(a fresh create runs devcontainer hooks — image and model pulls take minutes)"))
+	// Each path narrates ITS wait: a resume borrowing the fresh-create
+	// wording promised minutes for a gate that usually opens in seconds.
+	if created {
+		u.log("Waiting for the stack %s", u.dim("(a fresh create runs devcontainer hooks — image and model pulls take minutes)"))
+	} else {
+		u.log("Waiting for the stack %s", u.dim("(resume: the VM wakes already provisioned — usually seconds)"))
+	}
 	// A fresh create narrates its hooks: tail the creation log while the
 	// health gate waits. Resume tails nothing — its creation log is old.
 	var tail *creationLogTail
@@ -704,6 +711,9 @@ func startCreationLogTail(u *ui, name string) *creationLogTail {
 	lt := &creationLogTail{u: u, cmd: cmd, lastBeat: time.Now()}
 	go func() {
 		sc := bufio.NewScanner(out)
+		// Compose rewrites progress with bare \r; \n-only splitting
+		// stitched those fragments into mega-lines (observed live).
+		sc.Split(splitCRLines)
 		for sc.Scan() {
 			line := strings.TrimRight(sc.Text(), " \t")
 			if line == "" {
@@ -746,12 +756,42 @@ func (lt *creationLogTail) tick(elapsed time.Duration) {
 	for _, ln := range lines {
 		// Hard truncation keeps every window line to one terminal row —
 		// a wrapped line would break the cursor-up arithmetic.
-		if len(ln) > 100 {
-			ln = ln[:100] + "…"
-		}
-		fmt.Printf("\033[K  %s\n", lt.u.dim(ln))
+		fmt.Printf("\033[K  %s\n", lt.u.dim(truncateLine(ln, 100)))
 	}
 	lt.rendered = len(lines)
+}
+
+// truncateLine keeps a line to at most max runes plus an ellipsis. Rune
+// units, not bytes: compose output is full of box-drawing characters, and
+// a byte slice cut one in half on the first live run (─────? …).
+func truncateLine(s string, max int) string {
+	if len(s) <= max { // byte length ≤ max implies rune count ≤ max
+		return s
+	}
+	n := 0
+	for i := range s {
+		if n == max {
+			return s[:i] + "…"
+		}
+		n++
+	}
+	return s
+}
+
+// splitCRLines is a bufio.SplitFunc treating \r and \n alike as line ends —
+// compose progress rewrites lines with bare \r, and \n-only splitting
+// stitched those fragments together.
+func splitCRLines(data []byte, atEOF bool) (int, []byte, error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexAny(data, "\r\n"); i >= 0 {
+		return i + 1, data[:i], nil
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
 }
 
 // stop kills the follower and, on a terminal, collapses the window so the

--- a/apps/launcher/internal/launcher/codespace_test.go
+++ b/apps/launcher/internal/launcher/codespace_test.go
@@ -1,0 +1,47 @@
+package launcher
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+// The creation-log window renders compose output, which is full of
+// box-drawing runes and CR-rewritten progress lines. These pin the two
+// display bugs the first live run surfaced (LAUNCHER session 2026-07-23):
+// byte-sliced truncation broke a rune in half (─────? …), and \n-only
+// splitting stitched CR fragments into mega-lines.
+
+func TestTruncateLineRuneSafe(t *testing.T) {
+	rule := strings.Repeat("─", 60) // 3 bytes per rune: byte-slicing would cut mid-rune
+	got := truncateLine(rule, 40)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated line missing ellipsis: %q", got)
+	}
+	if strings.ContainsRune(got, '�') || !strings.HasPrefix(got, "───") {
+		t.Errorf("truncation broke a rune: %q", got)
+	}
+	if n := len([]rune(got)); n != 41 { // 40 kept + ellipsis
+		t.Errorf("rune count = %d, want 41: %q", n, got)
+	}
+	if short := truncateLine("abc", 40); short != "abc" {
+		t.Errorf("short line altered: %q", short)
+	}
+}
+
+func TestSplitCRLines(t *testing.T) {
+	// Compose progress: CR-rewritten fragments, then a real newline.
+	in := "pulling 1%\rpulling 50%\rpulling 100%\n ✔ backend Pulled\r\n"
+	sc := bufio.NewScanner(strings.NewReader(in))
+	sc.Split(splitCRLines)
+	var lines []string
+	for sc.Scan() {
+		if tok := sc.Text(); tok != "" {
+			lines = append(lines, tok)
+		}
+	}
+	want := []string{"pulling 1%", "pulling 50%", "pulling 100%", " ✔ backend Pulled"}
+	if strings.Join(lines, "|") != strings.Join(want, "|") {
+		t.Errorf("split = %v, want %v", lines, want)
+	}
+}

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -275,9 +275,12 @@ func waitForHTTP(u *ui, name, url string, seconds int) (time.Duration, bool) {
 }
 
 // waitForHTTPTick is waitForHTTP with a per-iteration hook — the seam the
-// codespace health wait uses to render its creation-log window without a
-// second wait loop that could drift from this one's deadline discipline.
-func waitForHTTPTick(u *ui, name, url string, seconds int, tick func(elapsed time.Duration)) (time.Duration, bool) {
+// codespace health wait uses to render its creation-log window and watch
+// the forward's pulse without a second wait loop that could drift from
+// this one's deadline discipline. A tick returning false ABORTS the wait:
+// the tick has diagnosed and printed the real failure (a dead forward),
+// so the generic did-not-become-ready message must not overwrite it.
+func waitForHTTPTick(u *ui, name, url string, seconds int, tick func(elapsed time.Duration) bool) (time.Duration, bool) {
 	t0 := time.Now()
 	deadline := t0.Add(time.Duration(seconds) * time.Second)
 	for {
@@ -287,8 +290,8 @@ func waitForHTTPTick(u *ui, name, url string, seconds int, tick func(elapsed tim
 		if !time.Now().Before(deadline) {
 			break
 		}
-		if tick != nil {
-			tick(time.Since(t0))
+		if tick != nil && !tick(time.Since(t0)) {
+			return time.Since(t0), false
 		}
 		time.Sleep(time.Second)
 	}

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -271,6 +271,13 @@ func took(d time.Duration) string {
 // claiming 600. A deadline makes the number honest, and the message reports
 // the time actually spent so it can never drift from reality again.
 func waitForHTTP(u *ui, name, url string, seconds int) (time.Duration, bool) {
+	return waitForHTTPTick(u, name, url, seconds, nil)
+}
+
+// waitForHTTPTick is waitForHTTP with a per-iteration hook — the seam the
+// codespace health wait uses to render its creation-log window without a
+// second wait loop that could drift from this one's deadline discipline.
+func waitForHTTPTick(u *ui, name, url string, seconds int, tick func(elapsed time.Duration)) (time.Duration, bool) {
 	t0 := time.Now()
 	deadline := t0.Add(time.Duration(seconds) * time.Second)
 	for {
@@ -279,6 +286,9 @@ func waitForHTTP(u *ui, name, url string, seconds int) (time.Duration, bool) {
 		}
 		if !time.Now().Before(deadline) {
 			break
+		}
+		if tick != nil {
+			tick(time.Since(t0))
 		}
 		time.Sleep(time.Second)
 	}

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1592,7 +1592,13 @@ func TestCodespaceBareResumeRootless(t *testing.T) {
 	}
 	mustContain(t, "stdout", stdout,
 		"Using recorded stack's runtime: codespace",
-		"Resuming recorded codespace fake-cs-1")
+		"Resuming recorded codespace fake-cs-1",
+		// The wait narrates a RESUME, not a fresh create — the VM wakes
+		// with the stack already provisioned.
+		"already provisioned")
+	if strings.Contains(stdout, "a fresh create runs devcontainer hooks") {
+		t.Errorf("resume borrowed the fresh-create wait wording:\n%s", stdout)
+	}
 	log, _ := os.ReadFile(s.log)
 	if strings.Contains(string(log), "codespace create") {
 		t.Errorf("resume created a new codespace:\n%s", log)

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1756,7 +1756,7 @@ func TestCodespaceMachinePreflight(t *testing.T) {
 	s := newCodespaceScenario(t)
 	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
 	if code != 0 {
-		t.Fatalf("default: exit %d\nstderr:\n%s", code, stderr)
+		t.Fatalf("default: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 	log, _ := os.ReadFile(s.log)
 	mustContain(t, "argv log", string(log),
@@ -1767,11 +1767,12 @@ func TestCodespaceMachinePreflight(t *testing.T) {
 	}
 
 	// No premium: fall back to the largest offered, announced with the reason.
+	s.killServes() // free the parked forward: THIS test is about machine selection, not port laddering
 	s2 := newCodespaceScenario(t)
 	s2.extraEnv = append(s2.extraEnv, only("standardLinux32gb"))
 	stdout, stderr, code = s2.run(t, "start", "--runtime", "codespace")
 	if code != 0 {
-		t.Fatalf("fallback: exit %d\nstderr:\n%s", code, stderr)
+		t.Fatalf("fallback: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 	mustContain(t, "fallback stdout", stdout,
 		"premiumLinux isn't available to you for "+csRepo,
@@ -1780,19 +1781,21 @@ func TestCodespaceMachinePreflight(t *testing.T) {
 	mustContain(t, "argv log", string(log), "--machine standardLinux32gb")
 
 	// Largest wins the fallback, not merely the first offered.
+	s2.killServes() // free the parked forward: THIS test is about machine selection, not port laddering
 	s3 := newCodespaceScenario(t)
 	s3.extraEnv = append(s3.extraEnv, only("standardLinux32gb", "largePremiumLinux"))
 	if _, stderr, code := s3.run(t, "start", "--runtime", "codespace"); code != 0 {
-		t.Fatalf("largest: exit %d\nstderr:\n%s", code, stderr)
+		t.Fatalf("largest: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 	log, _ = os.ReadFile(s3.log)
 	mustContain(t, "argv log", string(log), "--machine largePremiumLinux")
 
 	// Explicit and available: used, no announcement.
+	s3.killServes() // free the parked forward: THIS test is about machine selection, not port laddering
 	s4 := newCodespaceScenario(t)
 	stdout, stderr, code = s4.run(t, "start", "--runtime", "codespace", "--machine", "standardLinux32gb")
 	if code != 0 {
-		t.Fatalf("explicit: exit %d\nstderr:\n%s", code, stderr)
+		t.Fatalf("explicit: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 	log, _ = os.ReadFile(s4.log)
 	mustContain(t, "argv log", string(log), "--machine standardLinux32gb")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1574,6 +1574,26 @@ func TestCodespaceStartCreates(t *testing.T) {
 	}
 }
 
+func TestCodespaceForwardDeathFailsFast(t *testing.T) {
+	// The mid-wait forward death observed live 2026-07-23: the tunnel
+	// bound, then its process died while the health gate polled — and the
+	// launcher burned the full budget blaming an innocent KB. A dead
+	// forward must fail FAST, name the forward, and point at the rerun.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv,
+		"FAKERT_GH_FORWARD_SICK=1",             // bound, but health never OK
+		"FAKERT_GH_FORWARD_DIES_AFTER_MS=2500") // dies during the health wait
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code == 0 {
+		t.Fatalf("start must fail when the forward dies\nstdout:\n%s", stdout)
+	}
+	mustContain(t, "diagnosis", stdout+stderr,
+		"port forward", "died", "semiont start")
+	if strings.Contains(stdout+stderr, "did not become ready") {
+		t.Errorf("forward death misblamed the KB:\n%s\n%s", stdout, stderr)
+	}
+}
+
 func TestCodespaceBareResumeRootless(t *testing.T) {
 	// After a create, a BARE `semiont start` from any directory resumes the
 	// recorded codespace: no --repo, no clone, no root discovery, no create.

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -625,8 +625,8 @@ func TestStateImageMismatchRefuses(t *testing.T) {
 		t.Fatalf("start over another image's data must refuse\nstdout:\n%s", stdout)
 	}
 	mustContain(t, "refusal", stdout+stderr,
-		"postgres:14.9-alpine",  // what wrote the data
-		"postgres:15.18-alpine", // what the plan wants
+		"postgres:14.9-alpine",           // what wrote the data
+		"postgres:15.18-alpine",          // what the plan wants
 		"semiont clean --store database") // the way out
 	if _, err := os.Stat(filepath.Join(pg, "PG_VERSION")); err != nil {
 		t.Error("a refusal must not touch the data dir")
@@ -1546,6 +1546,12 @@ func TestCodespaceStartCreates(t *testing.T) {
 		"KB repo: "+csRepo,
 		"Starting a CODESPACE for", "as PUSHED", "uncommitted changes",
 		"Creating codespace for "+csRepo,
+		// The health wait tails the creation log on the CREATE path (a
+		// resume's creation log is stale history). The echoed command is
+		// the deterministic observable — in the fake world health passes
+		// on the first probe and the follower is killed before it can
+		// exec, so the argv log may legitimately never see it.
+		"gh codespace logs --follow -c fake-cs-1",
 		"Reading admin credentials",
 		"Semiont KB is up in codespace fake-cs-1",
 		"Semiont KB         http://localhost:4000",


### PR DESCRIPTION
`semiont start --runtime codespace` used to go silent for its two long waits, and a tunnel that died mid-wait burned the whole health budget blaming an innocent KB. Both waits now narrate themselves, and a dead forward fails in seconds with the true diagnosis. Everything here was driven by one live create/resume session (2026-07-23) — each fix pins the exact failure observed.

## Wait UX

**VM wait (Provisioning → Available):** no log exists yet on GitHub's side, so the launcher renders honest liveness — on a terminal, one in-place redrawn line with the polled state and elapsed time (`Provisioning… (2m 14s)`), cleared when the VM is up; piped output gets a 30-second heartbeat line instead.

**Health wait (Available → healthy), fresh creates only:** the launcher tails `gh codespace logs --follow` — the devcontainer creation log, where the compose pulls and hook output actually stream — as a dimmed sliding window of the last 6 lines, redrawn in place and collapsed once the KB turns healthy. Piped, a 30s heartbeat carries the newest line. The tail is decoration, never a gate: if gh can't stream, the window stays empty and the health wait proceeds. Resumes tail nothing — a resumed codespace's creation log is stale history — and get their own wait wording (`resume: the VM wakes already provisioned — usually seconds`) instead of borrowing the fresh-create "takes minutes" text.

## Forward death fails fast

Observed live: the detached `gh codespace ports forward` died ~8 minutes into a create's health wait, sat unreaped as a zombie, and the launcher polled the dead tunnel for the full 600s before blaming the KB — which was answering 200 inside the codespace the whole time.

- `spawnForward` now attaches a reaping `Wait()` goroutine instead of `Release()` — a zombie passes kill-0 "aliveness", so only Wait yields a truthful death signal (the child still outlives a normally-exiting launcher).
- The health wait's per-tick hook (`waitForHTTPTick`, shared with the log window — one loop, one deadline discipline) takes the forward's pulse and aborts with the real story: `The port forward (pid N) died after Xs — the stack may be fine. Rerun to respawn it.`
- Pinned by a test whose fake forward binds, answers 503, then dies mid-wait: 183s harness-timeout RED → seconds GREEN.

## Window rendering fixes (from the first live run)

- Truncation is rune-safe: the 100-char cut is by runes with an ellipsis — byte-slicing had cut a compose box-drawing `─` in half (`─────? …`).
- The tail scanner splits on `\r` as well as `\n`: compose rewrites progress with bare CRs, and newline-only splitting stitched fragments into mega-lines.

## Test hardening

- `TestCodespaceMachinePreflight` no longer depends on port-cleanup timing: its four scenarios each free their parked forward before the next begins (it tests machine selection, not port laddering — that's `TestMultiStack*`'s job). It flaked twice under full-suite load; the mechanism was never caught in the act, so its failure diagnostics now include stdout for any future recurrence.
- fakert gains the personas these tests need: `codespace logs`, a strict whitelist for the daemon-liveness probes, and scripted forward sickness/death (`FAKERT_GH_FORWARD_SICK`, `FAKERT_GH_FORWARD_DIES_AFTER_MS`).

Gate: gofmt + vet + full launcher suite in golang:1.25, 0 FAIL.
