### PR TITLE
PDF detection — Phases 2 & 3: AI-directed Mark on text-based PDFs via a media-type registry

### DIFF
--- a/packages/content/src/__tests__/locate.test.ts
+++ b/packages/content/src/__tests__/locate.test.ts
@@ -30,7 +30,7 @@ describe('locate', () => {
         const layer = await extractPdfTextLayer(readFixture('single-line.pdf'));
         if (!layer) throw new Error('expected layer, got null');
         const start = layer.text.indexOf(KNOWN_PHRASE);
-        const rects = locate(layer, start, start + KNOWN_PHRASE.length);
+        const { rects } = locate(layer, start, start + KNOWN_PHRASE.length);
         if (rects.length === 0) throw new Error('expected rects, got empty array');
 
         const rect = rects[0];
@@ -50,7 +50,7 @@ describe('locate', () => {
         const layer = await extractPdfTextLayer(readFixture('single-line.pdf'));
         if (!layer) throw new Error('expected layer, got null');
         const start = layer.text.indexOf(KNOWN_PHRASE);
-        const rects = locate(layer, start, start + KNOWN_PHRASE.length);
+        const { rects } = locate(layer, start, start + KNOWN_PHRASE.length);
         expect(rects).toHaveLength(1);
 
         const fragment = createFragmentSelector(rects[0]);
@@ -64,7 +64,7 @@ describe('locate', () => {
         const start = layer.text.indexOf(KNOWN_PHRASE);
         expect(start).toBeGreaterThanOrEqual(0);
 
-        const rects = locate(layer, start, start + KNOWN_PHRASE.length);
+        const { rects } = locate(layer, start, start + KNOWN_PHRASE.length);
         expect(rects).toHaveLength(1);
         expect(rects[0].page).toBe(1);
         expect(rects[0].width).toBeGreaterThan(0);
@@ -75,7 +75,7 @@ describe('locate', () => {
     it('returns one rect per line for a multi-line span', async () => {
         const layer = await extractPdfTextLayer(readFixture('multi-line.pdf'));
         if (!layer) throw new Error('expected layer, got null');
-        const rects = locate(layer, 0, layer.text.length - 1);
+        const { rects } = locate(layer, 0, layer.text.length - 1);
         expect(rects.length).toBeGreaterThan(1);
 
         const ys = rects.map(r => r.y);  // Extracts y value from every rect into an array
@@ -86,7 +86,7 @@ describe('locate', () => {
     it('returns empty array when span has no matching items', async () => {
         const layer = await extractPdfTextLayer(readFixture('single-line.pdf'));
         if (!layer) throw new Error('expected layer, got null');
-        const rects = locate(layer, 99999, 100000);
+        const { rects } = locate(layer, 99999, 100000);
         expect(rects).toHaveLength(0);
     });
     

--- a/packages/content/src/locate.ts
+++ b/packages/content/src/locate.ts
@@ -11,22 +11,24 @@ const SAME_LINE_THRESHOLD_PT = 2;
 /**
  * Locates bounding rectangles for a span of text in a PdfTextLayer
  * (single-line or multi-line).
- * 
- * Finds all overlapping items [start, end), groups them by page and line,
- * and records one bounding rectangle per line as a PdfCoordinate.
- * 
- * Returns array of PdfCoordinate, one per line of text covered by the span.
- * Returns empty array if no items overlap the span.
+ *
+ * Finds all overlapping items [start, end), groups them by page and line, and
+ * records one bounding rectangle per line as a PdfCoordinate.
+ *
+ * Returns both the per-line `rects` and the `overlap` items they were computed
+ * from — so a caller that also needs the covered text (e.g. buildPdfAnnotation's
+ * geometry↔text containment invariant) reuses this single `layer.items` scan
+ * instead of re-filtering. Both arrays are empty if no item overlaps the span.
  */
 export function locate(
     layer: PdfTextLayer,
     start: number,
     end: number
-): PdfCoordinate[] {
+): { rects: PdfCoordinate[]; overlap: PdfTextItem[] } {
     const overlap: PdfTextItem[] = layer.items.filter(
         item => item.start < end && item.end > start
     );
-    if (overlap.length === 0) return [];
+    if (overlap.length === 0) return { rects: [], overlap };
 
     const pages: Map<number, PdfTextItem[]> = groupItemsByPage(overlap);
     const rects: PdfCoordinate[] = [];
@@ -43,7 +45,7 @@ export function locate(
             rects.push({page, x, y, width: right - x, height: top - y});
         }
     }
-    return rects;
+    return { rects, overlap };
 }
 
 function groupItemsByPage(items: PdfTextItem[]): Map<number, PdfTextItem[]> {

--- a/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
+++ b/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
@@ -1,0 +1,94 @@
+/**
+ * buildPdfAnnotation (#736) — the geometry tail shared by every PDF detection
+ * motivation. Pure over a synthetic PdfTextLayer: span + layer -> per-line
+ * FragmentSelectors + a TextQuoteSelector, no TextPositionSelector, with the
+ * geometry<->text containment invariant.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { resourceId, type components } from '@semiont/core';
+import type { PdfTextLayer } from '@semiont/content';
+
+vi.mock('@semiont/event-sourcing', () => ({
+  generateAnnotationId: vi.fn(() => 'ann-pdf-test'),
+}));
+
+import { buildPdfAnnotation } from '../processors';
+
+type Agent = components['schemas']['Agent'];
+
+const RID = resourceId('res-pdf');
+const USER_DID = 'did:web:test.local:users:alice%40test.local';
+const GENERATOR: Agent = {
+  '@type': 'Software',
+  '@id': 'did:web:test.local:agents:test:test',
+  name: 'test',
+  provider: 'test',
+  model: 'test',
+};
+
+// Synthetic two-line layer — "alpha beta" (line 1, y=720) / "gamma delta" (line 2, y=700):
+//   a0 l1 p2 h3 a4 _5 b6 e7 t8 a9 \n10 g11 a12 m13 m14 a15 _16 d17 e18 l19 t20 a21
+const LAYER: PdfTextLayer = {
+  pages: [{ pageNumber: 1, widthPt: 612, heightPt: 792 }],
+  text: 'alpha beta\ngamma delta',
+  items: [
+    { start: 0,  end: 5,  page: 1, x: 72,  y: 720, width: 40, height: 12 }, // alpha
+    { start: 6,  end: 10, page: 1, x: 118, y: 720, width: 34, height: 12 }, // beta
+    { start: 11, end: 16, page: 1, x: 72,  y: 700, width: 45, height: 12 }, // gamma
+    { start: 17, end: 22, page: 1, x: 125, y: 700, width: 42, height: 12 }, // delta
+  ],
+};
+
+type PdfSel = { type: string; value?: string; conformsTo?: string; exact?: string; prefix?: string; suffix?: string };
+const sels = (ann: ReturnType<typeof buildPdfAnnotation>): PdfSel[] => ann.target.selector as PdfSel[];
+const frags = (ann: ReturnType<typeof buildPdfAnnotation>) => sels(ann).filter(s => s.type === 'FragmentSelector');
+
+describe('buildPdfAnnotation (#736 geometry tail)', () => {
+  it('single-line span -> one FragmentSelector + a TextQuoteSelector, and no TextPositionSelector', () => {
+    const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting',
+      { exact: 'alpha beta', start: 0, end: 10 });
+    const s = sels(ann);
+    expect(frags(ann)).toHaveLength(1);
+    expect(frags(ann)[0].value).toMatch(/^page=1&viewrect=/);
+    expect(s.some(x => x.type === 'TextQuoteSelector')).toBe(true);
+    expect(s.some(x => x.type === 'TextPositionSelector')).toBe(false);
+    expect(ann.motivation).toBe('highlighting');
+    expect(frags(ann)[0].conformsTo).toBe('http://tools.ietf.org/rfc/rfc3778');
+  });
+
+  it('multi-line span -> one FragmentSelector per line (2), each a distinct viewrect', () => {
+    const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting',
+      { exact: 'beta\ngamma', start: 6, end: 16 });
+    const f = frags(ann);
+    expect(f).toHaveLength(2);
+    expect(new Set(f.map(x => x.value)).size).toBe(2);
+  });
+
+  it('TextQuoteSelector carries exact + optional prefix/suffix', () => {
+    const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting',
+      { exact: 'beta', start: 6, end: 10, prefix: 'alpha ', suffix: '\ngamma' });
+    const tq = sels(ann).find(s => s.type === 'TextQuoteSelector');
+    expect(tq?.exact).toBe('beta');
+    expect(tq?.prefix).toBe('alpha ');
+    expect(tq?.suffix).toBe('\ngamma');
+  });
+
+  it('invariant: throws when the covered text does not contain exact', () => {
+    expect(() => buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting',
+      { exact: 'zzz not present', start: 0, end: 5 })).toThrow(/covered text does not contain exact/);
+  });
+
+  it('invariant: whitespace-normalized containment tolerates layer spacing (space vs newline)', () => {
+    // `exact` uses a single space where the layer text has a line break.
+    const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting',
+      { exact: 'beta gamma', start: 6, end: 16 });
+    expect(frags(ann).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('attaches a body when provided (e.g. commenting)', () => {
+    const body = { type: 'TextualBody', value: 'a note', format: 'text/plain' };
+    const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'commenting',
+      { exact: 'alpha', start: 0, end: 5 }, body);
+    expect((ann as Record<string, unknown>).body).toEqual(body);
+  });
+});

--- a/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
+++ b/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
@@ -91,4 +91,31 @@ describe('buildPdfAnnotation (#736 geometry tail)', () => {
       { exact: 'alpha', start: 0, end: 5 }, body);
     expect((ann as Record<string, unknown>).body).toEqual(body);
   });
+
+  it('linking motivation carries its detection-time body through the shared geometry', () => {
+    // #737: at detection time a linking reference's body is the entity type as a
+    // TextualBody (the SpecificResource target is appended later, at bind). The
+    // geometry tail is identical to highlighting; only motivation + body differ.
+    const body = { type: 'TextualBody', value: 'Person', purpose: 'tagging', format: 'text/plain' };
+    const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'linking',
+      { exact: 'gamma delta', start: 11, end: 22 }, body);
+    expect(ann.motivation).toBe('linking');
+    expect((ann as Record<string, unknown>).body).toEqual(body);
+    expect(frags(ann).length).toBeGreaterThanOrEqual(1);
+    expect(sels(ann).some(x => x.type === 'TextQuoteSelector')).toBe(true);
+    expect(sels(ann).some(x => x.type === 'TextPositionSelector')).toBe(false);
+  });
+
+  it('carries an array body (as commenting/tagging pass) unchanged', () => {
+    // comment and tag hand buildAnnotation an ARRAY of bodies; the geometry tail
+    // must pass either shape (single object | array) through verbatim.
+    const body = [
+      { type: 'TextualBody', value: 'Rule',   purpose: 'tagging',    format: 'text/plain' },
+      { type: 'TextualBody', value: 'a note', purpose: 'commenting', format: 'text/plain' },
+    ];
+    const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'tagging',
+      { exact: 'alpha', start: 0, end: 5 }, body);
+    expect((ann as Record<string, unknown>).body).toEqual(body);
+    expect(Array.isArray((ann as Record<string, unknown>).body)).toBe(true);
+  });
 });

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -49,6 +49,7 @@ vi.mock('@semiont/event-sourcing', () => ({
 import { AnnotationDetection } from '../workers/annotation-detection';
 import { extractEntities } from '../workers/detection/entity-extractor';
 import { generateResourceFromTopic } from '../workers/generation/resource-generation';
+import type { PdfTextLayer } from '@semiont/content';
 import {
   processHighlightJob,
   processCommentJob,
@@ -57,6 +58,7 @@ import {
   processTagJob,
   processGenerationJob,
   buildTextAnnotation,
+  buildPdfAnnotation,
   type BuildAnnotation,
 } from '../processors';
 
@@ -76,6 +78,24 @@ const GENERATOR: Agent = {
 // internally). Attribution shape is exercised through this closure.
 const textBuild = (content: string, userId: string = USER_DID): BuildAnnotation =>
   (motivation, match, body) => buildTextAnnotation(content, RID, userId, GENERATOR, motivation, match, body);
+
+// Synthetic two-line text layer — "alpha beta" / "gamma delta" — for the PDF
+// path. `.text` is what a PDF processor detects over; `pdfBuild` anchors each
+// detected span via `buildPdfAnnotation` (FragmentSelector viewrects, no
+// TextPositionSelector), the media-appropriate builder `prepareDetection`
+// hands a `pdf-text-layer` job.
+const PDF_LAYER: PdfTextLayer = {
+  pages: [{ pageNumber: 1, widthPt: 612, heightPt: 792 }],
+  text: 'alpha beta\ngamma delta',
+  items: [
+    { start: 0,  end: 5,  page: 1, x: 72,  y: 720, width: 40, height: 12 }, // alpha
+    { start: 6,  end: 10, page: 1, x: 118, y: 720, width: 34, height: 12 }, // beta
+    { start: 11, end: 16, page: 1, x: 72,  y: 700, width: 45, height: 12 }, // gamma
+    { start: 17, end: 22, page: 1, x: 125, y: 700, width: 42, height: 12 }, // delta
+  ],
+};
+const pdfBuild = (layer: PdfTextLayer, userId: string = USER_DID): BuildAnnotation =>
+  (motivation, match, body) => buildPdfAnnotation(layer, RID, userId, GENERATOR, motivation, match, body);
 
 function makeInferenceClient(): InferenceClient {
   return {
@@ -124,6 +144,34 @@ describe('processHighlightJob', () => {
     expect(result.result).toEqual({ highlightsFound: 2, highlightsCreated: 2 });
     expect(progress).toHaveBeenCalledWith(10, expect.any(String), 'analyzing');
     expect(progress).toHaveBeenLastCalledWith(100, expect.stringContaining('2 highlights'), 'creating');
+  });
+
+  it('keeps distinct PDF highlights (dedupe must not key on an absent TextPositionSelector)', async () => {
+    // Regression: PDF annotations carry no TextPositionSelector, so a dedupe
+    // key built only from position offsets degrades to `highlighting|?|?|null`
+    // and collapses every bodiless PDF highlight to one. Two distinct spans
+    // must survive as two annotations, anchored by FragmentSelector geometry.
+    const content = PDF_LAYER.text; // 'alpha beta\ngamma delta'
+    vi.mocked(AnnotationDetection.detectHighlights).mockResolvedValue([
+      { exact: 'alpha', start: 0, end: 5 },
+      { exact: 'delta', start: 17, end: 22 },
+    ]);
+
+    const result = await processHighlightJob(
+      content,
+      makeInferenceClient(),
+      { resourceId: RID, density: 5 },
+      pdfBuild(PDF_LAYER),
+      vi.fn(),
+    );
+
+    expect(result.annotations).toHaveLength(2);
+    expect(result.result).toEqual({ highlightsFound: 2, highlightsCreated: 2 });
+    for (const ann of result.annotations) {
+      const selectors = (ann as { target: { selector: Array<{ type: string }> } }).target.selector;
+      expect(selectors.some((s) => s.type === 'FragmentSelector')).toBe(true);
+      expect(selectors.some((s) => s.type === 'TextPositionSelector')).toBe(false);
+    }
   });
 });
 

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -56,6 +56,8 @@ import {
   processReferenceJob,
   processTagJob,
   processGenerationJob,
+  buildTextAnnotation,
+  type BuildAnnotation,
 } from '../processors';
 
 const RID = resourceId('res-test');
@@ -67,6 +69,13 @@ const GENERATOR: Agent = {
   provider: 'test',
   model: 'test',
 };
+
+// The detection processors now take a media-agnostic `buildAnnotation`; for
+// these text-detection tests it is `buildTextAnnotation` curried with the
+// resource + attribution context (exactly what the processors used to do
+// internally). Attribution shape is exercised through this closure.
+const textBuild = (content: string, userId: string = USER_DID): BuildAnnotation =>
+  (motivation, match, body) => buildTextAnnotation(content, RID, userId, GENERATOR, motivation, match, body);
 
 function makeInferenceClient(): InferenceClient {
   return {
@@ -101,8 +110,7 @@ describe('processHighlightJob', () => {
       content,
       makeInferenceClient(),
       { resourceId: RID, density: 5 },
-      USER_DID,
-      GENERATOR,
+      textBuild(content),
       progress,
     );
 
@@ -131,8 +139,7 @@ describe('processCommentJob', () => {
       'passage here',
       makeInferenceClient(),
       { resourceId: RID, density: 3 },
-      USER_DID,
-      GENERATOR,
+      textBuild('passage here'),
       vi.fn(),
     );
 
@@ -161,8 +168,7 @@ describe('processAssessmentJob', () => {
       'claim made',
       makeInferenceClient(),
       { resourceId: RID, density: 3 },
-      USER_DID,
-      GENERATOR,
+      textBuild('claim made'),
       vi.fn(),
     );
 
@@ -195,8 +201,7 @@ describe('processReferenceJob', () => {
       'Paris and Berlin',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
-      USER_DID,
-      GENERATOR,
+      textBuild('Paris and Berlin'),
       progress,
       LOGGER,
     );
@@ -226,8 +231,7 @@ describe('processReferenceJob', () => {
       'good stuff',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Thing')] },
-      USER_DID,
-      GENERATOR,
+      textBuild('good stuff'),
       vi.fn(),
       LOGGER,
     );
@@ -243,8 +247,7 @@ describe('processReferenceJob', () => {
       'content',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
-      USER_DID,
-      GENERATOR,
+      textBuild('content'),
       vi.fn(),
       LOGGER,
     );
@@ -271,8 +274,7 @@ describe('processTagJob', () => {
       'foo bar baz',
       makeInferenceClient(),
       { resourceId: RID, schema: SCHEMA_1, categories: ['catA', 'catB'] },
-      USER_DID,
-      GENERATOR,
+      textBuild('foo bar baz'),
       vi.fn(),
     );
 
@@ -483,8 +485,7 @@ describe('annotation attribution composition', () => {
       'snippet',
       makeInferenceClient(),
       { resourceId: RID, density: 1 },
-      USER_DID, // human DID
-      GENERATOR, // Software agent
+      textBuild('snippet'),
       vi.fn(),
     );
 
@@ -517,8 +518,7 @@ describe('annotation attribution composition', () => {
       'snippet',
       makeInferenceClient(),
       { resourceId: RID, density: 1 },
-      autonomousDid as never,
-      GENERATOR,
+      textBuild('snippet', autonomousDid),
       vi.fn(),
     );
 
@@ -544,10 +544,10 @@ describe('annotation attribution composition', () => {
     ]);
 
     const sources = await Promise.all([
-      processCommentJob('x', makeInferenceClient(), { resourceId: RID, density: 1 }, USER_DID, GENERATOR, vi.fn()),
-      processAssessmentJob('x', makeInferenceClient(), { resourceId: RID, density: 1 }, USER_DID, GENERATOR, vi.fn()),
-      processReferenceJob('x', makeInferenceClient(), { resourceId: RID, entityTypes: [entityType('Person')] }, USER_DID, GENERATOR, vi.fn(), LOGGER),
-      processTagJob('x', makeInferenceClient(), { resourceId: RID, schema: 'schema-1', categories: ['c'], sourceLanguage: 'en' } as never, USER_DID, GENERATOR, vi.fn()),
+      processCommentJob('x', makeInferenceClient(), { resourceId: RID, density: 1 }, textBuild('x'), vi.fn()),
+      processAssessmentJob('x', makeInferenceClient(), { resourceId: RID, density: 1 }, textBuild('x'), vi.fn()),
+      processReferenceJob('x', makeInferenceClient(), { resourceId: RID, entityTypes: [entityType('Person')] }, textBuild('x'), vi.fn(), LOGGER),
+      processTagJob('x', makeInferenceClient(), { resourceId: RID, schema: 'schema-1', categories: ['c'], sourceLanguage: 'en' } as never, textBuild('x'), vi.fn()),
     ]);
 
     for (const result of sources) {
@@ -587,8 +587,7 @@ describe('locale threading', () => {
         'passage here',
         makeInferenceClient(),
         { resourceId: RID, language: 'fr' },
-        USER_DID,
-        GENERATOR,
+        textBuild('passage here'),
         vi.fn(),
       );
 
@@ -606,8 +605,7 @@ describe('locale threading', () => {
         'claim made',
         makeInferenceClient(),
         { resourceId: RID, language: 'fr' },
-        USER_DID,
-        GENERATOR,
+        textBuild('claim made'),
         vi.fn(),
       );
 
@@ -625,8 +623,7 @@ describe('locale threading', () => {
         'Paris',
         makeInferenceClient(),
         { resourceId: RID, entityTypes: [entityType('Location')], language: 'fr' },
-        USER_DID,
-        GENERATOR,
+        textBuild('Paris'),
         vi.fn(),
         LOGGER,
       );
@@ -645,8 +642,7 @@ describe('locale threading', () => {
         'foo bar',
         makeInferenceClient(),
         { resourceId: RID, schema: SCHEMA_1, categories: ['Issue'], language: 'de' },
-        USER_DID,
-        GENERATOR,
+        textBuild('foo bar'),
         vi.fn(),
       );
 
@@ -667,8 +663,7 @@ describe('locale threading', () => {
         'passage here',
         makeInferenceClient(),
         { resourceId: RID },
-        USER_DID,
-        GENERATOR,
+        textBuild('passage here'),
         vi.fn(),
       );
 
@@ -687,7 +682,7 @@ describe('locale threading', () => {
       await processHighlightJob(
         'content', client,
         { resourceId: RID, sourceLanguage: 'fr' },
-        USER_DID, GENERATOR, vi.fn(),
+        textBuild('content'), vi.fn(),
       );
 
       expect(AnnotationDetection.detectHighlights).toHaveBeenCalledWith(
@@ -702,7 +697,7 @@ describe('locale threading', () => {
       await processCommentJob(
         'content', client,
         { resourceId: RID, language: 'de', sourceLanguage: 'fr' },
-        USER_DID, GENERATOR, vi.fn(),
+        textBuild('content'), vi.fn(),
       );
 
       expect(AnnotationDetection.detectComments).toHaveBeenCalledWith(
@@ -717,7 +712,7 @@ describe('locale threading', () => {
       await processAssessmentJob(
         'content', client,
         { resourceId: RID, language: 'es', sourceLanguage: 'pt' },
-        USER_DID, GENERATOR, vi.fn(),
+        textBuild('content'), vi.fn(),
       );
 
       expect(AnnotationDetection.detectAssessments).toHaveBeenCalledWith(
@@ -732,7 +727,7 @@ describe('locale threading', () => {
       await processReferenceJob(
         'content', client,
         { resourceId: RID, entityTypes: [entityType('Location')], sourceLanguage: 'fr' },
-        USER_DID, GENERATOR, vi.fn(),
+        textBuild('content'), vi.fn(),
         LOGGER,
       );
 
@@ -748,7 +743,7 @@ describe('locale threading', () => {
       await processTagJob(
         'content', client,
         { resourceId: RID, schema: SCHEMA_1, categories: ['Issue'], sourceLanguage: 'fr' },
-        USER_DID, GENERATOR, vi.fn(),
+        textBuild('content'), vi.fn(),
       );
 
       // Worker now receives the full schema (resolved by the dispatcher),
@@ -763,7 +758,7 @@ describe('locale threading', () => {
       const client = makeInferenceClient();
 
       await processHighlightJob(
-        'content', client, { resourceId: RID }, USER_DID, GENERATOR, vi.fn(),
+        'content', client, { resourceId: RID }, textBuild('content'), vi.fn(),
       );
 
       expect(AnnotationDetection.detectHighlights).toHaveBeenCalledWith(
@@ -822,8 +817,7 @@ describe('buildTextAnnotation invariant', () => {
         'the quick brown fox',
         makeInferenceClient(),
         { resourceId: RID, density: 5 },
-        USER_DID,
-        GENERATOR,
+        textBuild('the quick brown fox'),
         vi.fn(),
       ),
     ).rejects.toThrow(/buildTextAnnotation invariant: content\.substring/);
@@ -841,8 +835,7 @@ describe('buildTextAnnotation invariant', () => {
         content,
         makeInferenceClient(),
         { resourceId: RID, density: 5 },
-        USER_DID,
-        GENERATOR,
+        textBuild(content),
         vi.fn(),
       ),
     ).rejects.toThrow(/buildTextAnnotation invariant: content prefix-slice/);
@@ -859,8 +852,7 @@ describe('buildTextAnnotation invariant', () => {
         content,
         makeInferenceClient(),
         { resourceId: RID, density: 5 },
-        USER_DID,
-        GENERATOR,
+        textBuild(content),
         vi.fn(),
       ),
     ).rejects.toThrow(/buildTextAnnotation invariant: content suffix-slice/);
@@ -876,8 +868,7 @@ describe('buildTextAnnotation invariant', () => {
         'short',
         makeInferenceClient(),
         { resourceId: RID, density: 5 },
-        USER_DID,
-        GENERATOR,
+        textBuild('short'),
         vi.fn(),
       ),
     ).rejects.toThrow(new RegExp(`resource ${RID}, motivation highlighting`));
@@ -908,8 +899,7 @@ describe('Layer 2: worker-parser integration via real reconcileSelector', () => 
       content,
       makeInferenceClient(),
       { resourceId: RID, density: 5 },
-      USER_DID,
-      GENERATOR,
+      textBuild(content),
       vi.fn(),
     );
 
@@ -943,8 +933,7 @@ describe('Layer 2: worker-parser integration via real reconcileSelector', () => 
       content,
       makeInferenceClient(),
       { resourceId: RID, schema: SCHEMA_1, categories: ['Issue'] },
-      USER_DID,
-      GENERATOR,
+      textBuild(content),
       vi.fn(),
     );
 
@@ -970,8 +959,7 @@ describe('Layer 2: worker-parser integration via real reconcileSelector', () => 
       'Alice went to Paris.',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Person')] },
-      USER_DID,
-      GENERATOR,
+      textBuild('Alice went to Paris.'),
       vi.fn(),
       LOGGER,
     );
@@ -1004,8 +992,7 @@ describe('Layer 2: worker-parser integration via real reconcileSelector', () => 
       content,
       makeInferenceClient(),
       { resourceId: RID, density: 3 },
-      USER_DID,
-      GENERATOR,
+      textBuild(content),
       vi.fn(),
     );
 
@@ -1030,8 +1017,7 @@ describe('Layer 2: worker-parser integration via real reconcileSelector', () => 
       content,
       makeInferenceClient(),
       { resourceId: RID, density: 3 },
-      USER_DID,
-      GENERATOR,
+      textBuild(content),
       vi.fn(),
     );
 
@@ -1067,8 +1053,7 @@ describe('annotation de-duplication', () => {
       'A trip to Paris.',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
-      USER_DID,
-      GENERATOR,
+      textBuild('A trip to Paris.'),
       vi.fn(),
       LOGGER,
     );
@@ -1089,8 +1074,7 @@ describe('annotation de-duplication', () => {
       'The metal Mercury is dense.',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Planet'), entityType('Element')] },
-      USER_DID,
-      GENERATOR,
+      textBuild('The metal Mercury is dense.'),
       vi.fn(),
       LOGGER,
     );
@@ -1110,8 +1094,7 @@ describe('annotation de-duplication', () => {
       content,
       makeInferenceClient(),
       { resourceId: RID, density: 5 },
-      USER_DID,
-      GENERATOR,
+      textBuild(content),
       vi.fn(),
     );
 
@@ -1131,8 +1114,7 @@ describe('annotation de-duplication', () => {
       content,
       makeInferenceClient(),
       { resourceId: RID, schema: SCHEMA_1, categories: ['Issue'] },
-      USER_DID,
-      GENERATOR,
+      textBuild(content),
       vi.fn(),
     );
 

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -44,8 +44,12 @@ import {
 } from '../processors';
 import { extractPdfTextLayer } from '@semiont/content';
 
-// Mock all six processors. Each test sets its own return value.
-vi.mock('../processors', async () => ({
+// Mock the six processor entry points; keep every other export real.
+// `prepareDetection` imports `buildTextAnnotation`/`buildPdfAnnotation` from
+// this same module, so replacing it wholesale would leave those undefined —
+// spread the original and override only the processors.
+vi.mock('../processors', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../processors')>()),
   processHighlightJob:  vi.fn(),
   processCommentJob:    vi.fn(),
   processAssessmentJob: vi.fn(),

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -42,6 +42,7 @@ import {
   processTagJob,
   processGenerationJob,
 } from '../processors';
+import { extractPdfTextLayer } from '@semiont/content';
 
 // Mock all six processors. Each test sets its own return value.
 vi.mock('../processors', async () => ({
@@ -51,6 +52,15 @@ vi.mock('../processors', async () => ({
   processReferenceJob:  vi.fn(),
   processTagJob:        vi.fn(),
   processGenerationJob: vi.fn(),
+}));
+
+// prepareDetection's 'pdf-text-layer' branch runs extractPdfTextLayer over the
+// fetched PDF bytes. Mock only that export so orchestration tests drive the
+// text-layer-vs-scanned decision without real PDF fixtures; everything else in
+// @semiont/content (deriveStorageUri, etc.) stays real.
+vi.mock('@semiont/content', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@semiont/content')>()),
+  extractPdfTextLayer: vi.fn(),
 }));
 
 const RID = 'res-abc';
@@ -90,6 +100,12 @@ function makeFakeSessionAndAdapter() {
           representations: [{ mediaType: 'text/plain' }],
         })),
         resourceContent: vi.fn(async (_rid: string) => 'the content'),
+        // PDF detection ('pdf-text-layer') fetches the raw bytes here; the
+        // bytes are inert because extractPdfTextLayer is mocked per test.
+        resourceRepresentation: vi.fn(async (_rid: string) => ({
+          data: new ArrayBuffer(8),
+          contentType: 'application/pdf',
+        })),
       },
       yield: {
         resource: vi.fn(async (data: Parameters<SemiontSession['client']['yield']['resource']>[0]) => {
@@ -453,18 +469,56 @@ describe('handleJob orchestration', () => {
       expect(h.busEmits.some(e => e.channel === 'job:complete')).toBe(false);
     });
 
-    it('fails a detection job on a PDF with a distinct not-yet-supported message', async () => {
+    it('runs detection on a text-layer PDF via the pdf-text-layer strategy', async () => {
+      // application/pdf resolves to 'pdf-text-layer': the source is the
+      // extracted layer's text (not decoded bytes), anchored by a PDF-aware
+      // buildAnnotation. The processor receives exactly that text.
+      vi.mocked(processHighlightJob).mockResolvedValue({
+        annotations: [] as never,
+        result: {} as never,
+      });
+      vi.mocked(extractPdfTextLayer).mockResolvedValue({
+        text: 'the quick brown fox',
+        items: [],
+      } as never);
       const h = makeFakeSessionAndAdapter();
       vi.mocked(h.session.client.browse.resource).mockResolvedValue({
         representations: [{ mediaType: 'application/pdf' }],
       } as never);
 
-      await expect(
-        handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'))
-      ).rejects.toThrow(/text-layer detection is not yet supported/);
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
 
+      // pdf-text-layer fetches the representation bytes, never resourceContent.
+      expect(h.session.client.browse.resourceRepresentation).toHaveBeenCalled();
       expect(h.session.client.browse.resourceContent).not.toHaveBeenCalled();
+      expect(processHighlightJob).toHaveBeenCalledWith(
+        'the quick brown fox',   // source.text — the extracted layer
+        expect.anything(),       // inferenceClient
+        expect.anything(),       // job.params
+        expect.any(Function),    // source.buildAnnotation — PDF-aware anchor
+        expect.any(Function),    // onProgress
+      );
+      expect(h.busEmits.some(e => e.channel === 'job:complete')).toBe(true);
+    });
+
+    it('declines cleanly (no throw, no processor) for a scanned PDF with no text layer', async () => {
+      // extractPdfTextLayer returns null for a scanned / image-only PDF.
+      // The dispatch declines cleanly — completes the job with a no-text-layer
+      // result — rather than crashing or running the model on nothing.
+      vi.mocked(extractPdfTextLayer).mockResolvedValue(null);
+      const h = makeFakeSessionAndAdapter();
+      vi.mocked(h.session.client.browse.resource).mockResolvedValue({
+        representations: [{ mediaType: 'application/pdf' }],
+      } as never);
+
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
+
       expect(processHighlightJob).not.toHaveBeenCalled();
+      const complete = h.busEmits.find(e => e.channel === 'job:complete');
+      expect(complete).toBeDefined();
+      expect((complete!.payload as { result?: unknown }).result)
+        .toMatchObject({ declined: true, reason: 'no-text-layer' });
+      expect(h.adapterCalls.some(c => c.method === 'completeJob')).toBe(true);
     });
 
     it('fails a detection job when the resource has no primary representation', async () => {

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -469,35 +469,53 @@ describe('handleJob orchestration', () => {
       expect(h.busEmits.some(e => e.channel === 'job:complete')).toBe(false);
     });
 
-    it('runs detection on a text-layer PDF via the pdf-text-layer strategy', async () => {
-      // application/pdf resolves to 'pdf-text-layer': the source is the
-      // extracted layer's text (not decoded bytes), anchored by a PDF-aware
-      // buildAnnotation. The processor receives exactly that text.
-      vi.mocked(processHighlightJob).mockResolvedValue({
-        annotations: [] as never,
-        result: {} as never,
-      });
-      vi.mocked(extractPdfTextLayer).mockResolvedValue({
-        text: 'the quick brown fox',
-        items: [],
-      } as never);
+    // #737 (Phase 3): all five detection motivations fan out to the PDF
+    // text-layer path. Geometry is shared (buildPdfAnnotation, covered in
+    // build-pdf-annotation.test.ts); this proves the dispatch routes every
+    // motivation through 'pdf-text-layer' — feeding each processor the extracted
+    // layer text (arg 0) and a PDF-aware buildAnnotation (arg 3), never the
+    // decoded-bytes path. `lastCall` closes over the concrete mock so each
+    // processor's own arg tuple is read (their signatures differ).
+    type PdfFanoutCase = {
+      jobType: ActiveJob['type'];
+      arm: () => void;                    // set this processor's resolved value
+      lastCall: () => unknown[] | undefined;
+    };
+    const PDF_FANOUT: PdfFanoutCase[] = [
+      { jobType: 'highlight-annotation',
+        arm: () => { vi.mocked(processHighlightJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
+        lastCall: () => vi.mocked(processHighlightJob).mock.calls[0] },
+      { jobType: 'comment-annotation',
+        arm: () => { vi.mocked(processCommentJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
+        lastCall: () => vi.mocked(processCommentJob).mock.calls[0] },
+      { jobType: 'assessment-annotation',
+        arm: () => { vi.mocked(processAssessmentJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
+        lastCall: () => vi.mocked(processAssessmentJob).mock.calls[0] },
+      { jobType: 'reference-annotation',
+        arm: () => { vi.mocked(processReferenceJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
+        lastCall: () => vi.mocked(processReferenceJob).mock.calls[0] },
+      { jobType: 'tag-annotation',
+        arm: () => { vi.mocked(processTagJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
+        lastCall: () => vi.mocked(processTagJob).mock.calls[0] },
+    ];
+
+    it.each(PDF_FANOUT)('fans $jobType out to the pdf-text-layer path', async ({ jobType, arm, lastCall }) => {
+      arm();
+      vi.mocked(extractPdfTextLayer).mockResolvedValue({ text: 'the quick brown fox', items: [] } as never);
       const h = makeFakeSessionAndAdapter();
       vi.mocked(h.session.client.browse.resource).mockResolvedValue({
         representations: [{ mediaType: 'application/pdf' }],
       } as never);
 
-      await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
+      await handleJob(h.adapter, makeConfig(h.session), makeJob(jobType));
 
       // pdf-text-layer fetches the representation bytes, never resourceContent.
       expect(h.session.client.browse.resourceRepresentation).toHaveBeenCalled();
       expect(h.session.client.browse.resourceContent).not.toHaveBeenCalled();
-      expect(processHighlightJob).toHaveBeenCalledWith(
-        'the quick brown fox',   // source.text — the extracted layer
-        expect.anything(),       // inferenceClient
-        expect.anything(),       // job.params
-        expect.any(Function),    // source.buildAnnotation — PDF-aware anchor
-        expect.any(Function),    // onProgress
-      );
+      const call = lastCall();
+      expect(call).toBeDefined();
+      expect(call![0]).toBe('the quick brown fox'); // source.text — the extracted layer
+      expect(typeof call![3]).toBe('function');      // source.buildAnnotation — PDF-aware anchor
       expect(h.busEmits.some(e => e.channel === 'job:complete')).toBe(true);
     });
 

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -249,13 +249,14 @@ export function buildPdfAnnotation(
   match: { exact: string; start: number; end: number; prefix?: string; suffix?: string },
   body?: Record<string, unknown> | Record<string, unknown>[],
 ) {
-  const rects = locate(layer, match.start, match.end);
+  // `locate` returns both the per-line rects and the overlap items it found;
+  // reuse `overlap` for the containment check rather than re-scanning layer.items.
+  const { rects, overlap } = locate(layer, match.start, match.end);
 
-  const covered = layer.items.filter((i) => i.start < match.end && i.end > match.start);
-  const coveredText = covered.length
+  const coveredText = overlap.length
     ? layer.text.substring(
-        Math.min(...covered.map((i) => i.start)),
-        Math.max(...covered.map((i) => i.end)),
+        Math.min(...overlap.map((i) => i.start)),
+        Math.max(...overlap.map((i) => i.end)),
       )
     : '';
   const normalize = (s: string) => s.replace(/\s+/g, ' ').trim();

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -92,15 +92,26 @@ function toMatch(r: ReconciledSelector): { exact: string; start: number; end: nu
  * Two annotations with the same key are the same event written twice.
  */
 function annotationDedupeKey(ann: Record<string, unknown>): string {
-  const target = ann.target as { selector?: Array<{ type: string; start?: number; end?: number }> } | undefined;
+  const target = ann.target as
+    | { selector?: Array<{ type: string; start?: number; end?: number; value?: string; exact?: string; prefix?: string; suffix?: string }> }
+    | undefined;
   const selectors = Array.isArray(target?.selector) ? target.selector : [];
   const pos = selectors.find((s) => s.type === 'TextPositionSelector');
-  return [
-    ann.motivation as string,
-    pos?.start ?? '?',
-    pos?.end ?? '?',
-    JSON.stringify(ann.body ?? null),
-  ].join('|');
+  // Anchor identity is media-specific. Text annotations carry a
+  // TextPositionSelector (durable char offsets). PDF annotations have none —
+  // their anchor is the per-line FragmentSelector viewrect geometry plus the
+  // TextQuoteSelector text. Keying only on TextPositionSelector would collapse
+  // every PDF annotation sharing a motivation+body onto one (its offsets fall
+  // back to '?'), so e.g. multiple PDF highlights emit as a single annotation.
+  let anchor: string;
+  if (pos) {
+    anchor = `pos:${pos.start ?? '?'}:${pos.end ?? '?'}`;
+  } else {
+    const frags = selectors.filter((s) => s.type === 'FragmentSelector').map((s) => s.value ?? '').join(',');
+    const quote = selectors.find((s) => s.type === 'TextQuoteSelector');
+    anchor = `frag:${frags}|quote:${quote?.exact ?? ''}:${quote?.prefix ?? ''}:${quote?.suffix ?? ''}`;
+  }
+  return [ann.motivation as string, anchor, JSON.stringify(ann.body ?? null)].join('|');
 }
 
 /**

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -15,8 +15,9 @@ import { generateResourceFromTopic } from './workers/generation/resource-generat
 import { resolveCitationTokens, collectContextResourceIds, type GenerationCitation } from './workers/generation/citation-resolver';
 import { generateAnnotationId } from '@semiont/event-sourcing';
 import { didToAgent, type Logger, type ResourceId, type SupportedMediaType, type components } from '@semiont/core';
-import { reconcileSelector, type ReconciledSelector } from '@semiont/core';
+import { reconcileSelector, createFragmentSelector, type ReconciledSelector } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
+import { locate, type PdfTextLayer } from '@semiont/content';
 import type {
   HighlightDetectionParams,
   CommentDetectionParams,
@@ -33,6 +34,22 @@ import type {
 } from './types';
 
 type Agent = components['schemas']['Agent'];
+
+/** A detected span — offsets into the extracted `.text`, plus optional context. */
+export type SpanMatch = { exact: string; start: number; end: number; prefix?: string; suffix?: string };
+
+/**
+ * Turn a detected span into a stored annotation. The media type, resource, and
+ * attribution context are closed over by the caller (see `prepareDetection`);
+ * the detection processor supplies only the motivation, the span, and any
+ * motivation-specific body. This is the single axis that varies by media type,
+ * so the detection processors themselves stay media-agnostic.
+ */
+export type BuildAnnotation = (
+  motivation: string,
+  match: SpanMatch,
+  body?: Record<string, unknown> | Record<string, unknown>[],
+) => Record<string, unknown>;
 
 /**
  * Progress callback. The three positional args satisfy the minimum
@@ -115,7 +132,7 @@ function dedupeAnnotations(annotations: Record<string, unknown>[]): Record<strin
   return out;
 }
 
-function buildTextAnnotation(
+export function buildTextAnnotation(
   content: string,
   resourceId: ResourceId,
   userId: string,
@@ -195,12 +212,88 @@ function buildTextAnnotation(
   };
 }
 
+/**
+ * PDF sibling of `buildTextAnnotation`. The model returns the same
+ * `{ exact, start, end, prefix?, suffix? }` match over the extracted text
+ * layer's `text`; geometry comes from the layer, never the model.
+ *
+ * `target.selector` = one `FragmentSelector` per line (`locate` unions the
+ * overlapping text-layer items into per-line viewrects) plus a
+ * `TextQuoteSelector` anchor. No `TextPositionSelector`: the extracted text
+ * layer is a derived artifact, not the stored content, so its char offsets are
+ * not a durable anchor.
+ *
+ * Write-time invariant (geometry <-> text): geometry is item-level (word runs),
+ * so the covered items' text must *contain* `exact` (whitespace-normalized) —
+ * containment, not reconstruction. An empty cover (no overlapping items -> no
+ * rects) also fails. Throws loudly, naming the resource + motivation, rather
+ * than persisting geometry that doesn't back the quoted text.
+ */
+export function buildPdfAnnotation(
+  layer: PdfTextLayer,
+  resourceId: ResourceId,
+  userId: string,
+  generator: Agent,
+  motivation: string,
+  match: { exact: string; start: number; end: number; prefix?: string; suffix?: string },
+  body?: Record<string, unknown> | Record<string, unknown>[],
+) {
+  const rects = locate(layer, match.start, match.end);
+
+  const covered = layer.items.filter((i) => i.start < match.end && i.end > match.start);
+  const coveredText = covered.length
+    ? layer.text.substring(
+        Math.min(...covered.map((i) => i.start)),
+        Math.max(...covered.map((i) => i.end)),
+      )
+    : '';
+  const normalize = (s: string) => s.replace(/\s+/g, ' ').trim();
+  if (rects.length === 0 || !normalize(coveredText).includes(normalize(match.exact))) {
+    throw new Error(
+      `buildPdfAnnotation invariant: covered text does not contain exact ` +
+        `for resource ${resourceId}, motivation ${motivation}`,
+    );
+  }
+
+  const creator = didToAgent(userId);
+  const wasAttributedTo: Agent[] =
+    creator['@id'] === generator['@id'] ? [generator] : [creator, generator];
+
+  return {
+    '@context': 'http://www.w3.org/ns/anno.jsonld' as const,
+    'type': 'Annotation' as const,
+    'id': generateAnnotationId(),
+    motivation,
+    creator,
+    generator,
+    wasAttributedTo,
+    created: new Date().toISOString(),
+    target: {
+      type: 'SpecificResource' as const,
+      source: resourceId as string,
+      selector: [
+        ...rects.map((coord) => ({
+          type: 'FragmentSelector' as const,
+          conformsTo: 'http://tools.ietf.org/rfc/rfc3778' as const,
+          value: createFragmentSelector(coord),
+        })),
+        {
+          type: 'TextQuoteSelector' as const,
+          exact: match.exact,
+          ...(match.prefix && { prefix: match.prefix }),
+          ...(match.suffix && { suffix: match.suffix }),
+        },
+      ],
+    },
+    ...(body !== undefined ? { body } : {}),
+  };
+}
+
 export async function processHighlightJob(
   content: string,
   inferenceClient: InferenceClient,
   params: HighlightDetectionParams,
-  userId: string,
-  generator: Agent,
+  buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
 ): Promise<ProcessorResult<HighlightDetectionResult>> {
   onProgress(10, 'Loading resource...', 'analyzing');
@@ -215,7 +308,7 @@ export async function processHighlightJob(
   // Highlights carry no body — motivation:'highlighting' on a target
   // is a complete annotation per the W3C Web Annotation Model.
   const annotations = dedupeAnnotations(highlights.map((h) =>
-    buildTextAnnotation(content, params.resourceId, userId, generator, 'highlighting', h),
+    buildAnnotation('highlighting', h),
   ));
 
   onProgress(100, `Complete! Created ${annotations.length} highlights`, 'creating');
@@ -230,8 +323,7 @@ export async function processCommentJob(
   content: string,
   inferenceClient: InferenceClient,
   params: CommentDetectionParams,
-  userId: string,
-  generator: Agent,
+  buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
 ): Promise<ProcessorResult<CommentDetectionResult>> {
   onProgress(10, 'Loading resource...', 'analyzing');
@@ -252,7 +344,7 @@ export async function processCommentJob(
     // Match the pre-#651 CommentAnnotationWorker: include format and
     // language on the body TextualBody. Optional in the schema, but
     // consumers that do language-aware rendering rely on them.
-    buildTextAnnotation(content, params.resourceId, userId, generator, 'commenting', c, [
+    buildAnnotation('commenting', c, [
       { type: 'TextualBody', value: c.comment, purpose: 'commenting', format: 'text/plain' satisfies SupportedMediaType, language: bodyLanguage },
     ]),
   ));
@@ -269,8 +361,7 @@ export async function processAssessmentJob(
   content: string,
   inferenceClient: InferenceClient,
   params: AssessmentDetectionParams,
-  userId: string,
-  generator: Agent,
+  buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
 ): Promise<ProcessorResult<AssessmentDetectionResult>> {
   onProgress(10, 'Loading resource...', 'analyzing');
@@ -291,7 +382,7 @@ export async function processAssessmentJob(
     // purpose='describing' — that loses the "this is an assessment, not
     // a description" signal and breaks existing readers that access
     // `body.value` directly on the object.
-    buildTextAnnotation(content, params.resourceId, userId, generator, 'assessing', a, {
+    buildAnnotation('assessing', a, {
       type: 'TextualBody', value: a.assessment, purpose: 'assessing', format: 'text/plain' satisfies SupportedMediaType, language: bodyLanguage,
     }),
   ));
@@ -308,8 +399,7 @@ export async function processReferenceJob(
   content: string,
   inferenceClient: InferenceClient,
   params: DetectionParams,
-  userId: string,
-  generator: Agent,
+  buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
   logger: Logger,
 ): Promise<ProcessorResult<DetectionResult>> {
@@ -377,9 +467,7 @@ export async function processReferenceJob(
           anchorMethod: reconciled.anchorMethod,
         });
       }
-      const ann = buildTextAnnotation(
-        content, params.resourceId, userId, generator, 'linking', toMatch(reconciled), unresolvedBody,
-      );
+      const ann = buildAnnotation('linking', toMatch(reconciled), unresolvedBody);
       allAnnotations.push(ann);
       totalEmitted++;
     }
@@ -403,8 +491,7 @@ export async function processTagJob(
   content: string,
   inferenceClient: InferenceClient,
   params: TagDetectionParams,
-  userId: string,
-  generator: Agent,
+  buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
 ): Promise<ProcessorResult<TagDetectionResult>> {
   onProgress(10, 'Loading resource...', 'analyzing');
@@ -429,7 +516,7 @@ export async function processTagJob(
     // plus the tagging-schema id as a classifying TextualBody. The
     // classifying body is the only trace of schema provenance in the
     // event log — do not drop it.
-    return buildTextAnnotation(content, params.resourceId, userId, generator, 'tagging', t, [
+    return buildAnnotation('tagging', t, [
       { type: 'TextualBody', value: category,         purpose: 'tagging',     format: 'text/plain' satisfies SupportedMediaType, language: bodyLanguage },
       { type: 'TextualBody', value: params.schema.id, purpose: 'classifying', format: 'text/plain' satisfies SupportedMediaType },
     ]);

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -20,8 +20,9 @@ import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
 import { getPrimaryMediaType, textExtractionOf, assembleAnnotation, type EventMap } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
-import type { Logger, components } from '@semiont/core';
+import type { Logger, ResourceId, components } from '@semiont/core';
 import { deriveStorageUri } from '@semiont/content';
+import { prepareDetection } from './workers/detection/prepare-detection';
 import { SpanKind, recordJobOutcome, withSpan } from '@semiont/observability';
 import {
   processHighlightJob,
@@ -174,23 +175,33 @@ async function handleJobInner(
     return;
   }
 
-  // Detection jobs decode the source resource as text — fetchContent()
-  // sends Accept: text/plain and TextDecoder-decodes whatever returns —
-  // so gate on the registry's extraction strategy before fetching:
-  // binary types have no text to analyze (the LLM would see mojibake),
-  // and PDFs need the text-layer path that arrives with PDF-DETECTION.md.
-  // Generation reads the annotation carried in its params, not the
-  // source bytes, so it is not gated. Throwing here surfaces as a normal
-  // job:fail through the startWorkerProcess catch.
+  // Detection needs the resource's text plus a media-appropriate way to anchor a
+  // detected span. Both come from the media-type registry's extraction strategy
+  // (textExtractionOf, see prepareDetection): 'decode' -> decoded text + text
+  // selectors, 'pdf-text-layer' -> extracted layer + viewrect selectors. Gating
+  // on the strategy up front keeps binary bytes away from the model — a 'none'
+  // type would TextDecoder-decode to mojibake. A scanned PDF (no text layer)
+  // declines cleanly; a non-textual 'none' type is a user error and throws
+  // (surfaces as job:fail via the startWorkerProcess catch). Generation reads the
+  // annotation in its params, not the source bytes, so it is not prepared here.
+  let source: Awaited<ReturnType<typeof prepareDetection>> = null;
   if (jobType !== 'generation') {
     const descriptor = await session.client.browse.resource(resourceId as never);
     const mediaType = getPrimaryMediaType(descriptor);
-    const extraction = mediaType ? textExtractionOf(mediaType) : 'none';
-    if (extraction === 'pdf-text-layer') {
-      throw new Error(`Cannot run ${jobType} on resource ${resourceId}: PDF text-layer detection is not yet supported`);
-    }
-    if (extraction !== 'decode') {
+    const strategy = mediaType ? textExtractionOf(mediaType) : 'none';
+    if (strategy === 'none') {
       throw new Error(`Cannot run ${jobType} on resource ${resourceId}: media type '${mediaType ?? 'unknown'}' has no extractable text to analyze`);
+    }
+    source = await prepareDetection(strategy, session, resourceId as ResourceId, userId, generator);
+    if (!source) {
+      // 'pdf-text-layer' that yielded no text layer: a scanned / image-only PDF.
+      // Decline cleanly (not a crash) — complete the job with a no-text-layer result.
+      await emitEvent(session, 'job:complete', {
+        ...lifecycleBase,
+        result: { declined: true, reason: 'no-text-layer', message: 'This PDF has no extractable text layer (scanned or image-only); detection is not supported.' } as never,
+      });
+      adapter.completeJob();
+      return;
     }
   }
 
@@ -210,14 +221,9 @@ async function handleJobInner(
     }).catch(() => {});
   };
 
-  const fetchContent = async (): Promise<string> => {
-    return session.client.browse.resourceContent(resourceId as never);
-  };
-
   if (jobType === 'highlight-annotation') {
-    const content = await fetchContent();
     const { annotations, result } = await processHighlightJob(
-      content, inferenceClient, job.params as never, userId, generator, onProgress,
+      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -229,9 +235,8 @@ async function handleJobInner(
     adapter.completeJob();
 
   } else if (jobType === 'comment-annotation') {
-    const content = await fetchContent();
     const { annotations, result } = await processCommentJob(
-      content, inferenceClient, job.params as never, userId, generator, onProgress,
+      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -243,9 +248,8 @@ async function handleJobInner(
     adapter.completeJob();
 
   } else if (jobType === 'assessment-annotation') {
-    const content = await fetchContent();
     const { annotations, result } = await processAssessmentJob(
-      content, inferenceClient, job.params as never, userId, generator, onProgress,
+      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -257,9 +261,8 @@ async function handleJobInner(
     adapter.completeJob();
 
   } else if (jobType === 'reference-annotation') {
-    const content = await fetchContent();
     const { annotations, result } = await processReferenceJob(
-      content, inferenceClient, job.params as never, userId, generator, onProgress, config.logger,
+      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress, config.logger,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -271,9 +274,8 @@ async function handleJobInner(
     adapter.completeJob();
 
   } else if (jobType === 'tag-annotation') {
-    const content = await fetchContent();
     const { annotations, result } = await processTagJob(
-      content, inferenceClient, job.params as never, userId, generator, onProgress,
+      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });

--- a/packages/jobs/src/workers/detection/prepare-detection.ts
+++ b/packages/jobs/src/workers/detection/prepare-detection.ts
@@ -1,0 +1,49 @@
+import type { SemiontSession } from '@semiont/sdk';
+import type { ResourceId, TextExtraction, components } from '@semiont/core';
+import { extractPdfTextLayer } from '@semiont/content';
+import { buildTextAnnotation, buildPdfAnnotation, type BuildAnnotation } from '../../processors';
+
+type Agent = components['schemas']['Agent'];
+
+/**
+ * For one detection job, resolve the text the model detects over and the
+ * media-appropriate way to turn a detected span into a stored annotation —
+ * keyed by the media-type registry's `TextExtraction` strategy
+ * (`textExtractionOf`). The detection processors stay media-agnostic: they take
+ * the `.text` and the returned `buildAnnotation` and never see a layer or a
+ * media type. Adding a media type is a new `case` here, nothing on the processors.
+ *
+ * Returns `null` when the resource has no usable text (a scanned/image-only PDF,
+ * or a non-textual `'none'` type), so the dispatch can decline cleanly instead
+ * of running the model on nothing.
+ */
+export async function prepareDetection(
+  strategy: TextExtraction,
+  session: SemiontSession,
+  resourceId: ResourceId,
+  userId: string,
+  generator: Agent,
+): Promise<{ text: string; buildAnnotation: BuildAnnotation } | null> {
+  switch (strategy) {
+    case 'decode': {
+      const text = await session.client.browse.resourceContent(resourceId as never);
+      return {
+        text,
+        buildAnnotation: (motivation, match, body) =>
+          buildTextAnnotation(text, resourceId, userId, generator, motivation, match, body),
+      };
+    }
+    case 'pdf-text-layer': {
+      const { data } = await session.client.browse.resourceRepresentation(resourceId as never);
+      const layer = await extractPdfTextLayer(new Uint8Array(data));
+      if (!layer) return null; // scanned / image-only PDF — no text layer
+      return {
+        text: layer.text,
+        buildAnnotation: (motivation, match, body) =>
+          buildPdfAnnotation(layer, resourceId, userId, generator, motivation, match, body),
+      };
+    }
+    case 'none':
+      return null;
+  }
+}

--- a/packages/react-ui/src/components/resource/panels/AssessmentPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssessmentPanel.tsx
@@ -245,7 +245,7 @@ export function AssessmentPanel({
 
       {/* Scrollable content area */}
       <div ref={containerRef} className="semiont-panel__content">
-        {/* Assist Section - only in Annotate mode and for text resources */}
+        {/* Assist Section - only in Annotate mode; shown for any media type (AI detection is media-agnostic — text is resolved via the media-type registry, incl. PDF text layers) */}
         {annotateMode && (
           <AssistSection
             session={session}

--- a/packages/react-ui/src/components/resource/panels/CommentsPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/CommentsPanel.tsx
@@ -255,7 +255,7 @@ export function CommentsPanel({
 
       {/* Scrollable content area */}
       <div ref={containerRef} className="semiont-panel__content">
-        {/* Assist Section - only in Annotate mode and for text resources */}
+        {/* Assist Section - only in Annotate mode; shown for any media type (AI detection is media-agnostic — text is resolved via the media-type registry, incl. PDF text layers) */}
         {annotateMode && (
           <AssistSection
             session={session}

--- a/packages/react-ui/src/components/resource/panels/HighlightPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/HighlightPanel.tsx
@@ -153,7 +153,7 @@ export function HighlightPanel({
 
       {/* Scrollable content area */}
       <div ref={containerRef} className="semiont-panel__content">
-        {/* Assist Section - only in Annotate mode and for text resources */}
+        {/* Assist Section - only in Annotate mode; shown for any media type (AI detection is media-agnostic — text is resolved via the media-type registry, incl. PDF text layers) */}
         {annotateMode && (
           <AssistSection
             session={session}

--- a/packages/react-ui/src/components/resource/panels/ReferencesPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/ReferencesPanel.tsx
@@ -351,7 +351,7 @@ export function ReferencesPanel({
 
       {/* Scrollable content area */}
       <div ref={containerRef} className="semiont-panel__content">
-        {/* Assist Section - only in Annotate mode and for text resources */}
+        {/* Assist Section - only in Annotate mode; shown for any media type (AI detection is media-agnostic — text is resolved via the media-type registry, incl. PDF text layers) */}
         {annotateMode && (
           <div className="semiont-panel__section">
             <button

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../packages/core": {
       "name": "@semiont/core",
-      "version": "0.5.12",
+      "version": "0.5.20",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -28,15 +28,15 @@
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.8",
-        "fast-check": "^4.8.0",
+        "fast-check": "^4.9.0",
         "json-schema-to-typescript": "^15.0.2",
         "openapi-typescript": "^7.10.1",
         "rollup": "^4.61.0",
         "rollup-plugin-dts": "^6.4.1",
         "tsup": "^8.5.1",
-        "tsx": "^4.22.5",
+        "tsx": "^4.23.1",
         "typescript": "^6.0.2",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -52,7 +52,7 @@
     },
     "../../packages/sdk": {
       "name": "@semiont/sdk",
-      "version": "0.5.12",
+      "version": "0.5.20",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -62,12 +62,12 @@
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.8",
-        "fast-check": "^4.8.0",
+        "fast-check": "^4.9.0",
         "rollup": "^4.61.0",
         "rollup-plugin-dts": "^6.4.1",
         "tsup": "^8.5.1",
         "typescript": "^6.0.2",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/tests/e2e/scripts/seed.ts
+++ b/tests/e2e/scripts/seed.ts
@@ -9,12 +9,14 @@
  * 02-09 fail at the very first "open resource:" assertion.
  *
  * Seeds two `text/plain` resources (for the text-annotation specs) plus
- * one `application/pdf` resource (for `14-pdf-render.spec.ts`, the
- * PDFJS-6-UNIFY browser smoke). The PDF is seeded **first** on purpose:
- * Discover lists resources newest-first
- * (`make-meaning/src/resource-context.ts` `sortByDateDesc`), so the
- * oldest resource sorts last and never becomes the `.first()` card the
- * text specs (02-09) open. Adding the PDF must not displace that card.
+ * two `application/pdf` resources: a 3-word render smoke fixture (for
+ * `14-pdf-render.spec.ts`, the PDFJS-6-UNIFY browser smoke) and a
+ * text-layer fixture with a Concept-dense paragraph (for
+ * `20-pdf-assisted-detection.spec.ts`, AI detection on a PDF). Both PDFs are
+ * seeded **first** on purpose: Discover lists resources newest-first
+ * (`make-meaning/src/resource-context.ts` `sortByDateDesc`), so the two
+ * oldest resources sort last and never become the `.first()` card the text
+ * specs (02-09) open. Adding the PDFs must not displace that card.
  *
  * This module exports two entry points:
  *
@@ -67,6 +69,79 @@ const PDF_FIXTURE_BASE64 =
   'MDAwMDAxMTUgMDAwMDAgbiAKMDAwMDAwMDI0MSAwMDAwMCBuIAowMDAwMDAwMzcyIDAwMDAwIG4g' +
   'CnRyYWlsZXIKPDwgL1NpemUgNiAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKNDQyCiUlRU9G';
 
+/**
+ * A single-page (612×792) text-layer PDF whose content is a Concept-dense
+ * essay on cellular respiration (~346 words). Unlike the 3-word "Spatial Smoke
+ * PDF" above (a render smoke fixture), it carries enough extractable prose that
+ * density-gated AI detection (highlight/comment) reliably finds ≥1 span and
+ * entity extraction (reference/linking) finds many Concept entities —
+ * `20-pdf-assisted-detection.spec.ts` runs comment + reference assist against
+ * it. Standard Helvetica Type1 font; text drawn with BT/Tf/Td/Tj operators,
+ * one positioned line per string advanced by the T-star line-move. Verified
+ * through `@semiont/content`'s `extractPdfTextLayer` (pdfjs-dist@6): 1 page,
+ * 31 text items, text layer beginning "Cellular respiration is the set of
+ * metabolic reactions".
+ */
+const TEXT_PDF_FIXTURE_BASE64 =
+  'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5k' +
+  'b2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4K' +
+  'ZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3gg' +
+  'WzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA1IDAgUiA+PiA+PiAv' +
+  'Q29udGVudHMgNCAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCAyNTU4ID4+CnN0' +
+  'cmVhbQpCVAovRjEgMTAgVGYKMTQgVEwKNTQgNzQ4IFRkCihDZWxsdWxhciByZXNwaXJhdGlv' +
+  'biBpcyB0aGUgc2V0IG9mIG1ldGFib2xpYyByZWFjdGlvbnMgYW5kIHByb2Nlc3NlcyB0aGF0' +
+  'KSBUagpUKgoodGFrZSBwbGFjZSBpbiB0aGUgY2VsbHMgb2Ygb3JnYW5pc21zIHRvIGNvbnZl' +
+  'cnQgYmlvY2hlbWljYWwgZW5lcmd5IGZyb20pIFRqClQqCihudXRyaWVudHMgaW50byBhZGVu' +
+  'b3NpbmUgdHJpcGhvc3BoYXRlLCBhbmQgdGhlbiByZWxlYXNlIHdhc3RlIHByb2R1Y3RzLikg' +
+  'VGoKVCoKKFRoZSByZWFjdGlvbnMgaW52b2x2ZWQgaW4gcmVzcGlyYXRpb24gYXJlIGNhdGFi' +
+  'b2xpYyByZWFjdGlvbnMgdGhhdCBicmVhaykgVGoKVCoKKGxhcmdlIG1vbGVjdWxlcyBpbnRv' +
+  'IHNtYWxsZXIgb25lcywgcmVsZWFzaW5nIGVuZXJneSBhcyB0aGUgY292YWxlbnQgYm9uZHMp' +
+  'IFRqClQqCihiZXR3ZWVuIGF0b21zIGFyZSByZWFycmFuZ2VkLiBHbHljb2x5c2lzIGlzIGEg' +
+  'bWV0YWJvbGljIHBhdGh3YXkgdGhhdCBvY2N1cnMpIFRqClQqCihpbiB0aGUgY3l0b3BsYXNt' +
+  'LCBjb252ZXJ0aW5nIGEgbW9sZWN1bGUgb2YgZ2x1Y29zZSBpbnRvIHR3byBtb2xlY3VsZXMg' +
+  'b2YpIFRqClQqCihweXJ1dmF0ZSB3aGlsZSBwcm9kdWNpbmcgYSBzbWFsbCBuZXQgeWllbGQg' +
+  'b2YgQVRQIGFuZCB0aGUgZWxlY3Ryb24gY2FycmllcikgVGoKVCoKKE5BREguIFRoZSBweXJ1' +
+  'dmF0ZSBpcyB0aGVuIHRyYW5zcG9ydGVkIGludG8gdGhlIG1pdG9jaG9uZHJpYSwgd2hlcmUg' +
+  'aXQgaXMpIFRqClQqCihveGlkaXplZCBhbmQgY29tYmluZWQgd2l0aCBjb2VuenltZSBBIHRv' +
+  'IGZvcm0gYWNldHlsIGNvZW56eW1lIEEuIFRoZSBjaXRyaWMpIFRqClQqCihhY2lkIGN5Y2xl' +
+  'LCBhbHNvIGNhbGxlZCB0aGUgS3JlYnMgY3ljbGUsIG94aWRpemVzIGFjZXR5bC1Db0EgYW5k' +
+  'IHRyYW5zZmVycykgVGoKVCoKKGhpZ2gtZW5lcmd5IGVsZWN0cm9ucyB0byB0aGUgY2Fycmll' +
+  'cnMgTkFESCBhbmQgRkFESDIgd2hpbGUgcmVsZWFzaW5nIGNhcmJvbikgVGoKVCoKKGRpb3hp' +
+  'ZGUgYXMgYSBieXByb2R1Y3QuIE94aWRhdGl2ZSBwaG9zcGhvcnlsYXRpb24gdGhlbiB1c2Vz' +
+  'IHRoZSBlbGVjdHJvbikgVGoKVCoKKHRyYW5zcG9ydCBjaGFpbiBlbWJlZGRlZCBpbiB0aGUg' +
+  'aW5uZXIgbWl0b2Nob25kcmlhbCBtZW1icmFuZSB0byBwdW1wIHByb3RvbnMpIFRqClQqCiha' +
+  'Y3Jvc3MgaXQgYW5kIGVzdGFibGlzaCBhbiBlbGVjdHJvY2hlbWljYWwgZ3JhZGllbnQga25v' +
+  'd24gYXMgdGhlIHByb3RvbikgVGoKVCoKKG1vdGl2ZSBmb3JjZS4gVGhlIGVsZWN0cm9uIHRy' +
+  'YW5zcG9ydCBjaGFpbiBpcyBidWlsdCBmcm9tIGZvdXIgbGFyZ2UgcHJvdGVpbikgVGoKVCoK' +
+  'KGNvbXBsZXhlcywgbGFiZWxlZCBjb21wbGV4IG9uZSB0aHJvdWdoIGNvbXBsZXggZm91ciwg' +
+  'YWxvbmcgd2l0aCB0aGUgbW9iaWxlKSBUagpUKgooY2FycmllcnMgdWJpcXVpbm9uZSBhbmQg' +
+  'Y3l0b2Nocm9tZSBjIHRoYXQgZmVycnkgZWxlY3Ryb25zIGJldHdlZW4gdGhlbS4gQXMpIFRq' +
+  'ClQqCihlbGVjdHJvbnMgcGFzcyBkb3duIHRoZSBjaGFpbiB0b3dhcmQgb3h5Z2VuLCB0aGUg' +
+  'Y29tcGxleGVzIHB1bXAgaHlkcm9nZW4pIFRqClQqCihpb25zIGZyb20gdGhlIG1pdG9jaG9u' +
+  'ZHJpYWwgbWF0cml4IGludG8gdGhlIGludGVybWVtYnJhbmUgc3BhY2UsIHN0b3JpbmcpIFRq' +
+  'ClQqCihwb3RlbnRpYWwgZW5lcmd5IGluIHRoZSBncmFkaWVudC4gQVRQIHN5bnRoYXNlIGhh' +
+  'cm5lc3NlcyB0aGF0IGdyYWRpZW50KSBUagpUKgoodGhyb3VnaCBjaGVtaW9zbW9zaXMgdG8g' +
+  'cGhvc3Bob3J5bGF0ZSBBRFAgaW50byBBVFAsIHRoZSBwcmltYXJ5IGVuZXJneSkgVGoKVCoK' +
+  'KGN1cnJlbmN5IG9mIHRoZSBjZWxsLiBPeHlnZW4gc2VydmVzIGFzIHRoZSBmaW5hbCBlbGVj' +
+  'dHJvbiBhY2NlcHRvciwpIFRqClQqCihjb21iaW5pbmcgd2l0aCBzcGVudCBlbGVjdHJvbnMg' +
+  'YW5kIHByb3RvbnMgdG8gZm9ybSB3YXRlciBhdCB0aGUgZW5kIG9mIHRoZSkgVGoKVCoKKGNo' +
+  'YWluLiBBZXJvYmljIHJlc3BpcmF0aW9uIG9mIGEgc2luZ2xlIGdsdWNvc2UgbW9sZWN1bGUg' +
+  'Y2FuIHlpZWxkIHJvdWdobHkpIFRqClQqCih0aGlydHkgdG8gdGhpcnR5LWVpZ2h0IG1vbGVj' +
+  'dWxlcyBvZiBBVFAgYWNyb3NzIGFsbCBvZiB0aGVzZSBzdGFnZXMuIEluIHRoZSkgVGoKVCoK' +
+  'KGFic2VuY2Ugb2Ygb3h5Z2VuLCBtYW55IGNlbGxzIGZhbGwgYmFjayBvbiBmZXJtZW50YXRp' +
+  'b24sIGFuIGFuYWVyb2JpYykgVGoKVCoKKHBhdGh3YXkgdGhhdCByZWdlbmVyYXRlcyB0aGUg' +
+  'Y2FycmllcnMgZ2x5Y29seXNpcyByZXF1aXJlcy4gSW4gaHVtYW4gbXVzY2xlKSBUagpUKgoo' +
+  'Y2VsbHMgZmVybWVudGF0aW9uIHByb2R1Y2VzIGxhY3RpYyBhY2lkLCB3aGlsZSBpbiB5ZWFz' +
+  'dCBpdCBwcm9kdWNlcyBldGhhbm9sKSBUagpUKgooYW5kIGNhcmJvbiBkaW94aWRlLCB0aG91' +
+  'Z2ggYm90aCByb3V0ZXMgeWllbGQgZmFyIGxlc3MgdXNhYmxlIGVuZXJneSBwZXIpIFRqClQq' +
+  'Cihtb2xlY3VsZSBvZiBnbHVjb3NlIHRoYW4gYWVyb2JpYyByZXNwaXJhdGlvbiBwcm92aWRl' +
+  'cyB0byB0aGUgb3JnYW5pc20uKSBUagpFVAplbmRzdHJlYW0KZW5kb2JqCjUgMCBvYmoKPDwg' +
+  'L1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVu' +
+  'ZG9iagp4cmVmCjAgNgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAK' +
+  'MDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAwIG4gCjAwMDAwMDAyNDEgMDAw' +
+  'MDAgbiAKMDAwMDAwMjg1MSAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDYgL1Jvb3QgMSAw' +
+  'IFIgPj4Kc3RhcnR4cmVmCjI5MjEKJSVFT0Y=';
+
 // Names + storageUris are stable so a re-run sees the same KB shape.
 //
 // The two text documents are `text/plain` (NOT `text/markdown`): the
@@ -79,8 +154,8 @@ const PDF_FIXTURE_BASE64 =
 // manual-highlight / manual-reference / comment / hover-beckon specs
 // have text to select.
 //
-// The PDF is listed FIRST so it is created first → oldest → sorts last
-// in Discover (see the module doc); the text specs' `.first()` card
+// The two PDFs are listed FIRST so they are created first → oldest → sort
+// last in Discover (see the module doc); the text specs' `.first()` card
 // stays a text resource.
 const SEED_RESOURCES: readonly SeedSpec[] = [
   {
@@ -89,6 +164,13 @@ const SEED_RESOURCES: readonly SeedSpec[] = [
     format: 'application/pdf',
     language: 'en',
     bytes: Buffer.from(PDF_FIXTURE_BASE64, 'base64'),
+  },
+  {
+    name: 'Cellular Respiration PDF',
+    storageUri: 'file://e2e/seed-cellular.pdf',
+    format: 'application/pdf',
+    language: 'en',
+    bytes: Buffer.from(TEXT_PDF_FIXTURE_BASE64, 'base64'),
   },
   {
     name: 'Quantum Computing Primer',

--- a/tests/e2e/specs/20-pdf-assisted-detection.spec.ts
+++ b/tests/e2e/specs/20-pdf-assisted-detection.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from '../fixtures/auth';
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Smoke test: AI-assisted (AI-directed) detection on a **text-layer PDF**
+ * (#736 Phase 2 + #737 Phase 3).
+ *
+ * User-directed PDF annotation already round-trips (14-pdf-render.spec.ts).
+ * This proves the *AI-directed* detection pipeline runs end-to-end on a PDF —
+ * the worker extracts the PDF's text layer (`prepareDetection` →
+ * `extractPdfTextLayer`), the model detects spans over that text, and the
+ * shared geometry tail (`buildPdfAnnotation`) anchors each span to PDF
+ * viewrects (FragmentSelector, RFC 3778). Those render on the PDF canvas as
+ * <rect>s in the same SVG overlay 14 asserts on, and survive a reload.
+ *
+ * Two motivations, the two detection body shapes #737 calls out:
+ *   - commenting → a generated TextualBody (density-gated),
+ *   - linking    → an entity-reference body (entity extraction).
+ * Both anchor through `buildPdfAnnotation`, so both surface as <rect>s; the
+ * per-body-shape detail is covered deterministically by the @semiont/jobs unit
+ * suites (prepareDetection fan-out + build-pdf-annotation).
+ *
+ * Seed dependency: `scripts/seed.ts` yields an `application/pdf` resource named
+ * "Cellular Respiration PDF" — a ~346-word Concept-dense text-layer PDF. (The
+ * "Spatial Smoke PDF" is 3 words: enough to render, too thin for detection to
+ * reliably fire.)
+ *
+ * Real-LLM spec (like 06-assisted-reference): each test runs a live inference
+ * round-trip, so it polls for the outcome with generous timeouts and asserts
+ * <rect> *growth* (the KB accumulates across runs), never an absolute count.
+ */
+
+const PDF_CARD = /^open resource:\s*cellular respiration pdf/i;
+const IMG = '.semiont-pdf-annotation-canvas__image';
+const SVG = '.semiont-pdf-annotation-canvas__svg';
+
+async function openPdfInAnnotateMode(page: Page) {
+  await page.goto('/en/know/discover');
+  // `.first()` — the seed accumulates duplicate PDF cards across runs (14's
+  // note); any is an identical fresh fixture. The name filter keeps us off the
+  // "Spatial Smoke PDF".
+  const card = page.getByRole('button', { name: PDF_CARD }).first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await card.click();
+  await expect(page.getByText(/loading resource/i)).toBeHidden({ timeout: 30_000 });
+
+  // Annotate mode mounts PdfAnnotationCanvas; the SVG overlay mounts once the
+  // page <img> + dimensions are measured (see 14-pdf-render).
+  await page.getByRole('button', { name: /^mode$/i }).click();
+  await page.getByRole('menuitem', { name: /^annotate$/i }).click();
+  await expect(page.locator(IMG)).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator(SVG)).toBeVisible({ timeout: 15_000 });
+
+  // Open the right-sidebar Annotations panel so the per-motivation assist
+  // sections are in the DOM.
+  await page.getByRole('button', { name: /^annotations$/i }).click();
+}
+
+// Annotations sub-tabs are icon-only buttons (aria-pressed) in the panel's tab
+// strip; select by emoji, scoped to the strip so it can't collide elsewhere.
+async function selectSubTab(page: Page, emoji: string) {
+  const tab = page.locator('.semiont-unified-panel__tabs').getByRole('button', { name: emoji, exact: true });
+  await expect(tab).toBeVisible({ timeout: 10_000 });
+  if ((await tab.getAttribute('aria-pressed')) !== 'true') await tab.click();
+  await expect(tab).toHaveAttribute('aria-pressed', 'true');
+}
+
+// After a live assist + SSE delivery, the detected annotations anchor to PDF
+// viewrects and render as <rect>s on the canvas — reload and confirm they
+// persist. Mirrors 14's persistence tail.
+async function expectRectsPersist(page: Page, rects: Locator, before: number) {
+  const url = page.url();
+  await page.reload();
+  await expect(page).toHaveURL(url);
+  await expect(page.getByText(/loading resource/i)).toBeHidden({ timeout: 30_000 });
+  await page.getByRole('button', { name: /^mode$/i }).click();
+  await page.getByRole('menuitem', { name: /^annotate$/i }).click();
+  await expect(page.locator(SVG)).toBeVisible({ timeout: 30_000 });
+  await expect.poll(async () => rects.count(), { timeout: 30_000 }).toBeGreaterThan(before);
+}
+
+test.describe('assisted detection on a text-layer PDF', () => {
+  test('assisted commenting on a PDF dispatches, renders rect-anchored annotations, and persists', async ({ signedInPage: page, bus }) => {
+    test.setTimeout(150_000); // includes a real LLM comment round-trip
+
+    await openPdfInAnnotateMode(page);
+    const rects = page.locator(`${SVG} rect`);
+    const rectsBefore = await rects.count();
+
+    // Comments sub-tab (💬) → expand "Annotate Comments".
+    await selectSubTab(page, '💬');
+    const main = page.getByRole('main');
+    const toggle = main.getByRole('button', { name: /annotate comments/i }).first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click();
+
+    // Drop the density cap: the fixture is only ~346 words, so a "N per 2000
+    // words" target rounds toward zero. Unchecked → no density guidance (the
+    // prompt lets the passage decide), so the model comments on what's salient.
+    const densityToggle = page.locator('input[type="checkbox"][data-variant="comment"]');
+    if (await densityToggle.isChecked()) await densityToggle.uncheck();
+
+    bus.clear();
+    const submit = page.locator('button[data-variant="assist"][data-type="comment"]');
+    await expect(submit).toBeEnabled({ timeout: 5_000 });
+    await submit.click();
+
+    // Dispatch — the assist crossed the wire as a comment-annotation job.
+    const { request } = await bus.expectRequestResponse('job:create', 'job:created', 30_000);
+    expect(request.channel).toBe('job:create');
+
+    // Outcome — detected comments anchor to PDF viewrects and render as <rect>s.
+    // Poll for growth (LLM + SSE latency); PRE-#736 this job threw on a PDF.
+    await expect.poll(async () => rects.count(), { timeout: 110_000 }).toBeGreaterThan(rectsBefore);
+
+    await expectRectsPersist(page, rects, rectsBefore);
+  });
+
+  test('assisted linking on a PDF dispatches, renders rect-anchored references, and persists', async ({ signedInPage: page, bus }) => {
+    test.setTimeout(150_000); // includes a real LLM entity-extraction round-trip
+
+    await openPdfInAnnotateMode(page);
+    const rects = page.locator(`${SVG} rect`);
+    const rectsBefore = await rects.count();
+
+    // References sub-tab (🔵) → expand "Annotate References".
+    await selectSubTab(page, '🔵');
+    const main = page.getByRole('main');
+    const toggle = main.getByRole('button', { name: /annotate references/i }).first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click();
+
+    // Select the Concept entity-type chip — the respiration passage is
+    // Concept-dense (glucose, ATP, mitochondria, …), so extraction reliably
+    // yields references. Mirrors 06-assisted-reference's chip flow.
+    const conceptChip = page
+      .locator('.semiont-assist-widget__chips .semiont-chip--selectable')
+      .filter({ hasText: /concept/i });
+    await expect(conceptChip).toBeVisible({ timeout: 10_000 });
+    await conceptChip.click();
+    await expect(conceptChip).toHaveAttribute('data-selected', 'true');
+
+    bus.clear();
+    const submit = page.locator('button[data-variant="assist"][data-type="reference"]');
+    await expect(submit).toBeEnabled({ timeout: 5_000 });
+    await submit.click();
+
+    // Dispatch — the assist crossed the wire as a reference-annotation job
+    // (jobType for `linking`; see namespaces/mark.ts jobTypeMap).
+    const { request } = await bus.expectRequestResponse('job:create', 'job:created', 30_000);
+    expect(request.channel).toBe('job:create');
+
+    // Outcome — detected references anchor to PDF viewrects and render as <rect>s.
+    await expect.poll(async () => rects.count(), { timeout: 110_000 }).toBeGreaterThan(rectsBefore);
+
+    await expectRectsPersist(page, rects, rectsBefore);
+  });
+});


### PR DESCRIPTION
## Description

Runs AI-directed annotation **detection** against text-based PDFs and renders the results as W3C Web Annotations — the next slice of the PDF annotation epic (#351). The codebase already supported *user-directed* PDF annotation; this adds the *AI-directed* path for every motivation.

Phase 2 (#736) is implemented as a **media-type registry refactor** rather than a highlight-only path, which delivers Phase 3 (#737) — the fan-out to the other four motivations — at the same time.

## What changed

- **`prepareDetection(strategy, session, resourceId, userId, generator)`** (`packages/jobs/src/workers/detection/prepare-detection.ts`) — the media axis, keyed on the registry's `textExtractionOf`: `'decode'` → decoded text + `buildTextAnnotation`; `'pdf-text-layer'` → `extractPdfTextLayer` + `buildPdfAnnotation`; returns `null` for a scanned / image-only PDF.
- **All five `processXJob`** (highlighting, commenting, assessing, linking = `processReferenceJob`, tagging) now take a `BuildAnnotation` function (FP-style) instead of `userId`/`generator` — no media-specific arguments on the detection interfaces. A new media type is a new `case` in `prepareDetection`, nothing on the processors (5 + N, not 5 × N).
- **`buildPdfAnnotation`** — the shared geometry tail: one `FragmentSelector` viewrect per line (RFC 3778) + a `TextQuoteSelector`, no `TextPositionSelector` (the extracted layer is derived, not stored), with a geometry↔text containment invariant that throws rather than persist geometry that doesn't back the quoted text.
- **Dispatch** (`packages/jobs/src/worker-process.ts`): text-layer PDFs detect-and-render; scanned PDFs **decline cleanly** (`job:complete` with `{ declined: true, reason: 'no-text-layer' }`); non-textual types throw (surface as `job:fail`).
- **react-ui** — corrected four stale `…and for text resources` comments on the assist sections; assist is `annotateMode`-gated only, not media-gated. (Confirmed there is no media-type gate on the AI-assist path across UI / SDK `dispatchAssist` / backend `job:create`.)

## Testing

- `@semiont/jobs` typecheck + full suite green in a `node:24` container (322 pass / 1 skip) — including a parametrized PDF (`pdf-text-layer`) dispatch fan-out over **all five motivations**, the scanned-PDF clean-decline path, and `buildPdfAnnotation` geometry + body-shape coverage (single-object, array, linking bodies).
- New e2e `tests/e2e/specs/20-pdf-assisted-detection.spec.ts` — **comment + linking** assist on a seeded text-layer PDF, asserting the detected annotations anchor to PDF viewrects, render as `<rect>` on the canvas, and survive a reload (mirrors `06-assisted-reference` + `14-pdf-render`). Adds a validated ~346-word Concept-dense seed PDF ("Cellular Respiration PDF") to `tests/e2e/scripts/seed.ts`, round-tripped through `@semiont/content`'s `extractPdfTextLayer`. Spec typechecks; CI's e2e job runs it.
- **Remaining:** the *live* per-motivation spot-check on a real text PDF — the inherently human confirmation of geometry + body quality.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Areas Changed

- [x] `packages/jobs` (detection processors, `prepareDetection`, dispatch)
- [x] `packages/react-ui` (assist-section comments)
- [x] `tests/e2e` (PDF-assisted-detection spec + seed fixture)

## Security

N/A — no authentication, authorization, or admin changes.

---

Closes #736
Closes #737

Part of #351
