### PR TITLE
Scanned PDFs become annotatable: OCR coordinate mapping, one extraction entry point, and machine-read provenance

### DIFF
--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -1306,9 +1306,21 @@ func serve(ports []string) {
 							if msg := os.Getenv("FAKERT_JOB_FAIL"); msg != "" {
 								busPublish("job:fail", map[string]any{"jobId": jobID, "error": msg})
 							} else {
+								// FAKERT_JOB_RESULT=<json>: which member of the
+								// JobResult union this job completes with. A
+								// DECLINE is one of them — a job that ran fine
+								// and deliberately produced nothing.
+								var result any = map[string]any{"resourceId": "res-new", "resourceName": "Generated"}
+								if raw := os.Getenv("FAKERT_JOB_RESULT"); raw != "" {
+									var custom any
+									if json.Unmarshal([]byte(raw), &custom) != nil {
+										custom = map[string]any{}
+									}
+									result = custom
+								}
 								busPublish("job:complete", map[string]any{
 									"jobId": jobID, "resourceId": "res-src", "jobType": "generation",
-									"result": map[string]any{"resourceId": "res-new", "resourceName": "Generated"},
+									"result": result,
 								})
 							}
 						}

--- a/apps/launcher/internal/launcher/yield.go
+++ b/apps/launcher/internal/launcher/yield.go
@@ -469,9 +469,33 @@ func runYieldDelegate(u *ui, t verbTarget, positional []string, opts delegateOpt
 				if json.Unmarshal(ev.Payload, &done) != nil || done.JobId != jobID {
 					continue
 				}
+				// A DECLINE is read first, and by its DISCRIMINANT. Every
+				// generated As*() accessor is a bare json.Unmarshal with no
+				// discriminant check, so a declined result decodes cleanly
+				// into JobGenerationResult with an empty resource id —
+				// indistinguishable, to the check below, from a generation
+				// that simply had no id to print. Ordering alone would not
+				// be enough either: AsJobDeclinedResult succeeds on a
+				// generation too, with Declined false.
+				declined, ok := declinedResult(done.Result)
 				if opts.asJSON {
 					fmt.Println(string(ev.Payload))
+					// The exit code is a property of the outcome, not of the
+					// output format.
+					if ok {
+						return 1
+					}
 					return 0
+				}
+				if ok {
+					// Not a failure — the job ran correctly and found nothing
+					// to work with, so this is deliberately not the job:fail
+					// wording. Non-zero all the same: the caller asked for a
+					// resource and has none, and nothing downstream of a
+					// `yield --delegate && ...` should run.
+					u.fail("Declined (%s): %s", declined.Reason, declined.Message)
+					fmt.Fprintf(os.Stderr, "  Nothing was written to %s.\n", opts.storageURI)
+					return 1
 				}
 				// JobResult is a union over every job type; a generation names
 				// the resource it produced.
@@ -486,6 +510,27 @@ func runYieldDelegate(u *ui, t verbTarget, positional []string, opts delegateOpt
 			}
 		}
 	}
