### PR TITLE
fix: authenticate the KB identity check, dispose its client, and stop the codespace start from killing its own tunnel

### DIFF
--- a/apps/frontend/messages-source/ar.json
+++ b/apps/frontend/messages-source/ar.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "موجود على هذا الجهاز",
     "managedBadge": "مُدار بواسطة المُشغِّل",
     "placementLocal": "محلي",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "غير معروف",
+    "anotherCopy": "نسخة أخرى من قاعدة المعرفة التي أنت متصل بها",
+    "addressConflict": "{{count}} من قواعد المعرفة تدّعي امتلاك العنوان {{address}} — من المرجّح أن إحداها قديمة.",
+    "connectToAddress": "الاتصال بـ{{address}}",
+    "connectedToOther": "متصل بـ{{actual}}، وليس {{expected}}.",
+    "identityCheckFailed": "تم تسجيل الدخول، لكن تعذّر على التحقق من الهوية الوصول إلى قاعدة المعرفة هذه.",
+    "identityNotReported": "تم تسجيل الدخول، لكن قاعدة المعرفة هذه لم تُبلِغ عن أي هوية."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "لا توجد قواعد معرفة",

--- a/apps/frontend/messages-source/bn.json
+++ b/apps/frontend/messages-source/bn.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "এই মেশিনে পাওয়া গেছে",
     "managedBadge": "লঞ্চার দ্বারা পরিচালিত",
     "placementLocal": "স্থানীয়",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "অজানা",
+    "anotherCopy": "আপনি যে জ্ঞান ভাণ্ডারে সংযুক্ত আছেন তার আরেকটি অনুলিপি",
+    "addressConflict": "{{count}}টি জ্ঞান ভাণ্ডার {{address}} দাবি করছে — সম্ভবত একটি পুরনো।",
+    "connectToAddress": "{{address}}-এ সংযুক্ত হন",
+    "connectedToOther": "{{actual}}-এ সংযুক্ত, {{expected}}-এ নয়।",
+    "identityCheckFailed": "সাইন ইন হয়েছে, কিন্তু পরিচয় যাচাই এই জ্ঞান ভাণ্ডারে পৌঁছাতে পারেনি।",
+    "identityNotReported": "সাইন ইন হয়েছে, কিন্তু এই জ্ঞান ভাণ্ডার কোনো পরিচয় জানায়নি।"
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "কোনো জ্ঞান ভাণ্ডার নেই",

--- a/apps/frontend/messages-source/cs.json
+++ b/apps/frontend/messages-source/cs.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Nalezeno v tomto počítači",
     "managedBadge": "Spravováno spouštěčem",
     "placementLocal": "místní",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Neznámý",
+    "anotherCopy": "další kopie znalostní báze, ke které jste připojeni",
+    "addressConflict": "{{count}} znalostních bází si nárokuje {{address}} — jedna je pravděpodobně zastaralá.",
+    "connectToAddress": "Připojit k {{address}}",
+    "connectedToOther": "Připojeno k {{actual}}, ne k {{expected}}.",
+    "identityCheckFailed": "Přihlášeno, ale kontrola identity nemohla tuto znalostní bázi kontaktovat.",
+    "identityNotReported": "Přihlášeno, ale tato znalostní báze neuvedla žádnou identitu."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Žádné znalostní báze",

--- a/apps/frontend/messages-source/da.json
+++ b/apps/frontend/messages-source/da.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Fundet på denne maskine",
     "managedBadge": "Administreret af launcher",
     "placementLocal": "lokal",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Ukendt",
+    "anotherCopy": "en anden kopi af den videnbase, du er forbundet til",
+    "addressConflict": "{{count}} videnbaser hævder {{address}} — én er sandsynligvis forældet.",
+    "connectToAddress": "Opret forbindelse til {{address}}",
+    "connectedToOther": "Forbundet til {{actual}}, ikke {{expected}}.",
+    "identityCheckFailed": "Logget ind, men identitetstjekket kunne ikke nå denne videnbase.",
+    "identityNotReported": "Logget ind, men denne videnbase rapporterede ingen identitet."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Ingen videnbaser",

--- a/apps/frontend/messages-source/de.json
+++ b/apps/frontend/messages-source/de.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Auf diesem Computer gefunden",
     "managedBadge": "Vom Launcher verwaltet",
     "placementLocal": "lokal",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Unbekannt",
+    "anotherCopy": "eine weitere Kopie der Wissensbasis, mit der Sie verbunden sind",
+    "addressConflict": "{{count}} Wissensbasen beanspruchen {{address}} — eine ist wahrscheinlich veraltet.",
+    "connectToAddress": "Mit {{address}} verbinden",
+    "connectedToOther": "Verbunden mit {{actual}}, nicht mit {{expected}}.",
+    "identityCheckFailed": "Angemeldet, aber die Identitätsprüfung konnte diese Wissensbasis nicht erreichen.",
+    "identityNotReported": "Angemeldet, aber diese Wissensbasis hat keine Identität gemeldet."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Keine Wissensbasen",

--- a/apps/frontend/messages-source/el.json
+++ b/apps/frontend/messages-source/el.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Βρέθηκε σε αυτόν τον υπολογιστή",
     "managedBadge": "Διαχειρίζεται από τον launcher",
     "placementLocal": "τοπικό",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Άγνωστο",
+    "anotherCopy": "ένα ακόμη αντίγραφο της βάσης γνώσης με την οποία είστε συνδεδεμένοι",
+    "addressConflict": "{{count}} βάσεις γνώσης διεκδικούν τη διεύθυνση {{address}} — μία είναι πιθανώς παρωχημένη.",
+    "connectToAddress": "Σύνδεση με {{address}}",
+    "connectedToOther": "Συνδεδεμένο με {{actual}}, όχι με {{expected}}.",
+    "identityCheckFailed": "Έχετε συνδεθεί, αλλά ο έλεγχος ταυτότητας δεν μπόρεσε να προσεγγίσει αυτή τη βάση γνώσης.",
+    "identityNotReported": "Έχετε συνδεθεί, αλλά αυτή η βάση γνώσης δεν ανέφερε ταυτότητα."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Δεν υπάρχουν βάσεις γνώσης",

--- a/apps/frontend/messages-source/en.json
+++ b/apps/frontend/messages-source/en.json
@@ -275,11 +275,12 @@
     "placementLocal": "local",
     "placementCodespace": "codespace",
     "unknownName": "Unknown",
-    "identityUnverifiable": "Connected, but could not determine which knowledge base this is.",
     "anotherCopy": "another copy of the knowledge base you're connected to",
     "addressConflict": "{{count}} knowledge bases claim {{address}} — one is likely stale.",
     "connectToAddress": "Connect to {{address}}",
-    "connectedToOther": "Connected to {{actual}}, not {{expected}}."
+    "connectedToOther": "Connected to {{actual}}, not {{expected}}.",
+    "identityCheckFailed": "Signed in, but the identity check could not reach this knowledge base.",
+    "identityNotReported": "Signed in, but this knowledge base did not report an identity."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "No knowledge bases",

--- a/apps/frontend/messages-source/es.json
+++ b/apps/frontend/messages-source/es.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Encontrado en este equipo",
     "managedBadge": "Gestionado por el lanzador",
     "placementLocal": "local",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Desconocido",
+    "anotherCopy": "otra copia de la base de conocimiento a la que estás conectado",
+    "addressConflict": "{{count}} bases de conocimiento reclaman {{address}} — es probable que una esté obsoleta.",
+    "connectToAddress": "Conectar a {{address}}",
+    "connectedToOther": "Conectado a {{actual}}, no a {{expected}}.",
+    "identityCheckFailed": "Sesión iniciada, pero la verificación de identidad no pudo alcanzar esta base de conocimiento.",
+    "identityNotReported": "Sesión iniciada, pero esta base de conocimiento no informó ninguna identidad."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Sin bases de conocimiento",

--- a/apps/frontend/messages-source/fa.json
+++ b/apps/frontend/messages-source/fa.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "یافت‌شده روی این دستگاه",
     "managedBadge": "مدیریت‌شده توسط راه‌انداز",
     "placementLocal": "محلی",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "ناشناخته",
+    "anotherCopy": "یک نسخهٔ دیگر از پایگاه دانشی که به آن متصل هستید",
+    "addressConflict": "{{count}} پایگاه دانش آدرس {{address}} را ادعا می‌کنند — احتمالاً یکی منسوخ شده است.",
+    "connectToAddress": "اتصال به {{address}}",
+    "connectedToOther": "متصل به {{actual}}، نه {{expected}}.",
+    "identityCheckFailed": "وارد شده‌اید، اما بررسی هویت نتوانست به این پایگاه دانش دسترسی پیدا کند.",
+    "identityNotReported": "وارد شده‌اید، اما این پایگاه دانش هویتی گزارش نکرد."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "هیچ پایگاه دانشی وجود ندارد",

