### PR TITLE
launcher: self-maintaining sessions — auto-refresh on 401, logout, live-verified SESSIONS in status

### DIFF
--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -401,6 +401,15 @@ generation from gathered context) deliberately stays with the npm CLI.
 Both take `--repo <owner/name>` to target a codespace stack through its
 forward instead of the local one.
 
+Sessions maintain themselves: access tokens live an hour, and on a 401 the
+launcher renews one invisibly from the stored 30-day refresh token
+(announced, saved, retried once) — login is a once-a-month event, not an
+hourly chore. `semiont logout` ends a session (best-effort server-side,
+local token forgotten either way, said plainly when the server half
+didn't complete), and `semiont status --verbose` lists every stored
+session under SESSIONS, live-verified against the stack when reachable —
+valid / expired / unverified, never a guess.
+
 ### Where state lives
 
 Local-stack databases persist across restarts. Each local semiont root gets

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -894,6 +894,12 @@ func serve(ports []string) {
 				// exercise: refresh with the stored refresh token mints
 				// fake-jwt-token-2, which every bearer endpoint accepts.
 				bearerOK := func() bool {
+					// FAKERT_ALL_TOKENS_STALE: NO bearer is ever accepted,
+					// though refresh still succeeds — the "refreshed but
+					// still rejected" scenario (account disabled etc.).
+					if os.Getenv("FAKERT_ALL_TOKENS_STALE") != "" {
+						return false
+					}
 					a := r.Header.Get("Authorization")
 					if a == "Bearer fake-jwt-token-2" {
 						return true

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -879,8 +879,9 @@ func serve(ports []string) {
 					// would say text/plain), exactly like the real backend.
 					w.Header().Set("Content-Type", "application/json")
 					_ = json.NewEncoder(w).Encode(map[string]any{
-						"success": true,
-						"token":   "fake-jwt-token",
+						"success":      true,
+						"token":        "fake-jwt-token",
+						"refreshToken": "fake-refresh-token",
 						"user": map[string]any{
 							"id": "u1", "email": "admin@example.com", "name": nil,
 							"image": nil, "domain": "example.com", "isAdmin": true,
@@ -888,10 +889,62 @@ func serve(ports []string) {
 					})
 					return
 				}
+				// Session lifecycle (Tier 1). FAKERT_STALE_TOKEN=1 makes the
+				// login-issued token read as EXPIRED — the refresh flow's
+				// exercise: refresh with the stored refresh token mints
+				// fake-jwt-token-2, which every bearer endpoint accepts.
+				bearerOK := func() bool {
+					a := r.Header.Get("Authorization")
+					if a == "Bearer fake-jwt-token-2" {
+						return true
+					}
+					return a == "Bearer fake-jwt-token" && os.Getenv("FAKERT_STALE_TOKEN") == ""
+				}
+				if r.URL.Path == "/api/tokens/refresh" {
+					var req struct {
+						RefreshToken string `json:"refreshToken"`
+					}
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					w.Header().Set("Content-Type", "application/json")
+					if req.RefreshToken != "fake-refresh-token" {
+						w.WriteHeader(401)
+						_ = json.NewEncoder(w).Encode(map[string]any{"error": "invalid refresh token"})
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "fake-jwt-token-2"})
+					return
+				}
+				if r.URL.Path == "/api/users/logout" {
+					if !bearerOK() {
+						http.Error(w, `{"error":"unauthorized"}`, 401)
+						return
+					}
+					w.WriteHeader(204)
+					return
+				}
+				if r.URL.Path == "/api/users/me" {
+					w.Header().Set("Content-Type", "application/json")
+					if !bearerOK() {
+						w.WriteHeader(401)
+						_ = json.NewEncoder(w).Encode(map[string]any{"error": "token expired"})
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"id": "u1", "email": "admin@example.com", "name": nil, "image": nil,
+						"domain": "example.com", "provider": "password", "isAdmin": true, "isModerator": false,
+					})
+					return
+				}
 				// The yield upload (sdk-go glue): capture the multipart —
 				// fields, file bytes, auth header — for test assertions,
 				// then answer 202 {resourceId} like the real create route.
 				if r.URL.Path == "/resources" && r.Method == http.MethodPost {
+					if !bearerOK() {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(401)
+						_ = json.NewEncoder(w).Encode(map[string]any{"error": "token expired"})
+						return
+					}
 					_ = r.ParseMultipartForm(16 << 20)
 					capture := map[string]string{"authorization": r.Header.Get("Authorization")}
 					if r.MultipartForm != nil {

--- a/apps/launcher/internal/launcher/session.go
+++ b/apps/launcher/internal/launcher/session.go
@@ -1,0 +1,133 @@
+package launcher
+
+// session.go — the session lifecycle around login's stored tokens: the
+// invisible refresh (access tokens live an hour; the stored 30-day refresh
+// token renews them so login is a once-a-month event, not an hourly
+// chore), and `semiont logout`.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	semiont "github.com/The-AI-Alliance/semiont/packages/sdk-go"
+)
+
+// refreshSession trades the stored refresh token for a fresh access token
+// and SAVES the rotation — the next command must start from the new token.
+// The server does not rotate the refresh token; the stored one is kept.
+func refreshSession(u *ui, cli *semiont.ClientWithResponses, key string, e tokenEntry) (tokenEntry, bool) {
+	if e.RefreshToken == "" {
+		return e, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	resp, err := cli.PostApiTokensRefreshWithResponse(ctx, semiont.TokenRefreshRequest{
+		RefreshToken: e.RefreshToken,
+	})
+	if err != nil || resp.JSON200 == nil || resp.JSON200.AccessToken == "" {
+		return e, false
+	}
+	e.Token = resp.JSON200.AccessToken
+	e.ObtainedAt = time.Now().UTC()
+	if err := saveToken(key, e); err != nil {
+		u.warn("Refreshed token could not be stored (%v) — it will work for this command only.", err)
+	} else {
+		u.log("Session refreshed %s", u.dim("(access token renewed from the stored refresh token)"))
+	}
+	return e, true
+}
+
+const logoutUsage = `Usage: semiont logout [--repo <owner/name> | --runtime <rt>]
+
+End the stack's stored session: best-effort server-side logout, then the
+local token is forgotten either way.
+
+Options:
+  --repo <owner/name>  Target a codespace stack (default: the local stack)
+  --runtime <rt>       Target the local stack explicitly
+  --help               Show this help
+`
+
+func Logout(args []string) int {
+	u := newUI(false)
+	repo, wantLocal := "", false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --repo")
+				return 1
+			}
+			repo = args[i+1]
+			i++
+		case "--runtime":
+			if i+1 >= len(args) {
+				u.fail("Missing value for --runtime")
+				return 1
+			}
+			wantLocal = true
+			i++
+		case "--help", "-h":
+			fmt.Print(logoutUsage)
+			return 0
+		default:
+			u.fail("Unknown argument: %s", args[i])
+			return 1
+		}
+	}
+
+	ss := loadStackSet()
+	target, ok := selectVerbStack(u, "logout", ss, repo, wantLocal)
+	if !ok {
+		return 1
+	}
+	base, key := "", ""
+	if target != nil {
+		base = fmt.Sprintf("http://localhost:%d", target.ForwardPort)
+		key = "codespace:" + target.Repo
+	} else {
+		key = "local"
+		if local := ss.Stacks["local"]; local != nil {
+			base = backendBase(local)
+		}
+	}
+
+	e, have := loadTokens()[key]
+	if !have {
+		u.log("No session for %s — nothing to log out.", key)
+		return 0
+	}
+	// Server-side first, best-effort: an unreachable stack must not trap
+	// the user in a session they asked to end — but say what it means.
+	serverOut := false
+	if base != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if cli, err := semiont.NewClientWithResponses(base); err == nil {
+			if resp, err := cli.PostApiUsersLogoutWithResponse(ctx, bearer(e.Token)); err == nil && resp.HTTPResponse.StatusCode == 204 {
+				serverOut = true
+			}
+		}
+	}
+	if err := deleteToken(key); err != nil {
+		u.fail("Could not remove the stored session: %v", err)
+		return 1
+	}
+	if serverOut {
+		u.ok("Logged out of %s (%s) — session ended server-side, local token forgotten.", key, e.Email)
+	} else {
+		u.ok("Logged out of %s (%s) — local token forgotten.", key, e.Email)
+		u.warn("Server-side logout did not complete; the token remains valid there until it expires (~1h).")
+	}
+	return 0
+}
+
+// bearer is the RequestEditorFn stamping the session's Authorization header.
+func bearer(token string) semiont.RequestEditorFn {
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+}

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,8 +9,11 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
+
+	semiont "github.com/The-AI-Alliance/semiont/packages/sdk-go"
 )
 
 const statusUsage = `Usage: semiont status [--root <path|name>] [--repo <owner/name> [--refresh]] [--service <name>] [--runtime container|docker|podman] [--verbose] [--billing]
@@ -221,6 +225,7 @@ func Status(args []string) int {
 		printRemoteKBs(u, cs)
 	}
 	if service == "" && verbose {
+		printSessions(u, ss)
 		printLauncherPaths(u)
 	}
 
@@ -555,6 +560,50 @@ func printRoots(u *ui, st *stackState) {
 		if cfg != "" {
 			fmt.Printf("    %s\n", u.dim("config: "+cfg+" (used when --config is omitted)"))
 		}
+	}
+}
+
+// printSessions reports login sessions under --verbose: each stored token
+// (tokens.json) with its stack key and email, LIVE-verified against the
+// stack's /api/users/me when reachable — valid/expired is a runtime fact,
+// so an unreachable stack reads "unverified", never a guess.
+func printSessions(u *ui, ss *stackSet) {
+	u.section("SESSIONS")
+	toks := loadTokens()
+	if len(toks) == 0 {
+		fmt.Printf("  %s\n", u.dim("(none — semiont login --email <address>)"))
+		return
+	}
+	keys := make([]string, 0, len(toks))
+	for k := range toks {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		e := toks[k]
+		base := ""
+		if k == "local" {
+			if st := ss.Stacks["local"]; st != nil {
+				base = backendBase(st)
+			}
+		} else if st := ss.Stacks[k]; st != nil && st.ForwardPort != 0 {
+			base = fmt.Sprintf("http://localhost:%d", st.ForwardPort)
+		}
+		state := "unverified (stack not reachable)"
+		if base != "" {
+			if cli, err := semiont.NewClientWithResponses(base); err == nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				resp, err := cli.GetApiUsersMeWithResponse(ctx, bearer(e.Token))
+				cancel()
+				switch {
+				case err == nil && resp.JSON200 != nil:
+					state = "valid"
+				case err == nil && resp.JSON401 != nil:
+					state = "expired (auto-refreshes on next use, or semiont login)"
+				}
+			}
+		}
+		fmt.Printf("  %-24s %s %s\n", k, e.Email, u.dim("("+state+")"))
 	}
 }
 

--- a/apps/launcher/internal/launcher/tokens.go
+++ b/apps/launcher/internal/launcher/tokens.go
@@ -21,6 +21,32 @@ type tokenEntry struct {
 	ObtainedAt   time.Time `json:"obtainedAt"`
 }
 
+// deleteToken forgets one stack's session (logout).
+func deleteToken(key string) error {
+	m := loadTokens()
+	if _, ok := m[key]; !ok {
+		return nil
+	}
+	delete(m, key)
+	p := tokensPath()
+	if p == "" {
+		return os.ErrNotExist
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, append(b, '\n'), 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, p); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
 func tokensPath() string {
 	dir := stateDir()
 	if dir == "" {

--- a/apps/launcher/internal/launcher/yield.go
+++ b/apps/launcher/internal/launcher/yield.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"mime/multipart"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -154,7 +153,7 @@ func Yield(args []string) int {
 		return 1
 	}
 	for _, up := range uploads {
-		if code := yieldOne(u, cli, tok.Token, root, up, name); code != 0 {
+		if code := yieldOne(u, cli, key, &tok, root, up, name); code != 0 {
 			return code
 		}
 	}
@@ -164,7 +163,10 @@ func Yield(args []string) int {
 // yieldOne validates, builds the multipart per the spec's schema (name,
 // file, format, storageUri), and posts it. Fail-fast: the first refusal or
 // error stops the batch — partial silent success is how uploads get lost.
-func yieldOne(u *ui, cli *semiont.ClientWithResponses, token, root, up, name string) int {
+// A 401 triggers ONE invisible refresh-and-retry (session.go) before the
+// login fix-it — access tokens live an hour; that must be plumbing, not
+// the user's problem.
+func yieldOne(u *ui, cli *semiont.ClientWithResponses, key string, tok *tokenEntry, root, up, name string) int {
 	abs := up
 	if !filepath.IsAbs(abs) {
 		if a, err := filepath.Abs(abs); err == nil {
@@ -217,31 +219,37 @@ func yieldOne(u *ui, cli *semiont.ClientWithResponses, token, root, up, name str
 		return 1
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	resp, err := cli.PostResourcesWithBodyWithResponse(ctx, w.FormDataContentType(), &buf,
-		func(_ context.Context, req *http.Request) error {
-			req.Header.Set("Authorization", "Bearer "+token)
-			return nil
-		})
-	if err != nil {
-		u.fail("Backend unreachable: %v", err)
-		fmt.Fprintln(os.Stderr, "  Is the stack up?  semiont status")
-		return 1
-	}
-	switch {
-	case resp.JSON202 != nil:
-		u.ok("Yielded: %s → %s", up, resp.JSON202.ResourceId)
-		return 0
-	case resp.JSON401 != nil:
-		u.fail("Session rejected (expired?).")
-		fmt.Fprintln(os.Stderr, "  Log in again:  semiont login --email <address>")
-		return 1
-	case resp.JSON400 != nil:
-		u.fail("Backend rejected %s: %s", up, resp.JSON400.Error)
-		return 1
-	default:
-		u.fail("Upload of %s failed: HTTP %d.", up, resp.HTTPResponse.StatusCode)
-		return 1
+	body := buf.Bytes()
+	for attempt := 0; ; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		resp, err := cli.PostResourcesWithBodyWithResponse(ctx, w.FormDataContentType(),
+			bytes.NewReader(body), bearer(tok.Token))
+		cancel()
+		if err != nil {
+			u.fail("Backend unreachable: %v", err)
+			fmt.Fprintln(os.Stderr, "  Is the stack up?  semiont status")
+			return 1
+		}
+		switch {
+		case resp.JSON202 != nil:
+			u.ok("Yielded: %s → %s", up, resp.JSON202.ResourceId)
+			return 0
+		case resp.JSON401 != nil:
+			if attempt == 0 {
+				if refreshed, ok := refreshSession(u, cli, key, *tok); ok {
+					*tok = refreshed
+					continue
+				}
+			}
+			u.fail("Session rejected and the refresh token could not renew it.")
+			fmt.Fprintln(os.Stderr, "  Log in again:  semiont login --email <address>")
+			return 1
+		case resp.JSON400 != nil:
+			u.fail("Backend rejected %s: %s", up, resp.JSON400.Error)
+			return 1
+		default:
+			u.fail("Upload of %s failed: HTTP %d.", up, resp.HTTPResponse.StatusCode)
+			return 1
+		}
 	}
 }

--- a/apps/launcher/internal/launcher/yield.go
+++ b/apps/launcher/internal/launcher/yield.go
@@ -240,8 +240,12 @@ func yieldOne(u *ui, cli *semiont.ClientWithResponses, key string, tok *tokenEnt
 					*tok = refreshed
 					continue
 				}
+				u.fail("Session rejected and the refresh token could not renew it.")
+			} else {
+				// The refresh SUCCEEDED — saying it "could not renew" here
+				// would contradict the Session-refreshed line just printed.
+				u.fail("Session rejected even after a successful refresh — the backend no longer accepts this account's tokens.")
 			}
-			u.fail("Session rejected and the refresh token could not renew it.")
 			fmt.Fprintln(os.Stderr, "  Log in again:  semiont login --email <address>")
 			return 1
 		case resp.JSON400 != nil:

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1083,6 +1083,21 @@ func TestYieldAutoRefreshesExpiredToken(t *testing.T) {
 	mustContain(t, "tokens.json", string(tb), "fake-jwt-token-2", "fake-refresh-token")
 }
 
+func TestYieldPostRefreshRejectionSaysSo(t *testing.T) {
+	// Refresh SUCCEEDS but the renewed token is also rejected (account
+	// disabled, tokens revoked server-side): the failure must not claim
+	// "the refresh token could not renew it" — it did. Distinct message.
+	s := yieldScenario(t, true, "FAKERT_ALL_TOKENS_STALE=1")
+	stdout, stderr, code := s.run(t, "yield", "--upload", "docs/note.md")
+	if code == 0 {
+		t.Fatalf("yield must fail when every token is rejected\nstdout:\n%s", stdout)
+	}
+	mustContain(t, "post-refresh rejection", stdout+stderr, "after a successful refresh", "semiont login")
+	if strings.Contains(stdout+stderr, "could not renew") {
+		t.Errorf("claimed the refresh failed when it succeeded:\n%s\n%s", stdout, stderr)
+	}
+}
+
 func TestLogoutForgetsSession(t *testing.T) {
 	s := yieldScenario(t, true)
 	stdout, stderr, code := s.run(t, "logout")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -986,9 +986,12 @@ func TestLoginWithoutStackRefuses(t *testing.T) {
 // --- yield (sdk-go glue) ---
 
 // yieldScenario boots the fake stack, logs in, and seeds docs/note.md.
-func yieldScenario(t *testing.T, login bool) *scenario {
+// extraEnv lands BEFORE start: the fake backend serve keeps its birth env,
+// so per-run env set after start never reaches it (learned RED-first).
+func yieldScenario(t *testing.T, login bool, extraEnv ...string) *scenario {
 	t.Helper()
 	s := newScenario(t, "container")
+	s.extraEnv = append(s.extraEnv, extraEnv...)
 	if _, stderr, code := s.run(t, "start"); code != 0 {
 		t.Fatalf("start: exit %d\nstderr:\n%s", code, stderr)
 	}
@@ -1052,6 +1055,69 @@ func TestYieldWithoutSessionAdvisesLogin(t *testing.T) {
 		t.Fatalf("yield without a session must refuse\nstdout:\n%s", stdout)
 	}
 	mustContain(t, "fix-it", stdout+stderr, "semiont login")
+}
+
+func TestYieldAutoRefreshesExpiredToken(t *testing.T) {
+	// The login-issued access token has expired (they live an hour); the
+	// stored refresh token must renew it INVISIBLY — login is a
+	// once-a-month event, not an hourly chore. (Login itself never sends a
+	// bearer, so the from-birth stale flag doesn't break the setup.)
+	s := yieldScenario(t, true, "FAKERT_STALE_TOKEN=1")
+	stdout, stderr, code := s.run(t, "yield", "--upload", "docs/note.md")
+	if code != 0 {
+		t.Fatalf("yield with refreshable token: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout, "Yielded", "fake-resource-id")
+	// The upload went out under the REFRESHED token…
+	b, err := os.ReadFile(filepath.Join(s.fakertDir, "yield-upload.json"))
+	if err != nil {
+		t.Fatalf("upload capture: %v", err)
+	}
+	mustContain(t, "multipart", string(b), `"authorization":"Bearer fake-jwt-token-2"`)
+	// …and the rotation was SAVED: next command starts from the new token,
+	// keeping the original refresh token (the server does not rotate it).
+	tb, err := os.ReadFile(tokensPathFor(s.home))
+	if err != nil {
+		t.Fatalf("tokens.json: %v", err)
+	}
+	mustContain(t, "tokens.json", string(tb), "fake-jwt-token-2", "fake-refresh-token")
+}
+
+func TestLogoutForgetsSession(t *testing.T) {
+	s := yieldScenario(t, true)
+	stdout, stderr, code := s.run(t, "logout")
+	if code != 0 {
+		t.Fatalf("logout: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "stdout", stdout, "Logged out", "local")
+	if tb, err := os.ReadFile(tokensPathFor(s.home)); err == nil {
+		if strings.Contains(string(tb), "fake-jwt-token") {
+			t.Errorf("token survived logout:\n%s", tb)
+		}
+	}
+	// A second logout is a benign no-op, said plainly.
+	stdout, _, code = s.run(t, "logout")
+	if code != 0 {
+		t.Fatalf("repeat logout should no-op, got exit %d", code)
+	}
+	mustContain(t, "stdout", stdout, "No session")
+}
+
+func TestStatusVerboseShowsSessions(t *testing.T) {
+	s := newScenario(t, "container")
+	if _, stderr, code := s.run(t, "start"); code != 0 {
+		t.Fatalf("start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	// Before any login: the section says so, without inventing a session.
+	stdout, _, _ := s.run(t, "status", "--verbose")
+	mustContain(t, "no sessions yet", stdout, "SESSIONS", "none — semiont login")
+	s.stdin = "hunter2secret\n"
+	if _, stderr, code := s.run(t, "login", "--email", "admin@example.com"); code != 0 {
+		t.Fatalf("login: exit %d\nstderr:\n%s", code, stderr)
+	}
+	s.stdin = ""
+	stdout, _, _ = s.run(t, "status", "--verbose")
+	mustContain(t, "session row", stdout, "SESSIONS", "local", "admin@example.com", "valid")
 }
 
 // --- stop ---

--- a/apps/launcher/main.go
+++ b/apps/launcher/main.go
@@ -24,6 +24,7 @@ Commands:
   start     Start the local Semiont stack
   useradd   Create or update a user in the running stack
   login     Authenticate against a running stack (token stored, never the password)
+  logout    End the stored session (server best-effort, local token forgotten)
   yield     Upload files from the KB root as resources (needs login)
   secret    Register where config secrets come from (pointers, never values)
   status    Report container state and application health per service
@@ -55,6 +56,8 @@ func main() {
 		code = launcher.Useradd(rest)
 	case "login":
 		code = launcher.Login(rest)
+	case "logout":
+		code = launcher.Logout(rest)
 	case "yield":
 		code = launcher.Yield(rest)
 	case "secret":


### PR DESCRIPTION
Completes the session layer around `semiont login` (#1071): access tokens live an hour, and until now expiry meant a manual re-login mid-work. Sessions now maintain themselves, end cleanly, and report their state honestly.

## Invisible token refresh

A 401 from the backend triggers ONE refresh from the stored 30-day refresh token (`POST /api/tokens/refresh`), announced (`▸ Session refreshed`), **saved** (the next command starts from the new access token; the refresh token is kept — the server does not rotate it), and the request retried once. A failed refresh falls through to the honest fix-it (`semiont login` again). Wired into `yield`'s upload loop via a rebuildable request body; future verbs get it through the same `refreshSession` seam. Net effect: login is a once-a-month event, not an hourly chore.

Pinned by a test whose fake backend rejects the login-issued token from birth — the upload must land under the renewed token, and tokens.json must show the rotation (new access token, original refresh token).

## semiont logout

Ends a stack's session through the shared knowledge-verb ladder: server-side best-effort (`POST /api/users/logout`, bearer), then the local token is forgotten **either way** — an unreachable stack must not trap the user in a session they asked to end, but the asymmetry is said plainly ("the token remains valid there until it expires"). Repeat logout is a stated no-op.

## SESSIONS in `status --verbose`

Every stored session, one row per stack key, LIVE-verified against `/api/users/me` when the stack is reachable — `valid` / `expired (auto-refreshes on next use, or semiont login)` / `unverified (stack not reachable)` — never a guess, per status's verify-everything ethos. No sessions yet reads as a hint, not an empty table. This is the `whoami` answer, folded into the report that already covers every stack.

## Harness

fakert's fake backend grows the session endpoints (`/api/tokens/refresh`, `/api/users/logout`, `/api/users/me`, bearer checks on `/resources`) plus `FAKERT_STALE_TOKEN` for the expiry scenario. One measured harness lesson is now documented in the scenario helper: the fake backend serve keeps its **birth env**, so scenario knobs must be set before `start` — per-run env after start never reaches it (found RED-first when the stale flag silently didn't bite).

RED observed before GREEN for all three features; gate: strict gofmt + vet + full launcher suite in golang:1.25, 0 FAIL.
