### PR TITLE
fix(codeql): install Go before init so tracing actually works

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -118,7 +118,7 @@ NEXT_PUBLIC_OAUTH_ALLOWED_DOMAINS=example.com
 
 # Backend  
 DATABASE_URL=postgresql://testuser:testpassword@localhost:5432/testdb
-JWT_SECRET=test-secret-for-ci
+JWT_SECRET=test-secret-key-for-testing-32char   # requireJwtSecret() rejects < 32 chars
 GOOGLE_CLIENT_ID=test-client-id
 GOOGLE_CLIENT_SECRET=test-client-secret
 ```

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7.0.1
 
+    # Go must be installed BEFORE codeql-action/init: init injects a wrapper `go`
+    # into PATH to trace the build, and a later setup-go would shadow it (CodeQL
+    # warns "Expected `which go` to return .../codeql-action-go-tracing/bin/go").
+    # cache: false — the launcher is stdlib-only (no go.sum), so there is nothing
+    # to cache, and setup-go's default lookup warns on the missing root go.mod.
+    - name: Setup Go
+      if: matrix.language == 'go'
+      uses: actions/setup-go@v7.0.0
+      with:
+        go-version-file: apps/launcher/go.mod
+        cache: false
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4.37.2
       with:
@@ -54,12 +66,6 @@ jobs:
       continue-on-error: true
 
     # Go is a compiled language: the CodeQL extractor needs a real build to trace.
-    - name: Setup Go
-      if: matrix.language == 'go'
-      uses: actions/setup-go@v7.0.0
-      with:
-        go-version-file: apps/launcher/go.mod
-
     - name: Build launcher for CodeQL extraction
       if: matrix.language == 'go'
       run: cd apps/launcher && go build ./...


### PR DESCRIPTION
## Description

Fixes the CodeQL warnings surfaced on the repo's Security page ("CodeQL is reporting warnings"). These were **tool warnings, not vulnerabilities** — there are 0 open code-scanning alerts — and both came from the Go analysis leg added earlier.

### 1. Go tracing was broken (the real fix)

```
##[warning] Expected `which go` to return
  /home/runner/work/_temp/codeql-action-go-tracing/bin/go,
but got /opt/hostedtoolcache/go/1.25.12/x64/bin/go:
please ensure that the correct version of Go is installed
before the `codeql-action/init` Action is used.
```

`codeql-action/init` injects a wrapper `go` binary into `PATH` to trace compiled builds. `setup-go` was running **after** `init`, installing a real Go that shadowed that wrapper — so Go extraction ran degraded. Fix: move `Setup Go` ahead of `Initialize CodeQL`, exactly as the warning instructs.

**This matters beyond silencing the banner:** the Go leg previously reported `results: 0`, but with the tracing wrapper shadowed that zero wasn't trustworthy. This run's Go result is the first meaningful one.

### 2. Spurious cache warning

```
##[warning] Restore cache failed: Dependencies file is not found in
  /home/runner/work/semiont/semiont. Supported file pattern: go.mod
```

`setup-go` looks for `go.mod`/`go.sum` at the **repo root**; ours lives at `apps/launcher/go.mod`. The launcher is stdlib-only (no `go.sum`), so there is nothing to cache — set `cache: false`.

Resulting step order: `Checkout → Setup Go (go only) → Init CodeQL → Setup Node/npm (js only) → Build launcher (go only) → Analyze`.

### Also included

`3847018d` (`.github/ACTIONS.md`) — raises the documented CI `JWT_SECRET` example to 32 characters, since `requireJwtSecret()` rejects anything shorter. Docs-only, unrelated to the CodeQL change.

## Type of Change

- [x] Infrastructure/DevOps changes
- [x] Documentation update

## Areas Changed

- `.github/workflows/codeql-analysis.yml` — step ordering + `cache: false`
- `.github/ACTIONS.md` — CI `JWT_SECRET` doc example length

No application source touched.

## Security Checklist

N/A — no authentication, authorization, or admin code changed. This fixes the *configuration of* a security scanner; the `JWT_SECRET` change is a documentation example, not a real secret.

## Testing

Workflow ordering can only be verified on GitHub's runner — the CodeQL tracing wrapper exists only inside `codeql-action/init`, so there is no meaningful local reproduction. Verified locally: YAML parses, exactly one `Setup Go` step, and it precedes `Initialize CodeQL`.

What to check on this run's CodeQL job:
- Both `##[warning]` lines gone from the Go leg.
- The Go `results` count is now trustworthy — still `0` means a genuine clean result; any findings were previously being missed and should be triaged.

## Breaking Changes

None — CI configuration and documentation only.
