### PR TITLE
launcher: fix flaky codespace port collision — make the fake tell the truth about ports, fail fast when a forward can't bind

### DIFF
--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -413,12 +413,14 @@ func lsof(args []string) {
 	// launcher handed out a port that could not bind: the forward died
 	// instantly and the start failed 30s later blaming the tunnel (CI run
 	// 30143820210). A fake that lies about the world hides real bugs.
-	if c, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 300*time.Millisecond); err == nil {
-		_ = c.Close()
-		fmt.Println(os.Getpid()) // a pid, as real lsof prints
-		return
+	// Probe by BINDING, not dialing: bindability is the question the
+	// launcher is really asking, and a dial can report "free" for a port
+	// that is held but not accepting (backlog exhausted, filtered).
+	if ln, err := net.Listen("tcp", "127.0.0.1:"+port); err == nil {
+		_ = ln.Close()
+		os.Exit(1) // bindable ⇒ nothing holds it; real lsof exits 1
 	}
-	os.Exit(1) // real lsof exits 1 when nothing matches
+	fmt.Println(os.Getpid()) // a pid, as real lsof prints
 }
 
 // opCmd fakes the 1Password CLI: the launcher calls `op read op://<path>`.
@@ -875,13 +877,22 @@ func killServe(name string) bool {
 	if len(lines) > 1 {
 		for _, p := range strings.Fields(lines[1]) {
 			deadline := time.Now().Add(3 * time.Second)
+			freed := false
 			for time.Now().Before(deadline) {
-				c, err := net.DialTimeout("tcp", "127.0.0.1:"+p, 100*time.Millisecond)
-				if err != nil {
-					break // refused: the port is free
+				if ln, err := net.Listen("tcp", "127.0.0.1:"+p); err == nil {
+					_ = ln.Close()
+					freed = true
+					break
 				}
-				_ = c.Close()
 				time.Sleep(10 * time.Millisecond)
+			}
+			if !freed {
+				// Never silently give up: an unreleased port here becomes
+				// an unexplained failure in a LATER test. Say so where it
+				// happened. (Loud on stderr, not a nonzero exit — the exit
+				// code of `stop` means "did the container exist", which the
+				// launcher acts on.)
+				fmt.Fprintf(os.Stderr, "fakert stop: port %s still held 3s after killing %s — harness bug, later tests may fail\n", p, name)
 			}
 		}
 	}

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -9,7 +9,9 @@
 //	FAKERT_LOG               append-one-line-per-invocation argv log (the golden seam)
 //	FAKERT_DIR               scratch dir for serve pidfiles
 //	FAKERT_GIT_ROOT          `git rev-parse --show-toplevel` output; unset = not a repo
-//	FAKERT_LSOF_<port>       newline-separated PIDs "holding" the port; unset = free
+//	FAKERT_LSOF_<port>       newline-separated PIDs "holding" the port; UNSET =
+//	                         answer for real (dial it), because a fake that
+//	                         calls a truly-held port "free" hides real bugs
 //	FAKERT_PS_<pid>          comm= output for a PID (default "fakeproc")
 //	FAKERT_NSLOOKUP          "ok" makes the host-alias probe succeed
 //	FAKERT_GATEWAY           default-gateway probe output (default 192.168.64.1)
@@ -397,13 +399,26 @@ func lsof(args []string) {
 		fmt.Fprintf(os.Stderr, "fakert lsof: unscripted args %v\n", args)
 		os.Exit(64)
 	}
-	pids := os.Getenv("FAKERT_LSOF_" + strings.TrimPrefix(args[1], ":"))
-	if pids == "" {
-		os.Exit(1) // real lsof exits 1 when nothing matches
+	port := strings.TrimPrefix(args[1], ":")
+	if pids := os.Getenv("FAKERT_LSOF_" + port); pids != "" {
+		for _, p := range strings.Fields(pids) {
+			fmt.Println(p)
+		}
+		return
 	}
-	for _, p := range strings.Fields(pids) {
-		fmt.Println(p)
+	// FIDELITY: with nothing scripted, answer for REAL. A port something is
+	// actually listening on must read as BUSY — real lsof sees it, and the
+	// launcher trusts lsof for both its port preflight and KB-port
+	// allocation. An env-only fake reported "free" for a held port, so the
+	// launcher handed out a port that could not bind: the forward died
+	// instantly and the start failed 30s later blaming the tunnel (CI run
+	// 30143820210). A fake that lies about the world hides real bugs.
+	if c, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 300*time.Millisecond); err == nil {
+		_ = c.Close()
+		fmt.Println(os.Getpid()) // a pid, as real lsof prints
+		return
 	}
+	os.Exit(1) // real lsof exits 1 when nothing matches
 }
 
 // opCmd fakes the 1Password CLI: the launcher calls `op read op://<path>`.
@@ -648,8 +663,10 @@ func run(args []string) {
 			os.Exit(1)
 		}
 		if dir := os.Getenv("FAKERT_DIR"); dir != "" && name != "" {
+			// pid, then the ports it holds — `stop` waits for THOSE to be
+			// released, which is what a real stop guarantees (killServe).
 			_ = os.WriteFile(filepath.Join(dir, "serve-"+name+".pid"),
-				[]byte(strconv.Itoa(cmd.Process.Pid)), 0o644)
+				[]byte(strconv.Itoa(cmd.Process.Pid)+"\n"+strings.Join(ports, " ")), 0o644)
 		}
 	}
 	// The container identifier the runtime reports — name-derived so tests