--- a/apps/frontend/messages-source/fi.json
+++ b/apps/frontend/messages-source/fi.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Löytyi tältä koneelta",
     "managedBadge": "Käynnistimen hallinnassa",
     "placementLocal": "paikallinen",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Tuntematon",
+    "anotherCopy": "toinen kopio tietopankista, johon olet yhteydessä",
+    "addressConflict": "{{count}} tietopankkia ilmoittaa osoitteekseen {{address}} — yksi on todennäköisesti vanhentunut.",
+    "connectToAddress": "Yhdistä osoitteeseen {{address}}",
+    "connectedToOther": "Yhdistetty kohteeseen {{actual}}, ei {{expected}}.",
+    "identityCheckFailed": "Kirjautunut sisään, mutta identiteetin tarkistus ei tavoittanut tätä tietopankkia.",
+    "identityNotReported": "Kirjautunut sisään, mutta tämä tietopankki ei ilmoittanut identiteettiä."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Ei tietopankkeja",

--- a/apps/frontend/messages-source/fr.json
+++ b/apps/frontend/messages-source/fr.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Trouvé sur cette machine",
     "managedBadge": "Géré par le lanceur",
     "placementLocal": "local",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Inconnu",
+    "anotherCopy": "une autre copie de la base de connaissances à laquelle vous êtes connecté",
+    "addressConflict": "{{count}} bases de connaissances revendiquent {{address}} — l'une est probablement obsolète.",
+    "connectToAddress": "Se connecter à {{address}}",
+    "connectedToOther": "Connecté à {{actual}}, et non à {{expected}}.",
+    "identityCheckFailed": "Connecté, mais la vérification d'identité n'a pas pu joindre cette base de connaissances.",
+    "identityNotReported": "Connecté, mais cette base de connaissances n'a signalé aucune identité."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Aucune base de connaissances",

--- a/apps/frontend/messages-source/he.json
+++ b/apps/frontend/messages-source/he.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "נמצא במחשב זה",
     "managedBadge": "מנוהל על ידי המשגר",
     "placementLocal": "מקומי",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "לא ידוע",
+    "anotherCopy": "עותק נוסף של בסיס הידע שאליו אתה מחובר",
+    "addressConflict": "{{count}} בסיסי ידע טוענים לכתובת {{address}} — קרוב לוודאי שאחד מהם מיושן.",
+    "connectToAddress": "התחבר לכתובת {{address}}",
+    "connectedToOther": "מחובר אל {{actual}}, לא אל {{expected}}.",
+    "identityCheckFailed": "מחובר, אך בדיקת הזהות לא הצליחה להגיע אל בסיס ידע זה.",
+    "identityNotReported": "מחובר, אך בסיס ידע זה לא דיווח על זהות."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "אין בסיסי ידע",

--- a/apps/frontend/messages-source/hi.json
+++ b/apps/frontend/messages-source/hi.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "इस मशीन पर मिला",
     "managedBadge": "लॉन्चर द्वारा प्रबंधित",
     "placementLocal": "स्थानीय",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "अज्ञात",
+    "anotherCopy": "उस ज्ञान आधार की एक और प्रति जिससे आप जुड़े हुए हैं",
+    "addressConflict": "{{count}} ज्ञान आधार {{address}} होने का दावा करते हैं — इनमें से एक संभवतः पुराना है।",
+    "connectToAddress": "{{address}} से जुड़ें",
+    "connectedToOther": "{{actual}} से जुड़ा हुआ, {{expected}} से नहीं।",
+    "identityCheckFailed": "साइन इन हैं, लेकिन पहचान जांच इस ज्ञान आधार तक नहीं पहुंच सकी।",
+    "identityNotReported": "साइन इन हैं, लेकिन इस ज्ञान आधार ने कोई पहचान नहीं दी।"
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "कोई ज्ञान आधार नहीं",

--- a/apps/frontend/messages-source/id.json
+++ b/apps/frontend/messages-source/id.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Ditemukan di mesin ini",
     "managedBadge": "Dikelola oleh launcher",
     "placementLocal": "lokal",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Tidak diketahui",
+    "anotherCopy": "salinan lain dari basis pengetahuan yang terhubung dengan Anda",
+    "addressConflict": "{{count}} basis pengetahuan mengklaim {{address}} — salah satunya kemungkinan sudah usang.",
+    "connectToAddress": "Hubungkan ke {{address}}",
+    "connectedToOther": "Terhubung ke {{actual}}, bukan {{expected}}.",
+    "identityCheckFailed": "Sudah masuk, tetapi pemeriksaan identitas tidak dapat menjangkau basis pengetahuan ini.",
+    "identityNotReported": "Sudah masuk, tetapi basis pengetahuan ini tidak melaporkan identitas."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Tidak ada basis pengetahuan",

--- a/apps/frontend/messages-source/it.json
+++ b/apps/frontend/messages-source/it.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Trovato su questo computer",
     "managedBadge": "Gestito dal launcher",
     "placementLocal": "locale",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Sconosciuto",
+    "anotherCopy": "un'altra copia della base di conoscenza a cui sei connesso",
+    "addressConflict": "{{count}} basi di conoscenza rivendicano {{address}} — una è probabilmente obsoleta.",
+    "connectToAddress": "Connetti a {{address}}",
+    "connectedToOther": "Connesso a {{actual}}, non {{expected}}.",
+    "identityCheckFailed": "Accesso effettuato, ma il controllo dell'identità non è riuscito a raggiungere questa base di conoscenza.",
+    "identityNotReported": "Accesso effettuato, ma questa base di conoscenza non ha riportato un'identità."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Nessuna base di conoscenza",

--- a/apps/frontend/messages-source/ja.json
+++ b/apps/frontend/messages-source/ja.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "このマシンで見つかりました",
     "managedBadge": "ランチャーで管理",
     "placementLocal": "ローカル",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "不明",
+    "anotherCopy": "接続中のナレッジベースの別のコピー",
+    "addressConflict": "{{count}} 件のナレッジベースが {{address}} を主張しています — いずれかが古い可能性があります。",
+    "connectToAddress": "{{address}} に接続",
+    "connectedToOther": "{{expected}} ではなく {{actual}} に接続されています。",
+    "identityCheckFailed": "サインイン済みですが、アイデンティティの確認でこのナレッジベースに到達できませんでした。",
+    "identityNotReported": "サインイン済みですが、このナレッジベースはアイデンティティを報告しませんでした。"
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "ナレッジベースがありません",

--- a/apps/frontend/messages-source/ko.json
+++ b/apps/frontend/messages-source/ko.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "이 컴퓨터에서 발견됨",
     "managedBadge": "런처에서 관리",
     "placementLocal": "로컬",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "알 수 없음",
+    "anotherCopy": "연결된 지식 베이스의 다른 사본",
+    "addressConflict": "지식 베이스 {{count}}개가 {{address}}을(를) 주장합니다 — 하나는 오래된 것일 수 있습니다.",
+    "connectToAddress": "{{address}}에 연결",
+    "connectedToOther": "{{expected}}이(가) 아닌 {{actual}}에 연결되었습니다.",
+    "identityCheckFailed": "로그인되었지만 신원 확인이 이 지식 베이스에 연결하지 못했습니다.",
+    "identityNotReported": "로그인되었지만 이 지식 베이스가 신원을 보고하지 않았습니다."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "지식 베이스 없음",

--- a/apps/frontend/messages-source/ms.json
+++ b/apps/frontend/messages-source/ms.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Ditemui pada mesin ini",
     "managedBadge": "Diurus oleh launcher",
     "placementLocal": "tempatan",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Tidak diketahui",
+    "anotherCopy": "satu lagi salinan pangkalan pengetahuan yang anda sambungkan",
+    "addressConflict": "{{count}} pangkalan pengetahuan menuntut {{address}} — satu berkemungkinan sudah lapuk.",
+    "connectToAddress": "Sambung ke {{address}}",
+    "connectedToOther": "Disambungkan ke {{actual}}, bukan {{expected}}.",
+    "identityCheckFailed": "Telah log masuk, tetapi semakan identiti tidak dapat menghubungi pangkalan pengetahuan ini.",
+    "identityNotReported": "Telah log masuk, tetapi pangkalan pengetahuan ini tidak melaporkan sebarang identiti."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Tiada pangkalan pengetahuan",

--- a/apps/frontend/messages-source/nl.json
+++ b/apps/frontend/messages-source/nl.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Gevonden op deze machine",
     "managedBadge": "Beheerd door launcher",
     "placementLocal": "lokaal",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Onbekend",
