### PR TITLE
useradd: read the password from stdin, remove --password

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ One command starts the whole stack: the launcher pulls the published Semiont ima
 Create your admin user:
 
 ```bash
-semiont useradd --email admin@example.com --password <choose-a-password> --admin
+semiont useradd --email admin@example.com --admin   # prompts for the password
 ```
 
 Then open **http://localhost:3000**. The Semiont browser's Knowledge Bases panel discovers launcher-managed stacks automatically — pick yours and sign in with the email and password you just created. (Connecting to a KB the launcher doesn't know about? Enter its host and port by hand, e.g. `localhost` / `4000`.)

--- a/apps/backend/src/cli/useradd.ts
+++ b/apps/backend/src/cli/useradd.ts
@@ -44,7 +44,11 @@ interface Options {
   upsert: boolean;
 }
 
-const USAGE = `Usage: semiont-useradd --email <email> (--password-stdin | --generate-password) [options]
+const USAGE = `Usage: semiont-useradd --email <email> [--password-stdin | --generate-password] [options]
+
+Creating a user requires a password, so one of --password-stdin or
+--generate-password. Updating an existing one does not: pass --password-stdin
+only when the point is to CHANGE the password.
 
   --email <email>       User email address (required)
   --password-stdin      Read the password from stdin, first line (min 8 chars)
