### PR TITLE
reload-fast Browser: cache persistence (B17), KB-scoped tabs, working drag-and-drop upload

### DIFF
--- a/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
+++ b/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
@@ -533,6 +533,63 @@ describe('createActorStateUnit', () => {
     stateUnit.dispose();
   });
 
+  // ── B17 (LOCAL-STORAGE W4): lastEventId across reloads ────────────────
+
+  it('loads a persisted last event id and sends it on the FIRST connect', async () => {
+    mockSSEResponse();
+
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['mark:added'],
+      loadLastEventId: () => 'p-res-1-40',
+    });
+
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    const initOpts = mockFetch.mock.calls[0][1] as { headers: Record<string, string> };
+    expect(initOpts.headers['Last-Event-ID']).toBe('p-res-1-40');
+
+    stateUnit.dispose();
+  });
+
+  it('saves persisted ids as they arrive — and only persisted ids (e-* is live-only context)', async () => {
+    const sse = mockSSEResponse();
+    const saved: string[] = [];
+
+    const stateUnit = createActorStateUnit({
+      baseUrl: 'http://localhost:4000',
+      token: 'tok',
+      channels: ['mark:added'],
+      saveLastEventId: (id) => saved.push(id),
+    });
+
+    stateUnit.start();
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    sse.push(
+      'event: bus-event\nid: p-res-1-47\ndata: ' +
+        JSON.stringify({ channel: 'mark:added', payload: { foo: 'bar' } }) +
+        '\n\n',
+    );
+    sse.push(
+      'event: bus-event\nid: e-mark:added:abc\ndata: ' +
+        JSON.stringify({ channel: 'mark:added', payload: { foo: 'baz' } }) +
+        '\n\n',
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await vi.waitFor(() => expect(saved.length).toBeGreaterThan(0));
+    // An ephemeral id must never be persisted: the server treats it as
+    // "no resumption context", which after a reload would silently skip
+    // the replay that reconciles rehydrated caches.
+    expect(saved).toEqual(['p-res-1-47']);
+
+    stateUnit.dispose();
+  });
+
   it('does not send Last-Event-ID header on the first connect', async () => {
     mockSSEResponse();
 

--- a/packages/http-transport/src/transport/actor-state-unit.ts
+++ b/packages/http-transport/src/transport/actor-state-unit.ts
@@ -23,6 +23,17 @@ export interface ActorStateUnitOptions {
   channels: string[];
   scope?: string;
   reconnectMs?: number;
+  /**
+   * B17 (LOCAL-STORAGE) — IO-abstracted persistence for the last seen
+   * PERSISTED event id, so a reloaded client resumes instead of gapping.
+   * `load` runs once at construction; `save` fires per persisted (`p-*`)
+   * id — ephemeral (`e-*`) ids are never saved: the server treats them as
+   * "no resumption context", which after a reload would silently skip the
+   * replay that reconciles rehydrated caches. The transport stays
+   * storage-free; callers wrap their own adapter in these thunks.
+   */
+  loadLastEventId?: () => string | null;
+  saveLastEventId?: (id: string) => void;
 }
 
 /** Time in the `reconnecting` state before transitioning to `degraded`. */
@@ -152,7 +163,7 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
    * treats ephemeral ids as "no resumption context" and responds live-
    * only; persisted ids drive replay.
    */
-  let lastEventId: string | null = null;
+  let lastEventId: string | null = options.loadLastEventId?.() ?? null;
 
   /**
    * Recently-delivered event ids, to dedup the make-before-break overlap: the
@@ -314,6 +325,8 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
               if (currentId !== undefined) {
                 lastEventId = currentId;
                 rememberEventId(currentId);
+                // B17: persisted ids only — see ActorStateUnitOptions.
+                if (currentId.startsWith('p-')) options.saveLastEventId?.(currentId);
               }
               const parsed = JSON.parse(currentData) as BusEvent;
               busLog('RECV', parsed.channel, parsed.payload, parsed.scope);

--- a/packages/http-transport/src/transport/http-transport.ts
+++ b/packages/http-transport/src/transport/http-transport.ts
@@ -117,6 +117,12 @@ export interface HttpTransportConfig {
   logger?: Logger;
   /** Optional 401-recovery hook. See {@link TokenRefresher}. */
   tokenRefresher?: TokenRefresher;
+  /**
+   * B17 — persistence thunks for the last seen persisted SSE id, passed
+   * through to the actor state unit. See {@link ActorStateUnitOptions}.
+   */
+  loadLastEventId?: () => string | null;
+  saveLastEventId?: (id: string) => void;
 }
 
 export class HttpTransport implements ITransport, IBackendOperations {
@@ -145,8 +151,11 @@ export class HttpTransport implements ITransport, IBackendOperations {
   /** Buses we've been asked to bridge wire events into. */
   private readonly bridges: EventBus[] = [];
 
+  private readonly config: HttpTransportConfig;
+
   constructor(config: HttpTransportConfig) {
     const { baseUrl, timeout = 30000, retry = 2, logger, tokenRefresher } = config;
+    this.config = config;
 
     this.baseUrl = (baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl) as BaseUrl;
     this.token$ = config.token$ ?? new BehaviorSubject<AccessToken | null>(null);
@@ -262,6 +271,8 @@ export class HttpTransport implements ITransport, IBackendOperations {
         baseUrl: this.baseUrl,
         token: () => this.token$.getValue() ?? '',
         channels: [...BRIDGED_CHANNELS],
+        ...(this.config.loadLastEventId ? { loadLastEventId: this.config.loadLastEventId } : {}),
+        ...(this.config.saveLastEventId ? { saveLastEventId: this.config.saveLastEventId } : {}),
       });
       for (const channel of BRIDGED_CHANNELS) {
         this._actor.on$<Record<string, unknown>>(channel).subscribe((payload) => {

--- a/packages/react-ui/src/features/resource-compose/__tests__/ResourceComposePage.test.tsx
+++ b/packages/react-ui/src/features/resource-compose/__tests__/ResourceComposePage.test.tsx
@@ -311,6 +311,36 @@ describe('ResourceComposePage', () => {
 
       expect(screen.getByText('Drop file or click')).toBeInTheDocument();
     });
+
+    // The dropzone copy says "Drop file or click" — the drop half was never
+    // wired (the input is display:none, so native input drops can't land
+    // either): Chrome handled the drop by navigating to the file.
+    it('cancels dragover on the dropzone so the browser never takes the drop', () => {
+      const props = createMockProps();
+      const { container } = renderWithProviders(<ResourceComposePage {...props} />);
+
+      fireEvent.click(screen.getByText('Upload File').closest('button')!);
+      const dropzone = container.querySelector('.semiont-form__upload-dropzone')!;
+
+      // fireEvent returns false when the event was preventDefault-ed.
+      expect(fireEvent.dragOver(dropzone, { dataTransfer: { files: [] } })).toBe(false);
+    });
+
+    it('applies a dropped file: name shown, resource name defaulted', async () => {
+      const props = createMockProps();
+      const { container } = renderWithProviders(<ResourceComposePage {...props} />);
+
+      fireEvent.click(screen.getByText('Upload File').closest('button')!);
+      const dropzone = container.querySelector('.semiont-form__upload-dropzone')!;
+
+      const file = new File(['# notes'], 'field-notes.md', { type: 'text/markdown' });
+      fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText('field-notes.md')).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText('Resource Name')).toHaveValue('field-notes');
+    });
   });
 
   describe('Form Submission', () => {

--- a/packages/react-ui/src/features/resource-compose/components/ResourceComposePage.tsx
+++ b/packages/react-ui/src/features/resource-compose/components/ResourceComposePage.tsx
@@ -159,6 +159,7 @@ export function ResourceComposePage({
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [fileMimeType, setFileMimeType] = useState<string>('text/markdown');
   const [filePreviewUrl, setFilePreviewUrl] = useState<string | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   // Format selection for manual content entry
   const [selectedFormat, setSelectedFormat] = useState<string>('text/markdown');
@@ -192,7 +193,13 @@ export function ResourceComposePage({
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    applyUploadedFile(file);
+  };
 
+  // One application path for both entries into the dropzone: the file-input
+  // change (click) and a real drag-and-drop (the input is display:none, so
+  // native input drops can never land — the label owns the drop).
+  const applyUploadedFile = (file: File) => {
     const detectedMediaType = detectUploadMediaType(file);
     setUploadedFile(file);
     setFileMimeType(detectedMediaType);
@@ -548,7 +555,18 @@ export function ResourceComposePage({
             <div className="semiont-form__upload-section">
               <div>
                 <div className="semiont-form__upload-container">
-                  <label className="semiont-form__upload-dropzone">
+                  <label
+                    className="semiont-form__upload-dropzone"
+                    data-drag-over={isDragOver ? 'true' : 'false'}
+                    onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+                    onDragLeave={() => setIsDragOver(false)}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      setIsDragOver(false);
+                      const file = e.dataTransfer.files?.[0];
+                      if (file && !isCreating) applyUploadedFile(file);
+                    }}
+                  >
                     <div className="semiont-form__upload-area">
                       <input
                         type="file"

--- a/packages/react-ui/src/styles/features/compose.css
+++ b/packages/react-ui/src/styles/features/compose.css
@@ -114,6 +114,13 @@
   display: none;
 }
 
+/* The label owns drag-and-drop (the input above can't receive native drops);
+   highlight while a drag hovers. */
+.semiont-form__upload-dropzone[data-drag-over="true"] {
+  border-color: var(--semiont-color-primary-500);
+  background: var(--semiont-color-primary-50, rgba(59, 130, 246, 0.06));
+}
+
 .semiont-form__upload-text {
   font-size: 0.875rem;
   color: var(--semiont-color-gray-600);

--- a/packages/sdk/docs/CACHE-SEMANTICS.md
+++ b/packages/sdk/docs/CACHE-SEMANTICS.md
@@ -517,7 +517,12 @@ cache durable, per-KB rehydration (.plans/LOCAL-STORAGE.md):
    the persisted `Last-Event-ID` (persisted `p-*` ids only — an ephemeral
    `e-*` id means "no resumption context" server-side and is never saved),
    replayed events invalidate through the normal handlers, and
-   `bus:resume-gap` blanket-invalidates as always.
+   `bus:resume-gap` blanket-invalidates as always. The persisted id is
+   COUPLED to the cache flush (`coupledLastEventId`): stashed per event,
+   written only alongside a cache-document write (document first, id
+   second) — so the bookmark may lag the persisted caches (harmless:
+   replay re-invalidates idempotently) but can never lead them and
+   silently skip a reconciling event.
 3. **Settled values only.** The store never contains B15 failure markers,
    so neither does the persisted document; a previously-failed key
    rehydrates as absent and refetches on first observation.

--- a/packages/sdk/docs/CACHE-SEMANTICS.md
+++ b/packages/sdk/docs/CACHE-SEMANTICS.md
@@ -501,6 +501,36 @@ new behavior here must be accompanied by a new test case referencing
 its number (`// B7 — invalidate preserves stale value`). Removing or
 changing a behavior must update both this doc and the test.
 
+
+### B17 — Persistence is opt-in rehydration, reconciled by resumption
+
+An optional `CachePersister` on `createCache` (and the
+`sessionStoragePersister` adapter over the `SessionStorage` seam) gives a
+cache durable, per-KB rehydration (.plans/LOCAL-STORAGE.md):
+
+1. **Load-on-construct.** `persister.load()` seeds the store before the
+   first observation. A rehydrated key serves synchronously and issues NO
+   fetch — protocol behavior is indistinguishable from a warm in-memory
+   cache.
+2. **Rehydrated data is stale-until-reconciled.** Correctness comes from
+   the existing contract, not new machinery: the transport reconnects with
+   the persisted `Last-Event-ID` (persisted `p-*` ids only — an ephemeral
+   `e-*` id means "no resumption context" server-side and is never saved),
+   replayed events invalidate through the normal handlers, and
+   `bus:resume-gap` blanket-invalidates as always.
+3. **Settled values only.** The store never contains B15 failure markers,
+   so neither does the persisted document; a previously-failed key
+   rehydrates as absent and refetches on first observation.
+4. **Saves are debounced** (default 50 ms) and **`dispose()` flushes a
+   pending save synchronously before going inert** — the flush is part of
+   the disposal act, so a KB switch cannot lose the last write; nothing
+   may save after disposal (B16 extends to the persister).
+5. **Version-gated.** A stored document whose version doesn't match (or
+   that fails to parse) reads as empty — never an error into the cache.
+6. **Cross-context sync** rides the persister's `subscribe` (the
+   `SessionStorage.subscribe` seam): an external write replaces the store;
+   last writer wins.
+
 ## Revision log
 
 - 2026-04-19 — initial spec, written as part of CACHE-LIBRARY.md
@@ -516,3 +546,7 @@ changing a behavior must update both this doc and the test.
   (stale-beats-error requires a stale value). Driven by the
   LIVENESS-AXIOMS P2 property suite falsifying L1/L2 against the real
   composition (valueless-key-terminal-failure-starves-observers.md).
+- 2026-07-21 — B17 added (opt-in persistence: load-on-construct
+  rehydration reconciled by resumption; values-only; flush-then-inert
+  dispose; version-gated; cross-context via the SessionStorage seam).
+  Execution record in .plans/LOCAL-STORAGE.md.

--- a/packages/sdk/docs/DEVELOPER-GUIDE.md
+++ b/packages/sdk/docs/DEVELOPER-GUIDE.md
@@ -485,6 +485,44 @@ surface) and the same logic serves a browser app, a Node daemon, and a one-shot 
 
 ---
 
+## Cache persistence across reloads (B17)
+
+Sessions built through `createHttpSessionFactory` persist their read caches through the
+same `SessionStorage` adapter the session layer already uses — so a reloaded client
+renders **last-seen data immediately** and reconciles in the background instead of
+cold-starting every request. In the browser this is on by default (the react-ui
+`SemiontProvider` supplies `WebBrowserStorage`); a desktop or Node host gets it by
+supplying its own `SessionStorage` — no other wiring.
+
+What persists, per KB:
+- Five browse caches — resource descriptors, annotation lists, annotation details,
+  entity types, tag schemas — under `semiont.cache.<kbId>.<name>`. Lists, event
+  histories, and the collaborator directory deliberately stay in-memory.
+- The last **persisted** SSE event id (`semiont.lastEventId.<kbId>`). Ephemeral
+  (`e-*`) ids are never saved — the server treats them as "no resumption context,"
+  which would silently skip the replay that reconciles rehydrated data.
+
+How reconciliation works — there is no reconcile code path, only the existing
+contract: rehydrated entries serve synchronously with **no fetch**; the SSE
+reconnect sends the persisted `Last-Event-ID`; replayed events flow through the
+normal handlers and invalidate exactly what changed (stale value stays visible
+while the refetch runs); `bus:resume-gap` blanket-invalidates when replay can't
+cover. Failure states are never persisted, saves are debounced with a flush on
+dispose, and stored documents are version-gated (mismatch reads as empty).
+
+Constructing a client directly (no factory)? Opt in explicitly:
+
+```ts
+const client = new SemiontClient(transport, content, backend, {
+  cachePersistence: { storage, keyPrefix: kbId },
+});
+```
+
+Full behavioral contract: [CACHE-SEMANTICS.md](CACHE-SEMANTICS.md) **B17** (and the
+design record in `.plans/LOCAL-STORAGE.md`).
+
+---
+
 ## Where to go deeper
 
 - **[Usage.md](./Usage.md)** — the per-namespace reference: every method, every option.

--- a/packages/sdk/docs/DEVELOPER-GUIDE.md
+++ b/packages/sdk/docs/DEVELOPER-GUIDE.md
@@ -498,9 +498,11 @@ What persists, per KB:
 - Five browse caches — resource descriptors, annotation lists, annotation details,
   entity types, tag schemas — under `semiont.cache.<kbId>.<name>`. Lists, event
   histories, and the collaborator directory deliberately stay in-memory.
-- The last **persisted** SSE event id (`semiont.lastEventId.<kbId>`). Ephemeral
-  (`e-*`) ids are never saved — the server treats them as "no resumption context,"
-  which would silently skip the replay that reconciles rehydrated data.
+- The last **persisted** SSE event id (`semiont.lastEventId.<kbId>`), written
+  only alongside cache-document flushes so the bookmark can never claim more
+  than the caches contain. Ephemeral (`e-*`) ids are never saved — the server
+  treats them as "no resumption context," which would silently skip the replay
+  that reconciles rehydrated data.
 
 How reconciliation works — there is no reconcile code path, only the existing
 contract: rehydrated entries serve synchronously with **no fetch**; the SSE

--- a/packages/sdk/src/__tests__/cache-persistence.test.ts
+++ b/packages/sdk/src/__tests__/cache-persistence.test.ts
@@ -127,6 +127,27 @@ describe('cache persistence (B17)', () => {
     expect(persister.save).not.toHaveBeenCalled();
   });
 
+  it('an external change is applied but never echoed back as a save (no cross-tab ping-pong)', () => {
+    const { persister, pushExternal } = spyPersister<string, string>();
+    const cache = createCache<string, string>(async () => 'x', { persister });
+
+    pushExternal(new Map([['k', 'from-other-tab']]));
+    expect(cache.get('k')).toBe('from-other-tab');
+
+    // The other tab's save always re-stamps writtenAt, so an echoed save
+    // would differ byte-wise and re-fire its storage event: A saves → B
+    // echoes → A echoes → … . Applying without echoing breaks the loop.
+    vi.advanceTimersByTime(200);
+    expect(persister.save).not.toHaveBeenCalled();
+
+    // A real local mutation afterwards still saves normally.
+    cache.set('k2', 'local');
+    vi.advanceTimersByTime(50);
+    expect(persister.save).toHaveBeenCalledTimes(1);
+
+    cache.dispose();
+  });
+
   it('a throwing save is best-effort: neither the debounced path nor the dispose flush breaks', () => {
     const { persister } = spyPersister<string, string>();
     vi.mocked(persister.save).mockImplementation(() => {

--- a/packages/sdk/src/__tests__/cache-persistence.test.ts
+++ b/packages/sdk/src/__tests__/cache-persistence.test.ts
@@ -1,0 +1,136 @@
+/**
+ * B17 (LOCAL-STORAGE W1) — the persister hook on the cache primitive.
+ *
+ * Contract under test:
+ *  - load-on-construct: rehydrated entries are visible synchronously and an
+ *    observe() of a rehydrated key issues NO fetch (the protocol-silence pin).
+ *  - save-on-mutation: debounced (default 50 ms); bursts coalesce to one save.
+ *  - external change (cross-context): replaces the store; observers see it.
+ *  - dispose: flushes a pending save synchronously, then goes inert (B16) —
+ *    no save and no external-change application after disposal.
+ *  - B15 interaction: failure markers are never persisted — a key that
+ *    exhausts its retries mutates nothing, so nothing is saved.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { firstValueFrom, filter, take } from 'rxjs';
+import { createCache, type CachePersister } from '../cache';
+
+function spyPersister<K, V>(initial: Map<K, V> | null = null) {
+  const external: Array<(entries: Map<K, V>) => void> = [];
+  const persister: CachePersister<K, V> = {
+    load: vi.fn(() => initial),
+    save: vi.fn(),
+    subscribe: vi.fn((onExternalChange: (entries: Map<K, V>) => void) => {
+      external.push(onExternalChange);
+      return () => {
+        const i = external.indexOf(onExternalChange);
+        if (i >= 0) external.splice(i, 1);
+      };
+    }),
+  };
+  return { persister, pushExternal: (entries: Map<K, V>) => external.forEach((h) => h(entries)) };
+}
+
+describe('cache persistence (B17)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rehydrates on construction: value visible synchronously, NO fetch issued', async () => {
+    const fetchFn = vi.fn(async () => 'fetched');
+    const { persister } = spyPersister<string, string>(new Map([['k1', 'rehydrated']]));
+
+    const cache = createCache<string, string>(fetchFn, { persister });
+
+    expect(persister.load).toHaveBeenCalledTimes(1);
+    expect(cache.get('k1')).toBe('rehydrated');
+
+    const seen = await firstValueFrom(cache.observe('k1').pipe(filter((v) => v !== undefined), take(1)));
+    expect(seen).toBe('rehydrated');
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    cache.dispose();
+  });
+
+  it('saves on mutation, debounced — a burst coalesces into one save', () => {
+    const { persister } = spyPersister<string, string>();
+    const cache = createCache<string, string>(async () => 'x', { persister });
+
+    cache.set('a', '1');
+    cache.set('b', '2');
+    cache.set('a', '3');
+    expect(persister.save).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+    expect(persister.save).toHaveBeenCalledTimes(1);
+    const saved = vi.mocked(persister.save).mock.calls[0]![0];
+    expect(saved.get('a')).toBe('3');
+    expect(saved.get('b')).toBe('2');
+
+    cache.dispose();
+  });
+
+  it('applies an external change: observers and snapshots see the replacement', async () => {
+    const { persister, pushExternal } = spyPersister<string, string>(new Map([['k', 'old']]));
+    const cache = createCache<string, string>(async () => 'x', { persister });
+
+    pushExternal(new Map([['k', 'from-other-tab']]));
+
+    expect(cache.get('k')).toBe('from-other-tab');
+    const seen = await firstValueFrom(cache.observe('k').pipe(filter((v) => v === 'from-other-tab'), take(1)));
+    expect(seen).toBe('from-other-tab');
+
+    cache.dispose();
+  });
+
+  it('dispose flushes the pending save synchronously, then is inert', () => {
+    const { persister, pushExternal } = spyPersister<string, string>();
+    const cache = createCache<string, string>(async () => 'x', { persister });
+
+    cache.set('a', '1');
+    expect(persister.save).not.toHaveBeenCalled();
+
+    cache.dispose();
+    // The flush is part of disposal itself — the KB-switch teardown must not
+    // lose the last write.
+    expect(persister.save).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(persister.save).mock.calls[0]![0].get('a')).toBe('1');
+
+    // Inert afterwards: no further saves, external changes ignored.
+    vi.advanceTimersByTime(200);
+    expect(persister.save).toHaveBeenCalledTimes(1);
+    pushExternal(new Map([['b', '2']]));
+    expect(cache.get('b')).toBeUndefined();
+  });
+
+  it('never persists failure state: an exhausted key saves nothing', async () => {
+    const fetchFn = vi.fn(async () => { throw new Error('down'); });
+    const { persister } = spyPersister<string, string>();
+    const cache = createCache<string, string>(fetchFn, { persister });
+
+    const errored = new Promise<Error>((resolve) => {
+      cache.observe('k').subscribe({ error: (e: Error) => resolve(e) });
+    });
+    // Drive the B14 attempt + retry to exhaustion under fake timers.
+    await vi.runAllTimersAsync();
+    await errored;
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(persister.save).not.toHaveBeenCalled();
+
+    cache.dispose();
+    // Nothing was ever mutated, so even the dispose flush has nothing pending.
+    expect(persister.save).not.toHaveBeenCalled();
+  });
+
+  it('without options, behavior is unchanged (no persister calls anywhere)', async () => {
+    const cache = createCache<string, string>(async () => 'v');
+    cache.set('a', '1');
+    expect(cache.get('a')).toBe('1');
+    cache.dispose();
+  });
+});

--- a/packages/sdk/src/__tests__/cache-persistence.test.ts
+++ b/packages/sdk/src/__tests__/cache-persistence.test.ts
@@ -127,6 +127,23 @@ describe('cache persistence (B17)', () => {
     expect(persister.save).not.toHaveBeenCalled();
   });
 
+  it('a throwing save is best-effort: neither the debounced path nor the dispose flush breaks', () => {
+    const { persister } = spyPersister<string, string>();
+    vi.mocked(persister.save).mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    const cache = createCache<string, string>(async () => 'x', { persister });
+
+    cache.set('a', '1');
+    // Debounced save fires and throws inside its timer — must not propagate.
+    expect(() => vi.advanceTimersByTime(50)).not.toThrow();
+    expect(cache.get('a')).toBe('1');
+
+    cache.set('b', '2');
+    // Dispose flush hits the throwing save — teardown must still complete.
+    expect(() => cache.dispose()).not.toThrow();
+  });
+
   it('without options, behavior is unchanged (no persister calls anywhere)', async () => {
     const cache = createCache<string, string>(async () => 'v');
     cache.set('a', '1');

--- a/packages/sdk/src/__tests__/cache-persister.test.ts
+++ b/packages/sdk/src/__tests__/cache-persister.test.ts
@@ -1,0 +1,109 @@
+/**
+ * B17 (LOCAL-STORAGE W2) — the SessionStorage-backed persister adapter.
+ *
+ * Contract under test: round-trip through a storage adapter; version
+ * mismatch and parse garbage read as "nothing stored" (never throw);
+ * byte cap evicts oldest-written entries first; cross-context subscribe
+ * delegates through the storage's own subscription seam.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sessionStoragePersister } from '../cache-persister';
+import { TestStorage } from '../session/__tests__/test-storage-helpers';
+
+const KEY = 'semiont.cache.kb-1.resource';
+
+describe('sessionStoragePersister (B17)', () => {
+  let storage: TestStorage;
+
+  beforeEach(() => {
+    storage = new TestStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('round-trips a map through the storage adapter', () => {
+    const writer = sessionStoragePersister<string, { name: string }>({ storage, storageKey: KEY, version: 1 });
+    writer.save(new Map([['r1', { name: 'One' }], ['r2', { name: 'Two' }]]));
+
+    const reader = sessionStoragePersister<string, { name: string }>({ storage, storageKey: KEY, version: 1 });
+    const loaded = reader.load();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.get('r1')).toEqual({ name: 'One' });
+    expect(loaded!.get('r2')).toEqual({ name: 'Two' });
+  });
+
+  it('reads as empty on version mismatch', () => {
+    sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 1 })
+      .save(new Map([['r1', 'v']]));
+
+    const v2 = sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 2 });
+    expect(v2.load()).toBeNull();
+  });
+
+  it('reads as empty on parse garbage — never throws', () => {
+    storage.set(KEY, '{not json');
+    const persister = sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 1 });
+    expect(persister.load()).toBeNull();
+  });
+
+  it('evicts oldest-written entries first when over the byte cap', () => {
+    const persister = sessionStoragePersister<string, string>({
+      storage,
+      storageKey: KEY,
+      version: 1,
+      // Small enough that three entries with 100-char values cannot all fit.
+      maxBytes: 300,
+    });
+
+    persister.save(new Map([['old', 'x'.repeat(100)]]));
+    vi.setSystemTime(2_000_000);
+    persister.save(new Map([['old', 'x'.repeat(100)], ['mid', 'y'.repeat(100)]]));
+    vi.setSystemTime(3_000_000);
+    persister.save(new Map([['old', 'x'.repeat(100)], ['mid', 'y'.repeat(100)], ['new', 'z'.repeat(100)]]));
+
+    const loaded = sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 1 }).load();
+    expect(loaded).not.toBeNull();
+    // 'old' carries the earliest write stamp — evicted first.
+    expect(loaded!.has('old')).toBe(false);
+    expect(loaded!.has('new')).toBe(true);
+  });
+
+  it('delegates cross-context sync through storage.subscribe', () => {
+    const persister = sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 1 });
+    const onExternalChange = vi.fn();
+    persister.subscribe!(onExternalChange);
+
+    // Another context writes the same key.
+    const other = sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 1 });
+    other.save(new Map([['r1', 'from-elsewhere']]));
+    storage.dispatch(KEY, storage.get(KEY));
+
+    expect(onExternalChange).toHaveBeenCalledTimes(1);
+    const received = onExternalChange.mock.calls[0]![0] as Map<string, string>;
+    expect(received.get('r1')).toBe('from-elsewhere');
+
+    // Unrelated keys and version-mismatched payloads are ignored.
+    storage.dispatch('some.other.key', '{}');
+    storage.dispatch(KEY, JSON.stringify({ version: 99, writtenAt: 1, entries: [] }));
+    expect(onExternalChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports key transformers for non-string keys', () => {
+    const opts = {
+      storage,
+      storageKey: KEY,
+      version: 1,
+      keyToJson: (k: number) => String(k),
+      jsonToKey: (j: unknown) => Number(j),
+    };
+    sessionStoragePersister<number, string>(opts).save(new Map([[42, 'answer']]));
+
+    const loaded = sessionStoragePersister<number, string>(opts).load();
+    expect(loaded!.get(42)).toBe('answer');
+  });
+});

--- a/packages/sdk/src/__tests__/cache-persister.test.ts
+++ b/packages/sdk/src/__tests__/cache-persister.test.ts
@@ -74,6 +74,26 @@ describe('sessionStoragePersister (B17)', () => {
     expect(loaded!.has('new')).toBe(true);
   });
 
+  it('measures the byte cap in bytes, not UTF-16 code units', () => {
+    // '€' is 1 code unit but 3 UTF-8 bytes: 60 units ≈ 180 bytes per value.
+    // A cap that passes on code-unit length must still evict on real bytes.
+    const persister = sessionStoragePersister<string, string>({
+      storage,
+      storageKey: KEY,
+      version: 1,
+      maxBytes: 400,
+    });
+
+    persister.save(new Map([['old', '€'.repeat(60)]]));
+    vi.setSystemTime(2_000_000);
+    persister.save(new Map([['old', '€'.repeat(60)], ['new', '€'.repeat(60)]]));
+
+    const loaded = sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 1 }).load();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.has('old')).toBe(false);
+    expect(loaded!.has('new')).toBe(true);
+  });
+
   it('delegates cross-context sync through storage.subscribe', () => {
     const persister = sessionStoragePersister<string, string>({ storage, storageKey: KEY, version: 1 });
     const onExternalChange = vi.fn();

--- a/packages/sdk/src/__tests__/cache-persister.test.ts
+++ b/packages/sdk/src/__tests__/cache-persister.test.ts
@@ -7,7 +7,8 @@
  * delegates through the storage's own subscription seam.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { sessionStoragePersister } from '../cache-persister';
+import { coupledLastEventId, sessionStoragePersister } from '../cache-persister';
+import type { SessionStorage } from '../session/session-storage';
 import { TestStorage } from '../session/__tests__/test-storage-helpers';
 
 const KEY = 'semiont.cache.kb-1.resource';
@@ -105,5 +106,72 @@ describe('sessionStoragePersister (B17)', () => {
 
     const loaded = sessionStoragePersister<number, string>(opts).load();
     expect(loaded!.get(42)).toBe('answer');
+  });
+});
+
+describe('coupledLastEventId (B17 — the bookmark rides the cache flush)', () => {
+  const ID_KEY = 'semiont.lastEventId.kb-1';
+
+  function recordingStorage() {
+    const writes: Array<[string, string]> = [];
+    const inner = new TestStorage();
+    const storage: SessionStorage = {
+      get: (k) => inner.get(k),
+      set: (k, v) => { writes.push([k, v]); inner.set(k, v); },
+      delete: (k) => inner.delete(k),
+    };
+    return { storage, writes, inner };
+  }
+
+  it('saveLastEventId alone writes nothing — the id must never lead the caches', () => {
+    const { storage, writes } = recordingStorage();
+    const coupled = coupledLastEventId(storage, ID_KEY);
+
+    coupled.saveLastEventId('p-res-1-47');
+
+    expect(writes).toHaveLength(0);
+    expect(storage.get(ID_KEY)).toBeNull();
+  });
+
+  it('a cache-document write flushes the pending id — document first, id second', () => {
+    const { storage, writes } = recordingStorage();
+    const coupled = coupledLastEventId(storage, ID_KEY);
+
+    coupled.saveLastEventId('p-res-1-47');
+    coupled.storage.set('semiont.cache.kb-1.resource', '{"doc":1}');
+
+    expect(writes.map(([k]) => k)).toEqual(['semiont.cache.kb-1.resource', ID_KEY]);
+    expect(storage.get(ID_KEY)).toBe('p-res-1-47');
+  });
+
+  it('with no pending id, a document write is just a document write', () => {
+    const { storage, writes } = recordingStorage();
+    const coupled = coupledLastEventId(storage, ID_KEY);
+
+    coupled.storage.set('semiont.cache.kb-1.resource', '{"doc":1}');
+
+    expect(writes.map(([k]) => k)).toEqual(['semiont.cache.kb-1.resource']);
+  });
+
+  it('multiple events before one flush persist the latest id exactly once', () => {
+    const { storage, writes } = recordingStorage();
+    const coupled = coupledLastEventId(storage, ID_KEY);
+
+    coupled.saveLastEventId('p-res-1-47');
+    coupled.saveLastEventId('p-res-1-48');
+    coupled.storage.set('semiont.cache.kb-1.annotations', '{"doc":2}');
+    coupled.storage.set('semiont.cache.kb-1.resource', '{"doc":3}');
+
+    expect(storage.get(ID_KEY)).toBe('p-res-1-48');
+    expect(writes.filter(([k]) => k === ID_KEY)).toHaveLength(1);
+  });
+
+  it('loadLastEventId round-trips what a flush persisted', () => {
+    const { storage } = recordingStorage();
+    const coupled = coupledLastEventId(storage, ID_KEY);
+    coupled.saveLastEventId('p-res-1-47');
+    coupled.storage.set('semiont.cache.kb-1.resource', '{"doc":1}');
+
+    expect(coupledLastEventId(storage, ID_KEY).loadLastEventId()).toBe('p-res-1-47');
   });
 });

--- a/packages/sdk/src/__tests__/cache-rehydration.test.ts
+++ b/packages/sdk/src/__tests__/cache-rehydration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * B17 (LOCAL-STORAGE W3) — rehydration wired through BrowseNamespace.
+ *
+ * The protocol-silence pin: with a prepopulated storage adapter, observing a
+ * rehydrated key delivers the persisted value synchronously and emits NO
+ * `browse:*-requested` on the transport. An un-cached key still requests as
+ * today. Construction without the option is byte-for-byte today's behavior.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Subject, firstValueFrom, filter, take } from 'rxjs';
+import { EventBus, resourceId as makeResourceId } from '@semiont/core';
+import type { IContentTransport, ITransport, ResourceDescriptor } from '@semiont/core';
+import { BrowseNamespace } from '../namespaces/browse';
+import { sessionStoragePersister } from '../cache-persister';
+import { TestStorage } from '../session/__tests__/test-storage-helpers';
+
+function inertTransport(emit: ITransport['emit']): ITransport {
+  return {
+    baseUrl: 'http://test',
+    emit,
+    stream: () => new Subject().asObservable(),
+    subscribeToResource: () => () => {},
+    bridgeInto: () => {},
+    state$: new Subject(),
+    errors$: new Subject(),
+    dispose: () => {},
+  } as unknown as ITransport;
+}
+
+const RID = makeResourceId('res-cached');
+const DESCRIPTOR = { '@id': RID, name: 'Cached Doc' } as unknown as ResourceDescriptor;
+
+describe('BrowseNamespace cache rehydration (B17)', () => {
+  it('serves a rehydrated resource with NO transport request; un-cached keys still request', async () => {
+    const storage = new TestStorage();
+    sessionStoragePersister<string, ResourceDescriptor>({
+      storage,
+      storageKey: 'semiont.cache.kb-1.resource',
+      version: 1,
+    }).save(new Map([[String(RID), DESCRIPTOR]]));
+
+    const emit = vi.fn<(channel: string, ...rest: unknown[]) => Promise<void>>(async () => {});
+    const browse = new BrowseNamespace(
+      inertTransport(emit as unknown as ITransport['emit']),
+      new EventBus(),
+      {} as unknown as IContentTransport,
+      { busTimeoutMs: 50, cachePersistence: { storage, keyPrefix: 'kb-1' } },
+    );
+
+    const seen = await firstValueFrom(
+      browse.resource(RID).pipe(filter((r): r is ResourceDescriptor => r !== undefined), take(1)),
+    );
+    expect(seen.name).toBe('Cached Doc');
+    expect(emit).not.toHaveBeenCalled();
+
+    // An un-cached key still goes to the transport.
+    browse.resource(makeResourceId('res-uncached')).pipe(take(1)).subscribe();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0]![0]).toBe('browse:resource-requested');
+
+    browse.dispose();
+  });
+
+  it('persists what it fetches: a later construction rehydrates it', async () => {
+    const storage = new TestStorage();
+    const first = new BrowseNamespace(
+      inertTransport(async () => {}),
+      new EventBus(),
+      {} as unknown as IContentTransport,
+      { busTimeoutMs: 50, cachePersistence: { storage, keyPrefix: 'kb-1' } },
+    );
+    // Write-through (B13b) stands in for a fetch result reaching the store.
+    first.resource(RID); // materialize the per-key observable
+    (first as unknown as { resourceCache: { set(k: string, v: ResourceDescriptor): void } })
+      .resourceCache.set(String(RID), DESCRIPTOR);
+    await new Promise((resolve) => setTimeout(resolve, 80)); // > save debounce
+    first.dispose();
+
+    const emit = vi.fn(async () => {});
+    const second = new BrowseNamespace(
+      inertTransport(emit),
+      new EventBus(),
+      {} as unknown as IContentTransport,
+      { busTimeoutMs: 50, cachePersistence: { storage, keyPrefix: 'kb-1' } },
+    );
+    const seen = await firstValueFrom(
+      second.resource(RID).pipe(filter((r): r is ResourceDescriptor => r !== undefined), take(1)),
+    );
+    expect(seen.name).toBe('Cached Doc');
+    expect(emit).not.toHaveBeenCalled();
+    second.dispose();
+  });
+});

--- a/packages/sdk/src/cache-persister.ts
+++ b/packages/sdk/src/cache-persister.ts
@@ -1,0 +1,130 @@
+/**
+ * B17 (LOCAL-STORAGE) — `CachePersister` backed by the `SessionStorage`
+ * adapter seam. Environment-agnostic for the same reason the session layer
+ * is: the browser passes its localStorage-backed adapter, a desktop host
+ * passes its own, tests pass the in-memory one.
+ *
+ * Stored document (all-or-nothing under one key):
+ *   { version, writtenAt, entries: [[keyJson, value, entryWrittenAt], …] }
+ *
+ * - `version` gates load: mismatch or parse garbage reads as "nothing
+ *   stored" — never throws into the cache.
+ * - Per-entry `entryWrittenAt` stamps power byte-cap eviction: an entry
+ *   keeps its stamp while its serialized value is unchanged, so eviction
+ *   drops the entries that have gone longest without a write (not merely
+ *   whatever a full-map re-save touched last).
+ */
+
+import type { CachePersister } from './cache';
+import type { SessionStorage } from './session/session-storage';
+
+/** localStorage origins cap around 5–10 MB; leave plenty for everyone else. */
+const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
+
+interface StoredDocument {
+  version: number;
+  writtenAt: number;
+  entries: Array<[unknown, unknown, number]>;
+}
+
+function parseDocument(raw: string | null, version: number): StoredDocument | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as StoredDocument;
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    if (parsed.version !== version) return null;
+    if (!Array.isArray(parsed.entries)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function sessionStoragePersister<K, V>(opts: {
+  /** The environment's storage adapter — the seam, and the test seam. */
+  storage: SessionStorage;
+  /** Full storage key; callers scope it per KB (`semiont.cache.<kbId>.<name>`). */
+  storageKey: string;
+  /** Schema version; mismatch discards on load. Bump when the value shape changes. */
+  version: number;
+  /** Byte cap for the serialized document; oldest-written entries evicted first. */
+  maxBytes?: number;
+  /** Serialize a key to a JSON-safe value. Default identity (branded ids are strings). */
+  keyToJson?: (k: K) => unknown;
+  /** Deserialize a JSON value back to a key. Default identity. */
+  jsonToKey?: (j: unknown) => K;
+}): CachePersister<K, V> {
+  const { storage, storageKey, version } = opts;
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const keyToJson = opts.keyToJson ?? ((k: K) => k as unknown);
+  const jsonToKey = opts.jsonToKey ?? ((j: unknown) => j as K);
+
+  /**
+   * Prior write stamps, keyed by the serialized key. Seeded by load(),
+   * refreshed by save() and external changes — an unchanged value keeps its
+   * stamp so eviction order reflects real write recency.
+   */
+  let stamps = new Map<string, { valueJson: string; writtenAt: number }>();
+
+  const seedStamps = (doc: StoredDocument): void => {
+    stamps = new Map(
+      doc.entries.map(([keyJson, value, writtenAt]) => [
+        JSON.stringify(keyJson),
+        { valueJson: JSON.stringify(value), writtenAt },
+      ]),
+    );
+  };
+
+  const toMap = (doc: StoredDocument): Map<K, V> =>
+    new Map(doc.entries.map(([keyJson, value]) => [jsonToKey(keyJson), value as V]));
+
+  return {
+    load(): Map<K, V> | null {
+      const doc = parseDocument(storage.get(storageKey), version);
+      if (!doc) return null;
+      seedStamps(doc);
+      return toMap(doc);
+    },
+
+    save(entries: Map<K, V>): void {
+      const now = Date.now();
+      let records: Array<[unknown, unknown, number]> = [];
+      const nextStamps = new Map<string, { valueJson: string; writtenAt: number }>();
+
+      for (const [k, v] of entries) {
+        const keyJson = keyToJson(k);
+        const keyId = JSON.stringify(keyJson);
+        const valueJson = JSON.stringify(v);
+        const prior = stamps.get(keyId);
+        const writtenAt = prior !== undefined && prior.valueJson === valueJson ? prior.writtenAt : now;
+        nextStamps.set(keyId, { valueJson, writtenAt });
+        records.push([keyJson, v, writtenAt]);
+      }
+
+      // Byte-cap eviction: drop oldest-written entries until the document fits.
+      const documentSize = (list: Array<[unknown, unknown, number]>): number =>
+        JSON.stringify({ version, writtenAt: now, entries: list }).length;
+      if (documentSize(records) > maxBytes) {
+        records = [...records].sort((a, b) => a[2] - b[2]);
+        while (records.length > 0 && documentSize(records) > maxBytes) {
+          const [evicted] = records.splice(0, 1);
+          if (evicted) nextStamps.delete(JSON.stringify(evicted[0]));
+        }
+      }
+
+      stamps = nextStamps;
+      storage.set(storageKey, JSON.stringify({ version, writtenAt: now, entries: records }));
+    },
+
+    subscribe(onExternalChange: (entries: Map<K, V>) => void): () => void {
+      const unsubscribe = storage.subscribe?.((key, newValue) => {
+        if (key !== storageKey) return;
+        const doc = parseDocument(newValue, version);
+        if (!doc) return;
+        seedStamps(doc);
+        onExternalChange(toMap(doc));
+      });
+      return unsubscribe ?? (() => {});
+    },
+  };
+}

--- a/packages/sdk/src/cache-persister.ts
+++ b/packages/sdk/src/cache-persister.ts
@@ -147,9 +147,15 @@ export function sessionStoragePersister<K, V>(opts: {
         records.push([keyJson, v, writtenAt]);
       }
 
-      // Byte-cap eviction: drop oldest-written entries until the document fits.
+      // Byte-cap eviction: drop oldest-written entries until the document
+      // fits. Measured in real UTF-8 bytes (the option's name tells the
+      // truth): `.length` counts UTF-16 code units, which skews up to 3×
+      // for non-ASCII values. localStorage itself accounts in code units,
+      // so for that substrate the byte cap is conservative — acceptable
+      // for a guard rail.
+      const encoder = new TextEncoder();
       const documentSize = (list: Array<[unknown, unknown, number]>): number =>
-        JSON.stringify({ version, writtenAt: now, entries: list }).length;
+        encoder.encode(JSON.stringify({ version, writtenAt: now, entries: list })).length;
       if (documentSize(records) > maxBytes) {
         records = [...records].sort((a, b) => a[2] - b[2]);
         while (records.length > 0 && documentSize(records) > maxBytes) {

--- a/packages/sdk/src/cache-persister.ts
+++ b/packages/sdk/src/cache-persister.ts
@@ -18,6 +18,52 @@
 import type { CachePersister } from './cache';
 import type { SessionStorage } from './session/session-storage';
 
+/**
+ * B17 — couple the resumption bookmark to the cache flush.
+ *
+ * The persisted `Last-Event-ID` audits the persisted cache documents: on
+ * reload the client resumes replay from it, so any event at-or-before it
+ * whose effect is NOT in the persisted caches would be silently skipped.
+ * Writing the id immediately per event created exactly that hazard (a
+ * crash inside the refetch + save-debounce window persisted a bookmark
+ * ahead of the caches). Instead: `saveLastEventId` only STASHES the id;
+ * the wrapped storage writes it through — document first, id second — on
+ * the next cache-document write. The persisted id may therefore LAG the
+ * caches (harmless: replay re-invalidates idempotently) but can never
+ * lead them. A crash between the two writes leaves the id lagging — the
+ * safe direction. Cross-resource cases need no coupling at all: a
+ * scope-mismatched resume already yields `bus:resume-gap` → blanket
+ * invalidation.
+ */
+export function coupledLastEventId(
+  storage: SessionStorage,
+  lastEventIdKey: string,
+): {
+  /** Hand THIS to `cachePersistence` — its writes carry the bookmark forward. */
+  storage: SessionStorage;
+  saveLastEventId: (id: string) => void;
+  loadLastEventId: () => string | null;
+} {
+  let pending: string | null = null;
+  const coupled: SessionStorage = {
+    get: (k) => storage.get(k),
+    set: (k, v) => {
+      storage.set(k, v);
+      if (pending !== null) {
+        storage.set(lastEventIdKey, pending);
+        pending = null;
+      }
+    },
+    delete: (k) => storage.delete(k),
+    ...(storage.subscribe ? { subscribe: storage.subscribe.bind(storage) } : {}),
+  };
+  return {
+    storage: coupled,
+    saveLastEventId: (id) => { pending = id; },
+    loadLastEventId: () => storage.get(lastEventIdKey),
+  };
+}
+
 /** localStorage origins cap around 5–10 MB; leave plenty for everyone else. */
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
 

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -60,8 +60,25 @@ import {
   filter,
   map,
   merge,
+  skip,
   throwError,
 } from 'rxjs';
+
+/**
+ * B17 — optional persistence seam for a cache instance. `load` runs once at
+ * construction (settled values only — B15 failure markers live outside the
+ * store and are never serialized); `save` receives every store mutation,
+ * debounced by the cache; `subscribe` is the cross-context sync hook (the
+ * persister calls back when another tab/process wrote the same key).
+ */
+export interface CachePersister<K, V> {
+  /** Called once at cache construction. Returns initial entries, or null for none. */
+  load(): Map<K, V> | null;
+  /** Called on store mutations, debounced by the cache; flushed on dispose. */
+  save(entries: Map<K, V>): void;
+  /** Optional cross-context sync; returns an unsubscribe function. */
+  subscribe?(onExternalChange: (entries: Map<K, V>) => void): () => void;
+}
 
 export interface Cache<K, V> {
   /** Observable stream of the value at `key` (SWR). Triggers a fetch if not cached. */
@@ -102,8 +119,17 @@ export interface Cache<K, V> {
   dispose(): void;
 }
 
-export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> {
-  const store$ = new BehaviorSubject<Map<K, V>>(new Map());
+export function createCache<K, V>(
+  fetchFn: (key: K) => Promise<V>,
+  options?: {
+    /** B17 — persistence seam. Omitted = today's in-memory-only behavior. */
+    persister?: CachePersister<K, V>;
+    /** Debounce window for persister.save. Default 50 ms. */
+    saveDebounceMs?: number;
+  },
+): Cache<K, V> {
+  const persister = options?.persister;
+  const store$ = new BehaviorSubject<Map<K, V>>(persister?.load() ?? new Map());
   /** In-flight fetch promise per key — dedups concurrent fetches (B3). */
   const inflight = new Map<K, Promise<V>>();
   const obsCache = new Map<K, Observable<V | undefined>>();
@@ -128,6 +154,30 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
   const failures = new Map<K, Error>();
   const failure$ = new Subject<{ key: K; error: Error }>();
   const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)));
+
+  /**
+   * B17 — debounced persistence. The initial emission (the loaded map) is
+   * skipped: only mutations schedule a save. `dispose()` flushes a pending
+   * save synchronously (the KB-switch teardown must not lose the last
+   * write), then everything goes inert with the rest of B16.
+   */
+  const saveDebounceMs = options?.saveDebounceMs ?? 50;
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribeExternal: (() => void) | null = null;
+  if (persister) {
+    store$.pipe(skip(1)).subscribe((entries) => {
+      if (disposed) return;
+      if (saveTimer !== null) clearTimeout(saveTimer);
+      saveTimer = setTimeout(() => {
+        saveTimer = null;
+        persister.save(entries);
+      }, saveDebounceMs);
+    });
+    unsubscribeExternal = persister.subscribe?.((entries) => {
+      if (disposed) return;
+      store$.next(new Map(entries));
+    }) ?? null;
+  }
 
   /**
    * Run (or join) a fetch for `key`. Resolves with the value and updates the
@@ -319,6 +369,14 @@ export function createCache<K, V>(fetchFn: (key: K) => Promise<V>): Cache<K, V> 
     dispose(): void {
       if (disposed) return; // idempotent (B16)
       disposed = true;
+      // B17: flush a pending save before the store completes — the disposal
+      // act itself, not a post-disposal act.
+      if (saveTimer !== null) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+        persister?.save(store$.value);
+      }
+      unsubscribeExternal?.();
       store$.complete();
       // Must complete alongside store$: the per-key observable is a merge,
       // and merge completes only when ALL its sources complete — leaving

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -164,13 +164,27 @@ export function createCache<K, V>(
   const saveDebounceMs = options?.saveDebounceMs ?? 50;
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   let unsubscribeExternal: (() => void) | null = null;
+  /**
+   * Persistence is best-effort: a throwing save (localStorage quota, a
+   * broken adapter) must never break the cache — and above all must never
+   * break dispose(), which sits on the KB-switch teardown path.
+   */
+  const trySave = (entries: Map<K, V>): void => {
+    try {
+      persister?.save(entries);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('[cache PERSIST] save failed; persistence skipped (best-effort):',
+        e instanceof Error ? e.message : e);
+    }
+  };
   if (persister) {
     store$.pipe(skip(1)).subscribe((entries) => {
       if (disposed) return;
       if (saveTimer !== null) clearTimeout(saveTimer);
       saveTimer = setTimeout(() => {
         saveTimer = null;
-        persister.save(entries);
+        trySave(entries);
       }, saveDebounceMs);
     });
     unsubscribeExternal = persister.subscribe?.((entries) => {
@@ -374,7 +388,7 @@ export function createCache<K, V>(
       if (saveTimer !== null) {
         clearTimeout(saveTimer);
         saveTimer = null;
-        persister?.save(store$.value);
+        trySave(store$.value);
       }
       unsubscribeExternal?.();
       store$.complete();

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -178,9 +178,17 @@ export function createCache<K, V>(
         e instanceof Error ? e.message : e);
     }
   };
+  /**
+   * External changes are applied WITHOUT echoing a save back: the adapter
+   * re-stamps `writtenAt` on every save, so an echo is never byte-identical
+   * and would re-fire the other tab's storage event — an unbounded two-tab
+   * ping-pong at the debounce cadence. BehaviorSubject emission is
+   * synchronous, so the flag is set for exactly the external `next`.
+   */
+  let applyingExternal = false;
   if (persister) {
     store$.pipe(skip(1)).subscribe((entries) => {
-      if (disposed) return;
+      if (disposed || applyingExternal) return;
       if (saveTimer !== null) clearTimeout(saveTimer);
       saveTimer = setTimeout(() => {
         saveTimer = null;
@@ -189,7 +197,12 @@ export function createCache<K, V>(
     });
     unsubscribeExternal = persister.subscribe?.((entries) => {
       if (disposed) return;
-      store$.next(new Map(entries));
+      applyingExternal = true;
+      try {
+        store$.next(new Map(entries));
+      } finally {
+        applyingExternal = false;
+      }
     }) ?? null;
   }
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -15,6 +15,7 @@
 
 import type { BaseUrl, AccessToken } from '@semiont/core';
 import { EventBus, accessToken, baseUrl } from '@semiont/core';
+import type { SessionStorage } from './session/session-storage';
 import { BehaviorSubject } from 'rxjs';
 import { BrowseNamespace } from './namespaces/browse';
 import { MarkNamespace } from './namespaces/mark';
@@ -109,7 +110,18 @@ export class SemiontClient {
    * `HttpTransport` instance that's also passed as `transport` (HTTP
    * implements both `ITransport` and `IBackendOperations`).
    */
-  constructor(transport: ITransport, content: IContentTransport, backend?: IBackendOperations) {
+  constructor(
+    transport: ITransport,
+    content: IContentTransport,
+    backend?: IBackendOperations,
+    options?: {
+      /**
+       * B17 — cache persistence through the environment's SessionStorage
+       * adapter (keyPrefix = KB id). Omitted = in-memory-only caches.
+       */
+      cachePersistence?: { storage: SessionStorage; keyPrefix: string };
+    },
+  ) {
     this.transport = transport;
     this.content = content;
     this.baseUrl = transport.baseUrl;
@@ -118,7 +130,12 @@ export class SemiontClient {
     this.transport.bridgeInto(this.bus);
 
     this.frame  = new FrameNamespace(this.transport);
-    this.browse = new BrowseNamespace(this.transport, this.bus, this.content);
+    this.browse = new BrowseNamespace(
+      this.transport,
+      this.bus,
+      this.content,
+      options?.cachePersistence ? { cachePersistence: options.cachePersistence } : undefined,
+    );
     this.mark   = new MarkNamespace(this.transport, this.bus);
     this.bind   = new BindNamespace(this.transport, this.bus);
     this.gather = new GatherNamespace(this.transport, this.bus);

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -17,7 +17,16 @@ import type {
 } from '@semiont/core';
 import type { ITransport, IContentTransport } from '@semiont/core';
 import { busRequest } from '@semiont/core';
-import { createCache, type Cache } from '../cache';
+import { createCache, type Cache, type CachePersister } from '../cache';
+import { sessionStoragePersister } from '../cache-persister';
+import type { SessionStorage } from '../session/session-storage';
+
+/**
+ * B17 — serialized-shape version shared by every persisted browse cache.
+ * Bump when any persisted value shape changes; stale documents then read
+ * as empty and refetch.
+ */
+const CACHE_PERSISTENCE_VERSION = 1;
 import type {
   BrowseNamespace as IBrowseNamespace,
   ReferencedByEntry,
@@ -115,9 +124,32 @@ export class BrowseNamespace implements IBrowseNamespace {
     private readonly transport: ITransport,
     private readonly bus: EventBus,
     private readonly content: IContentTransport,
-    options?: { busTimeoutMs?: number },
+    options?: {
+      busTimeoutMs?: number;
+      /**
+       * B17 — opt into cache persistence through the environment's
+       * SessionStorage adapter. keyPrefix is the KB id (cache data is
+       * KB-specific). Omitted = in-memory-only, today's behavior.
+       */
+      cachePersistence?: { storage: SessionStorage; keyPrefix: string };
+    },
   ) {
     this.busTimeoutMs = options?.busTimeoutMs;
+
+    // The opt-in table (see .plans/LOCAL-STORAGE.md): small, first-paint
+    // caches persist; lists, event histories, and the collaborator
+    // directory stay in-memory.
+    const persistence = options?.cachePersistence;
+    const persisted = <K, V>(name: string): { persister: CachePersister<K, V> } | undefined =>
+      persistence
+        ? {
+            persister: sessionStoragePersister<K, V>({
+              storage: persistence.storage,
+              storageKey: `semiont.cache.${persistence.keyPrefix}.${name}`,
+              version: CACHE_PERSISTENCE_VERSION,
+            }),
+          }
+        : undefined;
 
     this.resourceCache = createCache<ResourceId, ResourceDescriptor>(async (id) => {
       const result = await busRequest(
@@ -127,7 +159,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.busTimeoutMs,
       );
       return result.resource as ResourceDescriptor;
-    });
+    }, persisted<ResourceId, ResourceDescriptor>('resource'));
 
     this.resourceListCache = createCache<string, ResourceDescriptor[]>(async (key) => {
       const filters = this.resourceListFilters.get(key) ?? {};
@@ -156,7 +188,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         { resourceId },
         this.busTimeoutMs,
       );
-    });
+    }, persisted<ResourceId, AnnotationsListResponse>('annotations'));
 
     this.annotationDetailCache = createCache<AnnotationId, Annotation>(async (annotationId) => {
       const resourceId = this.annotationResources.get(annotationId);
@@ -170,7 +202,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.busTimeoutMs,
       );
       return result.annotation as Annotation;
-    });
+    }, persisted<AnnotationId, Annotation>('annotation-detail'));
 
     this.entityTypesCache = createCache<string, string[]>(async () => {
       const result = await busRequest(
@@ -180,7 +212,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.busTimeoutMs,
       );
       return result.entityTypes;
-    });
+    }, persisted<string, string[]>('entity-types'));
 
     this.tagSchemasCache = createCache<string, TagSchema[]>(async () => {
       const result = await busRequest(
@@ -190,7 +222,7 @@ export class BrowseNamespace implements IBrowseNamespace {
         this.busTimeoutMs,
       );
       return result.tagSchemas;
-    });
+    }, persisted<string, TagSchema[]>('tag-schemas'));
 
     this.agentsCache = createCache<string, CollaboratorEntry[]>(async () => {
       const result = await busRequest(

--- a/packages/sdk/src/session/__tests__/semiont-browser.test.ts
+++ b/packages/sdk/src/session/__tests__/semiont-browser.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { firstValueFrom, skip, take } from 'rxjs';
+import { firstValueFrom, filter, skip, take } from 'rxjs';
 
 const mockGetMe = vi.fn();
 const mockDispose = vi.fn();
@@ -36,7 +36,7 @@ import { createHttpSessionFactory } from '../http-session-factory';
 import { getBrowser } from '../registry';
 import { __resetForTests } from '../testing';
 import { storageKey, seedStoredSession, TestStorage } from './test-storage-helpers';
-import { STORAGE_KEY, ACTIVE_KEY } from '../storage';
+import { STORAGE_KEY, ACTIVE_KEY, OPEN_RESOURCES_BY_KB_KEY } from '../storage';
 
 const KB_A = {
   id: 'kb-a',
@@ -216,9 +216,27 @@ describe('SemiontBrowser — setActiveKb (D2 disposal contract)', () => {
   });
 });
 
-describe('SemiontBrowser — open resources', () => {
-  it('addOpenResource, removeOpenResource, updateName, reorder', async () => {
+describe('SemiontBrowser — open resources (KB-scoped)', () => {
+  // Tabs are per-KB state; the visible list is a projection of the ACTIVE,
+  // CONNECTED KB (gate: activeSession$ non-null). Storage is the durable
+  // per-KB record; removeKb reaps it; the legacy flat key is ignored.
+
+  /** KB_A + KB_B registered with stored sessions; KB_A active and live. */
+  async function makeConnectedBrowser() {
+    seedStoredSession(storage, KB_A.id, freshJwt(), 'r');
+    seedStoredSession(storage, KB_B.id, freshJwt(), 'r');
+    storage.set(STORAGE_KEY, JSON.stringify([KB_A, KB_B]));
+    storage.set(ACTIVE_KEY, KB_A.id);
     const browser = makeBrowser();
+    await firstValueFrom(browser.activeSession$.pipe(filter((s) => s !== null), take(1)));
+    return browser;
+  }
+
+  const liveSession = (browser: SemiontBrowser) =>
+    firstValueFrom(browser.activeSession$.pipe(filter((s) => s !== null), take(1)));
+
+  it('addOpenResource, removeOpenResource, updateName, reorder — on the active KB', async () => {
+    const browser = await makeConnectedBrowser();
 
     browser.addOpenResource('r1', 'One');
     browser.addOpenResource('r2', 'Two', 'text/markdown', 'file://two.md');
@@ -242,11 +260,78 @@ describe('SemiontBrowser — open resources', () => {
   });
 
   it('reorderOpenResources ignores out-of-range indices', async () => {
-    const browser = makeBrowser();
+    const browser = await makeConnectedBrowser();
     browser.addOpenResource('r1', 'One');
     const before = browser.openResources$.getValue();
     browser.reorderOpenResources(0, 5);
     expect(browser.openResources$.getValue()).toEqual(before);
+    await browser.dispose();
+  });
+
+  it('is inert with no live session: nothing visible, nothing persisted', async () => {
+    const browser = makeBrowser();
+    browser.addOpenResource('r1', 'One');
+    expect(browser.openResources$.getValue()).toEqual([]);
+    expect(storage.get(OPEN_RESOURCES_BY_KB_KEY)).toBeNull();
+    await browser.dispose();
+  });
+
+  it('switching KBs switches the visible list; each KB keeps its own', async () => {
+    const browser = await makeConnectedBrowser();
+    browser.addOpenResource('r1', 'One');
+
+    await browser.setActiveKb(KB_B.id);
+    await liveSession(browser);
+    expect(browser.openResources$.getValue()).toEqual([]);
+    browser.addOpenResource('r2', 'Two');
+    expect(browser.openResources$.getValue().map((r) => r.id)).toEqual(['r2']);
+
+    await browser.setActiveKb(KB_A.id);
+    await liveSession(browser);
+    expect(browser.openResources$.getValue().map((r) => r.id)).toEqual(['r1']);
+
+    await browser.dispose();
+  });
+
+  it('signOut hides the tabs; storage retains them; signIn restores', async () => {
+    const browser = await makeConnectedBrowser();
+    browser.addOpenResource('r1', 'One');
+
+    await browser.signOut(KB_A.id);
+    expect(browser.openResources$.getValue()).toEqual([]);
+    const stored = JSON.parse(storage.get(OPEN_RESOURCES_BY_KB_KEY)!) as Record<string, Array<{ id: string }>>;
+    expect(stored[KB_A.id]!.map((r) => r.id)).toEqual(['r1']);
+
+    await browser.signIn(KB_A.id, freshJwt(), 'r');
+    expect(browser.openResources$.getValue().map((r) => r.id)).toEqual(['r1']);
+
+    await browser.dispose();
+  });
+
+  it('removeKb reaps the stored tabs for that KB', async () => {
+    const browser = await makeConnectedBrowser();
+    browser.addOpenResource('r1', 'One');
+
+    browser.removeKb(KB_A.id);
+    const stored = JSON.parse(storage.get(OPEN_RESOURCES_BY_KB_KEY) ?? '{}') as Record<string, unknown>;
+    expect(stored[KB_A.id]).toBeUndefined();
+
+    await browser.dispose();
+  });
+
+  it('cross-tab writes to the per-KB key update the projection', async () => {
+    const browser = await makeConnectedBrowser();
+    const payload = JSON.stringify({ [KB_A.id]: [{ id: 'rX', name: 'X', openedAt: 1, order: 0 }] });
+    storage.set(OPEN_RESOURCES_BY_KB_KEY, payload);
+    storage.dispatch(OPEN_RESOURCES_BY_KB_KEY, payload);
+    expect(browser.openResources$.getValue().map((r) => r.id)).toEqual(['rX']);
+    await browser.dispose();
+  });
+
+  it('ignores the legacy flat openDocuments key entirely', async () => {
+    storage.set('openDocuments', JSON.stringify([{ id: 'old', name: 'Old', openedAt: 1 }]));
+    const browser = await makeConnectedBrowser();
+    expect(browser.openResources$.getValue()).toEqual([]);
     await browser.dispose();
   });
 });

--- a/packages/sdk/src/session/__tests__/semiont-browser.test.ts
+++ b/packages/sdk/src/session/__tests__/semiont-browser.test.ts
@@ -259,6 +259,23 @@ describe('SemiontBrowser — open resources (KB-scoped)', () => {
     await browser.dispose();
   });
 
+  it('assigns a unique order after removals (no collision with surviving tabs)', async () => {
+    const browser = await makeConnectedBrowser();
+    browser.addOpenResource('r1', 'One');
+    browser.addOpenResource('r2', 'Two');
+    browser.addOpenResource('r3', 'Three');
+    browser.removeOpenResource('r2'); // surviving orders: 0, 2
+
+    browser.addOpenResource('r4', 'Four'); // length-based order would collide at 2
+
+    const list = browser.openResources$.getValue();
+    const orders = list.map((r) => r.order);
+    expect(new Set(orders).size).toBe(orders.length);
+    expect(list.map((r) => r.id)).toEqual(['r1', 'r3', 'r4']);
+
+    await browser.dispose();
+  });
+
   it('reorderOpenResources ignores out-of-range indices', async () => {
     const browser = await makeConnectedBrowser();
     browser.addOpenResource('r1', 'One');

--- a/packages/sdk/src/session/http-session-factory.ts
+++ b/packages/sdk/src/session/http-session-factory.ts
@@ -15,6 +15,7 @@ import { BehaviorSubject } from 'rxjs';
 import { HttpTransport, HttpContentTransport } from '@semiont/http-transport';
 import { baseUrl, type AccessToken } from '@semiont/core';
 import { SemiontClient } from '../client';
+import { coupledLastEventId } from '../cache-persister';
 import { SemiontSession, type UserInfo } from './semiont-session';
 import { SemiontSessionError } from './errors';
 import { kbBackendUrl, getStoredSession, setStoredSession } from './storage';
@@ -101,21 +102,25 @@ export function createHttpSessionFactory(): SessionFactory {
     // before any 401 could fire.
     const token$ = new BehaviorSubject<AccessToken | null>(null);
     let session!: SemiontSession;
+    // B17: resume from the last persisted SSE id across reloads, so
+    // rehydrated caches reconcile by replay instead of gapping. The id is
+    // COUPLED to the cache flush (stashed in memory, written only alongside
+    // cache-document writes) so the persisted bookmark can lag the caches
+    // but never lead them.
+    const coupled = coupledLastEventId(storage, `semiont.lastEventId.${kb.id}`);
     const transport = new HttpTransport({
       baseUrl: baseUrl(kbBackendUrl(endpoint)),
       token$,
       tokenRefresher: () => session.refresh().then((t) => t ?? null),
-      // B17: resume from the last persisted SSE id across reloads, so
-      // rehydrated caches reconcile by replay instead of gapping.
-      loadLastEventId: () => storage.get(`semiont.lastEventId.${kb.id}`),
-      saveLastEventId: (id) => storage.set(`semiont.lastEventId.${kb.id}`, id),
+      loadLastEventId: coupled.loadLastEventId,
+      saveLastEventId: coupled.saveLastEventId,
     });
     const content = new HttpContentTransport(transport);
     // B17: the real session's client persists its browse caches through the
     // environment's storage adapter, scoped by KB. (The token-refresh
     // throwaway clients above deliberately do not.)
     const client = new SemiontClient(transport, content, transport, {
-      cachePersistence: { storage, keyPrefix: kb.id },
+      cachePersistence: { storage: coupled.storage, keyPrefix: kb.id },
     });
     session = new SemiontSession({
       kb,

--- a/packages/sdk/src/session/http-session-factory.ts
+++ b/packages/sdk/src/session/http-session-factory.ts
@@ -105,9 +105,18 @@ export function createHttpSessionFactory(): SessionFactory {
       baseUrl: baseUrl(kbBackendUrl(endpoint)),
       token$,
       tokenRefresher: () => session.refresh().then((t) => t ?? null),
+      // B17: resume from the last persisted SSE id across reloads, so
+      // rehydrated caches reconcile by replay instead of gapping.
+      loadLastEventId: () => storage.get(`semiont.lastEventId.${kb.id}`),
+      saveLastEventId: (id) => storage.set(`semiont.lastEventId.${kb.id}`, id),
     });
     const content = new HttpContentTransport(transport);
-    const client = new SemiontClient(transport, content, transport);
+    // B17: the real session's client persists its browse caches through the
+    // environment's storage adapter, scoped by KB. (The token-refresh
+    // throwaway clients above deliberately do not.)
+    const client = new SemiontClient(transport, content, transport, {
+      cachePersistence: { storage, keyPrefix: kb.id },
+    });
     session = new SemiontSession({
       kb,
       storage,

--- a/packages/sdk/src/session/semiont-browser.ts
+++ b/packages/sdk/src/session/semiont-browser.ts
@@ -493,7 +493,10 @@ export class SemiontBrowser {
         id,
         name,
         openedAt: Date.now(),
-        order: existing.length,
+        // max+1, not length: after removals, length can collide with a
+        // surviving order (e.g. [0,2] + add), leaving placement to sort
+        // stability.
+        order: existing.reduce((m, r) => Math.max(m, r.order ?? -1), -1) + 1,
         ...(mediaType !== undefined ? { mediaType } : {}),
         ...(storageUri !== undefined ? { storageUri } : {}),
       }];

--- a/packages/sdk/src/session/semiont-browser.ts
+++ b/packages/sdk/src/session/semiont-browser.ts
@@ -26,6 +26,7 @@ import {
   getStoredSession,
   isJwtExpired,
   loadKnowledgeBases,
+  OPEN_RESOURCES_BY_KB_KEY,
   saveKnowledgeBases,
   setStoredSession,
 } from './storage';
@@ -41,8 +42,6 @@ import { SemiontSessionError } from './errors';
 import type { SessionStorage } from './session-storage';
 import type { SessionFactory } from './session-factory';
 
-const OPEN_RESOURCES_KEY = 'openDocuments';
-
 function sortOpenResources(resources: OpenResource[]): OpenResource[] {
   return [...resources].sort((a, b) => {
     if (a.order !== undefined && b.order !== undefined) return a.order - b.order;
@@ -50,14 +49,19 @@ function sortOpenResources(resources: OpenResource[]): OpenResource[] {
   });
 }
 
-function loadOpenResources(storage: SessionStorage): OpenResource[] {
+/**
+ * Tabs are per-KB state: Record<kbId, OpenResource[]>. State from the
+ * retired flat `openDocuments` key is deliberately ignored (it never
+ * recorded which KB its entries belonged to).
+ */
+function loadOpenResourcesByKb(storage: SessionStorage): Record<string, OpenResource[]> {
   try {
-    const stored = storage.get(OPEN_RESOURCES_KEY);
-    if (stored) return sortOpenResources(JSON.parse(stored) as OpenResource[]);
+    const stored = storage.get(OPEN_RESOURCES_BY_KB_KEY);
+    if (stored) return JSON.parse(stored) as Record<string, OpenResource[]>;
   } catch {
     // Ignore parse errors
   }
-  return [];
+  return {};
 }
 
 export interface SemiontBrowserConfig {
@@ -112,6 +116,8 @@ export class SemiontBrowser {
   private unsubscribeStorage: (() => void) | null = null;
   private disposed = false;
   private activating: Promise<void> | null = null;
+  /** Per-KB tab lists; `openResources$` projects the active, connected KB's. */
+  private openByKb: Record<string, OpenResource[]> = {};
 
   constructor(config: SemiontBrowserConfig) {
     this.storage = config.storage;
@@ -129,7 +135,8 @@ export class SemiontBrowser {
     this.activeSession$ = new BehaviorSubject<SemiontSession | null>(null);
     this.activeSignals$ = new BehaviorSubject<SessionSignals | null>(null);
     this.sessionActivating$ = new BehaviorSubject<boolean>(false);
-    this.openResources$ = new BehaviorSubject<OpenResource[]>(loadOpenResources(this.storage));
+    this.openByKb = loadOpenResourcesByKb(this.storage);
+    this.openResources$ = new BehaviorSubject<OpenResource[]>([]);
     this.error$ = new Subject<SemiontSessionError>();
     this.identityToken$ = new BehaviorSubject<string | null>(null);
 
@@ -140,16 +147,18 @@ export class SemiontBrowser {
       else this.storage.delete(ACTIVE_KEY);
     });
 
-    // Persist openResources$ on every change.
-    this.openResources$.subscribe((list) => {
-      this.storage.set(OPEN_RESOURCES_KEY, JSON.stringify(list));
-    });
+    // The visible tab list is a projection of the active, CONNECTED KB
+    // (gate: a live session). Connect/disconnect/switch all surface as
+    // activeSession$ transitions, so one subscription re-projects for all
+    // three; CRUD and cross-tab writes refresh explicitly.
+    this.activeSession$.subscribe(() => this.refreshOpenResources());
 
-    // Sync openResources$ from other contexts (cross-tab/cross-process).
+    // Sync the per-KB map from other contexts (cross-tab/cross-process).
     this.unsubscribeStorage = this.storage.subscribe?.((key, newValue) => {
-      if (key !== OPEN_RESOURCES_KEY || !newValue) return;
+      if (key !== OPEN_RESOURCES_BY_KB_KEY || !newValue) return;
       try {
-        this.openResources$.next(sortOpenResources(JSON.parse(newValue) as OpenResource[]));
+        this.openByKb = JSON.parse(newValue) as Record<string, OpenResource[]>;
+        this.refreshOpenResources();
       } catch {
         // Ignore parse errors
       }
@@ -208,6 +217,14 @@ export class SemiontBrowser {
 
   removeKb(id: string): void {
     clearStoredSession(this.storage, id);
+    // Reap the KB's tab record — removal of the connection is the one
+    // deliberate act that forgets the working set.
+    if (this.openByKb[id]) {
+      const rest = { ...this.openByKb };
+      delete rest[id];
+      this.openByKb = rest;
+      this.persistOpenResources();
+    }
     const next = this.kbs$.getValue().filter((kb) => kb.id !== id);
     this.kbs$.next(next);
     if (this.activeKbId$.getValue() === id) {
@@ -425,7 +442,31 @@ export class SemiontBrowser {
     }
   }
 
-  // ── Open resources ────────────────────────────────────────────────────
+  // ── Open resources (per-KB; the visible list is a projection) ─────────
+
+  private refreshOpenResources(): void {
+    const kbId = this.activeKbId$.getValue();
+    const session = this.activeSession$.getValue();
+    const list = kbId && session ? sortOpenResources(this.openByKb[kbId] ?? []) : [];
+    this.openResources$.next(list);
+  }
+
+  private persistOpenResources(): void {
+    this.storage.set(OPEN_RESOURCES_BY_KB_KEY, JSON.stringify(this.openByKb));
+  }
+
+  /**
+   * All tab CRUD funnels through here: inert without an active, connected
+   * KB (the projection gate), otherwise mutate that KB's list, persist the
+   * whole map, and re-project.
+   */
+  private mutateOpenResources(mutate: (list: OpenResource[]) => OpenResource[]): void {
+    const kbId = this.activeKbId$.getValue();
+    if (!kbId || !this.activeSession$.getValue()) return;
+    this.openByKb = { ...this.openByKb, [kbId]: mutate(this.openByKb[kbId] ?? []) };
+    this.persistOpenResources();
+    this.refreshOpenResources();
+  }
 
   addOpenResource(
     id: string,
@@ -433,51 +474,54 @@ export class SemiontBrowser {
     mediaType?: string,
     storageUri?: string,
   ): void {
-    const existing = this.openResources$.getValue();
-    const idx = existing.findIndex((r) => r.id === id);
-    if (idx >= 0) {
-      // Update metadata in place; keep position and openedAt.
-      const prev = existing[idx]!;
-      const updated: OpenResource = {
-        ...prev,
+    this.mutateOpenResources((existing) => {
+      const idx = existing.findIndex((r) => r.id === id);
+      if (idx >= 0) {
+        // Update metadata in place; keep position and openedAt.
+        const prev = existing[idx]!;
+        const updated: OpenResource = {
+          ...prev,
+          name,
+          ...(mediaType !== undefined ? { mediaType } : {}),
+          ...(storageUri !== undefined ? { storageUri } : {}),
+        };
+        const next = [...existing];
+        next[idx] = updated;
+        return next;
+      }
+      return [...existing, {
+        id,
         name,
+        openedAt: Date.now(),
+        order: existing.length,
         ...(mediaType !== undefined ? { mediaType } : {}),
         ...(storageUri !== undefined ? { storageUri } : {}),
-      };
-      const next = [...existing];
-      next[idx] = updated;
-      this.openResources$.next(next);
-      return;
-    }
-    const resource: OpenResource = {
-      id,
-      name,
-      openedAt: Date.now(),
-      order: existing.length,
-      ...(mediaType !== undefined ? { mediaType } : {}),
-      ...(storageUri !== undefined ? { storageUri } : {}),
-    };
-    this.openResources$.next([...existing, resource]);
+      }];
+    });
   }
 
   removeOpenResource(id: string): void {
-    this.openResources$.next(this.openResources$.getValue().filter((r) => r.id !== id));
+    this.mutateOpenResources((existing) => existing.filter((r) => r.id !== id));
   }
 
   updateOpenResourceName(id: string, name: string): void {
-    this.openResources$.next(
-      this.openResources$.getValue().map((r) => (r.id === id ? { ...r, name } : r)),
+    this.mutateOpenResources((existing) =>
+      existing.map((r) => (r.id === id ? { ...r, name } : r)),
     );
   }
 
   reorderOpenResources(oldIndex: number, newIndex: number): void {
-    const list = [...this.openResources$.getValue()];
-    if (oldIndex < 0 || oldIndex >= list.length || newIndex < 0 || newIndex >= list.length) {
-      return;
-    }
-    const [moved] = list.splice(oldIndex, 1);
-    if (moved) list.splice(newIndex, 0, moved);
-    this.openResources$.next(list);
+    this.mutateOpenResources((existing) => {
+      // Indices refer to the SORTED (visible) list; renumber `order` after
+      // the move so the drag survives persistence and re-sorting.
+      const list = sortOpenResources(existing);
+      if (oldIndex < 0 || oldIndex >= list.length || newIndex < 0 || newIndex >= list.length) {
+        return existing;
+      }
+      const [moved] = list.splice(oldIndex, 1);
+      if (moved) list.splice(newIndex, 0, moved);
+      return list.map((r, i) => ({ ...r, order: i }));
+    });
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────

--- a/packages/sdk/src/session/storage.ts
+++ b/packages/sdk/src/session/storage.ts
@@ -21,6 +21,8 @@ import type { SessionStorage } from './session-storage';
 const SESSION_PREFIX = 'semiont.session.';
 export const STORAGE_KEY = 'semiont.knowledgeBases';
 export const ACTIVE_KEY = 'semiont.activeKnowledgeBaseId';
+/** Per-KB open-resource tabs: Record<kbId, OpenResource[]>. */
+export const OPEN_RESOURCES_BY_KB_KEY = 'semiont.openResourcesByKb';
 
 /** Refresh the access token this many milliseconds before it expires. */
 export const REFRESH_BEFORE_EXP_MS = 5 * 60 * 1000;


### PR DESCRIPTION
Three Browser-experience changes that dogfooding surfaced together: reloads cold-started every cache, the left-nav tabs ignored KB boundaries, and the compose dropzone didn't actually accept drops. The first two land in `@semiont/sdk` (the Browser inherits them through the provider with zero frontend changes); the third is a react-ui fix.

## 1. Cache persistence across reloads (B17 — `.plans/LOCAL-STORAGE.md`)

**Motivation.** Every reload cold-started the `BrowseNamespace` caches: SSE subscribe, then resource → annotations → entity-types round-trips before the viewer renders. Tolerable on localhost; painful over codespace forwards. Persisting the caches lets a reload render last-seen data immediately and reconcile in the background.

**What changed.**
- `createCache` gains an optional `CachePersister` seam: load-on-construct rehydration, debounced saves (default 50 ms), cross-context sync, and a `dispose()` that flushes any pending save before going inert — the flush is part of the disposal act, so a KB switch never loses the last write. Saves are **best-effort**: a quota-exceeded or throwing adapter skips a beat with a breadcrumb, never breaks the cache or teardown. Failure markers (B15) are never serialized — a failed key rehydrates as absent.
- `sessionStoragePersister` rides the environment-agnostic `SessionStorage` adapter (browser, desktop host, tests — same seam the KB registry already uses): version-gated never-throwing loads, and per-entry write stamps that survive unchanged values so byte-cap eviction (default 2 MB/document) is genuinely oldest-written-first.
- Five browse caches opt in (resource, annotation list, annotation detail, entity types, tag schemas), keyed `semiont.cache.<kbId>.<name>`; lists, event histories, and the collaborator directory deliberately stay in-memory. `createHttpSessionFactory` wires it automatically; construction without the option is byte-for-byte the old behavior.
- **Reconciliation is the existing contract, not new machinery**: a rehydrated key serves synchronously with NO transport request (pinned); the SSE reconnect sends the persisted `Last-Event-ID`; replayed events invalidate through the normal handlers (stale value visible during the refetch); `bus:resume-gap` blanket-invalidates when replay can't cover.
- **The resumption bookmark is coupled to the cache flush** (`coupledLastEventId`): the id is stashed per persisted (`p-*`) event and written only alongside a cache-document write, document first — so the persisted id can lag the caches (harmless: replay re-invalidates idempotently) but can never lead them and silently skip a reconciling event. Ephemeral (`e-*`) ids are never saved: the server treats them as "no resumption context." Resumption is per-scope; a scope-mismatched resume already yields `bus:resume-gap`, which bounds the coupling to exactly the same-resource reload case.

**Docs**: behavioral contract added as **B17** in `packages/sdk/docs/CACHE-SEMANTICS.md`; consumer-facing section in the Developer Guide.

## 2. KB-scoped open-resource tabs (`.plans/KB-SCOPED-TABS.md`)

**Motivation.** The left-nav tab list was one flat app-scoped list of bare resource ids: switching KBs never synced it (the previous KB's tabs stayed visible and clickable), and connect/disconnect had no effect.

**What changed.** Tabs become per-KB state (`Record<kbId, OpenResource[]>` under `semiont.openResourcesByKb`; legacy `openDocuments` state is ignored outright — no migration shim), and `openResources$` becomes a projection of the **active, connected** KB's list, gated on `activeSession$`: switching KBs switches the sidebar; sign-out hides the tabs while storage retains them; sign-in restores them with no "reopen" step; `removeKb` reaps the record — the one deliberate act that forgets a working set. All CRUD funnels through one guarded mutate→persist→project path. Bug fixed en route: `reorderOpenResources` never renumbered `order`, so drags were undone by the next load's re-sort — reorder now renumbers on the sorted visible list. Consumers changed zero lines.

## 3. Compose dropzone accepts drops (react-ui)

**Motivation.** The upload dropzone said "Drop file or click to upload" but had no drag handlers, and its `display:none` input can't receive native drops — the browser handled a drop by navigating to the file. This never worked.

**What changed.** The dropzone label owns `dragOver`/`dragLeave`/`drop` (the `preventDefault` is what stops the navigation), routes drops through the same `applyUploadedFile` path as the file input (same media-type detection, name defaulting, preview/text handling), guards drops while a create is in flight, and highlights via `data-drag-over` while a file hovers.

## Verification (TDD throughout; node:24-alpine)

Every phase observed RED before its implementation: the persister-hook pins against the optionless `createCache`; the rehydration protocol-silence pin against an unwired `BrowseNamespace`; the `Last-Event-ID` pins against the hookless actor; the coupling pins (no-write-alone, document-then-id order); the KB-scoped-tabs lifecycle pins against the flat list; the dropzone pins against the handler-less label. Final gates: sdk suite **446/446** (34 files), http-transport **106/106**, react-ui compose suite 31/31, `tsc --noEmit` 0 in sdk / http-transport / react-ui; dists rebuilt. Zero regressions across the pre-existing cache-semantics pins (B1–B16).