+    "anotherCopy": "een andere kopie van de kennisbasis waarmee je verbonden bent",
+    "addressConflict": "{{count}} kennisbases claimen {{address}} — één is waarschijnlijk verouderd.",
+    "connectToAddress": "Verbinden met {{address}}",
+    "connectedToOther": "Verbonden met {{actual}}, niet met {{expected}}.",
+    "identityCheckFailed": "Ingelogd, maar de identiteitscontrole kon deze kennisbasis niet bereiken.",
+    "identityNotReported": "Ingelogd, maar deze kennisbasis heeft geen identiteit gerapporteerd."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Geen kennisbases",

--- a/apps/frontend/messages-source/no.json
+++ b/apps/frontend/messages-source/no.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Funnet på denne maskinen",
     "managedBadge": "Administrert av launcher",
     "placementLocal": "lokal",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Ukjent",
+    "anotherCopy": "en annen kopi av kunnskapsbasen du er koblet til",
+    "addressConflict": "{{count}} kunnskapsbaser hevder {{address}} — én er sannsynligvis utdatert.",
+    "connectToAddress": "Koble til {{address}}",
+    "connectedToOther": "Tilkoblet {{actual}}, ikke {{expected}}.",
+    "identityCheckFailed": "Logget inn, men identitetssjekken kunne ikke nå denne kunnskapsbasen.",
+    "identityNotReported": "Logget inn, men denne kunnskapsbasen rapporterte ingen identitet."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Ingen kunnskapsbaser",

--- a/apps/frontend/messages-source/pl.json
+++ b/apps/frontend/messages-source/pl.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Znaleziono na tym komputerze",
     "managedBadge": "Zarządzane przez launcher",
     "placementLocal": "lokalny",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Nieznana",
+    "anotherCopy": "kolejna kopia bazy wiedzy, z którą masz połączenie",
+    "addressConflict": "{{count}} bazy wiedzy zgłaszają adres {{address}} — jedna z nich jest prawdopodobnie nieaktualna.",
+    "connectToAddress": "Połącz z {{address}}",
+    "connectedToOther": "Połączono z {{actual}}, a nie z {{expected}}.",
+    "identityCheckFailed": "Zalogowano, ale sprawdzenie tożsamości nie mogło nawiązać połączenia z tą bazą wiedzy.",
+    "identityNotReported": "Zalogowano, ale ta baza wiedzy nie zgłosiła żadnej tożsamości."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Brak baz wiedzy",

--- a/apps/frontend/messages-source/pt.json
+++ b/apps/frontend/messages-source/pt.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Encontrado nesta máquina",
     "managedBadge": "Gerenciado pelo launcher",
     "placementLocal": "local",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Desconhecido",
+    "anotherCopy": "outra cópia da base de conhecimento à qual você está conectado",
+    "addressConflict": "{{count}} bases de conhecimento reivindicam {{address}} — uma provavelmente está desatualizada.",
+    "connectToAddress": "Conectar a {{address}}",
+    "connectedToOther": "Conectado a {{actual}}, não {{expected}}.",
+    "identityCheckFailed": "Conectado, mas a verificação de identidade não conseguiu acessar esta base de conhecimento.",
+    "identityNotReported": "Conectado, mas esta base de conhecimento não informou uma identidade."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Nenhuma base de conhecimento",

--- a/apps/frontend/messages-source/ro.json
+++ b/apps/frontend/messages-source/ro.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Găsit pe această mașină",
     "managedBadge": "Gestionat de launcher",
     "placementLocal": "local",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Necunoscut",
+    "anotherCopy": "altă copie a bazei de cunoștințe la care ești conectat",
+    "addressConflict": "{{count}} baze de cunoștințe revendică {{address}} — una este probabil învechită.",
+    "connectToAddress": "Conectare la {{address}}",
+    "connectedToOther": "Conectat la {{actual}}, nu {{expected}}.",
+    "identityCheckFailed": "Conectat, dar verificarea identității nu a putut accesa această bază de cunoștințe.",
+    "identityNotReported": "Conectat, dar această bază de cunoștințe nu a raportat o identitate."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Nicio bază de cunoștințe",

--- a/apps/frontend/messages-source/sv.json
+++ b/apps/frontend/messages-source/sv.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Hittades på den här datorn",
     "managedBadge": "Hanteras av launcher",
     "placementLocal": "lokal",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Okänd",
+    "anotherCopy": "en annan kopia av kunskapsbasen du är ansluten till",
+    "addressConflict": "{{count}} kunskapsbaser gör anspråk på {{address}} — en är troligen inaktuell.",
+    "connectToAddress": "Anslut till {{address}}",
+    "connectedToOther": "Ansluten till {{actual}}, inte {{expected}}.",
+    "identityCheckFailed": "Inloggad, men identitetskontrollen kunde inte nå den här kunskapsbasen.",
+    "identityNotReported": "Inloggad, men den här kunskapsbasen rapporterade ingen identitet."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Inga kunskapsbaser",

--- a/apps/frontend/messages-source/th.json
+++ b/apps/frontend/messages-source/th.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "พบในเครื่องนี้",
     "managedBadge": "จัดการโดย launcher",
     "placementLocal": "ในเครื่อง",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "ไม่ทราบ",
+    "anotherCopy": "สำเนาอีกชุดหนึ่งของฐานความรู้ที่คุณเชื่อมต่ออยู่",
+    "addressConflict": "ฐานความรู้ {{count}} แห่งอ้างสิทธิ์ {{address}} — หนึ่งในนั้นน่าจะล้าสมัย",
+    "connectToAddress": "เชื่อมต่อกับ {{address}}",
+    "connectedToOther": "เชื่อมต่อกับ {{actual}} ไม่ใช่ {{expected}}",
+    "identityCheckFailed": "เข้าสู่ระบบแล้ว แต่การตรวจสอบตัวตนไม่สามารถเข้าถึงฐานความรู้นี้ได้",
+    "identityNotReported": "เข้าสู่ระบบแล้ว แต่ฐานความรู้นี้ไม่ได้รายงานตัวตน"
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "ไม่มีฐานความรู้",

--- a/apps/frontend/messages-source/tr.json
+++ b/apps/frontend/messages-source/tr.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Bu makinede bulundu",
     "managedBadge": "Başlatıcı tarafından yönetiliyor",
     "placementLocal": "yerel",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Bilinmiyor",
+    "anotherCopy": "bağlı olduğunuz bilgi tabanının başka bir kopyası",
+    "addressConflict": "{{count}} bilgi tabanı {{address}} için hak iddia ediyor — biri büyük olasılıkla eski.",
+    "connectToAddress": "{{address}} adresine bağlan",
+    "connectedToOther": "{{actual}} ile bağlanıldı, {{expected}} ile değil.",
+    "identityCheckFailed": "Giriş yapıldı ancak kimlik kontrolü bu bilgi tabanına ulaşamadı.",
+    "identityNotReported": "Giriş yapıldı ancak bu bilgi tabanı bir kimlik bildirmedi."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Bilgi tabanı yok",

--- a/apps/frontend/messages-source/uk.json
+++ b/apps/frontend/messages-source/uk.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Знайдено на цьому комп'ютері",
     "managedBadge": "Керується лаунчером",
     "placementLocal": "локальний",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Невідомо",
+    "anotherCopy": "інша копія бази знань, до якої ви підключені",
+    "addressConflict": "{{count}} баз знань претендують на {{address}} — одна з них, імовірно, застаріла.",
+    "connectToAddress": "Підключитися до {{address}}",
+    "connectedToOther": "Підключено до {{actual}}, а не до {{expected}}.",
+    "identityCheckFailed": "Ви увійшли, але перевірка ідентичності не змогла зв'язатися з цією базою знань.",
+    "identityNotReported": "Ви увійшли, але ця база знань не повідомила ідентичність."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Немає баз знань",

--- a/apps/frontend/messages-source/vi.json
+++ b/apps/frontend/messages-source/vi.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "Được tìm thấy trên máy này",
     "managedBadge": "Được quản lý bởi trình khởi chạy",
     "placementLocal": "cục bộ",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "Không xác định",
+    "anotherCopy": "một bản sao khác của cơ sở kiến thức mà bạn đang kết nối",
+    "addressConflict": "{{count}} cơ sở kiến thức cùng khai báo {{address}} — một trong số đó có thể đã lỗi thời.",
+    "connectToAddress": "Kết nối với {{address}}",
+    "connectedToOther": "Đã kết nối với {{actual}}, không phải {{expected}}.",
+    "identityCheckFailed": "Đã đăng nhập, nhưng việc kiểm tra danh tính không thể tiếp cận cơ sở kiến thức này.",
+    "identityNotReported": "Đã đăng nhập, nhưng cơ sở kiến thức này không báo cáo danh tính nào."
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "Không có cơ sở kiến thức",