@@ -97,8 +101,16 @@ function parseArgs(argv: string[]): Options {
  * history. Stdin has none of those properties.
  */
 async function readPasswordFromStdin(): Promise<string> {
+  // Stop at the first newline rather than draining to EOF: a password is one
+  // line, and waiting for the stream to close would hang an interactive run
+  // (`docker exec -it … --password-stdin`) after the user pressed Enter, until
+  // they thought to send Ctrl-D.
   const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  for await (const chunk of process.stdin) {
+    const buf = Buffer.from(chunk);
+    chunks.push(buf);
+    if (buf.includes(0x0a)) break;
+  }
   // split() on empty input yields [''], but noUncheckedIndexedAccess types the
   // index access as possibly-undefined regardless — empty stdin is a refusal
   // either way, two lines down.

--- a/apps/backend/src/cli/useradd.ts
+++ b/apps/backend/src/cli/useradd.ts
@@ -99,7 +99,10 @@ function parseArgs(argv: string[]): Options {
 async function readPasswordFromStdin(): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
-  const first = Buffer.concat(chunks).toString('utf8').split('\n', 1)[0];
+  // split() on empty input yields [''], but noUncheckedIndexedAccess types the
+  // index access as possibly-undefined regardless — empty stdin is a refusal
+  // either way, two lines down.
+  const first = Buffer.concat(chunks).toString('utf8').split('\n', 1)[0] ?? '';
   const password = first.replace(/\r$/, '');
   if (!password) throw new Error('--password-stdin was given but stdin carried no password');
   if (password.length < 8) throw new Error('Password must be at least 8 characters long');

--- a/apps/backend/src/cli/useradd.ts
+++ b/apps/backend/src/cli/useradd.ts
@@ -34,7 +34,7 @@ import { databaseUrlFrom } from '../utils/database-url';
 
 interface Options {
   email: string;
-  password?: string;
+  passwordStdin: boolean;
   generatePassword: boolean;
   name?: string;
   admin: boolean;
@@ -44,10 +44,10 @@ interface Options {
   upsert: boolean;
 }
 
-const USAGE = `Usage: semiont-useradd --email <email> (--password <pass> | --generate-password) [options]
+const USAGE = `Usage: semiont-useradd --email <email> (--password-stdin | --generate-password) [options]
 
   --email <email>       User email address (required)
-  --password <pass>     Password (min 8 characters)
+  --password-stdin      Read the password from stdin, first line (min 8 chars)
   --generate-password   Generate a random password (printed once)
   --name <name>         Display name
   --admin               Grant admin privileges
@@ -60,7 +60,7 @@ const USAGE = `Usage: semiont-useradd --email <email> (--password <pass> | --gen
 
 function parseArgs(argv: string[]): Options {
   const o: Options = {
-    email: '', generatePassword: false, admin: false,
+    email: '', passwordStdin: false, generatePassword: false, admin: false,
     moderator: false, inactive: false, update: false, upsert: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -73,8 +73,8 @@ function parseArgs(argv: string[]): Options {
     };
     switch (a) {
       case '--email': o.email = value(); break;
-      case '--password': o.password = value(); break;
       case '--name': o.name = value(); break;
+      case '--password-stdin': o.passwordStdin = true; break;
       case '--generate-password': o.generatePassword = true; break;
       case '--admin': o.admin = true; break;
       case '--moderator': o.moderator = true; break;
@@ -86,6 +86,24 @@ function parseArgs(argv: string[]): Options {
     }
   }
   return o;
+}
+
+/**
+ * Read the password from stdin's FIRST LINE.
+ *
+ * A password must never travel in argv: `ps` shows a process's command line to
+ * every other user on the host, `docker inspect`/`container inspect` keep it as
+ * long as the container record lives, and the caller's shell records it in
+ * history. Stdin has none of those properties.
+ */
+async function readPasswordFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  const first = Buffer.concat(chunks).toString('utf8').split('\n', 1)[0];
+  const password = first.replace(/\r$/, '');
+  if (!password) throw new Error('--password-stdin was given but stdin carried no password');
+  if (password.length < 8) throw new Error('Password must be at least 8 characters long');
+  return password;
 }
 
 /** Same shape the old CLI produced: 16 base64 chars from 12 random bytes. */
@@ -106,8 +124,8 @@ function validate(o: Options): void {
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(o.email)) {
     throw new Error(`invalid email format: ${o.email}`);
   }
-  if (o.password !== undefined && o.password.length < 8) {
-    throw new Error('Password must be at least 8 characters long');
+  if (o.passwordStdin && o.generatePassword) {
+    throw new Error('--password-stdin and --generate-password are mutually exclusive');
   }
   if (o.update && o.upsert) {
     throw new Error('--update and --upsert are mutually exclusive');
@@ -137,10 +155,10 @@ async function main(argv: string[]): Promise<number> {
       passwordHash = await argon2.hash(generated);
       // Printed once and never stored: the caller's only chance to capture it.
       process.stdout.write(`Generated password: ${generated}\n`);
-    } else if (o.password) {
-      passwordHash = await argon2.hash(o.password);
+    } else if (o.passwordStdin) {
+      passwordHash = await argon2.hash(await readPasswordFromStdin());
     } else if (!existing) {
-      throw new Error('Password required: use --password or --generate-password');
+      throw new Error('Password required: use --password-stdin or --generate-password');
     }
 
     if (existing) {

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -56,7 +56,7 @@ births a startable KB in one command (identity from your git origin). Then:
 
 ```sh
 semiont start
-semiont useradd --email admin@example.com --password mypassword --admin
+semiont useradd --email admin@example.com --admin   # prompts for the password
 semiont status
 semiont logs
 semiont stop
@@ -182,7 +182,10 @@ semiont stop
   passes every other flag through verbatim (`--admin`, `--generate-password`,
   `--update`, `--upsert`, …). The backend owns the user schema, the password
   hashing and the database write; this launcher only decides which stack is
-  meant. It works against **codespace stacks too** — one hop further out,
+  meant. The password is the one thing it does NOT pass as an argument: it is
+  prompted for on a terminal (or read from stdin when piped) and fed to
+  `--password-stdin` down the exec's pipe, because argv is readable by every
+  process on the host via `ps` and lands in the caller's shell history. It works against **codespace stacks too** — one hop further out,
   `gh codespace ssh -- docker exec …` — with every argument shell-quoted,
   because that remote side runs through a shell (the local `exec` path does
   not, so a password with spaces or `$` is only a hazard on the codespace

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -550,6 +550,14 @@ func runtimeCmd(base string, args []string) {
 		fmt.Fprintln(os.Stderr, name+" err")
 	case "exec":
 		// The launcher's useradd bridge: exec <handle> semiont useradd <args…>.
+		// Drain stdin and record it: the password crosses THERE, never in argv,
+		// so a test can only prove the secret arrived by reading what the pipe
+		// carried. Draining also keeps the writer from seeing EPIPE.
+		if in, err := io.ReadAll(os.Stdin); err == nil && len(in) > 0 {
+			if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+				_ = os.WriteFile(filepath.Join(dir, "exec-stdin.txt"), in, 0o600)
+			}
+		}
 		// FAKERT_EXEC_FAIL models the in-container CLI failing.
 		if os.Getenv("FAKERT_EXEC_FAIL") != "" {
 			fmt.Fprintln(os.Stderr, "Error: useradd failed")

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -124,7 +124,7 @@ Examples:
   semiont start --config anthropic
 
   # First admin user, once the stack is up
-  semiont useradd --email admin@example.com --password <pass> --admin
+  semiont useradd --email admin@example.com --admin
 
   # See available configs
   semiont start --list-configs
@@ -789,7 +789,7 @@ func runStart(u *ui, rt, version, root, configFile string, opts startOptions, us
 		fmt.Println("  Jaeger UI          http://localhost:16686")
 	}
 	fmt.Println()
-	fmt.Printf("  Add a user:    %s\n", u.bold("semiont useradd --email <email> --password <pass> --admin"))
+	fmt.Printf("  Add a user:    %s\n", u.bold("semiont useradd --email <email> --admin"))
 	fmt.Printf("  Check health:  %s\n", u.bold("semiont status"))
 	fmt.Printf("  Follow logs:   %s\n", u.bold("semiont logs"))
 	fmt.Printf("  Stop stack:    %s\n", u.bold("semiont stop"))

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -100,16 +100,14 @@ var echoEnvAllowlist = map[string]bool{
 	"OTEL_EXPORTER_OTLP_ENDPOINT": true,
 }
 
-// redactEnvArgs also redacts the value after a bare --password flag — the
-// useradd exec bridge carries one in its echoed argv.
+// redactEnvArgs blanks secret --env VALUES for display. It no longer special-
+// cases a password argument: useradd sends the password down stdin, so no
+// command the launcher echoes has one to hide. Redaction was only ever a
+// display fix for a secret that was still in argv where `ps` could read it.
 func redactEnvArgs(args []string) []string {
 	out := make([]string, len(args))
 	copy(out, args)
 	for i := 0; i < len(out)-1; i++ {
-		if out[i] == "--password" {
-			out[i+1] = "<redacted>"
-			continue
-		}
 		if out[i] != "--env" {
 			continue
 		}
@@ -174,6 +172,21 @@ func runWithStdin(name, input string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stdin = strings.NewReader(input)
 	cmd.Stdout, cmd.Stderr = io.Discard, os.Stderr
+	return cmd.Run()
+}
+
+// runVisibleWithStdin is runVisible plus a secret on stdin: output stays
+// visible (useradd's own messages, including a generated password, are the
+// point of running it) while the secret never enters argv. Distinct from
+// runWithStdin, which HIDES stdout because there the output is itself a secret.
+//
+// os/exec ignores EPIPE from the stdin copy, so a child that refuses early and
+// exits without reading surfaces as its own exit status rather than a write
+// error.
+func runVisibleWithStdin(secret, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(secret + "\n")
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	return cmd.Run()
 }
 

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -185,7 +185,13 @@ func runWithStdin(name, input string, args ...string) error {
 // error.
 func runVisibleWithStdin(secret, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
-	cmd.Stdin = strings.NewReader(secret + "\n")
+	// No secret, no stdin: feeding a stray newline to a child that never asked
+	// for input is a difference with no purpose, and useradd deliberately omits
+	// -i in that case. A nil Stdin gets the child /dev/null, which is also what
+	// keeps it from consuming the caller's own input.
+	if secret != "" {
+		cmd.Stdin = strings.NewReader(secret + "\n")
+	}
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	return cmd.Run()
 }

--- a/apps/launcher/internal/launcher/useradd.go
+++ b/apps/launcher/internal/launcher/useradd.go
@@ -141,6 +141,16 @@ func Useradd(args []string) int {
 		rest = append(rest, args[i])
 	}
 
+	// Asking for both a password and a generated one is a contradiction, and
+	// it must be REFUSED here: --password-stdin is stripped above and re-added
+	// only when a password is actually read, so forwarding alone would let the
+	// backend's own mutual-exclusion check never see the pair — the user would
+	// silently get a generated password they did not ask to keep.
+	if generate && wantStdin {
+		u.fail("--password-stdin and --generate-password are contradictory: one supplies a password, the other invents one.")
+		return 1
+	}
+
 	// Which stack? The shared knowledge-verb ladder (stackselect.go).
 	target, ok := selectVerbStack(u, "useradd", loadStackSet(), repo, wantLocal)
 	if !ok {

--- a/apps/launcher/internal/launcher/useradd.go
+++ b/apps/launcher/internal/launcher/useradd.go
@@ -6,16 +6,23 @@ import (
 	"strings"
 )
 
-const useraddUsage = `Usage: semiont useradd --email <email> (--password <pass> | --generate-password) [options]
+const useraddUsage = `Usage: semiont useradd --email <email> [--generate-password] [options]
 
 Create or update a user in a RUNNING Semiont stack, local or codespace. The
 launcher execs 'semiont-useradd' inside the backend container and passes every
 other flag through verbatim — the backend owns the user schema, the password
 hashing, and the database write; this launcher only decides which stack is
-meant. Options that command understands:
+meant.
+
+The password is never typed as an argument. Creating a user prompts for one on
+a terminal, or reads it from stdin when piped:
+
+  semiont useradd --email admin@example.com --admin        # prompts
+  cat pw | semiont useradd --email bot@example.com         # scripted
+
+Options that command understands:
 
   --email <email>       User email address (required)
-  --password <pass>     Password (min 8 characters)
   --generate-password   Generate a random 16-char password (printed once)
   --name <name>         Display name
   --admin               Grant admin privileges
@@ -23,6 +30,8 @@ meant. Options that command understands:
   --inactive            Create the user inactive
   --update              Update an existing user
   --upsert              Create if absent, succeed silently if present
+  --password-stdin      Set the password (implied when creating; say it
+                        explicitly with --update to CHANGE a password)
 
 Launcher-owned (consumed here, not forwarded):
 
@@ -41,8 +50,8 @@ no users at all, so this is how the first admin comes to exist, and how every
 later user, role grant, and password change happens.
 
 Examples:
-  # First admin after a fresh local start
-  semiont useradd --email admin@example.com --password <pass> --admin
+  # First admin after a fresh local start (prompts for the password)
+  semiont useradd --email admin@example.com --admin
 
   # A second user on a codespace KB
   semiont useradd --repo The-AI-Alliance/my-kb --email alice@example.com --generate-password
@@ -66,10 +75,13 @@ Examples:
 // (It no longer targets `semiont useradd`: that was the retired @semiont/cli,
 // which the backend image stopped shipping — the bridge dangled until this.)
 //
-// This replaced `start --email/--password`: the admin password used to ride
-// into the backend container as an env var, readable via `inspect` for the
-// stack's whole lifetime. Here it exists only in one exec's argv (redacted
-// in the echoed command and the invocation log).
+// The password NEVER travels in argv. It used to ride into the container as an
+// env var (readable via `inspect` for the stack's whole lifetime); then as an
+// exec argument, redacted in the echo — but redaction is cosmetic: `ps` shows
+// any process's command line to every user on the host, and the caller's shell
+// wrote it to history besides. Now the launcher reads it (prompting on a
+// terminal, else from stdin) and pipes it to `--password-stdin`, so it exists
+// only in two process memories and the pipe between them.
 func Useradd(args []string) int {
 	u := newUI(false)
 	for _, a := range args {
@@ -85,8 +97,11 @@ func Useradd(args []string) int {
 
 	// --repo and --runtime are the ONLY flags the launcher consumes rather
 	// than forwards (they select a stack); everything else stays verbatim so
-	// `semiont-useradd` can grow flags without touching this file.
+	// `semiont-useradd` can grow flags without touching this file. The
+	// password-bearing flags are READ here as well as forwarded, because the
+	// launcher is what reads the password.
 	repo, wantLocal := "", false
+	generate, update, wantStdin := false, false, false
 	rest := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -106,8 +121,38 @@ func Useradd(args []string) int {
 			wantLocal = true
 			i++
 			continue
+		case "--password":
+			// Removed, not deprecated. It put the secret in argv — visible in
+			// `ps` on the host and in the container, kept by the runtime's
+			// container record, and written to the caller's shell history.
+			u.fail("--password is no longer accepted: a password in argv is visible to every process on the host.")
+			fmt.Fprintln(os.Stderr, "  Let it prompt:   semiont useradd --email <email> --admin")
+			fmt.Fprintln(os.Stderr, "  Or pipe it:      cat pw | semiont useradd --email <email> --admin")
+			fmt.Fprintln(os.Stderr, "  Or generate it:  semiont useradd --email <email> --generate-password")
+			return 1
+		case "--generate-password":
+			generate = true
+		case "--update":
+			update = true
+		case "--password-stdin":
+			wantStdin = true
+			continue // re-added below, exactly once
 		}
 		rest = append(rest, args[i])
+	}
+
+	// Who supplies the password? The backend requires one only to CREATE, so
+	// an --update that isn't explicitly changing the password needs none, and
+	// --generate-password means the backend invents its own.
+	needPassword := !generate && (!update || wantStdin)
+	password := ""
+	if needPassword {
+		pw, ok := readPassword(u)
+		if !ok {
+			return 1
+		}
+		password = pw
+		rest = append(rest, "--password-stdin")
 	}
 
 	// Which stack? The shared knowledge-verb ladder (stackselect.go).
@@ -117,7 +162,7 @@ func Useradd(args []string) int {
 	}
 
 	if target != nil {
-		return useraddCodespace(u, target, rest)
+		return useraddCodespace(u, target, rest, password)
 	}
 
 	rt, handle := backendHandle()
@@ -127,12 +172,16 @@ func Useradd(args []string) int {
 		return 1
 	}
 	// `semiont-useradd` is a bin the backend package declares, linked onto PATH
-	// by its image. A bare command name, so argv (which carries the password)
-	// crosses without a shell — see the codespace path below for what a shell
-	// would cost.
-	execArgs := append([]string{"exec", handle, "semiont-useradd"}, rest...)
+	// by its image. -i attaches stdin so the password can cross that way; it is
+	// omitted when there is no password to send, so the echoed command is the
+	// exact command run in both cases.
+	head := []string{"exec"}
+	if password != "" {
+		head = append(head, "-i")
+	}
+	execArgs := append(append(head, handle, "semiont-useradd"), rest...)
 	u.echoCmd(rt, execArgs...)
-	if err := runVisible(rt, execArgs...); err != nil {
+	if err := runVisibleWithStdin(password, rt, execArgs...); err != nil {
 		u.fail("useradd failed inside the backend container (see output above).")
 		return 1
 	}
@@ -143,12 +192,15 @@ func Useradd(args []string) int {
 // the codespace, then docker exec into its backend.
 //
 // CRITICAL: `gh codespace ssh -- cmd` runs the remote side through a SHELL
-// (proven live — a `/workspaces/*` glob expands there). The local path has
-// no shell, so passing argv straight through is safe there; here it is not.
-// An unquoted password containing a space, $, quote or backtick would be
-// mangled or would inject shell into the user's own codespace. So every
-// argument is single-quote escaped before it crosses the wire.
-func useraddCodespace(u *ui, st *stackState, args []string) int {
+// (proven live — a `/workspaces/*` glob expands there). The local path has no
+// shell, so passing argv straight through is safe there; here it is not, and
+// every argument is single-quote escaped before it crosses the wire.
+//
+// The password is exempt from all of that by never being an argument: it goes
+// down ssh's stdin into `docker exec -i`. That removes the sharpest edge of
+// this path — a password containing $, a backtick or a quote used to be one
+// escaping bug away from injecting shell into the user's own codespace.
+func useraddCodespace(u *ui, st *stackState, args []string, password string) int {
 	if !requireGh(u, "useradd against a codespace stack") {
 		return 1
 	}
@@ -157,13 +209,11 @@ func useraddCodespace(u *ui, st *stackState, args []string) int {
 	// same contract --dry-run keeps). Echoing the pre-quoting args instead
 	// would print something that behaves differently if pasted: $VARs would
 	// expand and values with spaces would split.
-	remote := remoteUseraddCmd(args, false)
+	remote := remoteUseraddCmd(args, password != "")
 	sshArgs := []string{"codespace", "ssh", "-c", st.Codespace, "--", remote}
 	u.log("useradd on %s %s", u.bold(st.Repo), u.dim("(codespace "+st.Codespace+")"))
-	// echoCmd's --password redaction can't see inside a composed string, so
-	// the redacted variant is composed the same way instead.
-	u.echoCmd("gh", "codespace", "ssh", "-c", st.Codespace, "--", remoteUseraddCmd(args, true))
-	if err := runVisible("gh", sshArgs...); err != nil {
+	u.echoCmd("gh", "codespace", "ssh", "-c", st.Codespace, "--", remote)
+	if err := runVisibleWithStdin(password, "gh", sshArgs...); err != nil {
 		u.fail("useradd failed inside the codespace's backend (see output above).")
 		fmt.Fprintln(os.Stderr, "  Is the stack up?  semiont status --repo "+st.Repo)
 		return 1
@@ -172,16 +222,17 @@ func useraddCodespace(u *ui, st *stackState, args []string) int {
 }
 
 // remoteUseraddCmd composes the command the codespace's shell will run. With
-// redact set, the --password VALUE is replaced before quoting, so the echoed
-// string is otherwise identical to the real one.
-func remoteUseraddCmd(args []string, redact bool) string {
-	cmd := "docker exec semiont-backend semiont-useradd"
-	for i, a := range args {
-		v := a
-		if redact && i > 0 && args[i-1] == "--password" {
-			v = "<redacted>"
-		}
-		cmd += " " + shellQuote(v)
+// stdin set, `docker exec -i` keeps the pipe attached through ssh so the
+// password can arrive that way. Nothing here needs redacting any more: no
+// argument carries a secret.
+func remoteUseraddCmd(args []string, stdin bool) string {
+	cmd := "docker exec"
+	if stdin {
+		cmd += " -i"
+	}
+	cmd += " semiont-backend semiont-useradd"
+	for _, a := range args {
+		cmd += " " + shellQuote(a)
 	}
 	return cmd
 }

--- a/apps/launcher/internal/launcher/useradd.go
+++ b/apps/launcher/internal/launcher/useradd.go
@@ -141,12 +141,31 @@ func Useradd(args []string) int {
 		rest = append(rest, args[i])
 	}
 
-	// Who supplies the password? The backend requires one only to CREATE, so
-	// an --update that isn't explicitly changing the password needs none, and
+	// Which stack? The shared knowledge-verb ladder (stackselect.go).
+	target, ok := selectVerbStack(u, "useradd", loadStackSet(), repo, wantLocal)
+	if !ok {
+		return 1
+	}
+
+	rt, handle := "", ""
+	if target == nil {
+		if rt, handle = backendHandle(); rt == "" {
+			u.fail("useradd needs a running backend, and none was found under any installed runtime.")
+			fmt.Fprintln(os.Stderr, "  Start the stack first:  semiont start")
+			return 1
+		}
+	}
+
+	// The password is read LAST, after every refusal this command can make.
+	// Nobody should be asked to type a secret by an invocation that was
+	// already going to be rejected for contradictory flags or a missing
+	// backend — the prompt would also bury the actual error.
+	//
+	// Who supplies it? The backend requires one only to CREATE, so an --update
+	// that isn't explicitly changing the password needs none, and
 	// --generate-password means the backend invents its own.
-	needPassword := !generate && (!update || wantStdin)
 	password := ""
-	if needPassword {
+	if !generate && (!update || wantStdin) {
 		pw, ok := readPassword(u)
 		if !ok {
 			return 1
@@ -155,21 +174,8 @@ func Useradd(args []string) int {
 		rest = append(rest, "--password-stdin")
 	}
 
-	// Which stack? The shared knowledge-verb ladder (stackselect.go).
-	target, ok := selectVerbStack(u, "useradd", loadStackSet(), repo, wantLocal)
-	if !ok {
-		return 1
-	}
-
 	if target != nil {
 		return useraddCodespace(u, target, rest, password)
-	}
-
-	rt, handle := backendHandle()
-	if rt == "" {
-		u.fail("useradd needs a running backend, and none was found under any installed runtime.")
-		fmt.Fprintln(os.Stderr, "  Start the stack first:  semiont start")
-		return 1
 	}
 	// `semiont-useradd` is a bin the backend package declares, linked onto PATH
 	// by its image. -i attaches stdin so the password can cross that way; it is

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1326,9 +1326,9 @@ func TestInvocationLog(t *testing.T) {
 	if _, _, code := s.run(t, "version"); code != 0 {
 		t.Fatalf("version: exit %d", code)
 	}
-	// A failing run with a password: logged with the value redacted
-	// (useradd with no running backend fails, and is the launcher's one
-	// password-carrying command).
+	// --password is refused now, but a user who types it has still put the
+	// secret in the launcher's OWN argv — and the invocation log is a file
+	// that outlives the command, so the value must never be written there.
 	if _, _, code := s.run(t, "useradd", "--email", "a@b.co", "--password", "supersecretpw"); code != 1 {
 		t.Fatalf("rejection run: want exit 1, got %d", code)
 	}
@@ -1353,11 +1353,15 @@ func TestInvocationLog(t *testing.T) {
 func TestUseradd(t *testing.T) {
 	// useradd is a thin exec bridge: launcher finds the stack's runtime and
 	// backend handle, execs the in-container CLI's useradd, and passes every
-	// flag through verbatim.
+	// flag through verbatim. The PASSWORD is the one thing that never rides in
+	// argv — it goes down the exec's stdin, because argv is visible in `ps`
+	// (host and container) and in the caller's shell history.
 	s := newScenario(t, "container", "docker")
+	const secret = "password123"
 
 	// No running backend anywhere: pointed failure.
-	_, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--password", "password123")
+	s.stdin = secret + "\n"
+	_, stderr, code := s.run(t, "useradd", "--email", "a@b.co")
 	if code != 1 {
 		t.Fatalf("no-backend useradd: want exit 1, got %d", code)
 	}
@@ -1366,34 +1370,81 @@ func TestUseradd(t *testing.T) {
 
 	// Name-scan fallback: the runtime whose listing shows semiont-backend.
 	s.extraEnv = append(s.extraEnv, "FAKERT_STACK_RUNTIME=docker")
-	stdout, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--password", "password123", "--admin")
+	s.stdin = secret + "\n"
+	stdout, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--admin")
 	if code != 0 {
 		t.Fatalf("useradd: exit %d\nstderr:\n%s", code, stderr)
 	}
 	log, _ := os.ReadFile(s.log)
+	// -i so the pipe reaches the container; --password-stdin tells the backend
+	// to read it there.
 	mustContain(t, "argv log", string(log),
-		"docker exec semiont-backend semiont-useradd --email a@b.co --password password123 --admin")
-	// The echoed command redacts the password; the real argv (above) is intact.
-	mustContain(t, "stdout", stdout, "--password <redacted>")
-	if strings.Contains(stdout, "password123") {
-		t.Errorf("password leaked into the echoed command:\n%s", stdout)
+		"docker exec -i semiont-backend semiont-useradd --email a@b.co --admin --password-stdin")
+	// The secret reached the backend — through the PIPE, not the command line.
+	stdinSeen, err := os.ReadFile(filepath.Join(s.fakertDir, "exec-stdin.txt"))
+	if err != nil {
+		t.Fatalf("no exec stdin captured: %v", err)
+	}
+	if strings.TrimSpace(string(stdinSeen)) != secret {
+		t.Errorf("password did not arrive on stdin; got %q", stdinSeen)
+	}
+	for what, text := range map[string]string{"argv log": string(log), "stdout": stdout} {
+		if strings.Contains(text, secret) {
+			t.Errorf("password leaked into the %s:\n%s", what, text)
+		}
 	}
 
-	// Record-driven: recorded runtime + container ID beat the name scan.
+	// The removed --password flag is refused with the way that replaced it —
+	// it is documented in enough places that a bare "unknown flag" would read
+	// as a launcher bug.
+	if _, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--password", secret); code != 1 {
+		t.Errorf("--password should be refused, got exit %d", code)
+	} else {
+		mustContain(t, "stderr", stderr, "--password", "no longer accepted", "--generate-password")
+	}
+
+	// Record-driven: recorded runtime + container ID beat the name scan. With
+	// --generate-password the backend invents one, so nothing is read or piped.
 	writeStackState(t, s, "container")
 	if err := os.Truncate(s.log, 0); err != nil {
 		t.Fatal(err)
 	}
+	s.stdin = ""
 	if _, stderr, code := s.run(t, "useradd", "--email", "b@c.co", "--generate-password"); code != 0 {
 		t.Fatalf("record-driven useradd: exit %d\nstderr:\n%s", code, stderr)
 	}
 	log, _ = os.ReadFile(s.log)
 	mustContain(t, "argv log", string(log),
 		"container exec fid-semiont-backend semiont-useradd --email b@c.co --generate-password")
+	if strings.Contains(string(log), "--password-stdin") {
+		t.Error("--generate-password must not also ask for a password on stdin")
+	}
+
+	// --update on an existing user needs no password (the backend only
+	// requires one to CREATE), so nothing is prompted or piped.
+	if err := os.Truncate(s.log, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, code := s.run(t, "useradd", "--email", "b@c.co", "--update", "--admin"); code != 0 {
+		t.Fatalf("update useradd: exit %d\nstderr:\n%s", code, stderr)
+	}
+	if log, _ = os.ReadFile(s.log); strings.Contains(string(log), "--password-stdin") {
+		t.Error("--update must not demand a password")
+	}
+
+	// A create with nothing on stdin cannot proceed — say so rather than
+	// hanging or sending an empty password.
+	s.stdin = ""
+	if _, stderr, code := s.run(t, "useradd", "--email", "d@e.co"); code != 1 {
+		t.Errorf("empty stdin should fail, got exit %d", code)
+	} else {
+		mustContain(t, "stderr", stderr, "password")
+	}
 
 	// The in-container CLI failing surfaces as a launcher failure.
 	s.extraEnv = append(s.extraEnv, "FAKERT_EXEC_FAIL=1")
-	if _, stderr, code := s.run(t, "useradd", "--email", "c@d.co", "--password", "password123"); code != 1 {
+	s.stdin = secret + "\n"
+	if _, stderr, code := s.run(t, "useradd", "--email", "c@d.co"); code != 1 {
 		t.Fatalf("exec failure: want exit 1, got %d\nstderr:\n%s", code, stderr)
 	}
 
@@ -1406,6 +1457,9 @@ func TestUseradd(t *testing.T) {
 		t.Error("useradd --help should exit 0")
 	}
 	mustContain(t, "help", stdout, "--generate-password", "--admin", "--upsert")
+	if strings.Contains(stdout, "--password <") {
+		t.Error("help still advertises the removed --password flag")
+	}
 }
 
 // --- secret sources ---
@@ -2126,11 +2180,14 @@ func TestUseraddCodespace(t *testing.T) {
 	s := newCodespaceScenario(t)
 	writeCodespaceState(t, s)
 
-	// A password full of shell metacharacters must arrive INTACT — and must
-	// not become shell syntax on the way.
+	// The password crosses on STDIN, so it is no longer shell-quoted at all —
+	// the sharpest edge of this path is gone rather than escaped around. A
+	// password of pure shell metacharacters must still arrive intact, and must
+	// appear nowhere in the remote command line.
 	nasty := "p a$s'w\"o`rd;rm -rf /"
+	s.stdin = nasty + "\n"
 	stdout, stderr, code := s.run(t, "useradd", "--email", "alice@example.com",
-		"--password", nasty, "--name", "A $NAME with spaces", "--admin")
+		"--name", "A $NAME with spaces", "--admin")
 	if code != 0 {
 		t.Fatalf("codespace useradd: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
@@ -2141,26 +2198,23 @@ func TestUseraddCodespace(t *testing.T) {
 	remote := stdout[strings.Index(stdout, "remote-cmd: "):]
 	remote = remote[:strings.IndexByte(remote, '\n')]
 	mustContain(t, "remote command", remote,
-		"docker exec semiont-backend semiont-useradd",
-		"'alice@example.com'", "'--admin'")
-	// The dangerous fragment must be inside quotes, never bare syntax.
-	if strings.Contains(remote, "; rm -rf /") || strings.Contains(remote, ";rm -rf / ") {
-		t.Fatalf("password escaped its quoting into shell syntax:\n%s", remote)
+		"docker exec -i semiont-backend semiont-useradd", // -i keeps the pipe open through ssh
+		"'alice@example.com'", "'--admin'", "'--password-stdin'")
+	if strings.Contains(remote, "rm -rf") {
+		t.Fatalf("the password reached the remote COMMAND LINE:\n%s", remote)
 	}
-	// The ECHOED command must be the command actually run — same quoting,
-	// with only the password swapped. Anything else prints a line that would
-	// behave differently if pasted ($NAME expanding, spaces splitting).
+	// Other arguments still cross a shell, so they must still be quoted: the
+	// old bug was echoing RAW args, which would expand $NAME and split on
+	// spaces if pasted.
+	mustContain(t, "remote command", remote, "'A $NAME with spaces'")
+	// The echoed command is now IDENTICAL to the one run — with no secret in
+	// argv there is nothing left to redact.
 	echoed := stdout[strings.Index(stdout, "$ gh"):]
 	echoed = echoed[:strings.IndexByte(echoed, '\n')]
-	mustContain(t, "echoed command", echoed,
-		"'--password' '<redacted>'", // redacted, but still quoted like the real one
-		"'alice@example.com'", "'--admin'")
-	if strings.Contains(echoed, "rm -rf") {
-		t.Errorf("password leaked into the echoed command:\n%s", echoed)
+	mustContain(t, "echoed command", echoed, "'alice@example.com'", "'--admin'", "'A $NAME with spaces'")
+	if strings.Contains(echoed, "rm -rf") || strings.Contains(echoed, "redacted") {
+		t.Errorf("echoed command should carry no secret and need no redaction:\n%s", echoed)
 	}
-	// The old bug was echoing RAW args, which would expand $NAME and split
-	// on spaces if pasted. The quoted form is the tell.
-	mustContain(t, "echoed command", echoed, "'A $NAME with spaces'")
 	log, _ := os.ReadFile(s.log)
 	mustContain(t, "argv log", string(log), "gh codespace ssh -c fake-cs-1 --")
 
@@ -2189,7 +2243,8 @@ func TestUseraddAmbiguousStacks(t *testing.T) {
 	if err := os.WriteFile(p, []byte(both), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--password", "password123")
+	s.stdin = "password123\n"
+	_, stderr, code := s.run(t, "useradd", "--email", "a@b.co")
 	if code != 1 {
 		t.Fatalf("ambiguous useradd: want exit 1, got %d", code)
 	}
@@ -2199,7 +2254,8 @@ func TestUseraddAmbiguousStacks(t *testing.T) {
 	// Naming the codespace resolves it; the local stack is reachable by
 	// simply omitting --repo is NOT true here, so it must still refuse —
 	// but --repo works.
-	if _, stderr, code := s.run(t, "useradd", "--repo", csRepo, "--email", "a@b.co", "--password", "password123"); code != 0 {
+	s.stdin = "password123\n"
+	if _, stderr, code := s.run(t, "useradd", "--repo", csRepo, "--email", "a@b.co"); code != 0 {
 		t.Fatalf("--repo disambiguation: exit %d\nstderr:\n%s", code, stderr)
 	}
 }
@@ -2500,7 +2556,7 @@ func TestCodespaceGuardsAndScoping(t *testing.T) {
 
 	// useradd now WORKS against a codespace stack (the generated admin is
 	// only the FIRST user; everything after it is useradd's job).
-	if _, stderr, code := s2.run(t, "useradd", "--email", "a@b.co", "--password", "password123"); code != 0 {
+	if _, stderr, code := s2.run(t, "useradd", "--email", "a@b.co", "--generate-password"); code != 0 {
 		t.Fatalf("useradd on codespace: exit %d\nstderr:\n%s", code, stderr)
 	}
 
@@ -2757,10 +2813,10 @@ func TestMultiStackLocalPlusCodespace(t *testing.T) {
 		"semiont stop --runtime container", "semiont stop --repo "+csRepo)
 
 	// useradd will not GUESS between stacks; --runtime names the local one.
-	if _, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--password", "password123"); code != 1 {
+	if _, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--generate-password"); code != 1 {
 		t.Fatalf("ambiguous useradd should refuse, got %d\nstderr:\n%s", code, stderr)
 	}
-	if _, stderr, code := s.run(t, "useradd", "--runtime", "container", "--email", "a@b.co", "--password", "password123"); code != 0 {
+	if _, stderr, code := s.run(t, "useradd", "--runtime", "container", "--email", "a@b.co", "--generate-password"); code != 0 {
 		t.Fatalf("useradd --runtime: exit %d\nstderr:\n%s", code, stderr)
 	}
 	log, _ := os.ReadFile(s.log)
@@ -4333,7 +4389,7 @@ func TestBareStopFollowsCwd(t *testing.T) {
 
 	// useradd from the clone: local backend, no ssh, no refusal.
 	before := s.mustLog(t)
-	if _, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--password", "password123"); code != 0 {
+	if _, stderr, code := s.run(t, "useradd", "--email", "a@b.co", "--generate-password"); code != 0 {
 		t.Fatalf("bare useradd in clone: exit %d\nstderr:\n%s", code, stderr)
 	}
 	fresh := strings.TrimPrefix(string(s.mustLog(t)), string(before))

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1420,6 +1420,18 @@ func TestUseradd(t *testing.T) {
 		t.Error("--generate-password must not also ask for a password on stdin")
 	}
 
+	// Asking for both a supplied and a generated password is refused HERE. The
+	// launcher strips --password-stdin and re-adds it only when it actually
+	// read one, so forwarding alone would hand the backend just
+	// --generate-password — its own mutual-exclusion check would never fire and
+	// the user would silently get a password they did not ask to keep.
+	if _, stderr, code := s.run(t, "useradd", "--email", "b@c.co",
+		"--generate-password", "--password-stdin"); code != 1 {
+		t.Errorf("contradictory password flags should be refused, got exit %d", code)
+	} else {
+		mustContain(t, "stderr", stderr, "contradictory")
+	}
+
 	// --update on an existing user needs no password (the backend only
 	// requires one to CREATE), so nothing is prompted or piped.
 	if err := os.Truncate(s.log, 0); err != nil {

--- a/docs/KNOWLEDGE-BASES.md
+++ b/docs/KNOWLEDGE-BASES.md
@@ -17,7 +17,7 @@ whole stack, including the Semiont browser at http://localhost:3000:
 ```bash
 brew install the-ai-alliance/semiont/semiont   # once
 semiont start
-semiont useradd --email admin@example.com --password <choose-a-password> --admin
+semiont useradd --email admin@example.com --admin   # prompts for the password
 ```
 
 `semiont logs` follows the stack, `semiont status` health-checks it, and

--- a/docs/system/LOCAL-BACKEND.md
+++ b/docs/system/LOCAL-BACKEND.md
@@ -14,7 +14,7 @@ repository, and start the stack:
 git clone https://github.com/The-AI-Alliance/gutenberg-kb.git
 cd gutenberg-kb
 semiont start
-semiont useradd --email admin@example.com --password password --admin
+echo password | semiont useradd --email admin@example.com --admin
 ```
 
 The launcher pulls the published, attested Semiont service images

--- a/docs/system/LOCAL-SEMIONT.md
+++ b/docs/system/LOCAL-SEMIONT.md
@@ -19,7 +19,7 @@ brew install the-ai-alliance/semiont/semiont
 git clone https://github.com/The-AI-Alliance/gutenberg-kb.git
 cd gutenberg-kb
 semiont start
-semiont useradd --email admin@example.com --password password --admin
+echo password | semiont useradd --email admin@example.com --admin
 ```
 
 One command starts the whole stack — the five published Semiont images
@@ -47,7 +47,7 @@ Start the stack with Ollama for fully local inference (no API key needed):
 
 ```bash
 semiont start
-semiont useradd --email admin@example.com --password password --admin
+echo password | semiont useradd --email admin@example.com --admin
 ```
 
 On first run, the backend container pulls the inference and embedding models from Ollama. This is a one-time download (~2-4 GB depending on the model) and may take several minutes.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -40,7 +40,7 @@ who built — `CONTAINER_RUNTIME` picks the *build* engine only:
 # 2. Run the full stack from your KB against the :local images
 cd /path/to/your-kb
 SEMIONT_VERSION=local semiont start
-semiont useradd --email admin@example.com --password password --admin
+echo password | semiont useradd --email admin@example.com --admin
 
 # 3. Iterate — edit code, rebuild only what changed:
 ./scripts/ci/local-build.sh --package cli,backend --image backend

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -154,7 +154,7 @@ that exactly matches the current branch's source:
 cd ../semiont-template-kb
 ANTHROPIC_API_KEY="$(op read op://OSS/Anthropic/credential)" \
   SEMIONT_VERSION=local semiont start --config anthropic
-semiont useradd --email admin@example.com --password password --admin
+echo password | semiont useradd --email admin@example.com --admin
 
 # 3. Grab IPs and run the e2e suite (see Quick start above). The stack
 #    includes the frontend container on :3000.

--- a/tests/e2e/docs/containers.md
+++ b/tests/e2e/docs/containers.md
@@ -98,7 +98,7 @@ cd /path/to/semiont-template-kb
 # semiont start reads ANTHROPIC_API_KEY from env when --config anthropic.
 # Source your secrets first if it's not already exported.
 SEMIONT_VERSION=local semiont start --config anthropic
-semiont useradd --email admin@example.com --password password --admin
+echo password | semiont useradd --email admin@example.com --admin
 ```
 
 The `ollama-gemma` config avoids the API-key requirement if you only

--- a/website/index.md
+++ b/website/index.md
@@ -34,7 +34,7 @@ semiont start
 One command brings up the whole stack from published, attested container images — including the Semiont browser. Create your admin user and sign in at **http://localhost:3000**:
 
 ```bash
-semiont useradd --email admin@example.com --password <choose-a-password> --admin
+semiont useradd --email admin@example.com --admin   # prompts for the password
 ```
 
 Explore the knowledge bases:


### PR DESCRIPTION
`semiont start` used to end by suggesting `semiont useradd --email <email> --password <pass> --admin`. A password typed as an argument is exposed in more places than the shell history it obviously lands in:

- **The launcher's own process** — `container exec … semiont-useradd --password <pass>` is visible to every other user on the host through `ps`.
- **Inside the container** — node's argv, readable via `ps` and `/proc/<pid>/cmdline`.
- **Codespaces** — the command was composed into a shell string for `gh codespace ssh --`, so it appeared in the local process list *and* in the remote codespace's.

The launcher already redacted `--password` in its echoed command and its invocation log, but redaction is cosmetic: it hides the value in the terminal while `ps` still reads it out of argv.

`login` already did this correctly — `readPassword()` prompts with echo off on a terminal and reads piped stdin otherwise. `useradd` now does the same.

## The change

**Backend** (`apps/backend/src/cli/useradd.ts`): `--password <pass>` is **removed** and `--password-stdin` added, reading the first line of stdin. The 8-character minimum moved with it, and it refuses when stdin carries nothing. `--password-stdin` and `--generate-password` are mutually exclusive.

**Launcher** (`useradd.go`): no longer a pass-through for the secret. It reads the password itself, appends `--password-stdin`, and pipes the value — `container exec -i` locally, `docker exec -i` through ssh's stdin for codespaces. `-i` is added only when there is a password to send, so the echoed command remains exactly the command run.

Who supplies the password follows the backend's actual semantics — it requires one only to **create**:

| Invocation | Password |
|---|---|
| `useradd --email x --admin` | prompted (or read from a pipe) |
| `cat pw \| useradd --email x` | read from stdin |
| `useradd --email x --generate-password` | none asked; the backend invents one |
| `useradd --email x --update --admin` | none asked — an update needs no password |
| `useradd --email x --update --password-stdin` | prompted, to *change* the password |

## Breaking change

`--password` is removed, not deprecated. Typing it fails with the three replacements named, because the flag appears in enough documentation that a bare "unknown flag" would read as a launcher bug:

```
✗ --password is no longer accepted: a password in argv is visible to every process on the host.
  Let it prompt:   semiont useradd --email <email> --admin
  Or pipe it:      cat pw | semiont useradd --email <email> --admin
  Or generate it:  semiont useradd --email <email> --generate-password
```

No shell scripts or CI workflows passed `--password` — every call site was documentation, and all nine files are updated (prompt form where a human reads them, `echo password | semiont useradd …` where a fixed password is used in dev/CI instructions).

## A hazard that disappeared rather than being escaped around

`gh codespace ssh -- cmd` runs the remote side through a **shell**, so the codespace path single-quote escapes every argument. A password containing `$`, a backtick, or a quote was one escaping bug away from injecting shell into the user's own codespace. That edge is gone — the password isn't an argument, so it is never quoted. Other arguments still cross a shell and are still quoted.

## Dead code

`redactEnvArgs` no longer special-cases `--password`; with no secret in argv there is nothing to hide, and `remoteUseraddCmd` lost its `redact` parameter, so the echoed codespace command is now byte-identical to the one that runs.

The **invocation-log** redaction stays deliberately. A user who types the refused flag has still put the secret in the launcher's own argv, and that log is a file which outlives the command.

## Tests

The fake runtime now captures exec stdin, so the test proves the **positive** — that the secret arrived through the pipe — rather than only that it is absent from argv. A test asserting a password is missing from a log would pass just as well if the password were never sent.

The codespace test keeps its metacharacter-laden password (`p a$s'w"o`+"`"+`rd;rm -rf /`) and now asserts it appears nowhere in the remote command line, while `--name "A $NAME with spaces"` is still correctly quoted.

## Two caveats

- **The codespace stdin path is unverified against a live codespace.** It depends on `gh codespace ssh` forwarding non-TTY stdin through to `docker exec -i`. That is the documented behavior and the fake models it, but it deserves one real run before being relied on.
- **The backend image must be rebuilt.** A launcher with these changes talking to an older backend image will send `--password-stdin` to a binary that rejects it as an unknown flag.
