### PR TITLE
codespace start: stop the readiness check from destroying the tunnel, and fail fast when the hooks fail

### DIFF
--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -149,6 +149,7 @@ func git(args []string) {
 //	FAKERT_GH_CS_NAME       name printed by `codespace create` (default "fake-cs-1")
 //	FAKERT_GH_CREATE_FAILS  N leading 503 failures before create succeeds (cursor file)
 //	FAKERT_GH_SSH_FAIL      ssh fails with the no-sshd error
+//	FAKERT_GH_HOOKS_FAIL    the devcontainer lifecycle command fails (stack never comes up)
 //	FAKERT_GH_ADMIN         admin.json content for `ssh -- cat .devcontainer/admin.json`
 //	FAKERT_GH_KBCONFIG      .semiont/config content for `ssh -- cat .semiont/config`
 //	FAKERT_OLLAMA_TAGS      models the fake Ollama already has (comma separated)
@@ -424,6 +425,19 @@ func ghCodespace(args []string, joined string) {
 		// treats the stream as decoration, never a gate).
 		fmt.Println("2026-01-01 00:00:00.000Z: Running onCreateCommand...")
 		fmt.Println("2026-01-01 00:00:01.000Z: Pulling semiont-backend:latest")
+		// FAKERT_GH_HOOKS_FAIL: the devcontainer's lifecycle command failed —
+		// the stack will never come up, so waiting is pointless. Shaped like
+		// the live 2026-07-27 log: the CAUSE (a service refusing to boot)
+		// several lines above the devcontainer's own announcement, which is
+		// why the launcher must print the run-up and not just the marker.
+		if os.Getenv("FAKERT_GH_HOOKS_FAIL") != "" {
+			fmt.Println("semiont-backend  | Error: JWT_SECRET is not set. `semiont start` generates one per knowledge base and injects it")
+			fmt.Println("semiont-backend  |     at requireJwtSecret (file:///home/semiont/.local/share/semiont/node_modules/@semiont/backend/dist/index.js:219:11)")
+			fmt.Println("2026-01-01 00:00:02.000Z: Retry after fixing with:  bash .devcontainer/post-start.sh")
+			fmt.Println("2026-01-01 00:00:02.100Z: postStartCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.")
+			fmt.Println("2026-01-01 00:00:02.200Z: devcontainer process exited with exit code 1")
+			return
+		}
 		fmt.Println("2026-01-01 00:00:02.000Z: postCreateCommand done")
 	case "stop", "delete":
 		// argv log is the observable, but state must follow too: a stopped

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -149,6 +149,7 @@ func git(args []string) {
 //	FAKERT_GH_CS_NAME       name printed by `codespace create` (default "fake-cs-1")
 //	FAKERT_GH_CREATE_FAILS  N leading 503 failures before create succeeds (cursor file)
 //	FAKERT_GH_SSH_FAIL      ssh fails with the no-sshd error
+//	FAKERT_GH_SSH_FAIL_FIRST  ssh fails for the first n attempts, then works
 //	FAKERT_GH_HOOKS_FAIL    the devcontainer lifecycle command fails (stack never comes up)
 //	FAKERT_GH_ADMIN         admin.json content for `ssh -- cat .devcontainer/admin.json`
 //	FAKERT_GH_KBCONFIG      .semiont/config content for `ssh -- cat .semiont/config`
@@ -197,6 +198,25 @@ func bumpRemoteProbe() int {
 	}
 	n := remoteProbeCount() + 1
 	_ = os.WriteFile(filepath.Join(dir, "remote-probes"), []byte(strconv.Itoa(n)), 0o644)
+	return n
+}
+
+// sshFailFirst / bumpSSHAttempt model sshd arriving late on a fresh create.
+func sshFailFirst() int {
+	n, _ := strconv.Atoi(os.Getenv("FAKERT_GH_SSH_FAIL_FIRST"))
+	return n
+}
+
+func bumpSSHAttempt() int {
+	dir := os.Getenv("FAKERT_DIR")
+	if dir == "" {
+		return 0
+	}
+	p := filepath.Join(dir, "ssh-attempts")
+	b, _ := os.ReadFile(p)
+	n, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	n++
+	_ = os.WriteFile(p, []byte(strconv.Itoa(n)), 0o644)
 	return n
 }
 
@@ -381,7 +401,20 @@ func ghCodespace(args []string, joined string) {
 		// destroys the tunnel. The old fake bound and parked unconditionally,
 		// which is why every test agreed a forward that binds is a forward
 		// that works.
+		// A forward attempt is a readiness probe too — the launcher may have no
+		// ssh to ask, and then this is the ONLY way it can learn the stack is
+		// up. Counting only ssh probes made a stack that comes up "after n
+		// probes" unreachable on that path, and the retry loop ran forever.
+		bumpRemoteProbe()
 		if remoteDown() {
+			// The pidfile is what makes the fake `ps` report this process as
+			// "gh", which forwardProcAlive requires — without it the launcher
+			// calls a live tunnel dead and never dials, so the death-on-first-
+			// contact this branch exists to model never happens.
+			if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+				_ = os.WriteFile(filepath.Join(dir, "serve-gh-forward-"+forwardLocalPort(args)+".pid"),
+					[]byte(strconv.Itoa(os.Getpid())), 0o644)
+			}
 			go func() {
 				ln, err := net.Listen("tcp", "127.0.0.1:"+forwardLocalPort(args))
 				if err != nil {
@@ -436,6 +469,12 @@ func ghCodespace(args []string, joined string) {
 			fmt.Println("2026-01-01 00:00:02.000Z: Retry after fixing with:  bash .devcontainer/post-start.sh")
 			fmt.Println("2026-01-01 00:00:02.100Z: postStartCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.")
 			fmt.Println("2026-01-01 00:00:02.200Z: devcontainer process exited with exit code 1")
+			// The stream does NOT stop at the failure. Enough trailing lines to
+			// overflow the report window, so a report built from the live ring
+			// would lose the cause entirely — which is the bug this models.
+			for i := 0; i < 30; i++ {
+				fmt.Printf("2026-01-01 00:00:03.%03dZ: Finished configuring codespace (trailing %d)\n", i, i)
+			}
 			return
 		}
 		fmt.Println("2026-01-01 00:00:02.000Z: postCreateCommand done")
@@ -450,7 +489,11 @@ func ghCodespace(args []string, joined string) {
 			}
 		}
 	case "ssh":
-		if os.Getenv("FAKERT_GH_SSH_FAIL") != "" {
+		// FAKERT_GH_SSH_FAIL: ssh never works. FAKERT_GH_SSH_FAIL_FIRST=n: it
+		// fails for the first n attempts and then works — sshd coming up
+		// during a fresh create, which is the case that must NOT be mistaken
+		// for a codespace that will never answer.
+		if os.Getenv("FAKERT_GH_SSH_FAIL") != "" || bumpSSHAttempt() <= sshFailFirst() {
 			fmt.Fprintln(os.Stderr, "failed to start SSH server")
 			os.Exit(1)
 		}

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -724,12 +724,34 @@ type creationLogTail struct {
 	u        *ui
 	cmd      *exec.Cmd
 	mu       sync.Mutex
-	lines    []string // ring: the newest creationLogWindow lines
+	lines    []string // ring: the newest creationLogWindow lines (the display)
 	rendered int      // lines currently drawn on the terminal
 	lastBeat time.Time
+	// The display window is far too small to explain a failure: in the live
+	// case the devcontainer marker sat ~18 lines below the real cause (a
+	// backend refusing to boot), so a report built from `lines` would show
+	// the stack trace and none of the reason. This wider ring exists only to
+	// be printed when the hooks fail.
+	context []string
+	failed  string // the marker line, latched on first sight
 }
 
 const creationLogWindow = 6
+
+// creationLogContext is what gets printed when hooks fail — enough to carry
+// the cause above the marker, not so much that it buries it.
+const creationLogContext = 60
+
+// hookFailureContextLines is how much of that ring gets printed — enough to
+// reach past the devcontainer's own stack trace to the failing command's
+// output, without burying the marker.
+const hookFailureContextLines = 18
+
+// hookFailure matches the devcontainer CLI announcing that one of the
+// lifecycle commands failed. Only an explicit non-zero exit counts: the tail
+// ENDING is legal and must stay benign (gh can drop a follow for its own
+// reasons), so EOF is never a failure — this is the one signal that is.
+var hookFailure = regexp.MustCompile(`(onCreateCommand|updateContentCommand|postCreateCommand|postStartCommand) from devcontainer\.json failed with exit code [1-9][0-9]*`)
 
 // startCreationLogTail spawns the follower. CREATE path only: a resumed
 // codespace's creation log is stale history and tailing it would narrate
@@ -761,6 +783,13 @@ func startCreationLogTail(u *ui, name string) *creationLogTail {
 			lt.lines = append(lt.lines, line)
 			if len(lt.lines) > creationLogWindow {
 				lt.lines = lt.lines[len(lt.lines)-creationLogWindow:]
+			}
+			lt.context = append(lt.context, line)
+			if len(lt.context) > creationLogContext {
+				lt.context = lt.context[len(lt.context)-creationLogContext:]
+			}
+			if lt.failed == "" && hookFailure.MatchString(line) {
+				lt.failed = line
 			}
 			lt.mu.Unlock()
 		}
@@ -834,6 +863,20 @@ func splitCRLines(data []byte, atEOF bool) (int, []byte, error) {
 
 // stop kills the follower and, on a terminal, collapses the window so the
 // final transcript keeps only the launcher's own lines.
+// failure reports the latched hook-failure marker and the surrounding log,
+// or "" while the hooks are merely still running. Nil-safe, like tick/stop.
+func (lt *creationLogTail) failure() (string, []string) {
+	if lt == nil {
+		return "", nil
+	}
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	if lt.failed == "" {
+		return "", nil
+	}
+	return lt.failed, append([]string(nil), lt.context...)
+}
+
 func (lt *creationLogTail) stop() {
 	if lt == nil {
 		return
@@ -1429,6 +1472,26 @@ func waitForRemoteKB(u *ui, name string, created bool) int {
 			fmt.Fprintln(os.Stderr, "  If the forward dies immediately, the stack inside the codespace is probably still coming up.")
 			tail.stop()
 			return 0
+		}
+		// Hooks that FAILED will never produce a stack, so waiting out the
+		// budget is time spent on a foregone conclusion — and the timeout
+		// message blames the KB for a setup error. The devcontainer says so
+		// in the log this wait is already streaming; read it.
+		if marker, context := tail.failure(); marker != "" {
+			tail.stop()
+			u.fail("The codespace's setup failed after %s — its stack will not come up.", took(time.Since(t0)))
+			fmt.Fprintln(os.Stderr, "  "+marker)
+			// The marker is the announcement, not the reason: print the run-up
+			// to it, which is where the failing command said what went wrong.
+			if n := len(context); n > 1 {
+				fmt.Fprintln(os.Stderr, "\n  Log leading up to it:")
+				for _, l := range context[max(0, n-hookFailureContextLines):] {
+					fmt.Fprintln(os.Stderr, "    "+l)
+				}
+			}
+			fmt.Fprintf(os.Stderr, "\n  Full log:  gh codespace logs -c %s\n", name)
+			fmt.Fprintf(os.Stderr, "  The codespace exists; delete it once fixed:  semiont stop --repo <owner/name> --delete\n")
+			return 1
 		}
 		if !time.Now().Before(deadline) {
 			break

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -232,43 +232,23 @@ func startCodespace(u *ui, opts startOptions) int {
 	// Readiness is therefore asked over ssh, which does not touch the
 	// tunnel, and the tunnel is built only once the answer is yes. On a
 	// resume the first probe usually succeeds, so the fast path stays fast.
+	askable := true
 	if code := waitForRemoteKB(u, name, created); code != 0 {
-		return code
+		if code != remoteAskUnavailable {
+			return code
+		}
+		// ssh cannot tell us. Probing by FORWARDING is the same question
+		// asked through a different door: gh exits with "connection refused"
+		// when the remote port has nothing behind it, so a tunnel that dies
+		// that way IS the not-ready answer — and one that survives is both
+		// the answer and the tunnel we wanted.
+		askable = false
+		u.log("Cannot check the stack over ssh — probing by connecting instead")
 	}
-	pid, fwdDead, code := spawnForward(u, name, kbPort)
+	pid, fwdDead, code := establishForward(u, name, kbPort, askable)
 	if code != 0 {
 		return code
 	}
-	// A forward that never binds is the failure mode that wasted the whole
-	// health budget in testing: gh can exit, or stay up forwarding nothing.
-	// Confirm the port actually answers before gating on the stack.
-	bound := false
-	for i := 0; i < 30; i++ {
-		if forwardAlive(pid, kbPort) {
-			bound = true
-			break
-		}
-		// A forward that EXITED cannot bind later — the usual cause is the
-		// local port already being in use (gh fails "address already in
-		// use" and dies at once). Watching the same death channel the
-		// health gate uses turns 30s of vagueness into an instant, honest
-		// diagnosis naming the port.
-		select {
-		case <-fwdDead:
-			u.fail("The port forward exited before it could bind — localhost:%d is probably already in use.", kbPort)
-			fmt.Fprintf(os.Stderr, "  See what holds it:  lsof -ti :%d\n", kbPort)
-			fmt.Fprintf(os.Stderr, "  Try it directly:    gh codespace ports forward %d:%d -c %s\n", kbRemotePort, kbPort, name)
-			return 1
-		default:
-		}
-		time.Sleep(time.Second)
-	}
-	if !bound {
-		u.fail("The port forward did not come up on localhost:%d within 30s.", kbPort)
-		fmt.Fprintf(os.Stderr, "  Try it directly:  gh codespace ports forward %d:%d -c %s\n", kbRemotePort, kbPort, name)
-		return 1
-	}
-
 	// The record binds the stack to its executor before the health gate —
 	// belief, verified by status; a failed wait leaves an honest record.
 	newSt := &stackState{
@@ -733,7 +713,8 @@ type creationLogTail struct {
 	// the stack trace and none of the reason. This wider ring exists only to
 	// be printed when the hooks fail.
 	context []string
-	failed  string // the marker line, latched on first sight
+	failed  string   // the marker line, latched on first sight
+	preMark []string // context AS OF the latch — see the scanner
 }
 
 const creationLogWindow = 6
@@ -784,12 +765,20 @@ func startCreationLogTail(u *ui, name string) *creationLogTail {
 			if len(lt.lines) > creationLogWindow {
 				lt.lines = lt.lines[len(lt.lines)-creationLogWindow:]
 			}
+			// Snapshot BEFORE this line joins the ring, so the saved context
+			// is what led UP TO the marker and excludes the marker itself.
+			// The stream does not stop at the failure — `gh … logs --follow`
+			// keeps emitting, and the readiness loop only looks every few
+			// seconds — so reporting from the live ring would let the arriving
+			// lines push the actual cause out of the window, and would print
+			// the marker twice.
+			if lt.failed == "" && hookFailure.MatchString(line) {
+				lt.failed = line
+				lt.preMark = append([]string(nil), lt.context...)
+			}
 			lt.context = append(lt.context, line)
 			if len(lt.context) > creationLogContext {
 				lt.context = lt.context[len(lt.context)-creationLogContext:]
-			}
-			if lt.failed == "" && hookFailure.MatchString(line) {
-				lt.failed = line
 			}
 			lt.mu.Unlock()
 		}
@@ -874,7 +863,7 @@ func (lt *creationLogTail) failure() (string, []string) {
 	if lt.failed == "" {
 		return "", nil
 	}
-	return lt.failed, append([]string(nil), lt.context...)
+	return lt.failed, append([]string(nil), lt.preMark...)
 }
 
 func (lt *creationLogTail) stop() {
@@ -1463,15 +1452,15 @@ func waitForRemoteKB(u *ui, name string, created bool) int {
 			tail.stop()
 			return 0
 		case remoteUnknown:
-			// Cannot ask, so cannot wait: ssh is a nicety here, and a stack
-			// that is actually healthy must still start. Proceed to the
-			// forward — with the caveat named, because if the stack is NOT
-			// up this is precisely the case where the tunnel dies on first
-			// contact and the reason will look like a forward problem.
-			u.warn("Could not reach %s over ssh to check the stack — continuing without that check.", name)
-			fmt.Fprintln(os.Stderr, "  If the forward dies immediately, the stack inside the codespace is probably still coming up.")
+			// ssh cannot answer — on a fresh create sshd is still being
+			// installed, which is exactly this window. Say so and let the
+			// caller probe by FORWARDING instead: a tunnel into a stack that
+			// is not up dies with "connection refused", which is the same
+			// answer this probe would have given. Waiting on ssh here would
+			// stall a codespace that never grows an sshd; guessing "ready"
+			// would rebuild the original bug (live 2026-07-28, caselaw-kb).
 			tail.stop()
-			return 0
+			return remoteAskUnavailable
 		}
 		// Hooks that FAILED will never produce a stack, so waiting out the
 		// budget is time spent on a foregone conclusion — and the timeout
@@ -1483,7 +1472,7 @@ func waitForRemoteKB(u *ui, name string, created bool) int {
 			fmt.Fprintln(os.Stderr, "  "+marker)
 			// The marker is the announcement, not the reason: print the run-up
 			// to it, which is where the failing command said what went wrong.
-			if n := len(context); n > 1 {
+			if n := len(context); n > 0 {
 				fmt.Fprintln(os.Stderr, "\n  Log leading up to it:")
 				for _, l := range context[max(0, n-hookFailureContextLines):] {
 					fmt.Fprintln(os.Stderr, "    "+l)
@@ -1512,6 +1501,9 @@ const (
 	// One `gh codespace ssh` per probe — seconds of resolution would only
 	// buy ssh handshakes.
 	remoteReadyPoll = 5 * time.Second
+	// Sentinel return: ssh could not answer, so readiness is unknown and the
+	// caller must find out another way.
+	remoteAskUnavailable = -1
 )
 
 // remoteReadiness is what the codespace can tell us about its own stack.
@@ -1607,4 +1599,129 @@ func lastForwardError(pid int) string {
 		return ""
 	}
 	return fl.String()
+}
+
+// forwardOutcome is what one attempt at a tunnel told us. The distinction
+// that matters is remoteEmpty: it is the only one that means "try again",
+// because it says something about the STACK rather than the forward.
+type forwardOutcome int
+
+const (
+	forwardUp          forwardOutcome = iota // bound, and answering
+	forwardRemoteEmpty                       // died: nothing listening on the codespace side
+	forwardDied                              // died for any other reason
+	forwardNeverBound                        // stayed up but never took the port
+)
+
+// forwardBindTries bounds one attempt: a tunnel that has not bound in this
+// long is not going to.
+const forwardBindTries = 30
+
+// forwardSettle is how long a tunnel must outlive its first connection before
+// it counts as working — the death it may die arrives just after the dial.
+const forwardSettle = time.Second
+
+// tryForward makes one attempt and reports how it went, with gh's own last
+// words when it died.
+//
+// forwardAlive DIALS the port, which is what kills a tunnel whose remote is
+// empty. That is deliberate here: the death is the measurement.
+func tryForward(u *ui, name string, kbPort int) (int, <-chan struct{}, forwardOutcome, string) {
+	pid, dead, code := spawnForward(u, name, kbPort)
+	if code != 0 {
+		return 0, nil, forwardDied, ""
+	}
+	for i := 0; i < forwardBindTries; i++ {
+		if forwardAlive(pid, kbPort) {
+			// The dial that just succeeded is ALSO what kills a tunnel whose
+			// remote is empty: gh accepts locally, then fails to open the
+			// channel through and exits — so "the dial worked" is not "the
+			// tunnel works" (live 2026-07-28: the bind check passed and the
+			// forward died a second later). It has to survive being used.
+			select {
+			case <-dead:
+				ghErr := lastForwardError(pid)
+				if remoteRefused(ghErr) {
+					return pid, nil, forwardRemoteEmpty, ghErr
+				}
+				return pid, nil, forwardDied, ghErr
+			case <-time.After(forwardSettle):
+				return pid, dead, forwardUp, ""
+			}
+		}
+		select {
+		case <-dead:
+			ghErr := lastForwardError(pid)
+			if remoteRefused(ghErr) {
+				return pid, nil, forwardRemoteEmpty, ghErr
+			}
+			return pid, nil, forwardDied, ghErr
+		default:
+		}
+		time.Sleep(time.Second)
+	}
+	return pid, nil, forwardNeverBound, lastForwardError(pid)
+}
+
+// establishForward brings up the port forward, retrying while the tunnel dies
+// because the remote side is not listening YET.
+//
+// When ssh answered (askable), the stack is already known healthy, so any
+// death is a genuine forward fault and is reported at once. When ssh could
+// not answer, the tunnel is the only instrument left: gh exits with
+// "connection refused" while the remote port is empty, so that death means
+// "not ready" and the answer is to wait and try again — not to fail, and not
+// to assume the stack is up, which is what rebuilt the original bug
+// (live 2026-07-28, semiont-caselaw-kb).
+func establishForward(u *ui, name string, kbPort int, askable bool) (int, <-chan struct{}, int) {
+	deadline := time.Now().Add(remoteReadyBudget)
+	announced := false
+	for {
+		pid, dead, outcome, ghErr := tryForward(u, name, kbPort)
+		if outcome == forwardUp {
+			return pid, dead, 0
+		}
+		// The one retriable case, and only while we have no better instrument.
+		if outcome == forwardRemoteEmpty && !askable && time.Now().Before(deadline) {
+			if !announced {
+				u.log("The stack is not accepting connections yet — waiting for it %s",
+					u.dim("(the codespace is still coming up)"))
+				announced = true
+			}
+			retireForward(pid)
+			time.Sleep(remoteReadyPoll)
+			continue
+		}
+		retireForward(pid)
+		switch outcome {
+		case forwardNeverBound:
+			u.fail("The port forward did not come up on localhost:%d within %ds.", kbPort, forwardBindTries)
+		case forwardRemoteEmpty:
+			u.fail("Nothing is listening on the codespace's port %d — its stack is not up.", kbRemotePort)
+		default:
+			u.fail("The port forward exited before it could bind — localhost:%d is probably already in use.", kbPort)
+			fmt.Fprintf(os.Stderr, "  See what holds it:  lsof -ti :%d\n", kbPort)
+		}
+		if ghErr != "" {
+			fmt.Fprintf(os.Stderr, "  gh said: %s\n", ghErr)
+		}
+		fmt.Fprintf(os.Stderr, "  Try it directly:  gh codespace ports forward %d:%d -c %s\n", kbRemotePort, kbPort, name)
+		return 0, nil, 1
+	}
+}
+
+// retireForward ends an attempt: nothing from it may outlive the try, and the
+// next attempt needs the local port back.
+func retireForward(pid int) {
+	if pid == 0 {
+		return
+	}
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+	time.Sleep(200 * time.Millisecond) // let the bind release
+}
+
+// remoteRefused recognises gh reporting that the codespace end of the tunnel
+// has nothing listening — the stack is still coming up, not a broken forward.
+func remoteRefused(ghErr string) bool {
+	return strings.Contains(ghErr, "connect failed") || strings.Contains(ghErr, "Connection refused")
 }

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -2013,6 +2013,37 @@ func TestCodespaceWaitsForRemoteBeforeForwarding(t *testing.T) {
 	}
 }
 
+func TestCodespaceWaitsOutATransientSshOutage(t *testing.T) {
+	// Live 2026-07-28 (semiont-caselaw-kb): on a FRESH create sshd is
+	// installed during the devcontainer build, so ssh is unreachable exactly
+	// during the window the readiness gate exists for. Treating the first
+	// "cannot ask" as permanent skipped the wait, built the tunnel into a
+	// stack that was still coming up, and reproduced the original bug —
+	// politely, with a warning that predicted it.
+	//
+	// The launcher no longer waits on ssh at all when ssh cannot answer: it
+	// probes by FORWARDING, and a tunnel that dies "connection refused" is
+	// the not-ready answer, so it waits and retries. Same conclusion, no
+	// timer — and a codespace that never grows an sshd is never stalled.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv,
+		"FAKERT_GH_SSH_FAIL_FIRST=2",  // sshd arrives on the 3rd attempt
+		"FAKERT_REMOTE_READY_AFTER=4") // the stack a beat after that
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	if code != 0 {
+		t.Fatalf("a late sshd must not fail the start: exit %d\nstderr:\n%s", code, stderr)
+	}
+	both := stdout + stderr
+	// It must have WAITED, not bailed: the give-up warning names the grace
+	// period, and reaching it here would mean the outage was called permanent.
+	if strings.Contains(both, "continuing without the stack check") {
+		t.Errorf("a transient ssh outage was treated as permanent:\n%s", both)
+	}
+	if strings.Contains(both, "died") {
+		t.Errorf("the forward was built before the stack was ready:\n%s", both)
+	}
+}
+
 func TestCodespaceHookFailureFailsFastWithTheCause(t *testing.T) {
 	// Live 2026-07-27: the devcontainer hooks failed, the creation log said so
 	// in plain text — "postStartCommand from devcontainer.json failed with
@@ -2047,6 +2078,22 @@ func TestCodespaceHookFailureFailsFastWithTheCause(t *testing.T) {
 		"gh codespace logs")     // ...with the way to see the rest
 	if strings.Contains(both, "did not come up inside") {
 		t.Errorf("a setup failure was reported as a readiness timeout:\n%s", both)
+	}
+	// The stream does NOT stop at the failure — the fake emits 30 trailing
+	// lines, as the real one does — and the readiness loop only looks every
+	// few seconds. Reporting from the LIVE ring would let those lines push the
+	// cause out of the window, so the context is snapshotted at the latch.
+	// The JWT assertion above proves the cause survived; this proves the
+	// window is not merely the tail of the stream.
+	if strings.Contains(both, "trailing 29") {
+		t.Errorf("the report window drifted past the failure into later output:\n%s", both)
+	}
+	// The marker is the headline. Repeating it inside its own run-up is noise,
+	// and its presence there would mean the snapshot included itself.
+	if i := strings.Index(both, "Log leading up to it:"); i >= 0 {
+		if strings.Contains(both[i:], "postStartCommand from devcontainer.json failed") {
+			t.Errorf("the marker is duplicated inside its own run-up:\n%s", both[i:])
+		}
 	}
 }
 

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -2013,6 +2013,43 @@ func TestCodespaceWaitsForRemoteBeforeForwarding(t *testing.T) {
 	}
 }
 
+func TestCodespaceHookFailureFailsFastWithTheCause(t *testing.T) {
+	// Live 2026-07-27: the devcontainer hooks failed, the creation log said so
+	// in plain text — "postStartCommand from devcontainer.json failed with
+	// exit code 1" — and the launcher waited out its whole readiness budget
+	// anyway, because the log was rendered but never read. A stack whose setup
+	// failed will never come up; waiting is time spent on a foregone
+	// conclusion, and the eventual timeout blames the KB for a setup error.
+	//
+	// Failing FAST is only half of it: the marker is the announcement, not the
+	// reason. The cause sat ~18 lines above it (a backend refusing to boot),
+	// so the report must carry the run-up or it is merely quick and useless.
+	s := newCodespaceScenario(t)
+	s.extraEnv = append(s.extraEnv,
+		"FAKERT_GH_HOOKS_FAIL=1",
+		"FAKERT_REMOTE_DOWN=1") // the stack never answers, as it cannot
+	start := time.Now()
+	stdout, stderr, code := s.run(t, "start", "--runtime", "codespace")
+	elapsed := time.Since(start)
+
+	if code == 0 {
+		t.Fatalf("a failed devcontainer setup must fail the start\nstdout:\n%s", stdout)
+	}
+	// The readiness budget is minutes; this must not approach it.
+	if elapsed > 90*time.Second {
+		t.Errorf("waited %s on hooks that had already failed", elapsed.Round(time.Second))
+	}
+	both := stdout + stderr
+	mustContain(t, "diagnosis", both,
+		"setup failed",          // named as a setup failure...
+		"postStartCommand",      // ...quoting the devcontainer's marker
+		"JWT_SECRET is not set", // ...and the CAUSE from the run-up
+		"gh codespace logs")     // ...with the way to see the rest
+	if strings.Contains(both, "did not come up inside") {
+		t.Errorf("a setup failure was reported as a readiness timeout:\n%s", both)
+	}
+}
+
 func TestCodespaceForwardDeathFailsFast(t *testing.T) {
 	// The mid-wait forward death observed live 2026-07-23: the tunnel
 	// bound, then its process died while the health gate polled — and the


### PR DESCRIPTION
Two failures in `semiont start --runtime codespace`, both of which reported the wrong culprit: a codespace whose setup had already failed was waited on for fifteen minutes, and a codespace still coming up had its tunnel destroyed by the launcher's own readiness check.

## 1. Hooks that fail are terminal, and the log already said so

Live 2026-07-27: the devcontainer hooks failed, the creation log printed `postStartCommand from devcontainer.json failed with exit code 1` within seconds, and the launcher kept polling until its budget expired — because it rendered that log without ever reading it.

The scanner now latches the devcontainer's own failure marker and the readiness wait acts on it:

```
✗ The codespace's setup failed after <1s — its stack will not come up.
  postStartCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.

  Log leading up to it:
    …
    semiont-backend  | Error: JWT_SECRET is not set. `semiont start` generates one per knowledge base…
    …
  Full log:  gh codespace logs -c <name>
```

**Only an explicit marker is terminal.** A tail that merely *ends* stays benign — `gh` can drop a follow for its own reasons, and the existing contract ("the launcher treats the stream as decoration, never a gate") exists for that.

**The context is snapshotted at the latch, not read live** (review catch). The stream does not stop at the failure and the readiness loop only looks every few seconds, so reporting from the live ring let later output push the actual cause out of the window — and printed the marker twice. Mutation-tested: reading live loses `JWT_SECRET is not set` entirely, which is the difference between failing fast and failing usefully.

## 2. The readiness check was destroying what it measured

`gh codespace ports forward` binds locally at once but **exits the first time a connection cannot be opened through to the remote port**. Devcontainer hooks run for minutes, so nothing is listening — and the launcher's bind check, `forwardAlive()`, **dials the port**. The checker killed the thing it checked, and the death surfaced a step later as *"the port forward died after 1s — the stack may be fine"*, which was exactly backwards.

Readiness is now asked over `gh codespace ssh`, which never touches the tunnel, and the tunnel is built only once the KB answers inside the VM.

### When ssh cannot answer

On a fresh create sshd is installed *during* the devcontainer build — so ssh is unavailable precisely in the window this gate exists for. An earlier version treated the first "cannot ask" as permanent, skipped the wait, and rebuilt the original bug (live 2026-07-28, `semiont-caselaw-kb`). A version after that waited out a 90-second grace, which worked but put a 90-second sleep in the test suite.

Neither is needed. **A tunnel that dies "connection refused" IS the not-ready answer**, so when ssh cannot answer the launcher probes by connecting and retries on that specific death. Same conclusion, no timer, and a codespace that never grows an sshd is never stalled.

The distinction is preserved where it matters: when ssh *did* answer, the stack is known healthy, so any forward death is a genuine fault and is reported at once.

### A successful dial is not a working tunnel

Found while removing a `goto` from the retry loop, and live in the code before that: gh accepts the connection locally, *then* fails to open the channel through and exits — so `forwardAlive` returns true for a tunnel that is already dying. That is exactly the live trace (bind check passed; death one second later). A tunnel must now **survive its first connection** to count as up.

### gh's stderr is kept

`spawnForward` set `cmd.Stderr = nil`, so a dead forward could be reported but never explained. A bounded last-line ring per forward means a death now prints `gh said: …`. **Verified live** on 2026-07-28: it printed the `ssh: rejected: connect failed (Connection refused)` line that had previously taken an hour of manual probing to obtain.

## Why the tests did not catch any of this

The fake's `codespace ports forward` bound a local port and parked — a healthy listener, never a tunnel to a dead remote — so every test agreed with the code that a forward which binds is a forward that works. Three fake defects had to be fixed before the tests could be honest:

- it modelled no remote at all (now `FAKERT_REMOTE_DOWN` / `FAKERT_REMOTE_READY_AFTER`, dying on first contact with gh's real error text);
- readiness advanced only on **ssh** probes, so once the launcher stopped asking ssh the modelled stack could never come up — a forward attempt is a readiness probe too;
- the remote-down path skipped the serve pidfile that makes the fake `ps` report the process as `gh`, so `forwardProcAlive` called a live tunnel dead and the modelled death never happened.

## Structure

One attempt at a tunnel is a unit with four named outcomes — `forwardUp`, `forwardRemoteEmpty`, `forwardDied`, `forwardNeverBound`. `tryForward` makes an attempt and reports which; `establishForward` decides what each means. Only `forwardRemoteEmpty`, and only while ssh cannot answer, is retriable. No `goto`, and each fatal case gets its own accurate message instead of one message covering three situations.

## Verification

Full launcher suite green (`ok 626s`); gofmt and vet clean. `TestCodespaceSshFailureDoesNotBlockAHealthyStack` — the invariant an earlier revision broke by making ssh load-bearing — runs in 2.1s.

Live: a fresh `semiont-legal-kb` create came up in one command with no forward death; a `semiont-caselaw-kb` create exercised the ssh-unavailable path and the stderr capture. **Not yet seen live:** the hook-failure fail-fast, and the probe-by-forwarding retry.