@@ -843,9 +860,29 @@ func killServe(name string) bool {
 	if err != nil {
 		return false
 	}
-	if pid, err := strconv.Atoi(strings.TrimSpace(string(b))); err == nil {
+	lines := strings.SplitN(strings.TrimSpace(string(b)), "\n", 2)
+	if pid, err := strconv.Atoi(strings.TrimSpace(lines[0])); err == nil {
 		if p, err := os.FindProcess(pid); err == nil {
 			_ = p.Kill()
+		}
+	}
+	// FIDELITY: a real `stop` does not return until the container is stopped
+	// and its published ports are RELEASED. Returning early let the
+	// launcher's very next port check still see the dying listener —
+	// invisible while the fake lsof was env-only, a flake the moment it told
+	// the truth. Waiting on the PORTS (not the pid) avoids depending on who
+	// reaps an orphaned serve.
+	if len(lines) > 1 {
+		for _, p := range strings.Fields(lines[1]) {
+			deadline := time.Now().Add(3 * time.Second)
+			for time.Now().Before(deadline) {
+				c, err := net.DialTimeout("tcp", "127.0.0.1:"+p, 100*time.Millisecond)
+				if err != nil {
+					break // refused: the port is free
+				}
+				_ = c.Close()
+				time.Sleep(10 * time.Millisecond)
+			}
 		}
 	}
 	_ = os.Remove(pidfile)

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -238,7 +238,7 @@ func startCodespace(u *ui, opts startOptions) int {
 		// diagnosis naming the port.
 		select {
 		case <-fwdDead:
-			u.fail("The port forward exited immediately — localhost:%d is probably already in use.", kbPort)
+			u.fail("The port forward exited before it could bind — localhost:%d is probably already in use.", kbPort)
 			fmt.Fprintf(os.Stderr, "  See what holds it:  lsof -ti :%d\n", kbPort)
 			fmt.Fprintf(os.Stderr, "  Try it directly:    gh codespace ports forward %d:%d -c %s\n", kbRemotePort, kbPort, name)
 			return 1

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -231,6 +231,19 @@ func startCodespace(u *ui, opts startOptions) int {
 			bound = true
 			break
 		}
+		// A forward that EXITED cannot bind later — the usual cause is the
+		// local port already being in use (gh fails "address already in
+		// use" and dies at once). Watching the same death channel the
+		// health gate uses turns 30s of vagueness into an instant, honest
+		// diagnosis naming the port.
+		select {
+		case <-fwdDead:
+			u.fail("The port forward exited immediately — localhost:%d is probably already in use.", kbPort)
+			fmt.Fprintf(os.Stderr, "  See what holds it:  lsof -ti :%d\n", kbPort)
+			fmt.Fprintf(os.Stderr, "  Try it directly:    gh codespace ports forward %d:%d -c %s\n", kbRemotePort, kbPort, name)
+			return 1
+		default:
+		}
 		time.Sleep(time.Second)
 	}
 	if !bound {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -155,7 +155,10 @@ func (s *scenario) killServes() {
 		if err != nil {
 			continue
 		}
-		if pid, err := strconv.Atoi(strings.TrimSpace(string(b))); err == nil {
+		// Pidfiles are "pid\n<ports>" (fakert records the ports so its own
+		// stop can wait for their release) — parse the FIRST line only.
+		first := strings.SplitN(strings.TrimSpace(string(b)), "\n", 2)[0]
+		if pid, err := strconv.Atoi(strings.TrimSpace(first)); err == nil {
 			pids = append(pids, pid)
 			if p, err := os.FindProcess(pid); err == nil {
 				_ = p.Kill()
@@ -2252,6 +2255,28 @@ func writeCodespaceState(t *testing.T, s *scenario) {
 	}
 }
 
+func TestKBPortAllocationDodgesLiveHolders(t *testing.T) {
+	// Two scenarios alive at once (separate HOMEs, so neither sees the
+	// other's records) must not collide on the KB port: allocation consults
+	// lsof, and the fake answers for REAL listeners — the fidelity gap that
+	// let CI hand out an unbindable 4000 (run 30143820210).
+	s := newCodespaceScenario(t)
+	if _, stderr, code := s.run(t, "start", "--runtime", "codespace"); code != 0 {
+		t.Fatalf("first create: exit %d\nstderr:\n%s", code, stderr)
+	}
+	s2 := newCodespaceScenario(t)
+	s2.cwd = t.TempDir()
+	stdout, stderr, code := s2.run(t, "start", "--runtime", "codespace", "--repo", "other/bar")
+	if code != 0 {
+		t.Fatalf("second create: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	// It stepped over the port the first scenario's forward really holds.
+	mustContain(t, "second stack's forward", string(s2.mustLog(t)), "ports forward 4000:4001")
+	if strings.Contains(stdout, "did not come up") || strings.Contains(stdout, "exited immediately") {
+		t.Errorf("second create collided on the KB port:\n%s", stdout)
+	}
+}
+
 func TestCodespaceDidIsRecordedNotInferred(t *testing.T) {
 	// did:web is the permanent identity in the committed event log, so the
 	// remote-KB line must show only what was READ from the clone whose origin
@@ -3769,7 +3794,13 @@ func TestStartServiceSecretUnreadableIsLoud(t *testing.T) {
 	// With an explicit env secret: proceeds, but warns about the mismatch
 	// risk instead of pretending recovery worked.
 	s.noWorkerSecret = false
-	serveHealth(t, 9090)
+	// NO serveHealth(9090) here: 9090 is the WORKER's own port, and the
+	// launcher must find it free to start the container that then serves it
+	// (the fake run -d binds it, as in TestStartServiceWorker). Pre-binding
+	// it modelled a foreign process squatting the port — fiction that only
+	// passed while the fake lsof lied about real listeners; now the launcher
+	// correctly refuses. serveHealth is for services the launcher does NOT
+	// start (an already-running backend, Jaeger, a host Ollama).
 	stdout, stderr2, code := s.run(t, "start", "--service", "worker")
 	if code != 0 {
 		t.Fatalf("env-secret path: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr2)

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -2272,7 +2272,8 @@ func TestKBPortAllocationDodgesLiveHolders(t *testing.T) {
 	}
 	// It stepped over the port the first scenario's forward really holds.
 	mustContain(t, "second stack's forward", string(s2.mustLog(t)), "ports forward 4000:4001")
-	if strings.Contains(stdout, "did not come up") || strings.Contains(stdout, "exited immediately") {
+	// Stable substrings, not the full sentences — wording may change.
+	if strings.Contains(stdout, "did not come up") || strings.Contains(stdout, "port forward exited") {
 		t.Errorf("second create collided on the KB port:\n%s", stdout)
 	}
 }


### PR DESCRIPTION
CI flaked in `TestCodespaceDidIsRecordedNotInferred` ("The port forward did not come up on localhost:4000 within 30s", run 30143820210). Root cause was a fake that lied about ports; fixing it also improved a real user-facing error.

## Cause

Two live test scenarios each got KB port 4000. The launcher's allocator dodges live holders via `lsof`, but fakert's `lsof` was env-only and blind to real listeners — it reported "free" for a port another scenario's forward genuinely held. The new forward then couldn't bind, died instantly, and the start burned its full 30-second window before blaming the tunnel.

## Fixes

**fakert `lsof` answers for real.** With nothing scripted it dials the port and reports a holder if one exists, as real `lsof` would (`FAKERT_LSOF_<port>` still overrides for deliberate conflict tests). A fake that calls a truly-held port free hides real bugs — the same lesson as the container name-holding fix.

**fakert `stop` is synchronous.** It now waits for the stopped container's published ports to be released, which is what a real `stop` guarantees. Serve pidfiles record their ports so the wait targets those rather than depending on who reaps an orphan. This alone fixed two tests that had been racing invisibly behind the env-only fake.

**Product: the bind wait fails fast.** The codespace bind loop now watches the forward's death channel (added with the health-gate fail-fast in #1070): a forward that exits immediately reports `The port forward exited immediately — localhost:4000 is probably already in use` with an `lsof -ti :4000` hint, in seconds instead of 30. Anyone with another service on 4000 previously waited half a minute for a misleading message.

## Test changes

- New `TestKBPortAllocationDodgesLiveHolders`: two concurrent scenarios must land on 4000 and 4001. Verified by mutation — with the env-only fake restored, it reproduces CI's failure exactly (and now via the new fast, accurate message).
- `TestStartServiceSecretUnreadableIsLoud` no longer pre-binds 9090. That's the worker's *own* port: the launcher must find it free to start the container that then serves it (as `TestStartServiceWorker` does). Pre-binding modelled a foreign squatter, and the launcher's refusal is correct behavior — the fiction only passed while the fake lied. `serveHealth` remains for services the launcher does not start (an already-running backend, Jaeger, a host Ollama).
- Harness `killServes` parses the first line of the new pidfile format (a missed second reader of that format briefly stopped all process reaping).

Gate: strict gofmt + vet + full launcher suite in golang:1.25, 0 FAIL.