--- a/apps/frontend/messages-source/zh.json
+++ b/apps/frontend/messages-source/zh.json
@@ -587,7 +587,14 @@
     "discoveredTitle": "在此计算机上找到",
     "managedBadge": "由启动器管理",
     "placementLocal": "本地",
-    "placementCodespace": "codespace"
+    "placementCodespace": "codespace",
+    "unknownName": "未知",
+    "anotherCopy": "您所连接的知识库的另一个副本",
+    "addressConflict": "{{count}} 个知识库都声称拥有 {{address}} — 其中一个可能已过时。",
+    "connectToAddress": "连接到 {{address}}",
+    "connectedToOther": "已连接到 {{actual}}，而非 {{expected}}。",
+    "identityCheckFailed": "已登录，但身份检查无法访问此知识库。",
+    "identityNotReported": "已登录，但此知识库未报告任何身份。"
   },
   "DiscoverEmptyState": {
     "noKnowledgeBases": "没有知识库",

--- a/apps/frontend/src/components/KnowledgeBasePanel.tsx
+++ b/apps/frontend/src/components/KnowledgeBasePanel.tsx
@@ -188,36 +188,43 @@ async function authenticateWithBackend(host: string, port: number, protocol: 'ht
   const transport = new HttpTransport({ baseUrl: baseUrl(origin), token$ });
   const client = new SemiontClient(transport, new HttpContentTransport(transport), transport);
 
-  const authResult = await client.auth!.password(emailStr, password);
-  const token = authResult.token;
-  const refreshToken = authResult.refreshToken;
-  if (!token) throw new Error('No access token received');
-  if (!refreshToken) throw new Error('No refresh token received');
-  // Every later call on this client is now authenticated.
-  token$.next(accessToken(token));
-
-  // The KB names itself: identity is read from the KB we actually reached,
-  // never inferred from the discovered row the user happened to click.
-  let status;
+  // The cleanup wraps EVERY exit, not just the status call. The transport
+  // subscribes to token$ the moment it is constructed, so a throw before the
+  // status check — a rejected password, a response missing either token —
+  // leaked it. Scoping the finally to the narrow try covered the one failure
+  // that happened to be on screen and none of the earlier ones.
   try {
-    status = await client.admin!.status();
-  } catch (e) {
-    throw new IdentityUnverifiableError('unreachable', e instanceof Error ? e.message : String(e));
+    const authResult = await client.auth!.password(emailStr, password);
+    const token = authResult.token;
+    const refreshToken = authResult.refreshToken;
+    if (!token) throw new Error('No access token received');
+    if (!refreshToken) throw new Error('No refresh token received');
+    // Every later call on this client is now authenticated.
+    token$.next(accessToken(token));
+
+    // The KB names itself: identity is read from the KB we actually reached,
+    // never inferred from the discovered row the user happened to click.
+    let status;
+    try {
+      status = await client.admin!.status();
+    } catch (e) {
+      throw new IdentityUnverifiableError('unreachable', e instanceof Error ? e.message : String(e));
+    }
+    if (!status.did) throw new IdentityUnverifiableError('not-reported', 'status reported no did');
+
+    return {
+      token,
+      refreshToken,
+      did: status.did,
+      // Absence is stored as absence — the WORD "Unknown" is a render concern
+      // (decision 7), and `host:port` is an address, never a name.
+      label: status.projectName ?? '',
+      ...(status.gitBranch ? { gitBranch: status.gitBranch } : {}),
+    };
   } finally {
     transport.dispose();
     token$.complete();
   }
-  if (!status.did) throw new IdentityUnverifiableError('not-reported', 'status reported no did');
-
-  return {
-    token,
-    refreshToken,
-    did: status.did,
-    // Absence is stored as absence — the WORD "Unknown" is a render concern
-    // (decision 7), and `host:port` is an address, never a name.
-    label: status.projectName ?? '',
-    ...(status.gitBranch ? { gitBranch: status.gitBranch } : {}),
-  };
 }
 
 export function KnowledgeBasePanel() {

--- a/apps/frontend/src/components/KnowledgeBasePanel.tsx
+++ b/apps/frontend/src/components/KnowledgeBasePanel.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CheckIcon, PlusIcon, ArrowRightStartOnRectangleIcon, XMarkIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { BehaviorSubject } from 'rxjs';
 import { SemiontClient, defaultProtocol, isValidHostname, type KnowledgeBase, type KbSessionStatus } from '@semiont/sdk';
 import { HttpContentTransport, HttpTransport } from '@semiont/http-transport';
-import { baseUrl } from '@semiont/core';
+import { accessToken, baseUrl, type AccessToken } from '@semiont/core';
 import type { DiscoveredKB } from '@semiont/core';
 import {
   useSemiont,
@@ -166,12 +167,25 @@ function ReauthForm({ t, kb, onSubmit, onCancel, error, isSubmitting }: {
  * decision 8), and there is nothing legitimate to fall back to: inventing one
  * from the address is the exact category error that document exists to end.
  * Decision 7's third verification outcome, made explicit.
+ *
+ * The two reasons are kept apart deliberately: collapsing them into one
+ * message made a live auth bug undiagnosable from the UI (2026-07-28).
  */
-class IdentityUnverifiableError extends Error {}
+class IdentityUnverifiableError extends Error {
+  constructor(readonly reason: 'unreachable' | 'not-reported', detail: string) {
+    super(detail);
+  }
+}
 
 async function authenticateWithBackend(host: string, port: number, protocol: 'http' | 'https', emailStr: string, password: string): Promise<{ token: string; refreshToken: string; did: string; label: string; gitBranch?: string }> {
   const origin = `${protocol}://${host}:${port}`;
-  const transport = new HttpTransport({ baseUrl: baseUrl(origin) });
+  // `/api/status` REQUIRES authentication, so the transport needs a token
+  // source: without one the identity check goes out unauthenticated and 401s
+  // on every connect (found live 2026-07-28 — previously swallowed, which is
+  // why labels silently fell back to `host:port`). Same pattern the session
+  // factory's `performValidate` uses.
+  const token$ = new BehaviorSubject<AccessToken | null>(null);
+  const transport = new HttpTransport({ baseUrl: baseUrl(origin), token$ });
   const client = new SemiontClient(transport, new HttpContentTransport(transport), transport);
 
   const authResult = await client.auth!.password(emailStr, password);
@@ -179,16 +193,18 @@ async function authenticateWithBackend(host: string, port: number, protocol: 'ht
   const refreshToken = authResult.refreshToken;
   if (!token) throw new Error('No access token received');
   if (!refreshToken) throw new Error('No refresh token received');
+  // Every later call on this client is now authenticated.
+  token$.next(accessToken(token));
 
   // The KB names itself: identity is read from the KB we actually reached,
   // never inferred from the discovered row the user happened to click.
   let status;
   try {
     status = await client.admin!.status();
-  } catch {
-    throw new IdentityUnverifiableError('status unavailable');
+  } catch (e) {
+    throw new IdentityUnverifiableError('unreachable', e instanceof Error ? e.message : String(e));
   }
-  if (!status.did) throw new IdentityUnverifiableError('no did reported');
+  if (!status.did) throw new IdentityUnverifiableError('not-reported', 'status reported no did');
 
   return {
     token,
@@ -305,6 +321,16 @@ export function KnowledgeBasePanel() {
     setConnectNotice(null);
   };
 
+  // An unreachable identity check and a KB that reports no identity are
+  // different problems with different fixes; one message for both hid a live
+  // auth bug for a whole release.
+  const identityAwareMessage = (err: unknown): string => {
+    if (err instanceof IdentityUnverifiableError) {
+      return err.reason === 'unreachable' ? t('identityCheckFailed') : t('identityNotReported');
+    }
+    return err instanceof Error ? err.message : String(err);
+  };
+
   const handleAdd = async (host: string, port: number, protocol: 'http' | 'https', email: string, password: string) => {
     setAddError(null);
     setAddSubmitting(true);
@@ -318,11 +344,7 @@ export function KnowledgeBasePanel() {
         signIn(existing.id, token, refreshToken);
         setAddForm(null);
       } catch (err) {
-        setAddError(
-          err instanceof IdentityUnverifiableError
-            ? t('identityUnverifiable')
-            : err instanceof Error ? err.message : String(err),
-        );
+        setAddError(identityAwareMessage(err));
       } finally {
         setAddSubmitting(false);
       }
@@ -352,11 +374,7 @@ export function KnowledgeBasePanel() {
       );
       setAddForm(null);
     } catch (err) {
-      setAddError(
-        err instanceof IdentityUnverifiableError
-          ? t('identityUnverifiable')
-          : err instanceof Error ? err.message : String(err),
-      );
+      setAddError(identityAwareMessage(err));
     } finally {
       setAddSubmitting(false);
     }

--- a/apps/frontend/src/components/KnowledgeBasePanel.tsx
+++ b/apps/frontend/src/components/KnowledgeBasePanel.tsx
@@ -203,6 +203,9 @@ async function authenticateWithBackend(host: string, port: number, protocol: 'ht
     status = await client.admin!.status();
   } catch (e) {
     throw new IdentityUnverifiableError('unreachable', e instanceof Error ? e.message : String(e));
+  } finally {
+    transport.dispose();
+    token$.complete();
   }
   if (!status.did) throw new IdentityUnverifiableError('not-reported', 'status reported no did');
 

--- a/apps/frontend/src/components/__tests__/KnowledgeBasePanel.test.tsx
+++ b/apps/frontend/src/components/__tests__/KnowledgeBasePanel.test.tsx
@@ -19,7 +19,8 @@ const translations: Record<string, string> = {
   'KnowledgeBasePanel.statusSignedOut': 'Signed out',
   'KnowledgeBasePanel.statusUnreachable': 'Unreachable',
   'KnowledgeBasePanel.unknownName': 'Unknown',
-  'KnowledgeBasePanel.identityUnverifiable': 'Connected, but could not determine which knowledge base this is.',
+  'KnowledgeBasePanel.identityCheckFailed': 'Signed in, but the identity check could not reach this knowledge base.',
+  'KnowledgeBasePanel.identityNotReported': 'Signed in, but this knowledge base did not report an identity.',
   'KnowledgeBasePanel.addressConflict': '{{count}} knowledge bases claim {{address}} — one is likely stale.',
   'KnowledgeBasePanel.connectToAddress': 'Connect to {{address}}',
   'KnowledgeBasePanel.connectedToOther': 'Connected to {{actual}}, not {{expected}}.',
@@ -130,12 +131,18 @@ vi.mock('@semiont/sdk', async () => {
   return { ...actual, SemiontClient: MockSemiontClient };
 });
 
+const { httpTransportConfigs } = vi.hoisted(() => ({ httpTransportConfigs: [] as any[] }));
+
 vi.mock('@semiont/http-transport', async () => {
   const actual = await vi.importActual<typeof import('@semiont/http-transport')>('@semiont/http-transport');
-  return {
-    ...actual,
-    SemiontClient: vi.fn(),
-  };
+  // Capture the transport config so a test can see whether the identity check
+  // was given a token source at all.
+  class MockHttpTransport {
+    config: any;
+    constructor(config: any) { this.config = config; httpTransportConfigs.push(config); }
+  }
+  class MockHttpContentTransport { constructor(_t: any) {} }
+  return { ...actual, HttpTransport: MockHttpTransport, HttpContentTransport: MockHttpContentTransport };
 });
 
 vi.mock('@semiont/core', async () => {
@@ -151,6 +158,7 @@ vi.mock('@semiont/core', async () => {
 describe('KnowledgeBasePanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    httpTransportConfigs.length = 0;
     kbs$.next([kb1, kb2]);
     // Panel reads `activeKnowledgeBase` from `activeSession$?.kb`, so a session
     // with `kb: kb1` emulates "kb1 is active".
@@ -265,8 +273,41 @@ describe('KnowledgeBasePanel', () => {
       await connect();
 
       await waitFor(() => {
-        expect(screen.getByText(/could not determine which knowledge base/i)).toBeInTheDocument();
+        expect(screen.getByText(/identity check could not reach/i)).toBeInTheDocument();
       });
+      expect(mockBrowser.addKb).not.toHaveBeenCalled();
+    });
+
+    it('sends the access token with the identity check', async () => {
+      // The bug this pins (found live 2026-07-28): the throwaway client was
+      // built with no token source, so `/api/status` — which REQUIRES auth —
+      // was called unauthenticated and 401'd on every connect. Before P3a the
+      // 401 was swallowed and the label silently fell back to `host:port`;
+      // after P3a it blocked connecting outright. The session factory's
+      // `performValidate` had the correct pattern (seed `token$`) all along.
+      let tokenAtIdentityCheck: string | null = null;
+      mockAdminStatus.mockImplementation(async () => {
+        const source = httpTransportConfigs.find((c) => c?.token$);
+        tokenAtIdentityCheck = source?.token$?.getValue() ?? null;
+        return { projectName: 'Caselaw Knowledge Base', did: 'did:web:caselaw.example' };
+      });
+
+      await connect();
+
+      await waitFor(() => expect(mockBrowser.addKb).toHaveBeenCalled());
+      expect(tokenAtIdentityCheck).toBe('tok');
+    });
+
+    it('distinguishes an unreachable identity check from a KB that reports none', async () => {
+      // One message for both left the live failure undiagnosable from the UI.
+      mockAdminStatus.mockResolvedValue({ projectName: 'Nameless' });
+
+      await connect();
+
+      await waitFor(() => {
+        expect(screen.getByText(/did not report an identity/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/could not reach/i)).not.toBeInTheDocument();
       expect(mockBrowser.addKb).not.toHaveBeenCalled();
     });
 

--- a/apps/frontend/src/components/__tests__/KnowledgeBasePanel.test.tsx
+++ b/apps/frontend/src/components/__tests__/KnowledgeBasePanel.test.tsx
@@ -131,7 +131,10 @@ vi.mock('@semiont/sdk', async () => {
   return { ...actual, SemiontClient: MockSemiontClient };
 });
 
-const { httpTransportConfigs } = vi.hoisted(() => ({ httpTransportConfigs: [] as any[] }));
+const { httpTransportConfigs, httpTransportDisposals } = vi.hoisted(() => ({
+  httpTransportConfigs: [] as any[],
+  httpTransportDisposals: [] as any[],
+}));
 
 vi.mock('@semiont/http-transport', async () => {
   const actual = await vi.importActual<typeof import('@semiont/http-transport')>('@semiont/http-transport');
@@ -140,6 +143,13 @@ vi.mock('@semiont/http-transport', async () => {
   class MockHttpTransport {
     config: any;
     constructor(config: any) { this.config = config; httpTransportConfigs.push(config); }
+    // The real transport subscribes to token$ and starts an SSE actor once a
+    // token arrives, so the throwaway auth client MUST be disposed. Recording
+    // the call rather than stubbing it silently: a mock that merely tolerates
+    // dispose() would let the leak come back unnoticed, and the missing method
+    // took the whole connect-flow suite red.
+    disposed = false;
+    dispose() { this.disposed = true; httpTransportDisposals.push(this.config); }
   }
   class MockHttpContentTransport { constructor(_t: any) {} }
   return { ...actual, HttpTransport: MockHttpTransport, HttpContentTransport: MockHttpContentTransport };
@@ -159,6 +169,7 @@ describe('KnowledgeBasePanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     httpTransportConfigs.length = 0;
+    httpTransportDisposals.length = 0;
     kbs$.next([kb1, kb2]);
     // Panel reads `activeKnowledgeBase` from `activeSession$?.kb`, so a session
     // with `kb: kb1` emulates "kb1 is active".
@@ -296,6 +307,21 @@ describe('KnowledgeBasePanel', () => {
 
       await waitFor(() => expect(mockBrowser.addKb).toHaveBeenCalled());
       expect(tokenAtIdentityCheck).toBe('tok');
+    });
+
+    it('disposes the throwaway transport even when auth fails', async () => {
+      // The transport subscribes to token$ as soon as it is constructed, and
+      // starts an SSE actor once a token arrives — so a connect attempt that
+      // throws must still tear it down. The original cleanup sat in a finally
+      // scoped to the /api/status call, which covered the one failure on
+      // screen and left every earlier one leaking: a rejected password, or a
+      // response missing either token.
+      mockAuthPassword.mockRejectedValue(new Error('bad password'));
+
+      await connect();
+
+      await waitFor(() => expect(httpTransportDisposals.length).toBeGreaterThan(0));
+      expect(mockBrowser.addKb).not.toHaveBeenCalled();
     });
 
     it('distinguishes an unreachable identity check from a KB that reports none', async () => {

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -156,8 +156,64 @@ func git(args []string) {
 //	FAKERT_OLLAMA_PULL_FAILS  /api/pull answers with an error
 //	FAKERT_SKIP_SERVE       host ports to leave unbound (crashed-after-start containers)
 //
-// `codespace ports forward A:B …` binds every host port and parks (the fake
-// dev tunnel), writing a serve pidfile so killServes reaps it.
+// remoteDown reports whether the codespace's KB is still unreachable. With
+// FAKERT_REMOTE_READY_AFTER=n the nth ssh probe is the first to succeed, so a
+// test can model a stack that comes up partway through the wait.
+func remoteDown() bool {
+	if os.Getenv("FAKERT_REMOTE_DOWN") != "" {
+		return true
+	}
+	after := os.Getenv("FAKERT_REMOTE_READY_AFTER")
+	if after == "" {
+		return false
+	}
+	n, err := strconv.Atoi(after)
+	if err != nil {
+		return false
+	}
+	return remoteProbeCount() < n
+}
+
+// remoteProbeCount reads the ssh-probe tally without incrementing it.
+func remoteProbeCount() int {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return 0
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "remote-probes"))
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return n
+}
+
+// bumpRemoteProbe records one ssh readiness probe and returns the new tally.
+func bumpRemoteProbe() int {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return 0
+	}
+	n := remoteProbeCount() + 1
+	_ = os.WriteFile(filepath.Join(dir, "remote-probes"), []byte(strconv.Itoa(n)), 0o644)
+	return n
+}
+
+// forwardLocalPort digs the LOCAL port out of `A:B` (real gh listens on B).
+func forwardLocalPort(args []string) string {
+	for _, a := range args {
+		if pair := strings.SplitN(a, ":", 2); len(pair) == 2 {
+			if _, err := strconv.Atoi(pair[1]); err == nil {
+				return pair[1]
+			}
+		}
+	}
+	return "0"
+}
+
+// `codespace ports forward A:B …` binds the LOCAL port and parks (the fake
+// dev tunnel), writing a serve pidfile so killServes reaps it — unless the
+// remote is down, in which case it dies on first contact like the real thing.
 func ghCmd(args []string) {
 	joined := strings.Join(args, " ")
 	switch {
@@ -311,6 +367,37 @@ func ghCodespace(args []string, joined string) {
 				}()
 			}
 		}
+		// FAKERT_REMOTE_DOWN / FAKERT_REMOTE_READY_AFTER: the REMOTE side is
+		// not listening yet. This is the behaviour that made a fresh create
+		// unusable live on 2026-07-27, and the fake could not express it: a
+		// real `gh codespace ports forward` binds locally straight away, then
+		// EXITS the first time a local connection cannot be opened through to
+		// the remote port —
+		//
+		//   ssh: rejected: connect failed (Connection refused)
+		//
+		// so any probe through the tunnel while the stack is still coming up
+		// destroys the tunnel. The old fake bound and parked unconditionally,
+		// which is why every test agreed a forward that binds is a forward
+		// that works.
+		if remoteDown() {
+			go func() {
+				ln, err := net.Listen("tcp", "127.0.0.1:"+forwardLocalPort(args))
+				if err != nil {
+					os.Exit(1)
+				}
+				c, err := ln.Accept() // the first probe is the fatal one
+				if err == nil {
+					c.Close()
+				}
+				fmt.Fprintln(os.Stderr, "error connecting to tunnel: connect to forwarded port failed: "+
+					"error connecting to forwarded port: failed to open streaming channel: "+
+					"failed to open port forward channel: failed to open channel: "+
+					"ssh: rejected: connect failed (Connection refused)")
+				os.Exit(1)
+			}()
+			select {} // park until that goroutine exits the process
+		}
 		if os.Getenv("FAKERT_GH_FORWARD_SICK") != "" {
 			// Scoped to THIS process: __serve children of `run -d` never
 			// see it, so container health fakes stay healthy.
@@ -369,6 +456,17 @@ func ghCodespace(args []string, joined string) {
 				body = `{"email":"admin@example.com","password":"fake-admin-pw"}`
 			}
 			fmt.Println(body)
+		case strings.Contains(joined, "api/health"):
+			// The readiness probe that does NOT go through the tunnel — the
+			// only way to ask "is the stack up?" without destroying the
+			// forward while it is still coming up. Each call is tallied so a
+			// test can say "ready on the nth probe".
+			n := bumpRemoteProbe()
+			if remoteDown() {
+				fmt.Fprintf(os.Stderr, "curl: (7) Failed to connect to localhost port 4000 after 1 ms: Connection refused (probe %d)\n", n)
+				os.Exit(7)
+			}
+			fmt.Println("200")
 		case strings.Contains(joined, ".semiont/config"):
 			// The KB's committed identity card, as the codespace holds it.
 			// FAKERT_GH_KBCONFIG overrides so a test can stage DRIFT — a

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -461,12 +461,15 @@ func ghCodespace(args []string, joined string) {
 			// only way to ask "is the stack up?" without destroying the
 			// forward while it is still coming up. Each call is tallied so a
 			// test can say "ready on the nth probe".
-			n := bumpRemoteProbe()
+			// The launcher's probe is `curl … && echo READY || echo WAIT`, so
+			// the sentinel — not the exit code — is the answer. A vanished
+			// sentinel is how it detects that ssh itself failed.
+			bumpRemoteProbe()
 			if remoteDown() {
-				fmt.Fprintf(os.Stderr, "curl: (7) Failed to connect to localhost port 4000 after 1 ms: Connection refused (probe %d)\n", n)
-				os.Exit(7)
+				fmt.Println("SEMIONT_KB_WAIT")
+				return
 			}
-			fmt.Println("200")
+			fmt.Println("SEMIONT_KB_READY")
 		case strings.Contains(joined, ".semiont/config"):
 			// The KB's committed identity card, as the codespace holds it.
 			// FAKERT_GH_KBCONFIG overrides so a test can stage DRIFT — a

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -1410,6 +1410,7 @@ func waitForRemoteKB(u *ui, name string, created bool) int {
 	if created {
 		tail = startCreationLogTail(u, name)
 	}
+	defer tail.stop()
 	t0 := time.Now()
 	deadline := t0.Add(remoteReadyBudget)
 	for {

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -218,6 +218,23 @@ func startCodespace(u *ui, opts startOptions) int {
 	if code := ensureCodespaceAvailable(u, repo, name); code != 0 {
 		return code
 	}
+	// THE STACK MUST BE UP BEFORE THE TUNNEL EXISTS. `gh codespace ports
+	// forward` binds locally at once but exits the first time a connection
+	// cannot be opened through to the remote port ("ssh: rejected: connect
+	// failed"). A fresh create runs devcontainer hooks for minutes, so any
+	// probe through the tunnel during that window destroys it — including
+	// the launcher's own bind check, which DIALS the port. The checker was
+	// killing the thing it checked (live 2026-07-27; every fresh create
+	// reported "the port forward died after 1s — the stack may be fine",
+	// which was exactly backwards: the stack was down, and that is why the
+	// forward died).
+	//
+	// Readiness is therefore asked over ssh, which does not touch the
+	// tunnel, and the tunnel is built only once the answer is yes. On a
+	// resume the first probe usually succeeds, so the fast path stays fast.
+	if code := waitForRemoteKB(u, name, created); code != 0 {
+		return code
+	}
 	pid, fwdDead, code := spawnForward(u, name, kbPort)
 	if code != 0 {
 		return code
@@ -267,38 +284,29 @@ func startCodespace(u *ui, opts startOptions) int {
 	}
 	saveStack(newSt)
 
-	// Health, not VM state, is readiness ("Available ≠ hooks finished" —
-	// on a fresh create the devcontainer hooks run minutes past Available).
-	// Each path narrates ITS wait: a resume borrowing the fresh-create
-	// wording promised minutes for a gate that usually opens in seconds.
-	if created {
-		u.log("Waiting for the stack %s", u.dim("(a fresh create runs devcontainer hooks — image and model pulls take minutes)"))
-	} else {
-		u.log("Waiting for the stack %s", u.dim("(resume: the VM wakes already provisioned — usually seconds)"))
-	}
-	// A fresh create narrates its hooks: tail the creation log while the
-	// health gate waits. Resume tails nothing — its creation log is old.
-	var tail *creationLogTail
-	if created {
-		tail = startCreationLogTail(u, name)
-	}
-	// Each tick renders the window AND takes the forward's pulse: a tunnel
-	// that dies mid-wait must fail in seconds with the true diagnosis, not
-	// burn the whole budget blaming a KB that may be healthy (observed
-	// live 2026-07-23 — 600s spent polling a defunct forward).
+	// The stack is already known healthy (waitForRemoteKB, over ssh). What
+	// is unproven is the TUNNEL, so this gate asks a different question and
+	// gets a short budget: the KB answered a moment ago inside the VM, so
+	// anything slow here is the forward, not the stack.
+	//
+	// The tick still takes the forward's pulse. A tunnel can die mid-wait
+	// for reasons unrelated to readiness (observed live 2026-07-23 — 600s
+	// spent polling a defunct forward), and reporting that as a sick KB
+	// sends the reader to the wrong machine.
 	tick := func(elapsed time.Duration) bool {
-		tail.tick(elapsed)
 		select {
 		case <-fwdDead:
-			u.fail("The port forward (pid %d) died after %s — the stack may be fine.", pid, took(elapsed))
+			u.fail("The port forward (pid %d) died after %s.", pid, took(elapsed))
+			if last := lastForwardError(pid); last != "" {
+				fmt.Fprintf(os.Stderr, "  gh said: %s\n", last)
+			}
 			fmt.Fprintln(os.Stderr, "  Rerun to respawn it:  semiont start --runtime codespace --repo "+repo)
 			return false
 		default:
 			return true
 		}
 	}
-	d, ok := waitForHTTPTick(u, "KB (through the forward)", fmt.Sprintf("http://localhost:%d/api/health", kbPort), 600, tick)
-	tail.stop()
+	d, ok := waitForHTTPTick(u, "KB (through the forward)", fmt.Sprintf("http://localhost:%d/api/health", kbPort), 60, tick)
 	if !ok {
 		return 1
 	}
@@ -857,12 +865,20 @@ func spawnForward(u *ui, name string, kbPort int) (int, <-chan struct{}, int) {
 		fmt.Sprintf("%d:%d", kbRemotePort, kbPort), "-c", name}
 	u.echoCmd("gh", args...)
 	cmd := exec.Command("gh", args...)
-	cmd.Stdout, cmd.Stderr = nil, nil
+	// Keep gh's stderr. It was discarded, so a dead forward could be
+	// reported but never EXPLAINED — and gh's own message is the whole
+	// diagnosis ("ssh: rejected: connect failed (Connection refused)" means
+	// the remote port is not listening; "address already in use" means the
+	// local one is taken). A bounded buffer: this is one or two lines, and
+	// an unbounded one would grow for the life of a long-running tunnel.
+	cmd.Stdout = nil
+	cmd.Stderr = newForwardLog()
 	if err := cmd.Start(); err != nil {
 		u.fail("Could not start the port forward: %v", err)
 		return 0, nil, 1
 	}
 	pid := cmd.Process.Pid
+	rememberForwardLog(pid, cmd.Stderr)
 	// A reaping Wait (not Release): the observed mid-wait death left a
 	// ZOMBIE, and a zombie still passes kill-0 aliveness — only Wait both
 	// reaps it and yields a truthful death signal for the health gate.
@@ -1371,4 +1387,118 @@ func forwardAlive(pid, port int) bool {
 	}
 	conn.Close()
 	return true
+}
+
+// waitForRemoteKB blocks until the KB answers INSIDE the codespace, asked over
+// ssh so nothing touches the port forward (which does not exist yet, and which
+// a premature probe would destroy — see the call site).
+//
+// The probe is `curl` against localhost:4000 in the VM: the same question the
+// health gate asks, one hop earlier, where a "connection refused" costs
+// nothing. Each attempt is a fresh `gh codespace ssh`, so the cadence is slow
+// on purpose — ssh setup dwarfs the request, and a fresh create is a
+// minutes-long wait where seconds of resolution buy nothing.
+func waitForRemoteKB(u *ui, name string, created bool) int {
+	if created {
+		u.log("Waiting for the stack %s", u.dim("(a fresh create runs devcontainer hooks — image and model pulls take minutes)"))
+	} else {
+		u.log("Waiting for the stack %s", u.dim("(resume: the VM wakes already provisioned — usually seconds)"))
+	}
+	// A fresh create narrates its hooks while the gate waits; a resume has
+	// only a stale creation log, so it tails nothing.
+	var tail *creationLogTail
+	if created {
+		tail = startCreationLogTail(u, name)
+	}
+	t0 := time.Now()
+	deadline := t0.Add(remoteReadyBudget)
+	for {
+		if remoteKBHealthy(name) {
+			u.ok("Stack ready inside the codespace %s", u.dim("("+took(time.Since(t0))+")"))
+			return 0
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		tail.tick(time.Since(t0))
+		time.Sleep(remoteReadyPoll)
+	}
+	u.fail("The stack did not come up inside %s within %s.", name, took(remoteReadyBudget))
+	fmt.Fprintf(os.Stderr, "  Look inside:  gh codespace ssh -c %s -- 'docker ps; docker logs --tail 50 semiont-backend'\n", name)
+	fmt.Fprintln(os.Stderr, "  A crash-looping backend is the usual cause; its logs name the reason.")
+	return 1
+}
+
+const (
+	// Long enough for a cold create: image pulls plus model pulls.
+	remoteReadyBudget = 15 * time.Minute
+	// One `gh codespace ssh` per probe — seconds of resolution would only
+	// buy ssh handshakes.
+	remoteReadyPoll = 5 * time.Second
+)
+
+// remoteKBHealthy asks the codespace whether its backend serves health. Any
+// non-zero exit (ssh down, curl refused, VM still booting) reads as "not yet"
+// — this is a readiness poll, and its only job is to say when to stop waiting.
+func remoteKBHealthy(name string) bool {
+	probe := fmt.Sprintf("curl -sf -o /dev/null -m 5 http://localhost:%d/api/health", kbRemotePort)
+	return runSilent("gh", "codespace", "ssh", "-c", name, "--", probe) == nil
+}
+
+// --- forward stderr, kept so a death can be explained ---
+
+// forwardLog is a last-lines ring for a forward's stderr. gh emits at most a
+// line or two, but the process can live for hours; an unbounded buffer would
+// be a slow leak for output nobody reads unless something dies.
+type forwardLog struct {
+	mu   sync.Mutex
+	last string
+}
+
+func newForwardLog() *forwardLog { return &forwardLog{} }
+
+func (f *forwardLog) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if line := strings.TrimSpace(string(p)); line != "" {
+		f.last = lastLine(line)
+	}
+	return len(p), nil
+}
+
+func (f *forwardLog) String() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.last
+}
+
+func lastLine(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	return strings.TrimSpace(lines[len(lines)-1])
+}
+
+var (
+	forwardLogsMu sync.Mutex
+	forwardLogs   = map[int]*forwardLog{}
+)
+
+func rememberForwardLog(pid int, w any) {
+	fl, ok := w.(*forwardLog)
+	if !ok {
+		return
+	}
+	forwardLogsMu.Lock()
+	defer forwardLogsMu.Unlock()
+	forwardLogs[pid] = fl
+}
+
+// lastForwardError returns the final stderr line a forward produced, or "".
+func lastForwardError(pid int) string {
+	forwardLogsMu.Lock()
+	fl := forwardLogs[pid]
+	forwardLogsMu.Unlock()
+	if fl == nil {
+		return ""
+	}
+	return fl.String()
 }

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -1413,8 +1413,20 @@ func waitForRemoteKB(u *ui, name string, created bool) int {
 	t0 := time.Now()
 	deadline := t0.Add(remoteReadyBudget)
 	for {
-		if remoteKBHealthy(name) {
+		switch askRemoteKB(name) {
+		case remoteReady:
 			u.ok("Stack ready inside the codespace %s", u.dim("("+took(time.Since(t0))+")"))
+			tail.stop()
+			return 0
+		case remoteUnknown:
+			// Cannot ask, so cannot wait: ssh is a nicety here, and a stack
+			// that is actually healthy must still start. Proceed to the
+			// forward — with the caveat named, because if the stack is NOT
+			// up this is precisely the case where the tunnel dies on first
+			// contact and the reason will look like a forward problem.
+			u.warn("Could not reach %s over ssh to check the stack — continuing without that check.", name)
+			fmt.Fprintln(os.Stderr, "  If the forward dies immediately, the stack inside the codespace is probably still coming up.")
+			tail.stop()
 			return 0
 		}
 		if !time.Now().Before(deadline) {
@@ -1423,6 +1435,7 @@ func waitForRemoteKB(u *ui, name string, created bool) int {
 		tail.tick(time.Since(t0))
 		time.Sleep(remoteReadyPoll)
 	}
+	tail.stop()
 	u.fail("The stack did not come up inside %s within %s.", name, took(remoteReadyBudget))
 	fmt.Fprintf(os.Stderr, "  Look inside:  gh codespace ssh -c %s -- 'docker ps; docker logs --tail 50 semiont-backend'\n", name)
 	fmt.Fprintln(os.Stderr, "  A crash-looping backend is the usual cause; its logs name the reason.")
@@ -1437,13 +1450,42 @@ const (
 	remoteReadyPoll = 5 * time.Second
 )
 
-// remoteKBHealthy asks the codespace whether its backend serves health. Any
-// non-zero exit (ssh down, curl refused, VM still booting) reads as "not yet"
-// — this is a readiness poll, and its only job is to say when to stop waiting.
-func remoteKBHealthy(name string) bool {
-	probe := fmt.Sprintf("curl -sf -o /dev/null -m 5 http://localhost:%d/api/health", kbRemotePort)
-	return runSilent("gh", "codespace", "ssh", "-c", name, "--", probe) == nil
+// remoteReadiness is what the codespace can tell us about its own stack.
+type remoteReadiness int
+
+const (
+	remoteReady    remoteReadiness = iota // the KB answered inside the VM
+	remoteNotReady                        // ssh worked; the KB is not up yet
+	remoteUnknown                         // ssh itself is unusable — we cannot ask
+)
+
+// askRemoteKB asks the codespace whether its backend serves health, and — the
+// part that matters — distinguishes "not ready" from "could not ask".
+//
+// ssh is a NICETY in this flow, never a gate: it can fail while the stack is
+// perfectly healthy (no sshd, auth trouble), and blocking on it would fail a
+// start that would otherwise have worked. Exit codes alone cannot separate
+// "curl refused" from "ssh died", so the remote command prints a sentinel and
+// we read stdout: no sentinel means the question never reached the VM.
+func askRemoteKB(name string) remoteReadiness {
+	probe := fmt.Sprintf(
+		"curl -sf -o /dev/null -m 5 http://localhost:%d/api/health && echo %s || echo %s",
+		kbRemotePort, readySentinel, notReadySentinel)
+	out, _ := capture("gh", "codespace", "ssh", "-c", name, "--", probe)
+	switch {
+	case strings.Contains(out, readySentinel):
+		return remoteReady
+	case strings.Contains(out, notReadySentinel):
+		return remoteNotReady
+	default:
+		return remoteUnknown
+	}
 }
+
+const (
+	readySentinel    = "SEMIONT_KB_READY"
+	notReadySentinel = "SEMIONT_KB_WAIT"
+)
 
 // --- forward stderr, kept so a death can be explained ---
 

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -1980,6 +1980,39 @@ func TestCodespaceStartCreates(t *testing.T) {
 	}
 }
 
+func TestCodespaceWaitsForRemoteBeforeForwarding(t *testing.T) {
+	// A FRESH create could never succeed in one command (live 2026-07-27).
+	// `gh codespace ports forward` binds locally at once but EXITS the first
+	// time a local connection cannot be opened through to the remote port
+	// ("ssh: rejected: connect failed"). Devcontainer hooks take minutes, so
+	// the launcher's own bind check — forwardAlive(), which DIALS the port —
+	// killed the tunnel it was checking, and the death surfaced a step later
+	// as "the port forward died after 1s — the stack may be fine."
+	//
+	// The checker must not destroy the thing it checks: readiness is asked
+	// over ssh (which does not touch the tunnel), and the forward is only
+	// established once the remote answers.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv, "FAKERT_REMOTE_READY_AFTER=3") // up on the 3rd probe
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("a stack that comes up mid-wait must succeed: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	// The readiness question was asked over ssh, before any forward existed.
+	log := s.argv(t)
+	sshAt := strings.Index(log, "api/health")
+	fwdAt := strings.Index(log, "ports forward")
+	if sshAt < 0 {
+		t.Fatalf("readiness was never asked over ssh:\n%s", log)
+	}
+	if fwdAt >= 0 && fwdAt < sshAt {
+		t.Errorf("the forward was established before the remote was known ready — the ordering that killed it:\n%s", log)
+	}
+	if strings.Contains(stdout+stderr, "died") {
+		t.Errorf("no forward should have died:\n%s\n%s", stdout, stderr)
+	}
+}
+
 func TestCodespaceForwardDeathFailsFast(t *testing.T) {
 	// The mid-wait forward death observed live 2026-07-23: the tunnel
 	// bound, then its process died while the health gate polled — and the

--- a/package-lock.json
+++ b/package-lock.json
@@ -16774,7 +16774,6 @@
       "version": "0.5.22",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-neptune": "3.1092.0",
         "@semiont/core": "*",
         "@semiont/http-transport": "*",
         "@semiont/ontology": "*",


### PR DESCRIPTION
Three fixes that arrived together, each found by running the thing rather than reading it. The connect flow could not authenticate its own identity check; the client it built for that check was never torn down; and a fresh codespace start destroyed its own tunnel before the stack could come up.

## 1. The identity check was unauthenticated (`c6877c7c`)

`authenticateWithBackend` built its transport with no token source, so `/api/status` — which requires authentication — was called unauthenticated and 401'd on every connect. The token from `auth.password` was returned to the caller but never fed back into the transport it came from. The transport now takes a `token$` subject, populated the moment auth succeeds, which is the pattern the session factory's `performValidate` already used.

Identity-verification failures also split into two: **unreachable** (`/api/status` threw) and **not-reported** (it answered without a `did`). One message for both left the live failure undiagnosable from the UI.

## 2. The throwaway auth client leaked (`f7c3b2a0`, `06e30fba`)

`HttpTransport` subscribes to `token$` at construction and starts an SSE actor once a token arrives, so the client built purely for auth + `/api/status` must be disposed — otherwise every connect leaves a background connection running.

Two follow-ups from review, both real:

- **The test mock had no `dispose()`.** Production called it in a `finally`, so the connect-flow suite threw `TypeError: transport.dispose is not a function` — three tests were **already red on the branch**. The mock now implements it and *records* the call: a mock that merely tolerates `dispose()` would let the leak return unnoticed, which is exactly how it got here.
- **Cleanup covered one exit path of several.** The `finally` was scoped to the `/api/status` call, so a rejected password — or a response missing either token — leaked the transport anyway. It now wraps everything from construction onward, with a test pinning the rejected-password path (mutation-tested: restoring the narrow scoping makes it fail).

## 3. A fresh codespace start killed its own tunnel (`1847fd03`, `06e30fba`)

Every fresh `semiont start --runtime codespace` failed with:

```
✗ The port forward (pid 32690) died after 1s — the stack may be fine.
```

which was exactly backwards. `gh codespace ports forward` binds locally at once but **exits the first time a connection cannot be opened through to the remote port** (`ssh: rejected: connect failed (Connection refused)`). Devcontainer hooks run for minutes, so nothing is listening remotely — and the launcher's own bind check, `forwardAlive()`, **dials the port**. The checker was killing the thing it checked; the death then surfaced a step later and blamed the KB.

Proven in isolation: the forward lives indefinitely untouched and dies from **exactly one** probe while the remote is down.

**The fix inverts the order.** Readiness is asked over `gh codespace ssh` — which never touches the tunnel — and the tunnel is built only once the KB answers inside the VM. The through-tunnel gate stays but now asks a different question ("does the tunnel work?"), so its budget drops 600s → 60s: the KB answered a moment ago inside the VM, so anything slow at that point is the forward.

**ssh stays a nicety, not a gate.** `TestCodespaceSshFailureDoesNotBlockAHealthyStack` caught the first version of this doing the opposite — a broken ssh blocked a healthy stack for the full budget. Exit codes cannot separate "curl refused" from "ssh died", so the remote command prints a sentinel and the launcher reads stdout: no sentinel means the question never reached the VM, and it proceeds rather than waiting.

**gh's stderr is no longer discarded.** `spawnForward` set `cmd.Stderr = nil`, so a dead forward could be reported but never explained. A bounded last-line ring per forward means a death now prints `gh said: …` — the one line that turns this class of debugging from an hour into a minute.

### Why the tests never caught it

The fake's `codespace ports forward` bound a local port and parked — a healthy listener, never a tunnel to a dead remote. Every test agreed with the code that "a forward that binds is a forward that works." The fake now models the real behaviour (`FAKERT_REMOTE_DOWN` / `FAKERT_REMOTE_READY_AFTER`, dying on first contact with gh's actual error text), and the new test reproduced the live failure **before** the launcher was touched.

## 4. Translations (`71511cf1`)

The new identity/conflict strings across 28 `messages-source` locales.

## Note on `0fd788e4`

`defer tail.stop()` is a correct belt-and-braces addition — `stop()` is nil-guarded and zeroes `rendered`, so the double call is safe. The explicit `tail.stop()` calls are **not** redundant and must stay: they run *before* the success line prints, and `stop()` erases by moving the cursor up `rendered` lines. Deferring only would print the success line first and then erase over it.

## Verification

Frontend `tsc --noEmit` and the panel suite pass by exit code. Launcher: gofmt, vet, and the full `Codespace` family green (`ok 133.772s`).

## Known gap, found live while testing this

A devcontainer whose hooks **fail** is not detected. The creation log prints `postStartCommand … failed with exit code 1` and `devcontainer process exited with exit code 1`, and the readiness wait — which renders that log but never reads it — keeps polling a stack that provably cannot come up, until the budget expires. Same defect class as the forward-death fail-fast, one layer earlier. Not fixed here.