+}
+
+// declinedResult reads the DECLINE member out of a JobResult, and reports
+// false for every shape that actually did the work.
+//
+// The discriminant is what makes this safe, and it has to be checked
+// explicitly: oapi-codegen's As*() accessors are bare json.Unmarshal calls
+// with no discriminant test, so every union member "decodes" successfully
+// against every other member's payload. AsJobDeclinedResult on a generation
+// result returns a zero-valued struct — err nil, Declined false. Only the
+// schema's `"declined": true` const separates the two, so only reading it
+// tells them apart.
+func declinedResult(r *semiont.JobResult) (semiont.JobDeclinedResult, bool) {
+	if r == nil {
+		return semiont.JobDeclinedResult{}, false
+	}
+	d, err := r.AsJobDeclinedResult()
+	if err != nil || !bool(d.Declined) {
+		return semiont.JobDeclinedResult{}, false
+	}
+	return d, true
 }
 
 type delegateOptions struct {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -6242,6 +6242,47 @@ func TestYieldDelegateReportsJobFailure(t *testing.T) {
 	mustContain(t, "failure", stdout+stderr, "Generation failed", "model refused")
 }
 
+// A DECLINE completes the job — nothing went wrong, there was simply nothing
+// to work with (an encrypted PDF, a scan with no text layer). No resource
+// exists at the storage URI afterwards, so a ✓ here is the worst of the three
+// outcomes to get wrong: the caller's next step runs against nothing.
+//
+// The trap this guards is specific. Every generated As*() accessor is a bare
+// json.Unmarshal with no discriminant check, so a declined result decodes
+// CLEANLY into JobGenerationResult with an empty resource id — which reads
+// exactly like "a generation with no id to print".
+func TestYieldDelegateReportsADecline(t *testing.T) {
+	s := busScenario(t,
+		`FAKERT_BUS_REPLY_gather_resource_requested={"metadata":{},"focus":{},"graph":{}}`,
+		`FAKERT_JOB_RESULT={"declined":true,"reason":"encrypted","message":"the PDF is password-protected"}`)
+	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md")
+	if code == 0 {
+		t.Fatalf("a declined job produced nothing; exit 0 tells a script to carry on\nstdout:\n%s", stdout)
+	}
+	mustContain(t, "decline", stdout+stderr, "encrypted", "the PDF is password-protected")
+	if strings.Contains(stdout, "Yielded") {
+		t.Errorf("claimed a yield that never happened:\n%s", stdout)
+	}
+	// Reported as its own outcome, not dressed up as a crash — the schema is
+	// explicit that a decline is distinct from a failure.
+	if strings.Contains(stdout+stderr, "Generation failed") {
+		t.Errorf("a decline is not a failure:\n%s", stdout+stderr)
+	}
+}
+
+// The exit code must not depend on the output format: --json prints the raw
+// payload and still reports that nothing was produced.
+func TestYieldDelegateDeclineFailsUnderJSON(t *testing.T) {
+	s := busScenario(t,
+		`FAKERT_BUS_REPLY_gather_resource_requested={"metadata":{},"focus":{},"graph":{}}`,
+		`FAKERT_JOB_RESULT={"declined":true,"reason":"no-text-layer","message":"scanned pages, no recognizable text"}`)
+	stdout, _, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--json")
+	if code == 0 {
+		t.Fatalf("--json must not turn a decline into a success\nstdout:\n%s", stdout)
+	}
+	mustContain(t, "raw payload", stdout, `"declined":true`, `"no-text-layer"`)
+}
+
 func TestYieldDelegateNeedsStorageUri(t *testing.T) {
 	s := busScenario(t)
 	_, stderr, code := s.run(t, "yield", "--delegate", "res-src")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -6283,6 +6283,18 @@ func TestYieldDelegateDeclineFailsUnderJSON(t *testing.T) {
 	mustContain(t, "raw payload", stdout, `"declined":true`, `"no-text-layer"`)
 }
 
+// The other half of the format-independence rule: --json must not turn a
+// SUCCESS into a failure either. Without this, "always fail under --json"
+// passes the decline test above and nothing else notices.
+func TestYieldDelegateJSONSucceedsOnAGeneration(t *testing.T) {
+	s := busScenario(t, `FAKERT_BUS_REPLY_gather_resource_requested={"metadata":{},"focus":{},"graph":{}}`)
+	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--json")
+	if code != 0 {
+		t.Fatalf("a completed generation under --json must exit 0, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	mustContain(t, "raw payload", stdout, `"resourceId":"res-new"`)
+}
+
 func TestYieldDelegateNeedsStorageUri(t *testing.T) {
 	s := busScenario(t)
 	_, stderr, code := s.run(t, "yield", "--delegate", "res-src")

--- a/packages/content/src/__tests__/generate-fixtures.ts
+++ b/packages/content/src/__tests__/generate-fixtures.ts
@@ -129,6 +129,20 @@ export default async function setup() {
         await mixedDoc.save()
     );
 
+    // Off-origin scaled scan — the placement-transform fixture. Every other
+    // scanned fixture draws its image over the whole page, so the CTM is the
+    // page scale and a left/right multiplication mix-up would still produce
+    // the right answer. Here the image sits at (100, 200) at 300×400, so a
+    // wrong composition lands the geometry somewhere visibly else.
+    const placedDoc = await PDFDocument.create();
+    const placedImage = await placedDoc.embedPng(scanPixels);
+    const placedPage = placedDoc.addPage([612, 792]);
+    placedPage.drawImage(placedImage, { x: 100, y: 200, width: 300, height: 400 });
+    fs.writeFileSync(
+        path.join(FIXTURES, 'scanned-placed.pdf'),
+        await placedDoc.save()
+    );
+
     // Table fixture (class D) — a regular grid: 4 rows × 3 columns drawn at
     // fixed column origins, the shape a trial-report outcome table has. Read
     // in naive reading order the cells interleave; read as a grid the rows

--- a/packages/content/src/__tests__/ocr-assembly.test.ts
+++ b/packages/content/src/__tests__/ocr-assembly.test.ts
@@ -1,0 +1,75 @@
+/**
+ * OCR page assembly — text and word offsets, built together (#739).
+ *
+ * The offsets are the risky part: `buildPdfAnnotation` slices the assembled
+ * text between a match's overlapping items and THROWS unless that substring
+ * contains the match, so an off-by-one here surfaces as a failed annotation
+ * rather than a slightly wrong box. That cannot be tested through a synthetic
+ * raster — no legible glyphs — so the assembler is tested directly against a
+ * hand-built recognition tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assemblePage, type OcrBlock } from '../ocr';
+
+const word = (text: string, x0: number) => ({
+    text,
+    confidence: 90,
+    bbox: { x0, y0: 10, x1: x0 + text.length * 8, y1: 26 },
+});
+
+const tree = (lines: string[][][]): OcrBlock[] => [
+    {
+        paragraphs: lines.map((paragraph) => ({
+            lines: paragraph.map((words) => ({
+                words: words.map((w, i) => word(w, 20 + i * 60)),
+            })),
+        })),
+    },
+];
+
+describe('assemblePage', () => {
+    it('joins words with spaces and lines with newlines', () => {
+        const { text } = assemblePage(tree([[['the', 'quick'], ['brown', 'fox']]]));
+        expect(text).toBe('the quick\nbrown fox');
+    });
+
+    it('separates paragraphs with a blank line', () => {
+        const { text } = assemblePage(tree([[['first']], [['second']]]));
+        expect(text).toBe('first\n\nsecond');
+    });
+
+    it('gives every word an offset that selects exactly that word', () => {
+        const { text, words } = assemblePage(tree([[['the', 'quick'], ['brown', 'fox']]]));
+        expect(words.map((w) => w.text)).toEqual(['the', 'quick', 'brown', 'fox']);
+        // The invariant that matters: slicing by the recorded range returns the
+        // word itself, for every word.
+        for (const w of words) {
+            expect(text.slice(w.start, w.end)).toBe(w.text);
+        }
+    });
+
+    it('carries each word geometry and confidence through unchanged', () => {
+        const { words } = assemblePage(tree([[['alpha']]]));
+        expect(words[0]).toMatchObject({
+            text: 'alpha',
+            confidence: 90,
+            bbox: { x0: 20, y0: 10, x1: 60, y1: 26 },
+        });
+    });
+
+    it('skips empty words without disturbing the offsets', () => {
+        const blocks: OcrBlock[] = [
+            { paragraphs: [{ lines: [{ words: [word('real', 20), word('   ', 90), word('words', 150)] }] }] },
+        ];
+        const { text, words } = assemblePage(blocks);
+        expect(text).toBe('real words');
+        expect(words).toHaveLength(2);
+        for (const w of words) expect(text.slice(w.start, w.end)).toBe(w.text);
+    });
+
+    it('is empty for a page the engine could not read', () => {
+        expect(assemblePage(null)).toEqual({ text: '', words: [] });
+        expect(assemblePage([])).toEqual({ text: '', words: [] });
+    });
+});

--- a/packages/content/src/__tests__/ocr-assembly.test.ts
+++ b/packages/content/src/__tests__/ocr-assembly.test.ts
@@ -22,6 +22,7 @@ const tree = (lines: string[][][]): OcrBlock[] => [
     {
         paragraphs: lines.map((paragraph) => ({
             lines: paragraph.map((words) => ({
+                bbox: { x0: 20, y0: 10, x1: 400, y1: 26 },
                 words: words.map((w, i) => word(w, 20 + i * 60)),
             })),
         })),
@@ -60,7 +61,14 @@ describe('assemblePage', () => {
 
     it('skips empty words without disturbing the offsets', () => {
         const blocks: OcrBlock[] = [
-            { paragraphs: [{ lines: [{ words: [word('real', 20), word('   ', 90), word('words', 150)] }] }] },
+            {
+                paragraphs: [{
+                    lines: [{
+                        bbox: { x0: 20, y0: 10, x1: 400, y1: 26 },
+                        words: [word('real', 20), word('   ', 90), word('words', 150)],
+                    }],
+                }],
+            },
         ];
         const { text, words } = assemblePage(blocks);
         expect(text).toBe('real words');
@@ -71,5 +79,32 @@ describe('assemblePage', () => {
     it('is empty for a page the engine could not read', () => {
         expect(assemblePage(null)).toEqual({ text: '', words: [] });
         expect(assemblePage([])).toEqual({ text: '', words: [] });
+    });
+
+    it('gives words on one line the same vertical extent, whatever their glyphs', () => {
+        // OCR boxes hug the glyphs, so a word with a descender ('page') has a
+        // lower box than one without ('the'). Downstream, `locate()` groups
+        // items into lines by comparing `y` within 2pt — a threshold that
+        // works because NATIVE runs take y from the shared baseline. Letting
+        // per-word descenders through would split one visual line into several
+        // rects, drawing a highlight as stacked fragments. Vertical extent is
+        // the line's; only the horizontal extent is the word's.
+        const blocks: OcrBlock[] = [
+            {
+                paragraphs: [{
+                    lines: [{
+                        bbox: { x0: 20, y0: 10, x1: 300, y1: 30 },
+                        words: [
+                            { text: 'the', confidence: 90, bbox: { x0: 20, y0: 12, x1: 60, y1: 24 } },
+                            { text: 'page', confidence: 90, bbox: { x0: 70, y0: 12, x1: 130, y1: 30 } },
+                        ],
+                    }],
+                }],
+            },
+        ];
+        const { words } = assemblePage(blocks);
+        expect(words.map((w) => [w.bbox.y0, w.bbox.y1])).toEqual([[10, 30], [10, 30]]);
+        // Horizontal extents stay per-word — that is the part that survives.
+        expect(words.map((w) => [w.bbox.x0, w.bbox.x1])).toEqual([[20, 60], [70, 130]]);
     });
 });

--- a/packages/content/src/__tests__/ocr-geometry.test.ts
+++ b/packages/content/src/__tests__/ocr-geometry.test.ts
@@ -1,0 +1,56 @@
+/**
+ * OCR word boxes → PDF points (#739).
+ *
+ * Pixel space is top-left origin; PDF space is bottom-left. The composition is
+ * pixel → unit square → placement matrix, so rotation and non-uniform scale
+ * fall out of the matrix instead of needing cases.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mapWordsToItems } from '../ocr-geometry';
+import type { OcrWord } from '../ocr';
+
+const word = (text: string, bbox: { x0: number; y0: number; x1: number; y1: number }, start = 0): OcrWord =>
+    ({ text, start, end: start + text.length, bbox, confidence: 90 });
+
+/** A 100×100 image covering a 612×792 page. */
+const fullPage = { width: 100, height: 100, ctm: [612, 0, 0, 792, 0, 0] };
+
+describe('mapWordsToItems', () => {
+    it('flips the Y axis — a word at the top of the image is high on the page', () => {
+        const [item] = mapWordsToItems([word('top', { x0: 0, y0: 0, x1: 50, y1: 50 })], fullPage, 1, 0);
+        expect(item).toMatchObject({ page: 1, x: 0, y: 396, width: 306, height: 396 });
+    });
+
+    it('places a bottom-right word at the bottom right of the page', () => {
+        const [item] = mapWordsToItems([word('end', { x0: 50, y0: 50, x1: 100, y1: 100 })], fullPage, 1, 0);
+        expect(item).toMatchObject({ x: 306, y: 0, width: 306, height: 396 });
+    });
+
+    it('honors an off-origin scaled placement', () => {
+        // The image sits at (100, 200) sized 300×400 — the whole image maps
+        // onto exactly that rectangle.
+        const placed = { width: 100, height: 100, ctm: [300, 0, 0, 400, 100, 200] };
+        const [item] = mapWordsToItems([word('all', { x0: 0, y0: 0, x1: 100, y1: 100 })], placed, 2, 0);
+        expect(item).toMatchObject({ page: 2, x: 100, y: 200, width: 300, height: 400 });
+    });
+
+    it('shifts character offsets by where the page landed in the document', () => {
+        const items = mapWordsToItems(
+            [word('alpha', { x0: 0, y0: 0, x1: 10, y1: 10 }, 0), word('beta', { x0: 20, y0: 0, x1: 30, y1: 10 }, 6)],
+            fullPage,
+            1,
+            1000,
+        );
+        expect(items.map((i) => [i.start, i.end])).toEqual([[1000, 1005], [1006, 1010]]);
+    });
+
+    it('produces a normalized rectangle even when the matrix flips an axis', () => {
+        // A negative Y scale (mirrored placement) must still yield a positive
+        // width and height — consumers bound rects, they do not orient them.
+        const mirrored = { width: 100, height: 100, ctm: [612, 0, 0, -792, 0, 792] };
+        const [item] = mapWordsToItems([word('x', { x0: 0, y0: 0, x1: 50, y1: 50 })], mirrored, 1, 0);
+        expect(item!.width).toBeGreaterThan(0);
+        expect(item!.height).toBeGreaterThan(0);
+    });
+});

--- a/packages/content/src/__tests__/ocr-geometry.test.ts
+++ b/packages/content/src/__tests__/ocr-geometry.test.ts
@@ -8,7 +8,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { mapWordsToItems } from '../ocr-geometry';
-import type { OcrWord } from '../ocr';
+import { assemblePage, type OcrBlock, type OcrWord } from '../ocr';
+import { locate } from '../locate';
 
 const word = (text: string, bbox: { x0: number; y0: number; x1: number; y1: number }, start = 0): OcrWord =>
     ({ text, start, end: start + text.length, bbox, confidence: 90 });
@@ -43,6 +44,31 @@ describe('mapWordsToItems', () => {
             1000,
         );
         expect(items.map((i) => [i.start, i.end])).toEqual([[1000, 1005], [1006, 1010]]);
+    });
+
+    it('a recognized line resolves to ONE rect, not one per descender', () => {
+        // The end-to-end reason words share their line's vertical extent:
+        // `locate()` groups items into lines within 2pt of each other, and at
+        // scan scale a descender is worth far more than that. Per-word boxes
+        // would draw this highlight as stacked fragments.
+        const blocks: OcrBlock[] = [
+            {
+                paragraphs: [{
+                    lines: [{
+                        bbox: { x0: 10, y0: 10, x1: 90, y1: 22 },
+                        words: [
+                            { text: 'the', confidence: 90, bbox: { x0: 10, y0: 12, x1: 40, y1: 20 } },
+                            { text: 'page', confidence: 90, bbox: { x0: 50, y0: 12, x1: 90, y1: 22 } },
+                        ],
+                    }],
+                }],
+            },
+        ];
+        const { text, words } = assemblePage(blocks);
+        const items = mapWordsToItems(words, fullPage, 1, 0);
+        const { rects } = locate({ text, items }, 0, text.length);
+        expect(rects).toHaveLength(1);
+        expect(rects[0]!.page).toBe(1);
     });
 
     it('produces a normalized rectangle even when the matrix flips an axis', () => {

--- a/packages/content/src/__tests__/ocr.test.ts
+++ b/packages/content/src/__tests__/ocr.test.ts
@@ -38,7 +38,11 @@ describe('recognizeImages', () => {
         // point: a missing vendor is a hard failure, not a silent empty read.
         const results = await recognizeImages([image]);
         expect(results).toHaveLength(1);
-        expect(typeof results[0]).toBe('string');
+        expect(results[0]).toMatchObject({ text: expect.any(String), words: expect.any(Array) });
+        // Whatever the engine read, every word must select itself in the text.
+        for (const word of results[0]!.words) {
+            expect(results[0]!.text.slice(word.start, word.end)).toBe(word.text);
+        }
     }, 30_000);
 
     it('recognizes nothing without calling the engine', async () => {

--- a/packages/content/src/__tests__/pdf-extractor.test.ts
+++ b/packages/content/src/__tests__/pdf-extractor.test.ts
@@ -37,7 +37,7 @@ describe('pdfExtractor (Phase 1 registry slot)', () => {
         expect(out.pdfClass).toBe('A');
         // blocks are the reader's items verbatim — the shared geometry shape.
         const layer = await extractPdfTextLayer(readFixture('single-line.pdf'));
-        expect(out.blocks).toEqual(layer!.items);
+        expect(out.items).toEqual(layer!.items);
     });
 
     it("class B: scanned PDF declines 'no-text-layer'", async () => {
@@ -109,7 +109,7 @@ describe('class D — table structure (Phase 2)', () => {
 
     it('anchors table cells to their page geometry', async () => {
         const out = await extract('table.pdf');
-        const cell = out.blocks?.find((b) => out.text.slice(b.start, b.end) === 'Drug A');
+        const cell = out.items?.find((b) => out.text.slice(b.start, b.end) === 'Drug A');
         expect(cell).toBeDefined();
         expect(cell!.page).toBe(1);
         // Row two of the fixture, first column: x 72, y 720 − 24.
@@ -161,7 +161,7 @@ describe('class E — AcroForm field values (Phase 2)', () => {
         const out = await extract('form.pdf');
         // The block's char range must select exactly the value, and carry the
         // field's own rectangle — folding adds text without inventing geometry.
-        const valueBlock = out.blocks?.find(
+        const valueBlock = out.items?.find(
             (b) => out.text.slice(b.start, b.end) === 'Ada Lovelace',
         );
         expect(valueBlock).toBeDefined();

--- a/packages/content/src/__tests__/pdf-extractor.test.ts
+++ b/packages/content/src/__tests__/pdf-extractor.test.ts
@@ -26,7 +26,7 @@ describe('pdfExtractor (Phase 1 registry slot)', () => {
         expect(EXTRACTORS['pdf-text-layer']).not.toBeNull();
     });
 
-    it('class A: extracts the text layer with blocks and pdfClass', async () => {
+    it('class A: extracts the text layer with items and pdfClass', async () => {
         const ex = EXTRACTORS['pdf-text-layer'];
         expect(ex).not.toBeNull();
         const out = await ex!.extract(readFixture('single-line.pdf'), 'application/pdf');
@@ -35,7 +35,7 @@ describe('pdfExtractor (Phase 1 registry slot)', () => {
         expect(out.text).toContain(KNOWN_PHRASE);
         expect(out.method).toBe('pdf-text-layer');
         expect(out.pdfClass).toBe('A');
-        // blocks are the reader's items verbatim — the shared geometry shape.
+        // items are the reader's own, verbatim — the shared geometry shape.
         const layer = await extractPdfTextLayer(readFixture('single-line.pdf'));
         expect(out.items).toEqual(layer!.items);
     });
@@ -78,10 +78,11 @@ describe('class C — hybrid native/scanned routing (Phase 3)', () => {
         expect(out.unreadPages).toBeUndefined();
     });
 
-    // Guard: increment 2 makes nothing newly searchable. A fully scanned
-    // document still declines and still writes no vectors — only OCR
-    // (increment 4) changes that.
-    it('a fully scanned document still declines', async () => {
+    // The fixture's raster is dark bars, not glyphs, so OCR reads nothing from
+    // it and the document declines. That is the honest outcome for an
+    // unreadable scan — `pdf-ocr.test.ts` stubs the engine to cover the case
+    // where OCR *does* recover text.
+    it('a scan OCR cannot read declines', async () => {
         const out = await extract('scanned-image.pdf');
         expect(out).toEqual({ declined: 'no-text-layer' });
     });
@@ -159,17 +160,17 @@ describe('class E — AcroForm field values (Phase 2)', () => {
 
     it('anchors each folded value with the widget geometry', async () => {
         const out = await extract('form.pdf');
-        // The block's char range must select exactly the value, and carry the
+        // The item's char range must select exactly the value, and carry the
         // field's own rectangle — folding adds text without inventing geometry.
-        const valueBlock = out.items?.find(
+        const valueItem = out.items?.find(
             (b) => out.text.slice(b.start, b.end) === 'Ada Lovelace',
         );
-        expect(valueBlock).toBeDefined();
+        expect(valueItem).toBeDefined();
 
         const layer = await extractPdfTextLayer(readFixture('form.pdf'));
         const field = layer!.fields.find((f) => f.name === 'policy.holderName');
         expect(field).toBeDefined();
-        expect(valueBlock).toMatchObject({
+        expect(valueItem).toMatchObject({
             page: field!.page,
             x: field!.x,
             y: field!.y,

--- a/packages/content/src/__tests__/pdf-ocr.test.ts
+++ b/packages/content/src/__tests__/pdf-ocr.test.ts
@@ -67,8 +67,8 @@ describe('class B — a fully scanned document', () => {
         const out = await extract('scanned-image.pdf');
         if ('declined' in out) throw new Error(`unexpected decline: ${out.declined}`);
         expect(out.items?.length).toBe(4);
-        for (const block of out.items!) {
-            expect(out.text.slice(block.start, block.end)).toMatch(/^(RECOVERED|FROM|THE|SCAN)$/);
+        for (const item of out.items!) {
+            expect(out.text.slice(item.start, item.end)).toMatch(/^(RECOVERED|FROM|THE|SCAN)$/);
         }
     });
 
@@ -76,14 +76,14 @@ describe('class B — a fully scanned document', () => {
         recognizesAs('SCANNED');
         const out = await extract('scanned-image.pdf');
         if ('declined' in out) throw new Error('unexpected decline');
-        const [block] = out.items!;
+        const [item] = out.items!;
         // The fixture's raster covers the whole 612×792 page, so any word must
         // land inside it — pixel coordinates (max 240×140) would not.
-        expect(block!.page).toBe(1);
-        expect(block!.x).toBeGreaterThanOrEqual(0);
-        expect(block!.x + block!.width).toBeLessThanOrEqual(612);
-        expect(block!.y).toBeGreaterThanOrEqual(0);
-        expect(block!.y + block!.height).toBeLessThanOrEqual(792);
+        expect(item!.page).toBe(1);
+        expect(item!.x).toBeGreaterThanOrEqual(0);
+        expect(item!.x + item!.width).toBeLessThanOrEqual(612);
+        expect(item!.y).toBeGreaterThanOrEqual(0);
+        expect(item!.y + item!.height).toBeLessThanOrEqual(792);
     });
 
     it("declines 'no-text-layer' when OCR finds nothing — now meaning it truly failed", async () => {
@@ -119,8 +119,8 @@ describe('class C — a hybrid document', () => {
         const scanned = out.items!.filter((b) => b.page === 2);
         expect(native.length).toBeGreaterThan(0);
         expect(scanned.length).toBe(5);
-        for (const block of scanned) {
-            expect(out.text.slice(block.start, block.end)).toMatch(/^(TEXT|FROM|THE|SCANNED|PAGE)$/);
+        for (const item of scanned) {
+            expect(out.text.slice(item.start, item.end)).toMatch(/^(TEXT|FROM|THE|SCANNED|PAGE)$/);
         }
         // One run, because the fixture draws the phrase in a single call —
         // native items are text runs, not words.

--- a/packages/content/src/__tests__/pdf-ocr.test.ts
+++ b/packages/content/src/__tests__/pdf-ocr.test.ts
@@ -66,8 +66,8 @@ describe('class B — a fully scanned document', () => {
         recognizesAs('RECOVERED FROM THE SCAN');
         const out = await extract('scanned-image.pdf');
         if ('declined' in out) throw new Error(`unexpected decline: ${out.declined}`);
-        expect(out.blocks?.length).toBe(4);
-        for (const block of out.blocks!) {
+        expect(out.items?.length).toBe(4);
+        for (const block of out.items!) {
             expect(out.text.slice(block.start, block.end)).toMatch(/^(RECOVERED|FROM|THE|SCAN)$/);
         }
     });
@@ -76,7 +76,7 @@ describe('class B — a fully scanned document', () => {
         recognizesAs('SCANNED');
         const out = await extract('scanned-image.pdf');
         if ('declined' in out) throw new Error('unexpected decline');
-        const [block] = out.blocks!;
+        const [block] = out.items!;
         // The fixture's raster covers the whole 612×792 page, so any word must
         // land inside it — pixel coordinates (max 240×140) would not.
         expect(block!.page).toBe(1);
@@ -115,8 +115,8 @@ describe('class C — a hybrid document', () => {
 
         // Native and OCR'd geometry coexist, and each still selects its own
         // text — the native items were not disturbed by appending.
-        const native = out.blocks!.filter((b) => b.page === 1);
-        const scanned = out.blocks!.filter((b) => b.page === 2);
+        const native = out.items!.filter((b) => b.page === 1);
+        const scanned = out.items!.filter((b) => b.page === 2);
         expect(native.length).toBeGreaterThan(0);
         expect(scanned.length).toBe(5);
         for (const block of scanned) {

--- a/packages/content/src/__tests__/pdf-ocr.test.ts
+++ b/packages/content/src/__tests__/pdf-ocr.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EXTRACTORS } from '../content-extractor';
-import { recognizeImages } from '../ocr';
+import { recognizeImages, type OcrWord } from '../ocr';
 
 vi.mock('../ocr', () => ({ recognizeImages: vi.fn() }));
 
@@ -25,9 +25,25 @@ const readFixture = (name: string): Buffer => fs.readFileSync(path.join(FIXTURES
 const extract = (fixture: string) =>
     EXTRACTORS['pdf-text-layer']!.extract(readFixture(fixture), 'application/pdf');
 
-/** Every image recognizes as the same known text. */
+/** Every image recognizes as the same known text, as one word per token. */
 const recognizesAs = (text: string) => {
-    vi.mocked(recognizeImages).mockImplementation(async (images = []) => images.map(() => text));
+    vi.mocked(recognizeImages).mockImplementation(async (images = []) =>
+        images.map(() => {
+            const words: OcrWord[] = [];
+            let cursor = 0;
+            for (const token of text.split(' ').filter(Boolean)) {
+                words.push({
+                    text: token,
+                    start: cursor,
+                    end: cursor + token.length,
+                    bbox: { x0: cursor * 10, y0: 0, x1: cursor * 10 + token.length * 8, y1: 16 },
+                    confidence: 90,
+                });
+                cursor += token.length + 1;
+            }
+            return { text, words };
+        }),
+    );
 };
 
 describe('class B — a fully scanned document', () => {
@@ -41,6 +57,33 @@ describe('class B — a fully scanned document', () => {
         expect(out.pdfClass).toBe('B');
         expect(out.method).toBe('ocr');
         expect(out.unreadPages).toBeUndefined();
+    });
+
+    it('anchors every recovered word to a range that selects it', async () => {
+        // The offset invariant, end to end: `buildPdfAnnotation` slices the
+        // text by these ranges and throws if the result does not contain the
+        // match, so drift here surfaces as a failed annotation, not a nudged box.
+        recognizesAs('RECOVERED FROM THE SCAN');
+        const out = await extract('scanned-image.pdf');
+        if ('declined' in out) throw new Error(`unexpected decline: ${out.declined}`);
+        expect(out.blocks?.length).toBe(4);
+        for (const block of out.blocks!) {
+            expect(out.text.slice(block.start, block.end)).toMatch(/^(RECOVERED|FROM|THE|SCAN)$/);
+        }
+    });
+
+    it('places words on the page in PDF points, not pixels', async () => {
+        recognizesAs('SCANNED');
+        const out = await extract('scanned-image.pdf');
+        if ('declined' in out) throw new Error('unexpected decline');
+        const [block] = out.blocks!;
+        // The fixture's raster covers the whole 612×792 page, so any word must
+        // land inside it — pixel coordinates (max 240×140) would not.
+        expect(block!.page).toBe(1);
+        expect(block!.x).toBeGreaterThanOrEqual(0);
+        expect(block!.x + block!.width).toBeLessThanOrEqual(612);
+        expect(block!.y).toBeGreaterThanOrEqual(0);
+        expect(block!.y + block!.height).toBeLessThanOrEqual(792);
     });
 
     it("declines 'no-text-layer' when OCR finds nothing — now meaning it truly failed", async () => {
@@ -69,6 +112,19 @@ describe('class C — a hybrid document', () => {
         expect(out.method).toBe('ocr');
         // The gap is closed: nothing is left unread.
         expect(out.unreadPages).toBeUndefined();
+
+        // Native and OCR'd geometry coexist, and each still selects its own
+        // text — the native items were not disturbed by appending.
+        const native = out.blocks!.filter((b) => b.page === 1);
+        const scanned = out.blocks!.filter((b) => b.page === 2);
+        expect(native.length).toBeGreaterThan(0);
+        expect(scanned.length).toBe(5);
+        for (const block of scanned) {
+            expect(out.text.slice(block.start, block.end)).toMatch(/^(TEXT|FROM|THE|SCANNED|PAGE)$/);
+        }
+        // One run, because the fixture draws the phrase in a single call —
+        // native items are text runs, not words.
+        expect(out.text.slice(native[0]!.start, native[0]!.end)).toBe('native page text');
     });
 
     it('still reports a gap for pages OCR could not read', async () => {

--- a/packages/content/src/__tests__/pdf-page-images.test.ts
+++ b/packages/content/src/__tests__/pdf-page-images.test.ts
@@ -22,11 +22,11 @@ describe('extractPageImages', () => {
         const byPage = await extractPageImages(readFixture('scanned-image.pdf'));
         const images = byPage.get(1);
         expect(images).toHaveLength(1);
-        expect(images![0]!.subarray(0, 8)).toEqual(PNG_SIGNATURE);
+        expect(images![0]!.png.subarray(0, 8)).toEqual(PNG_SIGNATURE);
         // IHDR width/height are big-endian at fixed offsets — the fixture's
         // raster is 240x140, and extracting (not rendering) preserves it.
-        expect(images![0]!.readUInt32BE(16)).toBe(240);
-        expect(images![0]!.readUInt32BE(20)).toBe(140);
+        expect(images![0]!.png.readUInt32BE(16)).toBe(240);
+        expect(images![0]!.png.readUInt32BE(20)).toBe(140);
     });
 
     it('extracts only the requested pages', async () => {

--- a/packages/content/src/__tests__/pdf-placement.test.ts
+++ b/packages/content/src/__tests__/pdf-placement.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Placement transform — where a page's image actually sits (#739).
+ *
+ * OCR returns boxes in image-pixel space; anchoring them needs the matrix
+ * that placed the image on the page. Two things are tested separately here
+ * because a fixture cannot check both: `findPlacedImages` composes nested
+ * transforms in the right ORDER (needs two non-identity matrices, which
+ * pdf-lib never emits), and the fixtures check the composition produces the
+ * right ANSWER end to end.
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import { describe, it, expect } from 'vitest';
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
+import { extractPageImages, findPlacedImages } from '../pdf-page-images';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.join(__dirname, 'fixtures');
+const readFixture = (name: string): Buffer => fs.readFileSync(path.join(FIXTURES, name));
+
+describe('findPlacedImages — composition order', () => {
+    const { OPS } = pdfjs;
+
+    it('composes nested transforms so the innermost applies to the point first', () => {
+        // Outer: scale by 2. Inner: translate by (10, 20). A point at the
+        // image's unit origin must land at (20, 40) — the translation scaled by
+        // the enclosing matrix — NOT at (10, 20), which is what the reversed
+        // order would give.
+        const placed = findPlacedImages(
+            [OPS.save, OPS.transform, OPS.transform, OPS.paintImageXObject, OPS.restore],
+            [[], [2, 0, 0, 2, 0, 0], [1, 0, 0, 1, 10, 20], ['img', 8, 8], []],
+        );
+        expect(placed).toHaveLength(1);
+        expect(placed[0]!.ctm).toEqual([2, 0, 0, 2, 20, 40]);
+    });
+
+    it('restores the matrix saved before a nested transform', () => {
+        const placed = findPlacedImages(
+            [OPS.save, OPS.transform, OPS.restore, OPS.paintImageXObject],
+            [[], [5, 0, 0, 5, 0, 0], [], ['img', 8, 8]],
+        );
+        // The transform was scoped to the save/restore pair, so the image is
+        // painted under the identity matrix.
+        expect(placed[0]!.ctm).toEqual([1, 0, 0, 1, 0, 0]);
+    });
+
+    it('carries the image reference and its pixel dimensions', () => {
+        const placed = findPlacedImages([OPS.paintImageXObject], [['img_p0_1', 240, 140]]);
+        expect(placed[0]).toMatchObject({ ref: 'img_p0_1', width: 240, height: 140 });
+    });
+});
+
+describe('extractPageImages — placement end to end', () => {
+    it('reports a full-page scan as the page-sized matrix', async () => {
+        const byPage = await extractPageImages(readFixture('scanned-image.pdf'));
+        const image = byPage.get(1)![0]!;
+        expect(image.ctm).toEqual([612, 0, 0, 792, 0, 0]);
+        expect(image.width).toBe(240);
+        expect(image.height).toBe(140);
+    });
+
+    it('reports an off-origin scaled scan at its actual position', async () => {
+        const byPage = await extractPageImages(readFixture('scanned-placed.pdf'));
+        const image = byPage.get(1)![0]!;
+        // Drawn at (100, 200), 300×400 — the unit square maps onto exactly that.
+        expect(image.ctm).toEqual([300, 0, 0, 400, 100, 200]);
+    });
+});

--- a/packages/content/src/content-extractor.ts
+++ b/packages/content/src/content-extractor.ts
@@ -32,6 +32,24 @@ export interface ExtractedText {
   method: 'text-passthrough' | 'pdf-text-layer' | 'table' | 'form' | 'ocr';
   pdfClass?: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G';
   /**
+   * How well the engine read the pixels, when any of this text came from OCR.
+   *
+   * Extraction quality, deliberately NOT anchor confidence: the two answer
+   * different questions. `AnchorConfidence` asks whether the renderer
+   * relocated a stored span in the current text, and for a PDF the answer is
+   * always "exactly" — the viewrect is absolute. This asks whether the glyphs
+   * under that box were read correctly, which no client can recompute.
+   * Reported for operators rather than stored on annotations, following the
+   * existing rule that anchor-audit detail belongs in logs.
+   */
+  ocrConfidence?: {
+    /** Mean per-word confidence, 0–100. */
+    mean: number;
+    /** Words the engine was unsure of — the number worth acting on. */
+    lowConfidenceWords: number;
+    totalWords: number;
+  };
+  /**
    * 1-indexed pages this extraction could not read — present only when a
    * document is partially covered (class C). Naming the gap is the point:
    * without it a hybrid document embeds its native pages and says nothing

--- a/packages/content/src/content-extractor.ts
+++ b/packages/content/src/content-extractor.ts
@@ -22,8 +22,13 @@ import { pdfExtractor } from './pdf-extractor';
 export interface ExtractedText {
   /** Reading-order plain text, ready for the chunker. */
   text: string;
-  /** Native geometry (page+bbox) for callers that anchor; absent for pure text. */
-  blocks?: PdfTextItem[];
+  /**
+   * Positioned text runs indexing `text`, for callers that anchor; absent for
+   * pure text, where character offsets are the anchor. Named `items` to match
+   * `AnchoredText`/`PdfTextLayer` — one concept, one name, and no collision
+   * with the OCR engine's own "blocks" (which are page regions, not runs).
+   */
+  items?: PdfTextItem[];
   method: 'text-passthrough' | 'pdf-text-layer' | 'table' | 'form' | 'ocr';
   pdfClass?: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G';
   /**

--- a/packages/content/src/content-extractor.ts
+++ b/packages/content/src/content-extractor.ts
@@ -10,7 +10,7 @@
  *
  * Extraction is ephemeral: `extract` runs at read time, its output feeds the
  * chunker, and is discarded — no stored derived representation. Annotations
- * anchor to native geometry (`blocks`), never to extracted-text offsets, so
+ * anchor to native geometry (`items`), never to extracted-text offsets, so
  * re-extraction can never break an anchor.
  */
 

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -32,6 +32,7 @@ export {
 export { extractPdfTextLayer } from './extract-pdf-text-layer';
 export { locate } from './locate';
 export type {
+  AnchoredText,
   PdfTextLayer,
   PdfTextItem,
   PdfPageInfo,

--- a/packages/content/src/locate.ts
+++ b/packages/content/src/locate.ts
@@ -1,5 +1,5 @@
 import type { PdfCoordinate } from '@semiont/core';
-import type { PdfTextLayer, PdfTextItem } from './pdf-text-layer';
+import type { AnchoredText, PdfTextItem } from './pdf-text-layer';
 
 /**
  * Items whose baseline Y is within this many PDF points are treated as being on
@@ -9,7 +9,7 @@ import type { PdfTextLayer, PdfTextItem } from './pdf-text-layer';
 const SAME_LINE_THRESHOLD_PT = 2;
 
 /**
- * Locates bounding rectangles for a span of text in a PdfTextLayer
+ * Locates bounding rectangles for a span of text in an AnchoredText
  * (single-line or multi-line).
  *
  * Finds all overlapping items [start, end), groups them by page and line, and
@@ -21,11 +21,11 @@ const SAME_LINE_THRESHOLD_PT = 2;
  * instead of re-filtering. Both arrays are empty if no item overlaps the span.
  */
 export function locate(
-    layer: PdfTextLayer,
+    anchored: AnchoredText,
     start: number,
     end: number
 ): { rects: PdfCoordinate[]; overlap: PdfTextItem[] } {
-    const overlap: PdfTextItem[] = layer.items.filter(
+    const overlap: PdfTextItem[] = anchored.items.filter(
         item => item.start < end && item.end > start
     );
     if (overlap.length === 0) return { rects: [], overlap };

--- a/packages/content/src/ocr-geometry.ts
+++ b/packages/content/src/ocr-geometry.ts
@@ -1,0 +1,62 @@
+/**
+ * OCR word boxes → PDF-point geometry (#739).
+ *
+ * OCR reports boxes in the image's own pixel space, top-left origin. Anchoring
+ * them means going through the matrix that placed the image on the page:
+ *
+ *     pixel (px, py) → unit square (px/W, 1 − py/H) → CTM → PDF points
+ *
+ * Rotation and non-uniform scale fall out of the matrix, so there are no
+ * special cases for them — the only explicit work is normalizing the result,
+ * since a mirrored placement can invert an axis and consumers bound
+ * rectangles rather than orienting them.
+ */
+
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
+import type { OcrWord } from './ocr';
+import type { PdfTextItem } from './pdf-text-layer';
+
+/** The placement of one image: its pixel size and its matrix onto the page. */
+export interface ImagePlacement {
+    width: number;
+    height: number;
+    ctm: number[];
+}
+
+function toPagePoint(px: number, py: number, placement: ImagePlacement): [number, number] {
+    // Unit square, Y flipped: pixel rows run down, PDF space runs up.
+    const point: [number, number] = [px / placement.width, 1 - py / placement.height];
+    pdfjs.Util.applyTransform(point, placement.ctm);   // mutates in place
+    return point;
+}
+
+/**
+ * Map recognized words onto the page, shifting their character offsets by
+ * `textOffset` — where this page's text begins in the assembled document.
+ */
+export function mapWordsToItems(
+    words: OcrWord[],
+    placement: ImagePlacement,
+    page: number,
+    textOffset: number,
+): PdfTextItem[] {
+    if (placement.width <= 0 || placement.height <= 0) return [];
+
+    return words.map((word) => {
+        // Both corners through the matrix, then bound them — a flipped or
+        // rotated placement can put either one first.
+        const [ax, ay] = toPagePoint(word.bbox.x0, word.bbox.y0, placement);
+        const [bx, by] = toPagePoint(word.bbox.x1, word.bbox.y1, placement);
+        const x = Math.min(ax, bx);
+        const y = Math.min(ay, by);
+        return {
+            start: word.start + textOffset,
+            end: word.end + textOffset,
+            page,
+            x,
+            y,
+            width: Math.abs(bx - ax),
+            height: Math.abs(by - ay),
+        };
+    });
+}

--- a/packages/content/src/ocr.ts
+++ b/packages/content/src/ocr.ts
@@ -48,8 +48,13 @@ function langPath(): string {
  * `Block[]` still satisfies it.
  */
 export interface OcrBbox { x0: number; y0: number; x1: number; y1: number }
+export interface OcrLine {
+    /** The line's own box — the vertical extent shared by its words. */
+    bbox: OcrBbox;
+    words: { text: string; confidence: number; bbox: OcrBbox }[];
+}
 export interface OcrBlock {
-    paragraphs: { lines: { words: { text: string; confidence: number; bbox: OcrBbox }[] }[] }[];
+    paragraphs: { lines: OcrLine[] }[];
 }
 
 /** A recognized word, with the range it occupies in the assembled page text. */
@@ -96,7 +101,23 @@ export function assemblePage(blocks: OcrBlock[] | null): OcrPage {
                         text: value,
                         start,
                         end: text.length,
-                        bbox: word.bbox,
+                        // Horizontal extent from the word, vertical from the
+                        // line. OCR boxes hug their glyphs, so a descender
+                        // ('page') sits lower than its neighbours — and
+                        // `locate()` groups items into lines by comparing `y`
+                        // within a couple of points, a threshold that holds
+                        // because NATIVE runs take y from the shared baseline.
+                        // Passing per-word descenders through would split one
+                        // visual line into several rects and draw a highlight
+                        // as stacked fragments. Nothing is lost: `locate()`
+                        // bounds each line anyway, so per-word vertical extent
+                        // never reaches an annotation.
+                        bbox: {
+                            x0: word.bbox.x0,
+                            x1: word.bbox.x1,
+                            y0: line.bbox.y0,
+                            y1: line.bbox.y1,
+                        },
                         confidence: word.confidence,
                     });
                     wroteWord = true;

--- a/packages/content/src/ocr.ts
+++ b/packages/content/src/ocr.ts
@@ -42,11 +42,81 @@ function langPath(): string {
 }
 
 /**
- * Recognize a batch of PNG images, returning one string per image (empty
+ * The slice of tesseract's recognition tree this module reads. Declared
+ * structurally rather than importing `Tesseract.Block`, so tests can build a
+ * tree without satisfying a dozen fields nothing here looks at; a real
+ * `Block[]` still satisfies it.
+ */
+export interface OcrBbox { x0: number; y0: number; x1: number; y1: number }
+export interface OcrBlock {
+    paragraphs: { lines: { words: { text: string; confidence: number; bbox: OcrBbox }[] }[] }[];
+}
+
+/** A recognized word, with the range it occupies in the assembled page text. */
+export interface OcrWord {
+    text: string;
+    /** Offsets into `OcrPage.text` — `text.slice(start, end) === word.text`. */
+    start: number;
+    end: number;
+    /** Image pixel space, top-left origin — mapped to PDF points downstream. */
+    bbox: OcrBbox;
+    confidence: number;
+}
+
+export interface OcrPage {
+    text: string;
+    words: OcrWord[];
+}
+
+/**
+ * Assemble a page's text from its recognition tree, recording where each word
+ * lands as it is written.
+ *
+ * The text is built here rather than taken from tesseract's own `data.text`
+ * precisely so the offsets are exact **by construction** — deriving offsets by
+ * searching for words in a separately-produced string is where this kind of
+ * code goes wrong. Words join with a space, lines with a newline, paragraphs
+ * with a blank line.
+ */
+export function assemblePage(blocks: OcrBlock[] | null): OcrPage {
+    let text = '';
+    const words: OcrWord[] = [];
+
+    for (const block of blocks ?? []) {
+        for (const paragraph of block.paragraphs ?? []) {
+            for (const line of paragraph.lines ?? []) {
+                let wroteWord = false;
+                for (const word of line.words ?? []) {
+                    const value = word.text.trim();
+                    if (!value) continue;              // an empty box is not a word
+                    if (wroteWord) text += ' ';
+                    const start = text.length;
+                    text += value;
+                    words.push({
+                        text: value,
+                        start,
+                        end: text.length,
+                        bbox: word.bbox,
+                        confidence: word.confidence,
+                    });
+                    wroteWord = true;
+                }
+                if (wroteWord) text += '\n';
+            }
+            text += '\n';
+        }
+    }
+
+    // Only trailing separators are removed, so no recorded offset moves.
+    return { text: text.trimEnd(), words };
+}
+
+/**
+ * Recognize a batch of PNG images, returning one result per image (empty
  * where nothing legible was found). One worker serves the whole batch —
  * startup is the expensive part, not the pages.
  */
-export async function recognizeImages(images: Buffer[]): Promise<string[]> {
+export async function recognizeImages(images: Buffer[]): Promise<OcrPage[]> {
     if (images.length === 0) return [];
     // `cacheMethod: 'none'` — the data is already local, so there is nothing to
     // cache and no reason to write a copy into the working directory.
@@ -55,10 +125,12 @@ export async function recognizeImages(images: Buffer[]): Promise<string[]> {
         cacheMethod: 'none',
     });
     try {
-        const results: string[] = [];
+        const results: OcrPage[] = [];
         for (const image of images) {
-            const { data } = await worker.recognize(image);
-            results.push(data.text.trim());
+            // `blocks: true` is what carries the per-word geometry; without it
+            // tesseract returns text only and `data.blocks` is null.
+            const { data } = await worker.recognize(image, {}, { blocks: true, text: false });
+            results.push(assemblePage(data.blocks));
         }
         return results;
     } finally {

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -29,6 +29,22 @@ import { mapWordsToItems } from './ocr-geometry';
 interface OcrPageResult {
   text: string;
   items: PdfTextItem[];
+  /** Per-word confidences, kept only long enough to summarize. */
+  confidences: number[];
+}
+
+/** Words below this are worth an operator's attention. Tesseract reports
+ *  0–100; readable text on a clean scan sits well above this. */
+const LOW_CONFIDENCE = 60;
+
+function summarize(confidences: number[]): ExtractedText['ocrConfidence'] {
+  if (confidences.length === 0) return undefined;
+  const total = confidences.reduce((sum, c) => sum + c, 0);
+  return {
+    mean: Math.round((total / confidences.length) * 10) / 10,
+    lowConfidenceWords: confidences.filter((c) => c < LOW_CONFIDENCE).length,
+    totalWords: confidences.length,
+  };
 }
 
 /**
@@ -54,14 +70,16 @@ async function ocrPages(content: Buffer, pageNumbers?: number[]): Promise<Map<nu
     const images = imagesByPage.get(page)!;
     let text = '';
     const items: PdfTextItem[] = [];
+    const confidences: number[] = [];
     for (const image of images) {
       const result = recognized[cursor++];
       if (!result?.text.trim()) continue;
       if (text) text += '\n';
       items.push(...mapWordsToItems(result.words, image, page, text.length));
+      confidences.push(...result.words.map((word) => word.confidence));
       text += result.text;
     }
-    if (text) byPage.set(page, { text, items });
+    if (text) byPage.set(page, { text, items, confidences });
   }
   return byPage;
 }
@@ -74,15 +92,17 @@ async function ocrPages(content: Buffer, pageNumbers?: number[]): Promise<Map<nu
 function joinPages(byPage: Map<number, OcrPageResult>, baseOffset: number): OcrPageResult {
   let text = '';
   const items: PdfTextItem[] = [];
+  const confidences: number[] = [];
   for (const [, page] of [...byPage.entries()].sort((a, b) => a[0] - b[0])) {
     if (text) text += '\n\n';
     const shift = baseOffset + text.length;
     for (const item of page.items) {
       items.push({ ...item, start: item.start + shift, end: item.end + shift });
     }
+    confidences.push(...page.confidences);
     text += page.text;
   }
-  return { text, items };
+  return { text, items, confidences };
 }
 
 /**
@@ -168,9 +188,15 @@ export const pdfExtractor: ContentExtractor = {
     // empty, not that we never tried.
     if (!layer) {
       const ocr = joinPages(await ocrPages(content), 0);
-      return ocr.text
-        ? { text: ocr.text, items: ocr.items, method: 'ocr', pdfClass: 'B' }
-        : { declined: 'no-text-layer' };
+      if (!ocr.text) return { declined: 'no-text-layer' };
+      const confidence = summarize(ocr.confidences);
+      return {
+        text: ocr.text,
+        items: ocr.items,
+        method: 'ocr',
+        pdfClass: 'B',
+        ...(confidence ? { ocrConfidence: confidence } : {}),
+      };
     }
 
     // One class per document, so a filled form outranks a grid: its values
@@ -204,12 +230,14 @@ export const pdfExtractor: ContentExtractor = {
     // Appended, so the native pages' items keep pointing at the right
     // characters; the OCR'd words are offset to where they actually land.
     const ocr = joinPages(recovered, shaped.text.length);
+    const confidence = summarize(ocr.confidences);
     return {
       ...shaped,
       text: `${shaped.text}${ocr.text}\n`,
       items: [...(shaped.items ?? []), ...ocr.items],
       method: 'ocr',
       pdfClass: hybridClass,
+      ...(confidence ? { ocrConfidence: confidence } : {}),
       ...(stillUnread.length > 0 ? { unreadPages: stillUnread } : {}),
     };
   },

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -95,15 +95,15 @@ export function classifyPdfError(error: unknown): 'encrypted' | 'corrupt' {
  * A form's answers live in the form dictionary, not the drawn page, so a
  * naive text-layer read returns the blank labels and loses every value.
  * Each value is appended as a `name: value` line and anchored by its widget
- * rectangle, so `blocks` stays a complete geometry index of `text`.
+ * rectangle, so `items` stays a complete geometry index of `text`.
  */
 function foldFormFields(layer: PdfTextLayer): ExtractedText {
   let text = layer.text;
-  const blocks: PdfTextItem[] = [...layer.items];
+  const items: PdfTextItem[] = [...layer.items];
   for (const field of layer.fields) {
     const start = text.length + `${field.name}: `.length;
     text += `${field.name}: ${field.value}\n`;
-    blocks.push({
+    items.push({
       start,
       end: start + field.value.length,
       page: field.page,
@@ -113,7 +113,7 @@ function foldFormFields(layer: PdfTextLayer): ExtractedText {
       height: field.height,
     });
   }
-  return { text, blocks, method: 'form', pdfClass: 'E' };
+  return { text, items, method: 'form', pdfClass: 'E' };
 }
 
 /**
@@ -125,28 +125,28 @@ function foldFormFields(layer: PdfTextLayer): ExtractedText {
  */
 function shapeTables(layer: PdfTextLayer): ExtractedText | null {
   const pages = layer.pages.map((page) => {
-    const items = layer.items.filter((item) => item.page === page.pageNumber);
-    return { page, items, table: detectTable(items, layer.text) };
+    const pageItems = layer.items.filter((item) => item.page === page.pageNumber);
+    return { page, pageItems, table: detectTable(pageItems, layer.text) };
   });
   if (!pages.some((p) => p.table)) return null;
 
   let text = '';
-  const blocks: PdfTextItem[] = [];
-  for (const { page, items, table } of pages) {
+  const items: PdfTextItem[] = [];
+  for (const { page, pageItems, table } of pages) {
     if (table) {
       const rendered = renderTable(table, page.pageNumber, text.length);
       text += rendered.text;
-      blocks.push(...rendered.blocks);
+      items.push(...rendered.items);
     } else {
       // Verbatim page: copy its slice and shift its runs' offsets to match.
       const shift = text.length - page.textStart;
       text += layer.text.slice(page.textStart, page.textEnd);
-      for (const item of items) {
-        blocks.push({ ...item, start: item.start + shift, end: item.end + shift });
+      for (const item of pageItems) {
+        items.push({ ...item, start: item.start + shift, end: item.end + shift });
       }
     }
   }
-  return { text, blocks, method: 'table', pdfClass: 'D' };
+  return { text, items, method: 'table', pdfClass: 'D' };
 }
 
 export const pdfExtractor: ContentExtractor = {
@@ -163,7 +163,7 @@ export const pdfExtractor: ContentExtractor = {
     if (!layer) {
       const ocr = joinPages(await ocrPages(content), 0);
       return ocr.text
-        ? { text: ocr.text, blocks: ocr.items, method: 'ocr', pdfClass: 'B' }
+        ? { text: ocr.text, items: ocr.items, method: 'ocr', pdfClass: 'B' }
         : { declined: 'no-text-layer' };
     }
 
@@ -173,7 +173,7 @@ export const pdfExtractor: ContentExtractor = {
     const shaped = layer.fields.length > 0
       ? foldFormFields(layer)
       : shapeTables(layer)
-        ?? { text: layer.text, blocks: layer.items, method: 'pdf-text-layer' as const, pdfClass: 'A' as const };
+        ?? { text: layer.text, items: layer.items, method: 'pdf-text-layer' as const, pdfClass: 'A' as const };
 
     // A page with no text-showing operators is scanned: its characters exist
     // only as pixels. Report those pages rather than dropping them silently —
@@ -201,7 +201,7 @@ export const pdfExtractor: ContentExtractor = {
     return {
       ...shaped,
       text: `${shaped.text}${ocr.text}\n`,
-      blocks: [...(shaped.blocks ?? []), ...ocr.items],
+      items: [...(shaped.items ?? []), ...ocr.items],
       method: 'ocr',
       pdfClass: hybridClass,
       ...(stillUnread.length > 0 ? { unreadPages: stillUnread } : {}),

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -1,13 +1,19 @@
 /**
- * PDF extractor — the 'pdf-text-layer' strategy (SMELTER-MEDIA-TYPES Phase 1).
+ * PDF extractor — the 'pdf-text-layer' strategy (SMELTER-MEDIA-TYPES).
  *
  * Wraps the shared `extractPdfTextLayer` reader (detection's other consumer)
- * and classifies its failures into the decline vocabulary: class A (native
- * text layer) extracts; class B (scanned, no text items) declines
- * 'no-text-layer'; class F (encrypted) and class G (corrupt/truncated)
- * decline from the parser error. Class A runs inline on the smelter's hot
- * path — text-layer reading is cheap and deterministic; OCR (Phase 3) is
- * what moves off it.
+ * and turns a PDF into text plus the geometry that indexes it, by class:
+ *
+ *   A native text layer   → read directly
+ *   B scanned             → read the page pixels by OCR
+ *   C hybrid              → both, with any page still unread reported
+ *   D tables              → grid pages rewritten as markdown rows
+ *   E forms               → AcroForm values folded in, anchored to widgets
+ *   F/G encrypted, corrupt → declined by name, from the parser error
+ *
+ * Everything runs inline. OCR was originally planned off the hot path, but
+ * the Smelter's lanes are per-resource and concurrent, so a slow page delays
+ * only its own resource — see SMELTER-MEDIA-TYPES Design §4 (revised).
  */
 
 import { isObject } from '@semiont/core';
@@ -184,7 +190,7 @@ export const pdfExtractor: ContentExtractor = {
     if (unreadPages.length === 0) return shaped;
 
     // Class C — read the scanned pages and append what OCR recovers. Appended
-    // rather than spliced into reading order, so the blocks already computed
+    // rather than spliced into reading order, so the items already computed
     // for the native pages keep pointing at the right characters; OCR text
     // carries no geometry of its own this phase (mapping pixel boxes back to
     // page points needs the image's placement transform — #739's critical
@@ -195,7 +201,7 @@ export const pdfExtractor: ContentExtractor = {
     if (recovered.size === 0) {
       return { ...shaped, unreadPages: stillUnread, pdfClass: hybridClass };
     }
-    // Appended, so the native pages' blocks keep pointing at the right
+    // Appended, so the native pages' items keep pointing at the right
     // characters; the OCR'd words are offset to where they actually land.
     const ocr = joinPages(recovered, shaped.text.length);
     return {

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -17,35 +17,66 @@ import type { PdfTextLayer, PdfTextItem } from './pdf-text-layer';
 import { detectTable, renderTable } from './pdf-tables';
 import { extractPageImages } from './pdf-page-images';
 import { recognizeImages } from './ocr';
+import { mapWordsToItems } from './ocr-geometry';
+
+/** One OCR'd page: its text, and word geometry with page-local offsets. */
+interface OcrPageResult {
+  text: string;
+  items: PdfTextItem[];
+}
 
 /**
  * Read the pages that have no text layer by OCR'ing their pixels. Returns
- * text only for pages that yielded some; a page absent from the map stayed
+ * results only for pages that yielded text; a page absent from the map stayed
  * unread. Pages with no extractable image never reach the engine.
+ *
+ * Each word is anchored through the matrix that placed its image, so a scanned
+ * page ends up carrying the same kind of geometry a native one does.
  */
-async function ocrPages(content: Buffer, pageNumbers?: number[]): Promise<Map<number, string>> {
+async function ocrPages(content: Buffer, pageNumbers?: number[]): Promise<Map<number, OcrPageResult>> {
   const imagesByPage = await extractPageImages(content, pageNumbers);
   if (imagesByPage.size === 0) return new Map();
 
   // One batch for the whole document: worker startup dominates per-page cost.
   const pages = [...imagesByPage.keys()].sort((a, b) => a - b);
-  const batch = pages.flatMap((page) => imagesByPage.get(page)!);
+  const batch = pages.flatMap((page) => imagesByPage.get(page)!.map((image) => image.png));
   const recognized = await recognizeImages(batch);
 
-  const byPage = new Map<number, string>();
-  let offset = 0;
+  const byPage = new Map<number, OcrPageResult>();
+  let cursor = 0;
   for (const page of pages) {
-    const count = imagesByPage.get(page)!.length;
-    const text = recognized.slice(offset, offset + count).filter((t) => t.trim()).join('\n').trim();
-    offset += count;
-    if (text) byPage.set(page, text);
+    const images = imagesByPage.get(page)!;
+    let text = '';
+    const items: PdfTextItem[] = [];
+    for (const image of images) {
+      const result = recognized[cursor++];
+      if (!result?.text.trim()) continue;
+      if (text) text += '\n';
+      items.push(...mapWordsToItems(result.words, image, page, text.length));
+      text += result.text;
+    }
+    if (text) byPage.set(page, { text, items });
   }
   return byPage;
 }
 
-/** Recovered pages in page order, as one block of text. */
-function joinPages(byPage: Map<number, string>): string {
-  return [...byPage.entries()].sort((a, b) => a[0] - b[0]).map(([, text]) => text).join('\n\n');
+/**
+ * Recovered pages in page order as one block of text, with every word's
+ * offsets shifted to where its page actually lands. `baseOffset` is where this
+ * block begins in the document being assembled.
+ */
+function joinPages(byPage: Map<number, OcrPageResult>, baseOffset: number): OcrPageResult {
+  let text = '';
+  const items: PdfTextItem[] = [];
+  for (const [, page] of [...byPage.entries()].sort((a, b) => a[0] - b[0])) {
+    if (text) text += '\n\n';
+    const shift = baseOffset + text.length;
+    for (const item of page.items) {
+      items.push({ ...item, start: item.start + shift, end: item.end + shift });
+    }
+    text += page.text;
+  }
+  return { text, items };
 }
 
 /**
@@ -130,8 +161,10 @@ export const pdfExtractor: ContentExtractor = {
     // pixels, so read them. 'no-text-layer' now means OCR genuinely came up
     // empty, not that we never tried.
     if (!layer) {
-      const text = joinPages(await ocrPages(content));
-      return text ? { text, method: 'ocr', pdfClass: 'B' } : { declined: 'no-text-layer' };
+      const ocr = joinPages(await ocrPages(content), 0);
+      return ocr.text
+        ? { text: ocr.text, blocks: ocr.items, method: 'ocr', pdfClass: 'B' }
+        : { declined: 'no-text-layer' };
     }
 
     // One class per document, so a filled form outranks a grid: its values
@@ -162,9 +195,13 @@ export const pdfExtractor: ContentExtractor = {
     if (recovered.size === 0) {
       return { ...shaped, unreadPages: stillUnread, pdfClass: hybridClass };
     }
+    // Appended, so the native pages' blocks keep pointing at the right
+    // characters; the OCR'd words are offset to where they actually land.
+    const ocr = joinPages(recovered, shaped.text.length);
     return {
       ...shaped,
-      text: `${shaped.text}${joinPages(recovered)}\n`,
+      text: `${shaped.text}${ocr.text}\n`,
+      blocks: [...(shaped.blocks ?? []), ...ocr.items],
       method: 'ocr',
       pdfClass: hybridClass,
       ...(stillUnread.length > 0 ? { unreadPages: stillUnread } : {}),

--- a/packages/content/src/pdf-page-images.ts
+++ b/packages/content/src/pdf-page-images.ts
@@ -16,13 +16,66 @@
  */
 
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
-import { isObject, isNumber } from '@semiont/core';
+import { isObject, isNumber, isString, isArray } from '@semiont/core';
 import { encodePng } from './png-encode';
 
 /** pdf.js image kinds (`ImageKind` in its API). */
 const GRAYSCALE_1BPP = 1;
 const RGB_24BPP = 2;
 const RGBA_32BPP = 3;
+
+const IDENTITY: readonly number[] = [1, 0, 0, 1, 0, 0];
+
+/** An image painted on a page, with the matrix that placed it. */
+export interface PlacedImage {
+    ref: string;
+    /** Natural pixel dimensions, as reported by the paint operator itself. */
+    width: number;
+    height: number;
+    /** Maps the image's unit square onto the page, in PDF points. */
+    ctm: number[];
+}
+
+/**
+ * Walk an operator list and report every painted image with the matrix in
+ * effect when it was painted.
+ *
+ * Exported for its own tests: the composition ORDER cannot be checked with a
+ * generated fixture, because pdf-lib emits a single combined matrix per image
+ * and identity × M equals M × identity. It is checked directly instead, with
+ * two non-identity transforms.
+ *
+ * Order convention: `ctm = Util.transform(ctm, m)` puts each new matrix on the
+ * right, so it applies to a point FIRST and the enclosing matrices after —
+ * which is what PDF nesting means. `save`/`restore` bracket the stack.
+ */
+export function findPlacedImages(fnArray: number[], argsArray: unknown[][]): PlacedImage[] {
+    const placed: PlacedImage[] = [];
+    const stack: number[][] = [];
+    let ctm: number[] = [...IDENTITY];
+
+    for (let i = 0; i < fnArray.length; i++) {
+        const op = fnArray[i];
+        const args = argsArray[i];
+        if (op === pdfjs.OPS.save) {
+            stack.push([...ctm]);
+        } else if (op === pdfjs.OPS.restore) {
+            ctm = stack.pop() ?? [...IDENTITY];
+        } else if (op === pdfjs.OPS.transform) {
+            if (isArray(args) && args.length >= 6 && args.every(isNumber)) {
+                ctm = pdfjs.Util.transform(ctm, args as number[]);
+            }
+        } else if (op === pdfjs.OPS.paintImageXObject) {
+            const ref = args?.[0];
+            const width = args?.[1];
+            const height = args?.[2];
+            if (isString(ref) && isNumber(width) && isNumber(height)) {
+                placed.push({ ref, width, height, ctm: [...ctm] });
+            }
+        }
+    }
+    return placed;
+}
 
 /**
  * Normalize a decoded pdf.js image to 8-bit RGB, or null for a kind we do
@@ -86,17 +139,29 @@ function resolveImage(page: pdfjs.PDFPageProxy, ref: string): Promise<unknown> {
     });
 }
 
+/** A page image ready for OCR, with everything needed to map results back. */
+export interface PageImage {
+    png: Buffer;
+    /** Pixel dimensions of the decoded raster (may differ from the paint
+     *  operator's declared size if the image was resampled). */
+    width: number;
+    height: number;
+    /** Maps the image's unit square onto the page, in PDF points. */
+    ctm: number[];
+}
+
 /**
  * PNG-encoded images for the given pages (all pages when omitted), keyed by
- * 1-indexed page number. Pages with no usable image are absent from the map.
+ * 1-indexed page number, each with the matrix that placed it. Pages with no
+ * usable image are absent from the map.
  */
 export async function extractPageImages(
     bytes: Uint8Array | Buffer,
     pageNumbers?: number[],
-): Promise<Map<number, Buffer[]>> {
+): Promise<Map<number, PageImage[]>> {
     const wanted = pageNumbers ? new Set(pageNumbers) : null;
     const loadingTask = pdfjs.getDocument({ data: new Uint8Array(bytes) });
-    const byPage = new Map<number, Buffer[]>();
+    const byPage = new Map<number, PageImage[]>();
 
     try {
         const doc = await loadingTask.promise;
@@ -105,13 +170,16 @@ export async function extractPageImages(
             const page = await doc.getPage(pageNum);
             const ops = await page.getOperatorList();
 
-            const images: Buffer[] = [];
-            for (let i = 0; i < ops.fnArray.length; i++) {
-                if (ops.fnArray[i] !== pdfjs.OPS.paintImageXObject) continue;
-                const ref = ops.argsArray[i]?.[0];
-                if (typeof ref !== 'string') continue;
-                const rgb = toRgb(await resolveImage(page, ref));
-                if (rgb) images.push(encodePng(rgb.width, rgb.height, rgb.rgb));
+            const images: PageImage[] = [];
+            for (const placement of findPlacedImages(ops.fnArray, ops.argsArray)) {
+                const rgb = toRgb(await resolveImage(page, placement.ref));
+                if (!rgb) continue;
+                images.push({
+                    png: encodePng(rgb.width, rgb.height, rgb.rgb),
+                    width: rgb.width,
+                    height: rgb.height,
+                    ctm: placement.ctm,
+                });
             }
             if (images.length > 0) byPage.set(pageNum, images);
         }

--- a/packages/content/src/pdf-tables.ts
+++ b/packages/content/src/pdf-tables.ts
@@ -102,7 +102,7 @@ export function detectTable(items: PdfTextItem[], text: string): TableCell[][] |
   if (!rows.every((row) => row.length === columnCount)) return null;
 
   // Every column must start at the same offset down the page; ragged left
-  // edges mean prose that happens to wrap into blocks, not a grid.
+  // edges mean prose that happens to wrap into columns, not a grid.
   for (let column = 0; column < columnCount; column++) {
     const lefts = rows.map((row) => row[column]!.x);
     if (Math.max(...lefts) - Math.min(...lefts) > unit) return null;
@@ -115,7 +115,7 @@ export function detectTable(items: PdfTextItem[], text: string): TableCell[][] |
 /**
  * Render a grid as markdown rows, anchoring every cell to the geometry it
  * came from. `offset` is where this text lands in the assembled document, so
- * the returned blocks index the final string.
+ * the returned items index the final string.
  */
 export function renderTable(
   rows: TableCell[][],

--- a/packages/content/src/pdf-tables.ts
+++ b/packages/content/src/pdf-tables.ts
@@ -121,16 +121,16 @@ export function renderTable(
   rows: TableCell[][],
   page: number,
   offset: number,
-): { text: string; blocks: PdfTextItem[] } {
+): { text: string; items: PdfTextItem[] } {
   let text = '';
-  const blocks: PdfTextItem[] = [];
+  const items: PdfTextItem[] = [];
   rows.forEach((row, rowIndex) => {
     text += '|';
     for (const cell of row) {
       text += ' ';
       const start = offset + text.length;
       text += cell.text;
-      blocks.push({
+      items.push({
         start,
         end: offset + text.length,
         page,
@@ -145,5 +145,5 @@ export function renderTable(
     // Markdown needs the delimiter row for the header to read as a table.
     if (rowIndex === 0) text += `|${' --- |'.repeat(row.length)}\n`;
   });
-  return { text, blocks };
+  return { text, items };
 }

--- a/packages/content/src/pdf-text-layer.ts
+++ b/packages/content/src/pdf-text-layer.ts
@@ -58,14 +58,26 @@ export interface PdfPageInfo {
 }
 
 /**
+ * Text paired with the geometry that indexes it — the minimum needed to turn a
+ * character range into a Selection.
+ *
+ * This is the contract `locate()` and the annotation builders actually require;
+ * they do not need pages, form fields, or anything else a full layer carries.
+ * Naming it separately lets OCR'd content (recovered from pixels, so not a
+ * "text layer" in the PDF sense) satisfy the same anchoring path.
+ */
+export interface AnchoredText {
+    text: string;
+    items: PdfTextItem[];
+}
+
+/**
  * The full extracted text layer for a PDF.
  * `text` is the reading-order concatenation across all pages.
  * Each `item` is one text run carrying its character range into `text` plus PDF-point geometry.
  */
-export interface PdfTextLayer {
+export interface PdfTextLayer extends AnchoredText {
     pages: PdfPageInfo[];
-    text: string;
-    items: PdfTextItem[];
     /**
      * Filled AcroForm field values, empty for a document without a form.
      * Deliberately NOT folded into `text`: the reader reports what the

--- a/packages/event-sourcing/src/identifier-utils.ts
+++ b/packages/event-sourcing/src/identifier-utils.ts
@@ -3,12 +3,18 @@
  */
 
 import { nanoid } from 'nanoid';
+import { annotationId, type AnnotationId } from '@semiont/core';
 
 /**
  * Generate a unique annotation ID (bare nanoid)
  *
+ * Returns the branded type: this function is where an annotation id comes
+ * into existence, so it is the natural place to brand — every caller is
+ * constructing an `Annotation`, and branding here spares them all a cast
+ * (BRAND-UPSTREAM: brand at the boundary, not at every hop).
+ *
  * @returns A bare annotation ID (e.g., "V1StGXR8_Z5jdHi6B-myT")
  */
-export function generateAnnotationId(): string {
-  return nanoid(21);
+export function generateAnnotationId(): AnnotationId {
+  return annotationId(nanoid(21));
 }

--- a/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
+++ b/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
@@ -105,7 +105,7 @@ describe('buildPdfAnnotation (#736 geometry tail)', () => {
   });
 
   it('attaches a body when provided (e.g. commenting)', () => {
-    const body = { type: 'TextualBody', value: 'a note', format: 'text/plain' };
+    const body = { type: 'TextualBody' as const, value: 'a note', format: 'text/plain' };
     const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'commenting',
       { exact: 'alpha', start: 0, end: 5 }, body);
     expect((ann as Record<string, unknown>).body).toEqual(body);
@@ -115,7 +115,7 @@ describe('buildPdfAnnotation (#736 geometry tail)', () => {
     // #737: at detection time a linking reference's body is the entity type as a
     // TextualBody (the SpecificResource target is appended later, at bind). The
     // geometry tail is identical to highlighting; only motivation + body differ.
-    const body = { type: 'TextualBody', value: 'Person', purpose: 'tagging', format: 'text/plain' };
+    const body = { type: 'TextualBody' as const, value: 'Person', purpose: 'tagging' as const, format: 'text/plain' };
     const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'linking',
       { exact: 'gamma delta', start: 11, end: 22 }, body);
     expect(ann.motivation).toBe('linking');
@@ -129,8 +129,8 @@ describe('buildPdfAnnotation (#736 geometry tail)', () => {
     // comment and tag hand buildAnnotation an ARRAY of bodies; the geometry tail
     // must pass either shape (single object | array) through verbatim.
     const body = [
-      { type: 'TextualBody', value: 'Rule',   purpose: 'tagging',    format: 'text/plain' },
-      { type: 'TextualBody', value: 'a note', purpose: 'commenting', format: 'text/plain' },
+      { type: 'TextualBody' as const, value: 'Rule',   purpose: 'tagging' as const,    format: 'text/plain' },
+      { type: 'TextualBody' as const, value: 'a note', purpose: 'commenting' as const, format: 'text/plain' },
     ];
     const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'tagging',
       { exact: 'alpha', start: 0, end: 5 }, body);

--- a/packages/jobs/src/__tests__/prepare-detection.test.ts
+++ b/packages/jobs/src/__tests__/prepare-detection.test.ts
@@ -1,26 +1,32 @@
 /**
- * prepareDetection (#736) — direct coverage of the media-type axis, including
- * the returned `buildAnnotation` closures. The orchestration tests
- * (worker-process.test) mock all processors, so those closures never execute
- * there; this suite calls them and asserts real annotation output, proving the
- * delegation wiring: 'decode' → buildTextAnnotation over the SAME decoded text,
- * 'pdf-text-layer' → buildPdfAnnotation over the SAME extracted layer.
+ * prepareDetection (#736, rewritten for #739) — the media axis and the
+ * `buildAnnotation` closures it returns.
+ *
+ * Detection now reads through the SAME extractor registry the Smelter embeds
+ * from, so these tests drive the real registry wherever they can: a text
+ * resource decodes for real, and only the PDF slot is stubbed (jobs carries no
+ * PDF fixtures). The wiring being proven is that the anchoring model follows
+ * the GEOMETRY, not the media type — positioned runs anchor by viewrect,
+ * their absence anchors by character offset in that same text.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { resourceId } from '@semiont/core';
 import type { components } from '@semiont/core';
-import type { PdfTextLayer } from '@semiont/content';
+import type { PdfTextItem } from '@semiont/content';
 import type { SemiontSession } from '@semiont/sdk';
 
-vi.mock('@semiont/content', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@semiont/content')>()),
-  extractPdfTextLayer: vi.fn(),
-}));
+vi.mock('@semiont/content', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@semiont/content')>();
+  return {
+    ...actual,
+    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn() } },
+  };
+});
 vi.mock('@semiont/event-sourcing', () => ({
   generateAnnotationId: vi.fn(() => 'ann-prep-test'),
 }));
 
-import { extractPdfTextLayer } from '@semiont/content';
+import { EXTRACTORS } from '@semiont/content';
 import { prepareDetection } from '../workers/detection/prepare-detection';
 
 type Agent = components['schemas']['Agent'];
@@ -35,29 +41,26 @@ const GENERATOR: Agent = {
   model: 'test',
 };
 
-// Synthetic two-line layer — same shape build-pdf-annotation.test pins.
-const LAYER: PdfTextLayer = {
-  pages: [{ pageNumber: 1, widthPt: 612, heightPt: 792, textStart: 0, textEnd: 22, hasTextLayer: true }],
-  text: 'alpha beta\ngamma delta',
-  items: [
-    { start: 0,  end: 5,  page: 1, x: 72,  y: 720, width: 40, height: 12 },
-    { start: 6,  end: 10, page: 1, x: 118, y: 720, width: 34, height: 12 },
-    { start: 11, end: 16, page: 1, x: 72,  y: 700, width: 45, height: 12 },
-    { start: 17, end: 22, page: 1, x: 125, y: 700, width: 42, height: 12 },
-  ],
-  fields: [],
-};
+const PDF_TEXT = 'alpha beta\ngamma delta';
+const PDF_ITEMS: PdfTextItem[] = [
+  { start: 0,  end: 5,  page: 1, x: 72,  y: 720, width: 40, height: 12 },
+  { start: 6,  end: 10, page: 1, x: 118, y: 720, width: 34, height: 12 },
+  { start: 11, end: 16, page: 1, x: 72,  y: 700, width: 45, height: 12 },
+  { start: 17, end: 22, page: 1, x: 125, y: 700, width: 42, height: 12 },
+];
 
-function fakeSession() {
-  const resourceContent = vi.fn(async () => 'alpha beta gamma');
-  const resourceRepresentation = vi.fn(async () => ({
-    data: new ArrayBuffer(8),
-    contentType: 'application/pdf',
-  }));
+/** The PDF slot, stubbed — the only extractor these tests fake. */
+const pdfExtract = vi.mocked(EXTRACTORS['pdf-text-layer']!.extract);
+
+function fakeSession(text = 'alpha beta gamma') {
+  const bytes = new TextEncoder().encode(text);
+  const data = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(data).set(bytes);
+  const resourceRepresentation = vi.fn(async () => ({ data, contentType: 'text/markdown' }));
   const session = {
-    client: { browse: { resourceContent, resourceRepresentation } },
+    client: { browse: { resourceRepresentation } },
   } as unknown as SemiontSession;
-  return { session, resourceContent, resourceRepresentation };
+  return { session, resourceRepresentation };
 }
 
 type Sel = { type: string; start?: number; end?: number; value?: string };
@@ -65,16 +68,18 @@ const selectors = (ann: Record<string, unknown>): Sel[] =>
   (ann.target as { selector: Sel[] }).selector;
 
 describe('prepareDetection', () => {
-  it("'decode': returns the decoded text and a buildAnnotation that anchors by character offsets in that SAME text", async () => {
-    const { session, resourceContent, resourceRepresentation } = fakeSession();
+  beforeEach(() => pdfExtract.mockReset());
 
-    const source = await prepareDetection('decode', session, RID, USER_DID, GENERATOR);
+  it('text: decodes for real and anchors by character offsets in that SAME text', async () => {
+    const { session, resourceRepresentation } = fakeSession();
 
-    expect(resourceContent).toHaveBeenCalledOnce();
-    expect(resourceRepresentation).not.toHaveBeenCalled();
-    expect(source?.text).toBe('alpha beta gamma');
+    const source = await prepareDetection('text/markdown', session, RID, USER_DID, GENERATOR);
+    if ('declined' in source) throw new Error(`unexpected decline: ${source.declined}`);
 
-    const ann = source!.buildAnnotation('highlighting', { exact: 'alpha', start: 0, end: 5 }) as Record<string, unknown>;
+    expect(resourceRepresentation).toHaveBeenCalledOnce();
+    expect(source.text).toBe('alpha beta gamma');
+
+    const ann = source.buildAnnotation('highlighting', { exact: 'alpha', start: 0, end: 5 }) as Record<string, unknown>;
     expect(ann.motivation).toBe('highlighting');
     expect((ann.target as { source: string }).source).toBe(RID);
     const sels = selectors(ann);
@@ -82,38 +87,57 @@ describe('prepareDetection', () => {
     expect(sels.some((s) => s.type === 'TextQuoteSelector')).toBe(true);
     // The closure closed over the decoded text: a span that does not match it
     // trips buildTextAnnotation's content invariant.
-    expect(() => source!.buildAnnotation('highlighting', { exact: 'zzz', start: 0, end: 3 })).toThrow(/invariant/);
+    expect(() => source.buildAnnotation('highlighting', { exact: 'zzz', start: 0, end: 3 })).toThrow(/invariant/);
   });
 
-  it("'pdf-text-layer': fetches the representation bytes and anchors by viewrect geometry from the SAME layer", async () => {
-    const { session, resourceContent, resourceRepresentation } = fakeSession();
-    vi.mocked(extractPdfTextLayer).mockResolvedValue(LAYER);
+  it('positioned runs: anchors by viewrect geometry from the SAME extraction', async () => {
+    const { session } = fakeSession();
+    pdfExtract.mockResolvedValue({ text: PDF_TEXT, items: PDF_ITEMS, method: 'pdf-text-layer', pdfClass: 'A' });
 
-    const source = await prepareDetection('pdf-text-layer', session, RID, USER_DID, GENERATOR);
+    const source = await prepareDetection('application/pdf', session, RID, USER_DID, GENERATOR);
+    if ('declined' in source) throw new Error(`unexpected decline: ${source.declined}`);
+    expect(source.text).toBe(PDF_TEXT);
 
-    expect(resourceRepresentation).toHaveBeenCalledOnce();
-    expect(resourceContent).not.toHaveBeenCalled();
-    expect(source?.text).toBe(LAYER.text);
-
-    const ann = source!.buildAnnotation('highlighting', { exact: 'alpha', start: 0, end: 5 }) as Record<string, unknown>;
+    const ann = source.buildAnnotation('highlighting', { exact: 'alpha', start: 0, end: 5 }) as Record<string, unknown>;
     const sels = selectors(ann);
     expect(sels.find((s) => s.type === 'FragmentSelector')?.value).toMatch(/^page=1&viewrect=/);
     expect(sels.some((s) => s.type === 'TextPositionSelector')).toBe(false);
     expect(sels.some((s) => s.type === 'TextQuoteSelector')).toBe(true);
   });
 
-  it("'pdf-text-layer': returns null for a scanned / image-only PDF (no text layer)", async () => {
+  it('a scanned PDF that OCR read is anchored spatially, like any other geometry', async () => {
+    // The point of #739: OCR'd words are ordinary positioned runs, so class B
+    // takes the identical path a native text layer does.
     const { session } = fakeSession();
-    vi.mocked(extractPdfTextLayer).mockResolvedValue(null);
+    pdfExtract.mockResolvedValue({ text: PDF_TEXT, items: PDF_ITEMS, method: 'ocr', pdfClass: 'B' });
 
-    expect(await prepareDetection('pdf-text-layer', session, RID, USER_DID, GENERATOR)).toBeNull();
+    const source = await prepareDetection('application/pdf', session, RID, USER_DID, GENERATOR);
+    if ('declined' in source) throw new Error('unexpected decline');
+    const ann = source.buildAnnotation('highlighting', { exact: 'gamma', start: 11, end: 16 }) as Record<string, unknown>;
+    expect(selectors(ann).find((s) => s.type === 'FragmentSelector')?.value).toMatch(/^page=1&viewrect=/);
   });
 
-  it("'none': returns null without touching the session", async () => {
-    const { session, resourceContent, resourceRepresentation } = fakeSession();
+  it("passes an extractor's own decline through by name", async () => {
+    const { session } = fakeSession();
+    pdfExtract.mockResolvedValue({ declined: 'encrypted' });
 
-    expect(await prepareDetection('none', session, RID, USER_DID, GENERATOR)).toBeNull();
-    expect(resourceContent).not.toHaveBeenCalled();
+    expect(await prepareDetection('application/pdf', session, RID, USER_DID, GENERATOR))
+      .toEqual({ declined: 'encrypted' });
+  });
+
+  it("declines 'no-extractor' for a media type that can never yield text", async () => {
+    const { session, resourceRepresentation } = fakeSession();
+
+    expect(await prepareDetection('application/zip', session, RID, USER_DID, GENERATOR))
+      .toEqual({ declined: 'no-extractor' });
+    // Nothing is fetched — the media type alone settles it.
     expect(resourceRepresentation).not.toHaveBeenCalled();
+  });
+
+  it("declines 'empty' when extraction yields nothing to detect over", async () => {
+    const { session } = fakeSession('   \n  ');
+
+    expect(await prepareDetection('text/markdown', session, RID, USER_DID, GENERATOR))
+      .toEqual({ declined: 'empty' });
   });
 });

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -42,7 +42,7 @@ import {
   processTagJob,
   processGenerationJob,
 } from '../processors';
-import { extractPdfTextLayer } from '@semiont/content';
+import { EXTRACTORS } from '@semiont/content';
 
 // Mock the six processor entry points; keep every other export real.
 // `prepareDetection` imports `buildTextAnnotation`/`buildPdfAnnotation` from
@@ -58,14 +58,17 @@ vi.mock('../processors', async (importOriginal) => ({
   processGenerationJob: vi.fn(),
 }));
 
-// prepareDetection's 'pdf-text-layer' branch runs extractPdfTextLayer over the
-// fetched PDF bytes. Mock only that export so orchestration tests drive the
-// text-layer-vs-scanned decision without real PDF fixtures; everything else in
-// @semiont/content (deriveStorageUri, etc.) stays real.
-vi.mock('@semiont/content', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@semiont/content')>()),
-  extractPdfTextLayer: vi.fn(),
-}));
+// prepareDetection reads through the extractor registry. Stub only the PDF
+// slot so orchestration tests drive the extracted-vs-declined decision without
+// real PDF fixtures; everything else in @semiont/content (deriveStorageUri,
+// the passthrough extractor, etc.) stays real.
+vi.mock('@semiont/content', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@semiont/content')>();
+  return {
+    ...actual,
+    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn() } },
+  };
+});
 
 const RID = 'res-abc';
 const UID = 'did:web:example.com:users:test';
@@ -505,7 +508,9 @@ describe('handleJob orchestration', () => {
 
     it.each(PDF_FANOUT)('fans $jobType out to the pdf-text-layer path', async ({ jobType, arm, lastCall }) => {
       arm();
-      vi.mocked(extractPdfTextLayer).mockResolvedValue({ text: 'the quick brown fox', items: [] } as never);
+      vi.mocked(EXTRACTORS['pdf-text-layer']!.extract).mockResolvedValue({
+        text: 'the quick brown fox', items: [], method: 'pdf-text-layer', pdfClass: 'A',
+      });
       const h = makeFakeSessionAndAdapter();
       vi.mocked(h.session.client.browse.resource).mockReturnValue({
         fresh: async () => ({
@@ -526,10 +531,10 @@ describe('handleJob orchestration', () => {
     });
 
     it('declines cleanly (no throw, no processor) for a scanned PDF with no text layer', async () => {
-      // extractPdfTextLayer returns null for a scanned / image-only PDF.
-      // The dispatch declines cleanly — completes the job with a no-text-layer
-      // result — rather than crashing or running the model on nothing.
-      vi.mocked(extractPdfTextLayer).mockResolvedValue(null);
+      // A scan OCR could not read declines by name. The dispatch completes the
+      // job with that reason rather than crashing or running the model on
+      // nothing — and the reason is now the extractor's own, not a guess.
+      vi.mocked(EXTRACTORS['pdf-text-layer']!.extract).mockResolvedValue({ declined: 'no-text-layer' });
       const h = makeFakeSessionAndAdapter();
       vi.mocked(h.session.client.browse.resource).mockReturnValue({
         fresh: async () => ({

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -422,6 +422,31 @@ describe('handleJob orchestration', () => {
     });
   });
 
+  describe('wire contract', () => {
+    it('emits no field the channel does not declare', async () => {
+      // `emitEvent` is typed `EventMap[K]`, but TypeScript suppresses
+      // excess-property checking for spreads and for variables passed by
+      // reference — so `{ ...lifecycleBase }` can carry an undeclared field
+      // past the compiler. It did: `userId` rode every job lifecycle emit
+      // even though only `_userId` (gateway-injected) is declared. This
+      // pins the payload shapes so the next one is caught here instead.
+      vi.mocked(processHighlightJob).mockResolvedValue({
+        annotations: [{ id: 'a1' }] as never,
+        result: { highlightsFound: 1, highlightsCreated: 1 } as never,
+      });
+      const h = makeFakeSessionAndAdapter();
+
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
+
+      const keysOf = (channel: string) =>
+        Object.keys(h.busEmits.find(e => e.channel === channel)!.payload as object).sort();
+
+      expect(keysOf('job:start')).toEqual(['jobId', 'jobType', 'resourceId']);
+      expect(keysOf('job:complete')).toEqual(['jobId', 'jobType', 'resourceId', 'result']);
+      expect(keysOf('mark:create')).toEqual(['annotation', 'resourceId']);
+    });
+  });
+
   describe('unknown job type', () => {
     it('fails an unrecognized type without emitting — the lifecycle field is enumerated', async () => {
       const h = makeFakeSessionAndAdapter();

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -423,17 +423,33 @@ describe('handleJob orchestration', () => {
   });
 
   describe('unknown job type', () => {
-    it('calls adapter.failJob with a descriptive message after emitting job:start', async () => {
+    it('fails an unrecognized type without emitting — the lifecycle field is enumerated', async () => {
       const h = makeFakeSessionAndAdapter();
 
       await handleJob(h.adapter, makeConfig(h.session), makeJob('weird-thing' as never));
 
-      // job:start fires before the dispatch branch; unknown path calls failJob.
-      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start']);
+      // `jobType` is a required enum on every job lifecycle command, so an
+      // unrecognized value cannot produce a well-formed `job:start` — the
+      // gateway would reject it. Fail fast instead of sending a doomed emit.
+      expect(h.busEmits).toEqual([]);
       const fail = h.adapterCalls.find(c => c.method === 'failJob');
       expect(fail).toBeDefined();
       expect(fail!.args[0]).toBe(JID);
-      expect(String(fail!.args[1])).toMatch(/Worker not configured for job type: weird-thing/);
+      expect(String(fail!.args[1])).toMatch(/Unrecognized job type: weird-thing/);
+      expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(0);
+    });
+
+    it('emits job:start, then fails a valid type this worker does not serve', async () => {
+      const h = makeFakeSessionAndAdapter();
+      const config = { ...makeConfig(h.session), jobTypes: ['generation'] };
+
+      await handleJob(h.adapter, config, makeJob('highlight-annotation'));
+
+      // A real job type the worker is simply not configured for: the lifecycle
+      // is well-formed, so it starts and then fails.
+      expect(h.busEmits.map(e => e.channel)).toEqual(['job:start']);
+      const fail = h.adapterCalls.find(c => c.method === 'failJob');
+      expect(String(fail!.args[1])).toMatch(/Worker not configured for job type: highlight-annotation/);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(0);
     });
   });

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -17,7 +17,7 @@ import { generateAnnotationId } from '@semiont/event-sourcing';
 import { didToAgent, type Logger, type ResourceId, type SupportedMediaType, type components } from '@semiont/core';
 import { reconcileSelector, createFragmentSelector, type ReconciledSelector } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
-import { locate, type PdfTextLayer } from '@semiont/content';
+import { locate, type AnchoredText } from '@semiont/content';
 import type {
   HighlightDetectionParams,
   CommentDetectionParams,
@@ -241,7 +241,7 @@ export function buildTextAnnotation(
  * than persisting geometry that doesn't back the quoted text.
  */
 export function buildPdfAnnotation(
-  layer: PdfTextLayer,
+  anchored: AnchoredText,
   resourceId: ResourceId,
   userId: string,
   generator: Agent,
@@ -251,10 +251,10 @@ export function buildPdfAnnotation(
 ) {
   // `locate` returns both the per-line rects and the overlap items it found;
   // reuse `overlap` for the containment check rather than re-scanning layer.items.
-  const { rects, overlap } = locate(layer, match.start, match.end);
+  const { rects, overlap } = locate(anchored, match.start, match.end);
 
   const coveredText = overlap.length
-    ? layer.text.substring(
+    ? anchored.text.substring(
         Math.min(...overlap.map((i) => i.start)),
         Math.max(...overlap.map((i) => i.end)),
       )

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -14,7 +14,7 @@ import { extractEntities } from './workers/detection/entity-extractor';
 import { generateResourceFromTopic } from './workers/generation/resource-generation';
 import { resolveCitationTokens, collectContextResourceIds, type GenerationCitation } from './workers/generation/citation-resolver';
 import { generateAnnotationId } from '@semiont/event-sourcing';
-import { didToAgent, type Logger, type ResourceId, type SupportedMediaType, type components } from '@semiont/core';
+import { didToAgent, type Annotation, type Logger, type ResourceId, type SupportedMediaType, type components } from '@semiont/core';
 import { reconcileSelector, createFragmentSelector, type ReconciledSelector } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 import { locate, type AnchoredText } from '@semiont/content';
@@ -46,10 +46,10 @@ export type SpanMatch = { exact: string; start: number; end: number; prefix?: st
  * so the detection processors themselves stay media-agnostic.
  */
 export type BuildAnnotation = (
-  motivation: string,
+  motivation: Motivation,
   match: SpanMatch,
-  body?: Record<string, unknown> | Record<string, unknown>[],
-) => Record<string, unknown>;
+  body?: Annotation['body'],
+) => Annotation;
 
 /**
  * Progress callback. The three positional args satisfy the minimum
@@ -67,8 +67,12 @@ export type OnProgress = (
 
 type JobProgress = components['schemas']['JobProgress'];
 
+/** The five W3C motivations this system mints — a closed vocabulary, so it is
+ *  typed as one rather than as `string`. */
+export type Motivation = Annotation['motivation'];
+
 export interface ProcessorResult<R> {
-  annotations: Record<string, unknown>[];
+  annotations: Annotation[];
   result: R;
 }
 
@@ -131,9 +135,9 @@ function annotationDedupeKey(ann: Record<string, unknown>): string {
  *
  * Applied identically by every processor below.
  */
-function dedupeAnnotations(annotations: Record<string, unknown>[]): Record<string, unknown>[] {
+function dedupeAnnotations(annotations: Annotation[]): Annotation[] {
   const seen = new Set<string>();
-  const out: Record<string, unknown>[] = [];
+  const out: Annotation[] = [];
   for (const ann of annotations) {
     const key = annotationDedupeKey(ann);
     if (seen.has(key)) continue;
@@ -148,14 +152,14 @@ export function buildTextAnnotation(
   resourceId: ResourceId,
   userId: string,
   generator: Agent,
-  motivation: string,
+  motivation: Motivation,
   match: { exact: string; start: number; end: number; prefix?: string; suffix?: string },
   // Body may be a single AnnotationBody object or a non-empty array of
   // them, OR omitted entirely. W3C treats body as optional; annotations
   // whose motivation alone conveys meaning (highlighting) legitimately
   // skip it. Every other motivation currently passes something; the
   // processor that calls this makes the choice per-motivation.
-  body?: Record<string, unknown> | Record<string, unknown>[],
+  body?: Annotation['body'],
 ) {
   // Write-time invariant. Every selector that reaches storage must be
   // internally consistent with the source content. If a worker bypasses
@@ -245,9 +249,9 @@ export function buildPdfAnnotation(
   resourceId: ResourceId,
   userId: string,
   generator: Agent,
-  motivation: string,
+  motivation: Motivation,
   match: { exact: string; start: number; end: number; prefix?: string; suffix?: string },
-  body?: Record<string, unknown> | Record<string, unknown>[],
+  body?: Annotation['body'],
 ) {
   // `locate` returns both the per-line rects and the overlap items it found;
   // reuse `overlap` for the containment check rather than re-scanning layer.items.
@@ -427,7 +431,7 @@ export async function processReferenceJob(
   let totalFound = 0;
   let totalEmitted = 0;
   let errors = 0;
-  const allAnnotations: Record<string, unknown>[] = [];
+  const allAnnotations: Annotation[] = [];
 
   onProgress(10, 'Loading resource...', 'analyzing', { requestParams });
 
@@ -476,8 +480,8 @@ export async function processReferenceJob(
     // The bind flow later appends a SpecificResource (purpose: 'linking')
     // via mark:body-updated to produce the resolved shape. Emitting an
     // empty body would break the append contract.
-    const unresolvedBody = [
-      { type: 'TextualBody', value: entityTypeName, purpose: 'tagging', format: 'text/plain' satisfies SupportedMediaType, language: bodyLanguage },
+    const unresolvedBody: Annotation['body'] = [
+      { type: 'TextualBody' as const, value: entityTypeName, purpose: 'tagging' as const, format: 'text/plain' satisfies SupportedMediaType, language: bodyLanguage },
     ];
 
     for (const entity of extractedEntities) {

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -394,6 +394,49 @@ export type AnyJob = DetectionJob | GenerationJob | HighlightDetectionJob | Asse
 // Type Guards
 // ============================================================================
 
+const JOB_TYPES: ReadonlySet<string> = new Set<JobType>([
+  'reference-annotation',
+  'generation',
+  'highlight-annotation',
+  'assessment-annotation',
+  'comment-annotation',
+  'tag-annotation',
+]);
+
+/**
+ * Narrow a job type arriving off the bus, where it is only `string`.
+ *
+ * Worth checking rather than asserting: `jobType` is a required, enumerated
+ * field on every job lifecycle command, so an unrecognized value produces a
+ * payload the backend will reject — better caught at the worker with a clear
+ * error than as an opaque emit failure.
+ */
+export function isJobType(value: string): value is JobType {
+  return JOB_TYPES.has(value);
+}
+
+/**
+ * Narrow bus-delivered job params to the shape a processor expects.
+ *
+ * Job params cross the bus as `Record<string, unknown>`. Every params type in
+ * this file requires exactly one field — `resourceId` — with the rest
+ * optional, so that is what gets verified; absent optionals are legitimately
+ * absent, not a validation failure. Callers pass the params type for the job
+ * they have already branched on.
+ */
+export function asJobParams<T extends { resourceId: ResourceId }>(
+  params: Record<string, unknown>,
+): T {
+  if (typeof params.resourceId !== 'string') {
+    throw new Error('Job params are missing a resourceId');
+  }
+  return params as unknown as T;
+}
+
+// Generation params are deliberately NOT covered: generation is the one job
+// that does not read a source resource (it mints one), so it requires no
+// `resourceId` and there is nothing to verify.
+
 export function isPendingJob(job: AnyJob): job is PendingJob<any> {
   return job.status === 'pending';
 }

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -194,8 +194,13 @@ async function handleJobInner(
   // Resource-scoped jobs (bulk reference/tag/highlight/comment/
   // assessment detection scanning a whole resource) leave it unset.
   const annotationId = (job.params as { referenceId?: string }).referenceId;
+  // No `userId`: the job lifecycle commands declare only `_userId`, injected by
+  // the gateway from the authenticated session. Spreading an extra field would
+  // put out-of-contract data on a global channel — and would not be caught by
+  // `emitEvent`'s typing, because TypeScript suppresses excess-property checks
+  // for spreads and for variables passed by reference.
   const lifecycleBase = {
-    resourceId, userId, jobId, jobType,
+    resourceId, jobId, jobType,
     ...(annotationId ? { annotationId } : {}),
   };
 

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -18,11 +18,11 @@
 import { createJobClaimAdapter, type JobClaimAdapter, type ActiveJob } from './job-claim-adapter';
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
-import { getPrimaryMediaType, textExtractionOf, assembleAnnotation, type EventMap } from '@semiont/core';
+import { getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, type EventMap } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
-import type { Logger, ResourceId, components } from '@semiont/core';
+import type { Logger, components } from '@semiont/core';
 import { deriveStorageUri } from '@semiont/content';
-import { prepareDetection } from './workers/detection/prepare-detection';
+import { prepareDetection, type DetectionDecline } from './workers/detection/prepare-detection';
 import { SpanKind, recordJobOutcome, withSpan } from '@semiont/observability';
 import {
   processHighlightJob,
@@ -32,9 +32,23 @@ import {
   processTagJob,
   processGenerationJob,
   type OnProgress,
+  type BuildAnnotation,
 } from './processors';
 
 type Agent = components['schemas']['Agent'];
+
+/**
+ * What the user is told when a resource cannot be read. Keyed by the
+ * extraction vocabulary, minus `no-extractor` — that one is a user error
+ * (detection asked of a media type that can never yield text) and throws.
+ */
+const DECLINE_MESSAGES: Record<Exclude<DetectionDecline['declined'], 'no-extractor'>, string> = {
+  'no-text-layer': 'This PDF is a scan whose text could not be recognized; there is nothing to detect over.',
+  'encrypted': 'This PDF is password-protected, so its text cannot be read.',
+  'corrupt': 'This PDF could not be parsed — the file may be damaged or truncated.',
+  'too-large': 'This document is too large to extract text from.',
+  'empty': 'This document contains no text to detect over.',
+};
 
 export interface WorkerProcessConfig {
   /**
@@ -148,7 +162,11 @@ async function handleJobInner(
   job: ActiveJob,
 ): Promise<void> {
   const { session, inferenceClient, generator } = config;
-  const { resourceId, userId, jobId, type: jobType } = job;
+  const { userId, jobId, type: jobType } = job;
+  // The job arrives off the bus with a plain-string id — this is the entry
+  // boundary, so brand once here rather than casting at every call that wants
+  // a `ResourceId` (BRAND-UPSTREAM).
+  const resourceId = makeResourceId(job.resourceId);
 
   // Annotation-scoped jobs (today: generation, triggered from a
   // reference) carry the source annotation through every lifecycle
@@ -176,33 +194,38 @@ async function handleJobInner(
   }
 
   // Detection needs the resource's text plus a media-appropriate way to anchor a
-  // detected span. Both come from the media-type registry's extraction strategy
-  // (textExtractionOf, see prepareDetection): 'decode' -> decoded text + text
-  // selectors, 'pdf-text-layer' -> extracted layer + viewrect selectors. Gating
-  // on the strategy up front keeps binary bytes away from the model — a 'none'
-  // type would TextDecoder-decode to mojibake. A scanned PDF (no text layer)
-  // declines cleanly; a non-textual 'none' type is a user error and throws
-  // (surfaces as job:fail via the startWorkerProcess catch). Generation reads the
+  // detected span. Both come from `prepareDetection`, which reads through the
+  // same extractor registry the Smelter embeds from — so a resource that can be
+  // embedded can be detected over, scanned PDFs included.
+  //
+  // Two failures, deliberately distinguished. A media type with no extractor at
+  // all ('none' — a zip, an image) can never yield text, so asking to detect
+  // over it is a user error and throws (surfaces as job:fail). A resource whose
+  // extraction *failed* — encrypted, corrupt, a scan OCR could not read —
+  // declines cleanly and completes the job saying which. Generation reads the
   // annotation in its params, not the source bytes, so it is not prepared here.
-  let source: Awaited<ReturnType<typeof prepareDetection>> = null;
+  let ready: { text: string; buildAnnotation: BuildAnnotation } | null = null;
   if (jobType !== 'generation') {
-    const descriptor = await session.client.browse.resource(resourceId as never).fresh();
+    const descriptor = await session.client.browse.resource(resourceId).fresh();
     const mediaType = getPrimaryMediaType(descriptor);
-    const strategy = mediaType ? textExtractionOf(mediaType) : 'none';
-    if (strategy === 'none') {
-      throw new Error(`Cannot run ${jobType} on resource ${resourceId}: media type '${mediaType ?? 'unknown'}' has no extractable text to analyze`);
-    }
-    source = await prepareDetection(strategy, session, resourceId as ResourceId, userId, generator);
-    if (!source) {
-      // 'pdf-text-layer' that yielded no text layer: a scanned / image-only PDF.
-      // Decline cleanly (not a crash) — complete the job with a no-text-layer result.
+    const source = await prepareDetection(mediaType ?? '', session, resourceId, userId, generator);
+
+    if ('declined' in source) {
+      if (source.declined === 'no-extractor') {
+        throw new Error(`Cannot run ${jobType} on resource ${resourceId}: media type '${mediaType ?? 'unknown'}' has no extractable text to analyze`);
+      }
       await emitEvent(session, 'job:complete', {
         ...lifecycleBase,
-        result: { declined: true, reason: 'no-text-layer', message: 'This PDF has no extractable text layer (scanned or image-only); detection is not supported.' } as never,
+        result: {
+          declined: true,
+          reason: source.declined,
+          message: DECLINE_MESSAGES[source.declined],
+        } as never,
       });
       adapter.completeJob();
       return;
     }
+    ready = source;
   }
 
   const onProgress: OnProgress = (percentage, message, stage, extra) => {
@@ -223,7 +246,7 @@ async function handleJobInner(
 
   if (jobType === 'highlight-annotation') {
     const { annotations, result } = await processHighlightJob(
-      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -236,7 +259,7 @@ async function handleJobInner(
 
   } else if (jobType === 'comment-annotation') {
     const { annotations, result } = await processCommentJob(
-      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -249,7 +272,7 @@ async function handleJobInner(
 
   } else if (jobType === 'assessment-annotation') {
     const { annotations, result } = await processAssessmentJob(
-      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -262,7 +285,7 @@ async function handleJobInner(
 
   } else if (jobType === 'reference-annotation') {
     const { annotations, result } = await processReferenceJob(
-      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress, config.logger,
+      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress, config.logger,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
@@ -275,7 +298,7 @@ async function handleJobInner(
 
   } else if (jobType === 'tag-annotation') {
     const { annotations, result } = await processTagJob(
-      source!.text, inferenceClient, job.params as never, source!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
       await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -16,6 +16,17 @@
  */
 
 import { createJobClaimAdapter, type JobClaimAdapter, type ActiveJob } from './job-claim-adapter';
+import {
+  asJobParams,
+  isJobType,
+  type AssessmentDetectionParams,
+  type CommentDetectionParams,
+  type DetectionParams,
+  type GenerationParams,
+  type HighlightDetectionParams,
+  type JobType,
+  type TagDetectionParams,
+} from './types';
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
 import { getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, type EventMap } from '@semiont/core';
@@ -80,7 +91,7 @@ export interface WorkerProcessConfig {
 async function emitEvent<K extends keyof EventMap>(
   session: SemiontSession,
   channel: K,
-  payload: Record<string, unknown>,
+  payload: EventMap[K],
 ): Promise<void> {
   // All worker-emitted bus events are global. `job:complete` / `job:fail`
   // are global, `jobId`-keyed correlation signals (#847): the dispatching
@@ -109,14 +120,15 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
       const message = error instanceof Error ? error.message : String(error);
       logger.error('Job failed', { jobId: job.jobId, error: message, stack: error instanceof Error ? error.stack : undefined });
       const failAnnotationId = (job.params as { referenceId?: string }).referenceId;
-      emitEvent(session, 'job:fail', {
-        resourceId: job.resourceId,
-        userId: job.userId,
-        jobId: job.jobId,
-        jobType: job.type,
-        ...(failAnnotationId ? { annotationId: failAnnotationId } : {}),
-        error: message,
-      }).catch(() => {});
+      if (isJobType(job.type)) {
+        emitEvent(session, 'job:fail', {
+          resourceId: job.resourceId,
+          jobId: job.jobId,
+          jobType: job.type,
+          ...(failAnnotationId ? { annotationId: failAnnotationId } : {}),
+          error: message,
+        }).catch(() => {});
+      }
       adapter.failJob(job.jobId, message);
     });
   });
@@ -144,7 +156,7 @@ export async function handleJob(
         attrs: {
           'job.type': job.type,
           'job.id': job.jobId,
-          'resource.id': job.resourceId as unknown as string,
+          'resource.id': job.resourceId,
         },
       },
     );
@@ -162,7 +174,15 @@ async function handleJobInner(
   job: ActiveJob,
 ): Promise<void> {
   const { session, inferenceClient, generator } = config;
-  const { userId, jobId, type: jobType } = job;
+  const { userId, jobId } = job;
+  // `jobType` is a required, enumerated field on every lifecycle command, but
+  // arrives off the bus as a plain string. Narrow once here so the emits below
+  // are checked against the wire contract instead of asserted past it.
+  if (!isJobType(job.type)) {
+    adapter.failJob(jobId, `Unrecognized job type: ${job.type}`);
+    return;
+  }
+  const jobType: JobType = job.type;
   // The job arrives off the bus with a plain-string id — this is the entry
   // boundary, so brand once here rather than casting at every call that wants
   // a `ResourceId` (BRAND-UPSTREAM).
@@ -220,7 +240,7 @@ async function handleJobInner(
           declined: true,
           reason: source.declined,
           message: DECLINE_MESSAGES[source.declined],
-        } as never,
+        },
       });
       adapter.completeJob();
       return;
@@ -246,72 +266,72 @@ async function handleJobInner(
 
   if (jobType === 'highlight-annotation') {
     const { annotations, result } = await processHighlightJob(
-      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, asJobParams<HighlightDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
-      await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
+      await emitEvent(session, 'mark:create', { annotation: ann, resourceId });
     }
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
-      result: result as never,
+      result,
     });
     adapter.completeJob();
 
   } else if (jobType === 'comment-annotation') {
     const { annotations, result } = await processCommentJob(
-      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, asJobParams<CommentDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
-      await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
+      await emitEvent(session, 'mark:create', { annotation: ann, resourceId });
     }
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
-      result: result as never,
+      result,
     });
     adapter.completeJob();
 
   } else if (jobType === 'assessment-annotation') {
     const { annotations, result } = await processAssessmentJob(
-      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, asJobParams<AssessmentDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
-      await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
+      await emitEvent(session, 'mark:create', { annotation: ann, resourceId });
     }
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
-      result: result as never,
+      result,
     });
     adapter.completeJob();
 
   } else if (jobType === 'reference-annotation') {
     const { annotations, result } = await processReferenceJob(
-      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress, config.logger,
+      ready!.text, inferenceClient, asJobParams<DetectionParams>(job.params), ready!.buildAnnotation, onProgress, config.logger,
     );
     for (const ann of annotations) {
-      await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
+      await emitEvent(session, 'mark:create', { annotation: ann, resourceId });
     }
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
-      result: result as never,
+      result,
     });
     adapter.completeJob();
 
   } else if (jobType === 'tag-annotation') {
     const { annotations, result } = await processTagJob(
-      ready!.text, inferenceClient, job.params as never, ready!.buildAnnotation, onProgress,
+      ready!.text, inferenceClient, asJobParams<TagDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
     );
     for (const ann of annotations) {
-      await emitEvent(session, 'mark:create', { annotation: ann, userId, resourceId });
+      await emitEvent(session, 'mark:create', { annotation: ann, resourceId });
     }
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
-      result: result as never,
+      result,
     });
     adapter.completeJob();
 
   } else if (jobType === 'generation') {
     const genResult = await processGenerationJob(
-      inferenceClient, job.params as never, onProgress, config.logger,
+      inferenceClient, job.params as GenerationParams, onProgress, config.logger,
     );
 
     // Content never travels on the bus. Upload via the http-transport's
@@ -354,7 +374,7 @@ async function handleJobInner(
         },
         generator,
       );
-      await emitEvent(session, 'mark:create', { annotation: provenanceRef, userId, resourceId });
+      await emitEvent(session, 'mark:create', { annotation: provenanceRef, resourceId });
     }
 
     // Inline citations (INLINE-CITATIONS P1): the processor resolved the model's
@@ -377,12 +397,12 @@ async function handleJobInner(
         },
         generator,
       );
-      await emitEvent(session, 'mark:create', { annotation: citationRef, userId, resourceId: newResourceId });
+      await emitEvent(session, 'mark:create', { annotation: citationRef, resourceId: newResourceId });
     }
 
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
-      result: { resourceId: newResourceId, resourceName: genResult.title } as never,
+      result: { resourceId: newResourceId, resourceName: genResult.title },
     });
     adapter.completeJob();
 

--- a/packages/jobs/src/workers/detection/prepare-detection.ts
+++ b/packages/jobs/src/workers/detection/prepare-detection.ts
@@ -1,49 +1,79 @@
 import type { SemiontSession } from '@semiont/sdk';
-import type { ResourceId, TextExtraction, components } from '@semiont/core';
-import { extractPdfTextLayer } from '@semiont/content';
+import type { ResourceId, components } from '@semiont/core';
+import { textExtractionOf } from '@semiont/core';
+import { EXTRACTORS, type ExtractionDecline } from '@semiont/content';
 import { buildTextAnnotation, buildPdfAnnotation, type BuildAnnotation } from '../../processors';
 
 type Agent = components['schemas']['Agent'];
 
 /**
- * For one detection job, resolve the text the model detects over and the
- * media-appropriate way to turn a detected span into a stored annotation —
- * keyed by the media-type registry's `TextExtraction` strategy
- * (`textExtractionOf`). The detection processors stay media-agnostic: they take
- * the `.text` and the returned `buildAnnotation` and never see a layer or a
- * media type. Adding a media type is a new `case` here, nothing on the processors.
+ * What a detection job needs to run, or why it cannot.
  *
- * Returns `null` when the resource has no usable text (a scanned/image-only PDF,
- * or a non-textual `'none'` type), so the dispatch can decline cleanly instead
- * of running the model on nothing.
+ * Discriminated the same way `ContentExtractor` reports its own outcome —
+ * `'declined' in result` — so one idiom covers extraction end to end rather
+ * than a `null` that cannot say what went wrong.
+ */
+export type DetectionSource =
+  | { text: string; buildAnnotation: BuildAnnotation }
+  | DetectionDecline;
+
+/**
+ * Why detection could not read a resource. Widens the extractor's own reasons
+ * with the two only a *caller* can observe: no extractor exists for the media
+ * type at all, and extraction succeeded but produced nothing. Same vocabulary
+ * the Smelter reports on `smelt:settled`, so one resource declines identically
+ * whichever verb asked.
+ */
+export type DetectionDecline = {
+  declined: ExtractionDecline['declined'] | 'no-extractor' | 'empty';
+};
+
+/**
+ * For one detection job, resolve the text the model detects over and the
+ * media-appropriate way to turn a detected span into a stored annotation.
+ *
+ * Extraction goes through the **same registry the Smelter embeds from**
+ * (`EXTRACTORS`, keyed by the media-type registry's `TextExtraction`
+ * strategy), so detection and embedding always read a resource identically —
+ * including scanned PDFs, which are read by OCR rather than declined.
+ *
+ * The anchoring model follows the geometry, not the media type: an extraction
+ * that carries positioned runs anchors spatially (page + viewrect), one that
+ * does not anchors by character offset. Detection processors stay
+ * media-agnostic — they take `.text` and the returned `buildAnnotation`, and
+ * never see a layer or a media type.
  */
 export async function prepareDetection(
-  strategy: TextExtraction,
+  mediaType: string,
   session: SemiontSession,
   resourceId: ResourceId,
   userId: string,
   generator: Agent,
-): Promise<{ text: string; buildAnnotation: BuildAnnotation } | null> {
-  switch (strategy) {
-    case 'decode': {
-      const text = await session.client.browse.resourceContent(resourceId as never);
-      return {
-        text,
-        buildAnnotation: (motivation, match, body) =>
-          buildTextAnnotation(text, resourceId, userId, generator, motivation, match, body),
-      };
-    }
-    case 'pdf-text-layer': {
-      const { data } = await session.client.browse.resourceRepresentation(resourceId as never);
-      const layer = await extractPdfTextLayer(new Uint8Array(data));
-      if (!layer) return null; // scanned / image-only PDF — no text layer
-      return {
-        text: layer.text,
-        buildAnnotation: (motivation, match, body) =>
-          buildPdfAnnotation(layer, resourceId, userId, generator, motivation, match, body),
-      };
-    }
-    case 'none':
-      return null;
+): Promise<DetectionSource> {
+  const extractor = EXTRACTORS[textExtractionOf(mediaType)];
+  if (!extractor) return { declined: 'no-extractor' };
+
+  const { data } = await session.client.browse.resourceRepresentation(resourceId);
+  const extracted = await extractor.extract(Buffer.from(data), mediaType);
+  if ('declined' in extracted) return extracted;
+  if (!extracted.text.trim()) return { declined: 'empty' };
+
+  // Positioned runs mean the source has real geometry to anchor to — a PDF's
+  // text layer, its form widgets, its table cells, or OCR'd words. Without
+  // them the text itself is the coordinate system.
+  const items = extracted.items;
+  if (items && items.length > 0) {
+    const anchored = { text: extracted.text, items };
+    return {
+      text: extracted.text,
+      buildAnnotation: (motivation, match, body) =>
+        buildPdfAnnotation(anchored, resourceId, userId, generator, motivation, match, body),
+    };
   }
+
+  return {
+    text: extracted.text,
+    buildAnnotation: (motivation, match, body) =>
+      buildTextAnnotation(extracted.text, resourceId, userId, generator, motivation, match, body),
+  };
 }

--- a/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
+++ b/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
@@ -653,6 +653,36 @@ describe('generateResourceFromTopic', () => {
       expect(prompt).not.toContain('Source document context');
     });
 
+    it('warns the model when a passage was recognized from a scan', async () => {
+      // The model is the only reader of these passages — nobody sees the page
+      // it came from — so without this it would quote a scanned figure as
+      // confidently as a typed one.
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined,
+        makeResourceContext({
+          semanticContext: [
+            { text: 'TYPED-PASSAGE', resourceId: 'r1', score: 0.9 },
+            { text: 'SCANNED-PASSAGE', resourceId: 'r2', score: 0.8, machineRead: true },
+          ],
+        }),
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toMatch(/\[OCR\] SCANNED-PASSAGE/);
+      expect(prompt).toContain('character recognition');
+      // The passage read straight from its document carries no such caveat.
+      expect(prompt).toMatch(/\(0\.90\) TYPED-PASSAGE/);
+    });
+
+    it('says nothing about OCR when no passage was machine-read', async () => {
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined,
+        makeResourceContext({ semanticContext: [{ text: 'TYPED-PASSAGE', resourceId: 'r1', score: 0.9 }] }),
+      );
+
+      expect(promptArg()).not.toContain('character recognition');
+    });
+
     it('grounds the prompt in the resource summary, suggested references, and content', async () => {
       client.setResponses(['# X\n\nbody']);
       const context: GatheredContext = {

--- a/packages/jobs/src/workers/generation/resource-generation.ts
+++ b/packages/jobs/src/workers/generation/resource-generation.ts
@@ -202,8 +202,16 @@ ${after ? `${after}...` : ''}
     const lines = [...similar]
       .sort((a, b) => b.score - a.score)
       .slice(0, SEMANTIC_MATCH_LIMIT)
-      .map(m => `- ${idLabel(m.resourceId, m.annotationId)} (${m.score.toFixed(2)}) ${m.text.slice(0, SEMANTIC_MATCH_CHARS)}`);
-    semanticContextSection = `\n\nRelated passages from the knowledge base:\n${lines.join('\n')}`;
+      .map(m => `- ${idLabel(m.resourceId, m.annotationId)} (${m.score.toFixed(2)})${m.machineRead ? ' [OCR]' : ''} ${m.text.slice(0, SEMANTIC_MATCH_CHARS)}`);
+    // A passage marked [OCR] was recognized from a scanned image, so its
+    // wording — and especially its digits — may be misread. Saying so is the
+    // whole point of carrying the flag: the model is the only reader of these
+    // passages, and it would otherwise quote a scanned figure as confidently
+    // as a typed one.
+    const ocrNote = similar.some(m => m.machineRead)
+      ? '\nPassages marked [OCR] were read from scanned images by character recognition; treat their exact wording and numbers as uncertain, and say so if you rely on one.'
+      : '';
+    semanticContextSection = `\n\nRelated passages from the knowledge base:\n${lines.join('\n')}${ocrNote}`;
   }
 
   // ── Task framing (YIELD-STRUCTURE D1): canonical tasks map to tested framings;

--- a/packages/make-meaning/src/__tests__/smelter.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter.test.ts
@@ -468,6 +468,28 @@ describe('Smelter PDF embedding (Phase 1 — SMELTER-MEDIA-TYPES #744)', () => {
     }
   });
 
+  it('an annotation on a machine-read resource inherits the stamp', async () => {
+    // Annotation-focus gather searches annotation vectors, so a passage that
+    // came from OCR has to say so here too — otherwise half the gather paths
+    // lose the provenance the other half carries.
+    const h = await pdfHarness({ 'res-scan': SCANNED_PDF });
+    vi.mocked(EXTRACTORS['pdf-text-layer']!.extract).mockResolvedValueOnce({
+      text: 'recovered from a scan', items: [], method: 'ocr', pdfClass: 'B',
+    });
+    try {
+      h.events$.next({ type: 'yield:created', resourceId: 'res-scan', payload: {} });
+      await tick();
+      h.events$.next(annotationEvent('res-scan', 'ann-scan', 'recovered from a scan'));
+      await tick();
+
+      const [result] = await h.vectorStore.searchAnnotations(deterministicEmbed('recovered from a scan'), { limit: 5 });
+      expect(result!.annotationId).toBe('ann-scan');
+      expect(result!.machineRead).toBe(true);
+    } finally {
+      h.smelter.stop();
+    }
+  });
+
   it('leaves the stamp off a PDF read directly from its text layer', async () => {
     const h = await pdfHarness({ 'res-native': NATIVE_PDF });
     try {

--- a/packages/make-meaning/src/__tests__/smelter.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter.test.ts
@@ -20,7 +20,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import type { EventMap, components } from '@semiont/core';
 import { resourceId as makeResourceId, chunkText } from '@semiont/core';
-import { calculateChecksum, extractPdfTextLayer } from '@semiont/content';
+import { calculateChecksum, extractPdfTextLayer, EXTRACTORS } from '@semiont/content';
+
+vi.mock('@semiont/content', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@semiont/content')>();
+  return {
+    ...actual,
+    EXTRACTORS: {
+      ...actual.EXTRACTORS,
+      'pdf-text-layer': { extract: vi.fn(actual.EXTRACTORS['pdf-text-layer']!.extract) },
+    },
+  };
+});
 import { MemoryVectorStore } from '@semiont/vectors';
 import type { EmbeddingProvider } from '@semiont/vectors';
 import type { BusRequestPrimitive, ConnectionState } from '@semiont/core';
@@ -430,6 +441,41 @@ describe('Smelter PDF embedding (Phase 1 — SMELTER-MEDIA-TYPES #744)', () => {
         { resourceId: 'res-native', contentChecksum: rawChecksum, outcome: 'indexed' },
       ]);
       expect((await h.vectorStore.listResourceStamps()).get('res-native')?.contentChecksum).toBe(rawChecksum);
+    } finally {
+      h.smelter.stop();
+    }
+  });
+
+  it('stamps machine-read provenance on vectors whose text came from OCR', async () => {
+    // The chunk reaches its consumers — today, LLM prompts — with no document
+    // attached, and nothing downstream can recompute how the text was
+    // obtained. So the projection that carries the text carries the fact.
+    const h = await pdfHarness({ 'res-scan': SCANNED_PDF });
+    vi.mocked(EXTRACTORS['pdf-text-layer']!.extract).mockResolvedValueOnce({
+      text: 'recovered from a scan',
+      items: [],
+      method: 'ocr',
+      pdfClass: 'B',
+    });
+    try {
+      h.events$.next({ type: 'yield:created', resourceId: 'res-scan', payload: {} });
+      await tick();
+      const [result] = await h.vectorStore.searchResources(deterministicEmbed('recovered from a scan'), { limit: 5 });
+      expect(result!.resourceId).toBe('res-scan');
+      expect(result!.machineRead).toBe(true);
+    } finally {
+      h.smelter.stop();
+    }
+  });
+
+  it('leaves the stamp off a PDF read directly from its text layer', async () => {
+    const h = await pdfHarness({ 'res-native': NATIVE_PDF });
+    try {
+      h.events$.next({ type: 'yield:created', resourceId: 'res-native', payload: {} });
+      await tick();
+      const results = await h.vectorStore.searchResources(deterministicEmbed('anything'), { limit: 5 });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]!.machineRead).toBeUndefined();
     } finally {
       h.smelter.stop();
     }

--- a/packages/make-meaning/src/annotation-context.ts
+++ b/packages/make-meaning/src/annotation-context.ts
@@ -270,6 +270,7 @@ Summary:`;
               annotationId: r.annotationId,
               score: r.score,
               entityTypes: r.entityTypes,
+              ...(r.machineRead ? { machineRead: true } : {}),
             })),
           };
           logger?.debug('Semantic context found', { matches: results.length });

--- a/packages/make-meaning/src/llm-context.ts
+++ b/packages/make-meaning/src/llm-context.ts
@@ -167,6 +167,7 @@ export class LLMContext {
             ...(m.annotationId ? { annotationId: m.annotationId } : {}),
             score: m.score,
             ...(m.entityTypes ? { entityTypes: m.entityTypes } : {}),
+            ...(m.machineRead ? { machineRead: true } : {}),
           })),
           ...(excludeEntityTypes.length ? { excludedEntityTypes: excludeEntityTypes } : {}),
         };

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -136,7 +136,7 @@ function isWorkItem(input: SmelterInput): input is SmelterWorkItem {
 type SkipReason = NonNullable<EventMap['smelt:settled']['reason']>;
 
 type FetchedContent =
-  | { kind: 'text'; text: string; checksum: string }
+  | { kind: 'text'; text: string; checksum: string; machineRead: boolean }
   | { kind: 'skipped'; checksum: string; reason: SkipReason }
   | { kind: 'unavailable' };
 
@@ -412,7 +412,12 @@ export class Smelter {
           unreadPages: extracted.unreadPages,
         });
       }
-      return extracted.text.trim() ? { kind: 'text', text: extracted.text, checksum } : { kind: 'skipped', checksum, reason: 'empty' };
+      // Provenance for the projection: text recognized from pixels is not the
+      // same claim as text read from the document, and no consumer downstream
+      // can tell the difference once the chunk travels alone.
+      return extracted.text.trim()
+        ? { kind: 'text', text: extracted.text, checksum, machineRead: extracted.method === 'ocr' }
+        : { kind: 'skipped', checksum, reason: 'empty' };
     } catch (error) {
       this.logger.warn('Content unavailable for embedding', { resourceId, error: errField(error) });
       return { kind: 'unavailable' };
@@ -480,7 +485,7 @@ export class Smelter {
       chunkIndex: i, text: t, embedding: embeddings[i],
     }));
 
-    await this.vectorStore.upsertResourceVectors(makeResourceId(rid), embeddingChunks, fetched.checksum, entityTypes);
+    await this.vectorStore.upsertResourceVectors(makeResourceId(rid), embeddingChunks, fetched.checksum, entityTypes, fetched.machineRead);
     await this.emitSettled(rid, fetched.checksum, 'indexed');
     this.logger.info(logMessage, { resourceId: rid, chunks: chunks.length });
   }
@@ -562,7 +567,7 @@ export class Smelter {
    * embedBatch() call, then index per resource.
    */
   private async batchResourceCreated(events: SmelterInput[]): Promise<number> {
-    const resourceData: { rid: ResourceId; chunks: string[]; checksum: string; entityTypes: string[] }[] = [];
+    const resourceData: { rid: ResourceId; chunks: string[]; checksum: string; entityTypes: string[]; machineRead: boolean }[] = [];
     const allChunks: string[] = [];
 
     for (const event of events) {
@@ -586,7 +591,7 @@ export class Smelter {
       }
 
       const entityTypes = await this.resolveEntityTypes(rid);
-      resourceData.push({ rid: makeResourceId(rid), chunks, checksum: fetched.checksum, entityTypes });
+      resourceData.push({ rid: makeResourceId(rid), chunks, checksum: fetched.checksum, entityTypes, machineRead: fetched.machineRead });
       allChunks.push(...chunks);
     }
 
@@ -595,11 +600,11 @@ export class Smelter {
     const allEmbeddings = await this.embeddingProvider.embedBatch(allChunks);
 
     let offset = 0;
-    for (const { rid, chunks, checksum, entityTypes } of resourceData) {
+    for (const { rid, chunks, checksum, entityTypes, machineRead } of resourceData) {
       const embeddingChunks: EmbeddingChunk[] = chunks.map((t, i) => ({
         chunkIndex: i, text: t, embedding: allEmbeddings[offset + i],
       }));
-      await this.vectorStore.upsertResourceVectors(rid, embeddingChunks, checksum, entityTypes);
+      await this.vectorStore.upsertResourceVectors(rid, embeddingChunks, checksum, entityTypes, machineRead);
       await this.emitSettled(String(rid), checksum, 'indexed');
       this.logger.info('Batch-indexed resource', { resourceId: String(rid), chunks: chunks.length });
       offset += chunks.length;

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -543,12 +543,20 @@ export class Smelter {
     const aid = makeAnnotationId(annotation.id);
     const embedding = await this.embeddingProvider.embed(exactText);
 
+    // An annotation quotes its resource's text, so it inherits that text's
+    // provenance — but the annotation record does not carry it, and
+    // re-deriving it would mean re-extracting (for a scan, re-running OCR).
+    // Read it from the resource's own stamp instead: one targeted lookup,
+    // trivial beside the embedding call just made.
+    const stamp = await this.vectorStore.getResourceStamp(makeResourceId(rid));
+
     const payload: AnnotationPayload = {
       annotationId: aid,
       resourceId: makeResourceId(rid),
       motivation: annotation.motivation ?? '',
       entityTypes: ((annotation as Record<string, unknown>).entityTypes as string[] | undefined) ?? [],
       exactText,
+      ...(stamp?.machineRead ? { machineRead: true } : {}),
     };
     await this.vectorStore.upsertAnnotationVector(aid, embedding, payload);
     this.logger.info('Indexed annotation', { annotationId: String(aid) });

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -390,6 +390,18 @@ export class Smelter {
         this.logger.debug('Extractor declined', { resourceId, contentType, reason: extracted.declined });
         return { kind: 'skipped', checksum, reason: extracted.declined };
       }
+      if (extracted.ocrConfidence && extracted.ocrConfidence.lowConfidenceWords > 0) {
+        // Extraction quality, not anchor quality: the vectors and any
+        // annotations sit exactly where they belong, but some words under
+        // them may be misread. Reported to operators rather than stored —
+        // no client can recompute it, and it is a property of the document's
+        // text rather than of any one anchor.
+        this.logger.info('OCR read words it was unsure of', {
+          resourceId,
+          contentType,
+          ...extracted.ocrConfidence,
+        });
+      }
       if (extracted.unreadPages?.length) {
         // Partial coverage: this resource embeds, but semantic search cannot
         // see these pages until they are OCR'd. Logged where it is known, so

--- a/packages/react-ui/src/lib/job-outcome.ts
+++ b/packages/react-ui/src/lib/job-outcome.ts
@@ -1,12 +1,13 @@
 import { isObject, isString } from '@semiont/core';
 
 /**
- * A detection job can *decline* cleanly rather than succeed or fail — today:
- * a scanned / image-only PDF with no text layer to analyze (#736/#738). The
- * worker reports it on `job:complete` as a `{ declined, reason, message }`
- * result, which is not in the typed `JobResult` union, so narrow it
- * structurally. Returns the user-facing message, or null for an ordinary
- * (non-declined) result.
+ * A detection job can *decline* cleanly rather than succeed or fail: a PDF
+ * that is encrypted, damaged, or a scan whose text could not be recognized.
+ * The worker reports it on `job:complete` as a `{ declined, reason, message }`
+ * result — `JobDeclinedResult`, a member of the typed `JobResult` union since
+ * #739. Narrowed structurally anyway: this runs against whatever the wire
+ * delivered, and a runtime check is the honest guard at that boundary.
+ * Returns the user-facing message, or null for an ordinary result.
  *
  * A decline is neither a success nor an error: the caller should surface it as
  * info — not a "complete" success toast (misleading — nothing was detected) and

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -367,6 +367,48 @@ func (e JobCancelRequestJobType) Valid() bool {
 	}
 }
 
+// Defines values for JobDeclinedResultDeclined.
+const (
+	True JobDeclinedResultDeclined = true
+)
+
+// Valid indicates whether the value is a known member of the JobDeclinedResultDeclined enum.
+func (e JobDeclinedResultDeclined) Valid() bool {
+	switch e {
+	case True:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for JobDeclinedResultReason.
+const (
+	Corrupt     JobDeclinedResultReason = "corrupt"
+	Empty       JobDeclinedResultReason = "empty"
+	Encrypted   JobDeclinedResultReason = "encrypted"
+	NoTextLayer JobDeclinedResultReason = "no-text-layer"
+	TooLarge    JobDeclinedResultReason = "too-large"
+)
+
+// Valid indicates whether the value is a known member of the JobDeclinedResultReason enum.
+func (e JobDeclinedResultReason) Valid() bool {
+	switch e {
+	case Corrupt:
+		return true
+	case Empty:
+		return true
+	case Encrypted:
+		return true
+	case NoTextLayer:
+		return true
+	case TooLarge:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for JobStatusResponseStatus.
 const (
 	Cancelled JobStatusResponseStatus = "cancelled"
@@ -2172,6 +2214,24 @@ type JobCreatedResult struct {
 	} `json:"response"`
 }
 
+// JobDeclinedResult Result of a job that completed without doing its work because the resource could not be read. Distinct from a failure: nothing went wrong, there was simply no text to work with — an encrypted or damaged PDF, a scan whose text could not be recognized, or a document that yielded nothing. The reasons are the extraction vocabulary the Smelter reports on `smelt:settled`, MINUS `no-extractor`: a media type that can never yield text (a zip, an image) is a bad request rather than a decline, so a worker asked to detect over one throws and the job reports `job:fail`. Everything here is a resource-specific outcome — the same media type would have succeeded on a different document.
+type JobDeclinedResult struct {
+	// Declined Discriminant. Always true — a job that did its work reports one of the other result shapes.
+	Declined JobDeclinedResultDeclined `json:"declined"`
+
+	// Message Human-readable explanation, suitable for showing to the user.
+	Message string `json:"message"`
+
+	// Reason Why the resource could not be read.
+	Reason JobDeclinedResultReason `json:"reason"`
+}
+
+// JobDeclinedResultDeclined Discriminant. Always true — a job that did its work reports one of the other result shapes.
+type JobDeclinedResultDeclined bool
+
+// JobDeclinedResultReason Why the resource could not be read.
+type JobDeclinedResultReason string
+
 // JobFailCommand Command to mark a job as failed
 type JobFailCommand struct {
 	// UnderscoreUserId Authenticated user's DID, injected by the /bus/emit gateway. Clients do not set this.
@@ -3254,6 +3314,9 @@ type SemanticMatch struct {
 
 	// EntityTypes Entity types on the matched passage
 	EntityTypes *[]string `json:"entityTypes,omitempty"`
+
+	// MachineRead True when this passage's text was recognized from pixels (OCR of a scanned page) rather than read from the document. Absent means read directly — the common case — so the flag is only present where it changes how the text should be trusted. It travels with the passage because a consumer receives the chunk with no document attached and cannot recompute how the text was obtained.
+	MachineRead *bool `json:"machineRead,omitempty"`
 
 	// ResourceId Source resource ID
 	ResourceId string `json:"resourceId"`
@@ -6903,6 +6966,32 @@ func (t *JobResult) FromJobTagAnnotationResult(v JobTagAnnotationResult) error {
 
 // MergeJobTagAnnotationResult performs a merge with any union data inside the JobResult, using the provided JobTagAnnotationResult
 func (t *JobResult) MergeJobTagAnnotationResult(v JobTagAnnotationResult) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsJobDeclinedResult returns the union data inside the JobResult as a JobDeclinedResult
+func (t JobResult) AsJobDeclinedResult() (JobDeclinedResult, error) {
+	var body JobDeclinedResult
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromJobDeclinedResult overwrites any union data inside the JobResult as the provided JobDeclinedResult
+func (t *JobResult) FromJobDeclinedResult(v JobDeclinedResult) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeJobDeclinedResult performs a merge with any union data inside the JobResult, using the provided JobDeclinedResult
+func (t *JobResult) MergeJobDeclinedResult(v JobDeclinedResult) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err

--- a/packages/vectors/src/__tests__/memory-store.test.ts
+++ b/packages/vectors/src/__tests__/memory-store.test.ts
@@ -62,6 +62,23 @@ describe('MemoryVectorStore', () => {
       expect(result!.machineRead).toBeUndefined();
     });
 
+    it('reports a resource stamp for one resource without scanning the rest', async () => {
+      const vec = await embedding.embed('stamped');
+      await store.upsertResourceVectors('res-stamped' as ResourceId, [
+        { chunkIndex: 0, text: 'stamped', embedding: vec },
+      ], 'cs-stamped', ['Question'], true);
+
+      expect(await store.getResourceStamp('res-stamped' as ResourceId)).toEqual({
+        contentChecksum: 'cs-stamped',
+        entityTypes: ['Question'],
+        machineRead: true,
+      });
+    });
+
+    it('reports no stamp for a resource with no vectors', async () => {
+      expect(await store.getResourceStamp('res-absent' as ResourceId)).toBeUndefined();
+    });
+
     it('replaces existing vectors on re-upsert', async () => {
       const vec1 = await embedding.embed('original text');
       await store.upsertResourceVectors('res-1' as ResourceId, [
@@ -235,6 +252,24 @@ describe('MemoryVectorStore', () => {
       expect(results[0].annotationId).toBe('ann-1');
       expect(results[0].resourceId).toBe('res-1');
       expect(results[0].entityTypes).toEqual(['Person']);
+    });
+
+    it('carries the machine-read stamp on an annotation too', async () => {
+      // An annotation over a scanned page quotes OCR'd text, and
+      // annotation-focus gather searches THESE vectors — so the flag has to
+      // ride here as well, or half the gather paths lose it silently.
+      const vec = await embedding.embed('recognized from a scan');
+      await store.upsertAnnotationVector('ann-scan' as AnnotationId, vec, {
+        annotationId: 'ann-scan' as AnnotationId,
+        resourceId: 'res-scan' as ResourceId,
+        motivation: 'highlighting',
+        entityTypes: [],
+        exactText: 'recognized from a scan',
+        machineRead: true,
+      });
+
+      const [result] = await store.searchAnnotations(vec, { limit: 5 });
+      expect(result!.machineRead).toBe(true);
     });
 
     it('deletes annotation vectors', async () => {

--- a/packages/vectors/src/__tests__/memory-store.test.ts
+++ b/packages/vectors/src/__tests__/memory-store.test.ts
@@ -38,6 +38,30 @@ describe('MemoryVectorStore', () => {
       expect(results[0].text).toBe('Abraham Lincoln was the 16th president');
     });
 
+    it('carries the machine-read stamp back out of search', async () => {
+      // Provenance for text no human or native extractor produced: OCR read it
+      // off pixels. Nothing downstream can recompute that — the chunk reaches
+      // its consumers (today, LLM prompts) with no document attached — so the
+      // projection that carries the text carries the fact.
+      const vec = await embedding.embed('recovered from a scan');
+      await store.upsertResourceVectors('res-scan' as ResourceId, [
+        { chunkIndex: 0, text: 'recovered from a scan', embedding: vec },
+      ], 'cs-scan', [], true);
+
+      const [result] = await store.searchResources(vec, { limit: 5 });
+      expect(result!.machineRead).toBe(true);
+    });
+
+    it('leaves the stamp off text that was read directly', async () => {
+      const vec = await embedding.embed('typed by a person');
+      await store.upsertResourceVectors('res-native' as ResourceId, [
+        { chunkIndex: 0, text: 'typed by a person', embedding: vec },
+      ], 'cs-native', [], false);
+
+      const [result] = await store.searchResources(vec, { limit: 5 });
+      expect(result!.machineRead).toBeUndefined();
+    });
+
     it('replaces existing vectors on re-upsert', async () => {
       const vec1 = await embedding.embed('original text');
       await store.upsertResourceVectors('res-1' as ResourceId, [

--- a/packages/vectors/src/store/interface.ts
+++ b/packages/vectors/src/store/interface.ts
@@ -29,6 +29,14 @@ export interface VectorSearchResult {
   annotationId?: AnnotationId;
   text: string;
   entityTypes?: string[];
+  /**
+   * Set when this passage's text was recognized from pixels rather than read
+   * from the document. Absent means read directly — the common case — so the
+   * flag is only ever present where it changes how the text should be
+   * trusted. Carried here because a chunk reaches its consumers with no
+   * document attached, and no consumer can recompute it.
+   */
+  machineRead?: boolean;
 }
 
 export interface SearchOptions {
@@ -68,7 +76,14 @@ export interface VectorStore {
    * entity-type set, stamped onto every point so `searchResources` can
    * discriminate by kind (e.g. exclude `['Question']` from recall).
    */
-  upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[]): Promise<void>;
+  /**
+   * Stamp a resource's chunks. `machineRead` records that the text was
+   * recognized from pixels (OCR) rather than read from the document — see
+   * `VectorSearchResult.machineRead`. It rides the embed because that is the
+   * moment extraction provenance is known; `reconcile()` restores it on a
+   * rebuild the same way it restores the checksum.
+   */
+  upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[], machineRead?: boolean): Promise<void>;
   /**
    * Rewrite the `entityTypes` stamp on a resource's existing points —
    * payload-only, no embedding involved (SMELTER-AXIOMS.md, S13: a tag edit

--- a/packages/vectors/src/store/interface.ts
+++ b/packages/vectors/src/store/interface.ts
@@ -20,6 +20,21 @@ export interface AnnotationPayload {
   motivation: string;
   entityTypes: string[];
   exactText: string;
+  /** True when the quoted text was recognized from pixels — see
+   *  `VectorSearchResult.machineRead`. An annotation over a scanned page
+   *  quotes OCR'd text, and annotation-focus gather searches these vectors. */
+  machineRead?: boolean;
+}
+
+/**
+ * What a resource's vectors record about themselves: how fresh they are
+ * (`contentChecksum`), what they are tagged with (`entityTypes`), and how
+ * their text was obtained (`machineRead`).
+ */
+export interface ResourceStamp {
+  contentChecksum: string | undefined;
+  entityTypes: string[];
+  machineRead?: boolean;
 }
 
 export interface VectorSearchResult {
@@ -131,7 +146,14 @@ export interface VectorStore {
    * and the entity-type set (missing stamp reads as `[]`). Drives both the
    * S12 content-staleness diff and the S13 tag-staleness diff.
    */
-  listResourceStamps(): Promise<Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>>;
+  listResourceStamps(): Promise<Map<string, ResourceStamp>>;
+  /**
+   * One resource's stamp, or undefined when it has no vectors. Targeted so
+   * callers that need a single resource — the annotation index path, which
+   * must stamp provenance it cannot derive locally — do not scan the
+   * collection.
+   */
+  getResourceStamp(resourceId: ResourceId): Promise<ResourceStamp | undefined>;
   /** Distinct annotationIds present in the annotations collection. */
   listAnnotationIds(): Promise<Set<string>>;
 }

--- a/packages/vectors/src/store/memory.ts
+++ b/packages/vectors/src/store/memory.ts
@@ -19,6 +19,7 @@ interface StoredPoint {
     contentChecksum?: string;
     motivation?: string;
     entityTypes?: string[];
+    machineRead?: boolean;
   };
 }
 
@@ -57,7 +58,7 @@ export class MemoryVectorStore implements VectorStore {
     return this.connected;
   }
 
-  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[]): Promise<void> {
+  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[], machineRead?: boolean): Promise<void> {
     // Remove existing vectors for this resource
     this.resources = this.resources.filter(p => p.payload.resourceId !== String(resourceId));
 
@@ -71,6 +72,9 @@ export class MemoryVectorStore implements VectorStore {
           text: chunk.text,
           contentChecksum,
           entityTypes,
+          // Only stamped when true: absence is the common case and carries no
+          // claim, so a native extraction stores nothing extra.
+          ...(machineRead ? { machineRead: true } : {}),
         },
       });
     }
@@ -228,6 +232,7 @@ export class MemoryVectorStore implements VectorStore {
       annotationId: s.payload.annotationId as AnnotationId | undefined,
       text: s.payload.text,
       entityTypes: s.payload.entityTypes,
+      ...(s.payload.machineRead ? { machineRead: true } : {}),
     };
   }
 }

--- a/packages/vectors/src/store/memory.ts
+++ b/packages/vectors/src/store/memory.ts
@@ -6,7 +6,15 @@
  */
 
 import type { ResourceId, AnnotationId } from '@semiont/core';
-import type { VectorStore, EmbeddingChunk, AnnotationPayload, VectorSearchResult, SearchOptions } from './interface';
+import type { VectorStore, EmbeddingChunk, AnnotationPayload, VectorSearchResult, SearchOptions, ResourceStamp } from './interface';
+
+function toStamp(point: { payload: { contentChecksum?: string; entityTypes?: string[]; machineRead?: boolean } }): ResourceStamp {
+  return {
+    contentChecksum: point.payload.contentChecksum,
+    entityTypes: point.payload.entityTypes ?? [],
+    ...(point.payload.machineRead ? { machineRead: true } : {}),
+  };
+}
 
 interface StoredPoint {
   id: string;
@@ -95,6 +103,7 @@ export class MemoryVectorStore implements VectorStore {
         motivation: payload.motivation,
         entityTypes: payload.entityTypes,
         text: payload.exactText,
+        ...(payload.machineRead ? { machineRead: true } : {}),
       },
     });
   }
@@ -123,17 +132,19 @@ export class MemoryVectorStore implements VectorStore {
     }
   }
 
-  async listResourceStamps(): Promise<Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>> {
-    const stamps = new Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>();
+  async listResourceStamps(): Promise<Map<string, ResourceStamp>> {
+    const stamps = new Map<string, ResourceStamp>();
     for (const p of this.resources) {
       if (!stamps.has(p.payload.resourceId)) {
-        stamps.set(p.payload.resourceId, {
-          contentChecksum: p.payload.contentChecksum,
-          entityTypes: p.payload.entityTypes ?? [],
-        });
+        stamps.set(p.payload.resourceId, toStamp(p));
       }
     }
     return stamps;
+  }
+
+  async getResourceStamp(resourceId: ResourceId): Promise<ResourceStamp | undefined> {
+    const point = this.resources.find(p => p.payload.resourceId === String(resourceId));
+    return point ? toStamp(point) : undefined;
   }
 
   async listAnnotationIds(): Promise<Set<string>> {

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -94,7 +94,7 @@ export class QdrantVectorStore implements VectorStore {
     } catch { /* already indexed, or created concurrently */ }
   }
 
-  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[]): Promise<void> {
+  async upsertResourceVectors(resourceId: ResourceId, chunks: EmbeddingChunk[], contentChecksum: string, entityTypes: string[], machineRead?: boolean): Promise<void> {
     // Replace semantics: purge existing chunks first, or a resource that
     // shrinks leaves orphan points at the higher chunk indices.
     await this.deleteResourceVectors(resourceId);
@@ -109,6 +109,9 @@ export class QdrantVectorStore implements VectorStore {
         text: chunk.text,
         contentChecksum,
         entityTypes,
+        // Only stamped when true: absence is the common case and carries no
+        // claim, so a native extraction stores nothing extra.
+        ...(machineRead ? { machineRead: true } : {}),
       },
     }));
 
@@ -296,6 +299,7 @@ export class QdrantVectorStore implements VectorStore {
         annotationId: m.payload.annotationId as AnnotationId | undefined,
         text: m.payload.text as string,
         entityTypes: m.payload.entityTypes as string[] | undefined,
+        ...(m.payload.machineRead ? { machineRead: true } : {}),
       }));
   }
 
@@ -319,6 +323,7 @@ export class QdrantVectorStore implements VectorStore {
         annotationId: payload.annotationId as AnnotationId | undefined,
         text: payload.text as string,
         entityTypes: payload.entityTypes as string[] | undefined,
+        ...(payload.machineRead ? { machineRead: true } : {}),
       };
     });
   }

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -8,7 +8,7 @@
 import { createHash } from 'crypto';
 import type { QdrantClient, Schemas } from '@qdrant/js-client-rest';
 import type { ResourceId, AnnotationId } from '@semiont/core';
-import type { VectorStore, EmbeddingChunk, AnnotationPayload, VectorSearchResult, SearchOptions } from './interface';
+import type { VectorStore, EmbeddingChunk, AnnotationPayload, VectorSearchResult, SearchOptions, ResourceStamp } from './interface';
 
 /**
  * Generate a deterministic UUID v5-style ID from an arbitrary string.
@@ -23,6 +23,22 @@ export interface QdrantConfig {
   host: string;
   port: number;
   dimensions: number;
+}
+
+/** The payload fields a stamp is read from — one list for the scroll and the
+ *  targeted read, so the two cannot drift. */
+const STAMP_FIELDS = ['resourceId', 'contentChecksum', 'entityTypes', 'machineRead'];
+
+function toStamp(payload: Record<string, unknown> | null | undefined): ResourceStamp {
+  const checksum = payload?.contentChecksum;
+  const entityTypes = payload?.entityTypes;
+  return {
+    contentChecksum: typeof checksum === 'string' ? checksum : undefined,
+    entityTypes: Array.isArray(entityTypes)
+      ? entityTypes.filter((t): t is string => typeof t === 'string')
+      : [],
+    ...(payload?.machineRead ? { machineRead: true } : {}),
+  };
 }
 
 export class QdrantVectorStore implements VectorStore {
@@ -133,6 +149,7 @@ export class QdrantVectorStore implements VectorStore {
           motivation: payload.motivation,
           entityTypes: payload.entityTypes,
           text: payload.exactText,
+          ...(payload.machineRead ? { machineRead: true } : {}),
         },
       }],
     });
@@ -180,27 +197,31 @@ export class QdrantVectorStore implements VectorStore {
     });
   }
 
-  async listResourceStamps(): Promise<Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>> {
-    const stamps = new Map<string, { contentChecksum: string | undefined; entityTypes: string[] }>();
+  async getResourceStamp(resourceId: ResourceId): Promise<ResourceStamp | undefined> {
+    const page = await this.qdrant.scroll('resources', {
+      limit: 1,
+      filter: { must: [{ key: 'resourceId', match: { value: String(resourceId) } }] },
+      with_payload: STAMP_FIELDS,
+      with_vector: false,
+    });
+    const point = page.points[0];
+    return point ? toStamp(point.payload) : undefined;
+  }
+
+  async listResourceStamps(): Promise<Map<string, ResourceStamp>> {
+    const stamps = new Map<string, ResourceStamp>();
     let offset: Schemas['ScrollRequest']['offset'] = undefined;
     do {
       const page = await this.qdrant.scroll('resources', {
         limit: 1000,
         offset,
-        with_payload: ['resourceId', 'contentChecksum', 'entityTypes'],
+        with_payload: STAMP_FIELDS,
         with_vector: false,
       });
       for (const point of page.points) {
         const rid = point.payload?.resourceId;
         if (typeof rid !== 'string' || stamps.has(rid)) continue;
-        const checksum = point.payload?.contentChecksum;
-        const entityTypes = point.payload?.entityTypes;
-        stamps.set(rid, {
-          contentChecksum: typeof checksum === 'string' ? checksum : undefined,
-          entityTypes: Array.isArray(entityTypes)
-            ? entityTypes.filter((t): t is string => typeof t === 'string')
-            : [],
-        });
+        stamps.set(rid, toStamp(point.payload));
       }
       offset = page.next_page_offset ?? undefined;
     } while (offset !== undefined && offset !== null);

--- a/specs/src/components/schemas/JobDeclinedResult.json
+++ b/specs/src/components/schemas/JobDeclinedResult.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "description": "Result of a job that completed without doing its work because the resource could not be read. Distinct from a failure: nothing went wrong, there was simply no text to work with — an encrypted or damaged PDF, a scan whose text could not be recognized, or a document that yielded nothing. The reason vocabulary matches the extraction vocabulary the Smelter reports on `smelt:settled`, so one resource declines identically whichever verb asked.",
+  "properties": {
+    "declined": {
+      "type": "boolean",
+      "enum": [true],
+      "description": "Discriminant. Always true — a job that did its work reports one of the other result shapes."
+    },
+    "reason": {
+      "type": "string",
+      "enum": ["no-text-layer", "encrypted", "corrupt", "too-large", "empty"],
+      "description": "Why the resource could not be read."
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable explanation, suitable for showing to the user."
+    }
+  },
+  "required": ["declined", "reason", "message"]
+}

--- a/specs/src/components/schemas/JobDeclinedResult.json
+++ b/specs/src/components/schemas/JobDeclinedResult.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "description": "Result of a job that completed without doing its work because the resource could not be read. Distinct from a failure: nothing went wrong, there was simply no text to work with — an encrypted or damaged PDF, a scan whose text could not be recognized, or a document that yielded nothing. The reason vocabulary matches the extraction vocabulary the Smelter reports on `smelt:settled`, so one resource declines identically whichever verb asked.",
+  "description": "Result of a job that completed without doing its work because the resource could not be read. Distinct from a failure: nothing went wrong, there was simply no text to work with — an encrypted or damaged PDF, a scan whose text could not be recognized, or a document that yielded nothing. The reasons are the extraction vocabulary the Smelter reports on `smelt:settled`, MINUS `no-extractor`: a media type that can never yield text (a zip, an image) is a bad request rather than a decline, so a worker asked to detect over one throws and the job reports `job:fail`. Everything here is a resource-specific outcome — the same media type would have succeeded on a different document.",
   "properties": {
     "declined": {
       "type": "boolean",

--- a/specs/src/components/schemas/JobResult.json
+++ b/specs/src/components/schemas/JobResult.json
@@ -6,6 +6,7 @@
     { "$ref": "./JobHighlightAnnotationResult.json" },
     { "$ref": "./JobAssessmentAnnotationResult.json" },
     { "$ref": "./JobCommentAnnotationResult.json" },
-    { "$ref": "./JobTagAnnotationResult.json" }
+    { "$ref": "./JobTagAnnotationResult.json" },
+    { "$ref": "./JobDeclinedResult.json" }
   ]
 }

--- a/specs/src/components/schemas/SemanticMatch.json
+++ b/specs/src/components/schemas/SemanticMatch.json
@@ -21,6 +21,10 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "Entity types on the matched passage"
+    },
+    "machineRead": {
+      "type": "boolean",
+      "description": "True when this passage's text was recognized from pixels (OCR of a scanned page) rather than read from the document. Absent means read directly — the common case — so the flag is only present where it changes how the text should be trusted. It travels with the passage because a consumer receives the chunk with no document attached and cannot recompute how the text was obtained."
     }
   },
   "required": ["text", "resourceId", "score"]

--- a/specs/src/openapi.json
+++ b/specs/src/openapi.json
@@ -435,6 +435,9 @@
       "JobFailCommand": {
         "$ref": "components/schemas/JobFailCommand.json"
       },
+      "JobDeclinedResult": {
+        "$ref": "components/schemas/JobDeclinedResult.json"
+      },
       "JobFailedPayload": {
         "$ref": "components/schemas/JobFailedPayload.json"
       },

--- a/tests/e2e/scripts/seed.ts
+++ b/tests/e2e/scripts/seed.ts
@@ -155,6 +155,45 @@ const TEXT_PDF_FIXTURE_BASE64 =
 // have text to select.
 //
 // The two PDFs are listed FIRST so they are created first → oldest → sort
+/**
+ * A single-page (612×792) **scanned** PDF: one full-page raster image and no
+ * text operators at all, so `getTextContent()` is empty and the only way to
+ * read it is OCR. Its raster is dark bars — deliberately NOT glyph-shaped, so
+ * the recognizer reliably finds nothing and the job takes the *decline* path
+ * (`22-pdf-scanned-decline.spec.ts`).
+ *
+ * Why not a raster of real words: a synthetic bitmap font is not a typeface,
+ * and tesseract misreads it (measured: "SCANNED" read back as "SCHMNE" at
+ * confidence 0). Asserting recognized *text* therefore needs a genuine scanned
+ * document, which is a live-testing fixture, not a seed constant. What this
+ * fixture pins is the deterministic half: a scan that cannot be read declines
+ * cleanly and adds no garbage annotations.
+ */
+const SCANNED_PDF_FIXTURE_BASE64 =
+  'JVBERi0xLjcKJYGBgYEKCjQgMCBvYmoKPDwKL1R5cGUgL1hPYmplY3QKL1N1YnR5cGUg' +
+  'L0ltYWdlCi9CaXRzUGVyQ29tcG9uZW50IDgKL1dpZHRoIDI0MAovSGVpZ2h0IDE0MAov' +
+  'Q29sb3JTcGFjZSAvRGV2aWNlUkdCCi9GaWx0ZXIgL0ZsYXRlRGVjb2RlCi9MZW5ndGgg' +
+  'MjIyCj4+CnN0cmVhbQp4nO3cQQ0AIBDAMCv4NwlPFJAjS6th7+0NAAAAAAAAAAAAAAAA' +
+  'AHAteEDPlOiZEj1TomdK9EyJninRMyV6pkTPlOiZEj1TomdK9EzJVM8AAAAAAAAAAAAA' +
+  'AAAAAAAAAAC/mf5C0aRnSvRMiZ4p0TMleqZEz5TomRI9U6JnSvRMiZ4p0TMleqZkqmcA' +
+  'AAAAAAAAAAAAAAAAAAAAAIDfTH+haNIzJXqmRM+U6JkSPVOiZ0r0TImeKdEzJXqmRM+U' +
+  '6JkSPVMy1TMAAAAAAAAAAAAAAAAAAAAAAMALB8KyiJ8KZW5kc3RyZWFtCmVuZG9iagoK' +
+  'NiAwIG9iago8PAovRmlsdGVyIC9GbGF0ZURlY29kZQovTGVuZ3RoIDUzCj4+CnN0cmVh' +
+  'bQp4nCvkMlQwAEIImZyLzjUzNAIzzS2NcKjQ98xNTE/VNTewtDCxMDC3sFRwyecK5AIA' +
+  '+w8R2AplbmRzdHJlYW0KZW5kb2JqCgo3IDAgb2JqCjw8Ci9GaWx0ZXIgL0ZsYXRlRGVj' +
+  'b2RlCi9UeXBlIC9PYmpTdG0KL04gNAovRmlyc3QgMjAKL0xlbmd0aCAzMTkKPj4Kc3Ry' +
+  'ZWFtCnic1VJRS8MwEH7Pr7hHfZBc0zRppQzm2orIcEwfRPGhrmFMtJEug/nvvWs2xQfx' +
+  'WcpHcrnvy116XwIICrSGFGwOGWSpgrIU8u7j3YFctGu3FfJ6023hkbIIS3gScuZ3fYBE' +
+  'TCbimztrQ/vq1yKKIGHykbEYfLdbuQHKpm4aRIuIRhMMoqponREKgqKYciqnPcHqA+jM' +
+  'pojplHJNhLFRw/mRmx30Na3ENcypIlfnMf6qy7XqeIf6q59iIuTcd1UbHJxU5wqVwRyT' +
+  'pNCZTh9O6XcMrg3+/z5u7H/j+19f+GPOPF4e8uDYA+OU5dJt/W5Y0diZ13jK0IZk8v7m' +
+  '+cWtxlBevZH0zGKRU8s2L0AfPSLrfbi8DVw/6vhs7rpNe+H35DykzyQKbKHYf9O+94Ed' +
+  'OXqxD9QJR+bgTxJ/Ai/QqG0KZW5kc3RyZWFtCmVuZG9iagoKOCAwIG9iago8PAovU2l6' +
+  'ZSA5Ci9Sb290IDIgMCBSCi9JbmZvIDMgMCBSCi9GaWx0ZXIgL0ZsYXRlRGVjb2RlCi9U' +
+  'eXBlIC9YUmVmCi9MZW5ndGggNDIKL1cgWyAxIDIgMiBdCi9JbmRleCBbIDAgOSBdCj4+' +
+  'CnN0cmVhbQp4nGNgYPj/n4mBnYEBRDCCCCZGBgEIl5mRcQYDUFAUSDDvYmAAAGPrA6oK' +
+  'ZW5kc3RyZWFtCmVuZG9iagoKc3RhcnR4cmVmCjk1NAolJUVPRg==';
+
 // last in Discover (see the module doc); the text specs' `.first()` card
 // stays a text resource.
 const SEED_RESOURCES: readonly SeedSpec[] = [
@@ -171,6 +210,13 @@ const SEED_RESOURCES: readonly SeedSpec[] = [
     format: 'application/pdf',
     language: 'en',
     bytes: Buffer.from(TEXT_PDF_FIXTURE_BASE64, 'base64'),
+  },
+  {
+    name: 'Scanned Smoke PDF',
+    storageUri: 'file://e2e/seed-scanned.pdf',
+    format: 'application/pdf',
+    language: 'en',
+    bytes: Buffer.from(SCANNED_PDF_FIXTURE_BASE64, 'base64'),
   },
   {
     name: 'Quantum Computing Primer',

--- a/tests/e2e/specs/22-pdf-scanned-decline.spec.ts
+++ b/tests/e2e/specs/22-pdf-scanned-decline.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '../fixtures/auth';
+import type { Page } from '@playwright/test';
+
+/**
+ * A scanned PDF whose text cannot be recognized declines cleanly (#739/#746).
+ *
+ * The scanned path now runs for real: the worker reads the page's pixels and
+ * OCRs them rather than refusing outright. This spec pins the *other* outcome —
+ * what happens when recognition genuinely comes up empty. Three things must
+ * hold, and the third is the one that matters:
+ *
+ *   1. the job completes rather than failing — a scan we cannot read is not an
+ *      error, nothing broke;
+ *   2. the user is told why, as an INFO toast (`useOutcomeToasts` →
+ *      `declinedMessage`), not a success toast ("Annotation complete" would be
+ *      a lie) and not an error toast (alarming, and nothing is wrong);
+ *   3. **no annotations are created** — no garbage rects anchored to text the
+ *      recognizer never actually read.
+ *
+ * Seed dependency: `scripts/seed.ts` yields "Scanned Smoke PDF" — a full-page
+ * raster with no text operators, whose image is dark bars rather than glyphs so
+ * recognition reliably finds nothing.
+ *
+ * NOT covered here, deliberately: a scan OCR *can* read. That needs a genuine
+ * scanned document — a synthetic bitmap font is not a typeface, and the
+ * recognizer misreads it (measured: "SCANNED" → "SCHMNE" at confidence 0), so
+ * asserting recognized text against a seed constant would pin engine noise
+ * rather than behavior. That case belongs to live testing with a real receipt
+ * or FOIA page; the unit suites in `@semiont/content` cover the merge
+ * deterministically with the engine stubbed.
+ */
+
+const SCANNED_CARD = /^open resource:\s*scanned smoke pdf/i;
+const IMG = '.semiont-pdf-annotation-canvas__image';
+const SVG = '.semiont-pdf-annotation-canvas__svg';
+
+async function openScannedPdfInAnnotateMode(page: Page) {
+  await page.goto('/en/know/discover');
+  // `.first()` — the seed accumulates duplicate cards across runs (14's note);
+  // any is an identical fresh fixture.
+  const card = page.getByRole('button', { name: SCANNED_CARD }).first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await card.click();
+  await expect(page.getByText(/loading resource/i)).toBeHidden({ timeout: 30_000 });
+
+  await page.getByRole('button', { name: /^mode$/i }).click();
+  await page.getByRole('menuitem', { name: /^annotate$/i }).click();
+  // A scan still RENDERS — it is a normal PDF page, just one made of pixels.
+  await expect(page.locator(IMG)).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator(SVG)).toBeVisible({ timeout: 15_000 });
+
+  await page.getByRole('button', { name: /^annotations$/i }).click();
+}
+
+async function selectSubTab(page: Page, emoji: string) {
+  const tab = page.locator('.semiont-unified-panel__tabs').getByRole('button', { name: emoji, exact: true });
+  await expect(tab).toBeVisible({ timeout: 10_000 });
+  if ((await tab.getAttribute('aria-pressed')) !== 'true') await tab.click();
+  await expect(tab).toHaveAttribute('aria-pressed', 'true');
+}
+
+test.describe('assisted detection on an unreadable scanned PDF', () => {
+  test('completes with a decline notice and creates no annotations', async ({ signedInPage: page, bus }) => {
+    test.setTimeout(120_000);
+
+    await openScannedPdfInAnnotateMode(page);
+    const rects = page.locator(`${SVG} rect`);
+    const rectsBefore = await rects.count();
+
+    await selectSubTab(page, '💬');
+    const main = page.getByRole('main');
+    const toggle = main.getByRole('button', { name: /annotate comments/i }).first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click();
+
+    bus.clear();
+    const submit = page.locator('button[data-variant="assist"][data-type="comment"]');
+    await expect(submit).toBeEnabled({ timeout: 5_000 });
+    await submit.click();
+
+    // Dispatch — the assist crosses the wire like any other detection job. The
+    // decline happens in the worker, after it tries to read the page.
+    const { request } = await bus.expectRequestResponse('job:create', 'job:created', 30_000);
+    expect(request.channel).toBe('job:create');
+
+    // (1) the job COMPLETES rather than failing. Race the two so a genuine
+    // failure surfaces with its message instead of a bare timeout (09's
+    // pattern). A decline is not an error — `job:fail` here would be a
+    // regression to the pre-#746 behavior of throwing on an unreadable page.
+    const completeOrFail = await Promise.race([
+      bus.waitForRecv('job:complete', { timeout: 90_000 }).then((e) => ({ kind: 'complete' as const, entry: e })),
+      bus.waitForRecv('job:fail', { timeout: 90_000 }).then((e) => ({ kind: 'fail' as const, entry: e })),
+    ]);
+    if (completeOrFail.kind === 'fail') {
+      throw new Error(
+        'Expected job:complete (a decline), got job:fail. Recent bus entries:\n' +
+        bus.entries.slice(-15).map((e) => `  [${e.op}] ${e.channel} ${e.raw}`).join('\n'),
+      );
+    }
+
+    // (2) the user is told why, as INFO. The bus log records only a payload
+    // prefix, so the *reason* is asserted where it actually reaches a
+    // human — the toast text `DECLINE_MESSAGES['no-text-layer']` produces.
+    await expect(page.getByText(/scan whose text could not be recognized/i))
+      .toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/annotation complete/i)).toBeHidden();
+
+    // (3) the point: nothing was invented from text the recognizer never read.
+    await expect.poll(async () => rects.count(), { timeout: 10_000 }).toBe(rectsBefore);
+  });
+});


### PR DESCRIPTION
Scanned PDFs become **annotatable**, not just searchable. OCR landed in the Smelter previously (#742/#746) — this closes the other half: mapping recognized words back to page coordinates, and making detection read a resource the same way embedding does.

## The gap this closes

Before, the two paths disagreed about the same document:

| Path | Scanned PDF |
|---|---|
| yield → smelt (embedding) | OCR'd and embedded |
| detect → mark (annotation) | **declined** |

Embedding needs text. Detection needs text *plus* a reverse map from character offsets back to PDF points, because `buildPdfAnnotation` resolves a detected span through `locate()` against per-run geometry. OCR output carried none, so detection refused outright.

## What makes it work

**The anchoring model follows the geometry, not the media type.** An extraction carrying positioned runs anchors spatially; one without anchors by character offset. That is why scanned pages, form values, and table cells all reuse the viewrect path with no new branches — and why this needed no new selector model, no new storage, and no new render path.

Three pure functions, each tested where its risk actually lives:

- **`findPlacedImages`** walks the operator list with a graphics-state stack to recover each image's placement matrix. Its composition *order* is tested directly with two non-identity matrices — pdf-lib emits only one combined matrix per image, so a fixture cannot distinguish left- from right-multiplication. Then mutation-checked: reversing the order makes the unit test fail and the new off-origin fixture report `e,f` as `30000, 80000` instead of `100, 200`. The pre-existing full-page fixture stayed green under that mutation, which is exactly the blind spot the new fixture exists to cover.
- **`assemblePage`** builds page text *from* the word tree so offsets are exact by construction, rather than recovered by searching for words in a separately-produced string. `buildPdfAnnotation` throws when a span's covered text does not contain the match, so offset drift surfaces as a failed annotation rather than a nudged box — the offsets are the risky part here, not the matrices.
- **`mapWordsToItems`** composes pixel → unit square → placement matrix, normalizing for placements that flip an axis.

**A defect the line-threshold check found.** `locate()` groups items into lines within 2pt, which works because *native* runs take `y` from the text transform — the shared baseline. OCR boxes hug their glyphs, so `page` sits lower than `the`, and at scan scale that gap far exceeds 2pt: one visual line resolved to **two rects**, drawing a highlight as stacked fragments. Fixed at the source — a word takes its horizontal extent from its own box and its vertical extent from its line's. Nothing is lost, since `locate()` bounds each line anyway.

## Provenance: `machineRead`

Recognized text reaches its consumers with no document attached, and nothing downstream can recompute how it was obtained. So the projection that carries the text carries the fact: a boolean on the vector payload (resources *and* annotations), out through `VectorSearchResult`, into `SemanticMatch`, and finally into the generation prompt as an `[OCR]` marker plus one instruction — treat the wording and numbers as uncertain, and say so when relying on one.

Annotation vectors matter because annotation-focus gather (`annotation-context.ts`) searches *those*, feeding the same prompt; stamping only resources would have left half the gather paths silently dropping what the other half carried. Provenance is a property of the resource's text and the annotation record does not carry it, so `indexAnnotation` reads the resource's own stamp through a new targeted `getResourceStamp()` — trivial beside the embedding call already in that path, and far cheaper than re-extracting (which for a scan means re-running OCR).

Deliberately **not** a cache: a rebuild still re-fetches, re-extracts, and re-pays OCR, then re-derives the flag. What is stored is a projection stamp, like `contentChecksum`.

## Typing

Removing the blanket `as never` casts from `worker-process.ts` surfaced four real defects rather than style nits:

- **A dead field on five emits** — the worker passed `userId` to `mark:create`, which has no such property; attribution rides `_userId`, injected by the gateway.
- **A missing spec variant** — `{ declined, reason, message }` was emitted as a job result while `JobResult`'s union had no declined member. Added as `JobDeclinedResult` through the OpenAPI workflow, so decline reasons are now a contract the UI can rely on.
- **An unvalidated enum at the boundary** — `jobType` arrives as `string` but is a required enum on every lifecycle command. `isJobType` narrows once. Behavior change worth review: an unrecognized type no longer emits `job:start` first, because it cannot produce a well-formed one — the gateway would reject it. The old test conflated that with "valid type this worker does not serve"; both cases are now covered separately.
- **A closed vocabulary typed as `string`** — `motivation` is now `Annotation['motivation']`, `body` is `Annotation['body']`, and `ProcessorResult.annotations` is `Annotation[]`.

One change reached beyond jobs: `generateAnnotationId()` returned `string`, so every `Annotation` it built failed the branded `id`. Branded at the source rather than at fourteen call sites — that function is where an annotation id comes into existence.

Also renamed `ExtractedText.blocks` → `items`: one concept, one name, and it no longer collides with the OCR engine's own "blocks", which are page regions rather than runs.

## Testing

Unit and integration are green: content 114, vectors 38, make-meaning 497 (+1 expected-fail from the axiom ledger), jobs 351 (+1 pre-existing skip). Typechecks clean across content, vectors, make-meaning, jobs, core, sdk, event-sourcing, and backend.

**A new e2e (`22-pdf-scanned-decline`) pins the deterministic half**: a scan that cannot be read completes rather than fails, tells the user why as an info toast, and creates **no annotations** — no rects invented from text the recognizer never read.

**OCR accuracy is deliberately not asserted anywhere.** Measured, not assumed: a synthetic bitmap font is not a typeface, and the recognizer read "SCANNED" back as "SCHMNE" at confidence 0. Pinning that would test engine noise. Judging recognition quality needs a genuine scanned document, which is live-testing work; the unit suites cover the merge deterministically with the engine stubbed.

## Follow-ups (recorded, not blocking)

- Live validation over a real receipt or FOIA page — the epic's own Done criterion, and where `GRAYSCALE_1BPP` polarity and `locate()`'s threshold against a skewed page get confirmed.
- An annotation indexed *before* its resource embeds goes unstamped, and reconcile will not revisit it — the staleness shape S13 solved for entity tags. Benign in practice, since a scanned resource must embed before detection can annotate it.
- `worker-process.ts` still carries no casts, but the jobs/bus seam's remaining typing is untouched beyond what this PR needed.
