### PR TITLE
Bound extraction memory: oversized PDFs decline instead of OOM-ing the worker

### DIFF
--- a/packages/content/src/__tests__/extraction-limits.test.ts
+++ b/packages/content/src/__tests__/extraction-limits.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Extraction size guards — the bounds behind the `'too-large'` decline.
+ *
+ * `'too-large'` was declared in the decline vocabulary from the start and
+ * never emitted, which was the visible half of a real gap: nothing bounded
+ * what extraction would allocate. A PDF is a compressed container, so input
+ * size says little about decoded size — a few megabytes of JPEG can decode
+ * into gigabytes of raster, and the OCR path decodes every scanned page.
+ *
+ * Two bounds, deliberately different in kind:
+ *
+ *   - a whole-document input cap, which DECLINES: nothing can be safely done
+ *     with it, and the operator should be told why;
+ *   - a per-image pixel cap, which SKIPS that image and leaves its page
+ *     unread. One pathological page should not cost a document its other
+ *     forty — that is the same partial-coverage story class C already tells.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EXTRACTORS } from '../content-extractor';
+import { MAX_PDF_BYTES, withinByteBudget } from '../pdf-extractor';
+import { MAX_IMAGE_PIXELS, withinPixelBudget, extractPageImages } from '../pdf-page-images';
+
+/**
+ * A one-page PDF whose image XObject *declares* enormous dimensions while
+ * carrying a few bytes of data.
+ *
+ * The mismatch is the point, and it is only possible by hand — pdf-lib would
+ * never emit it. The guard reads the dimensions the paint operator itself
+ * reports and refuses BEFORE resolving the image, so a file that claims
+ * 20000×20000 costs nothing to reject: no allocation, no decode, no wait on
+ * an object that will never arrive.
+ */
+function pdfDeclaringImage(width: number, height: number, data: Buffer): Buffer {
+    const content = Buffer.from('q 612 0 0 792 0 0 cm /Im0 Do Q\n');
+    const objects = [
+        '<< /Type /Catalog /Pages 2 0 R >>',
+        '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+        '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+            + '/Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>',
+    ];
+    let out = Buffer.from('%PDF-1.4\n');
+    const offsets: number[] = [];
+    const push = (n: number, body: string, stream?: Buffer) => {
+        offsets[n] = out.length;
+        let chunk = Buffer.from(`${n} 0 obj\n${body}\n`);
+        if (stream) {
+            chunk = Buffer.concat([chunk, Buffer.from('stream\n'), stream, Buffer.from('\nendstream\n')]);
+        }
+        out = Buffer.concat([out, chunk, Buffer.from('endobj\n')]);
+    };
+    objects.forEach((body, i) => push(i + 1, body));
+    push(4, `<< /Length ${content.length} >>`, content);
+    push(5, `<< /Type /XObject /Subtype /Image /Width ${width} /Height ${height} `
+        + `/ColorSpace /DeviceRGB /BitsPerComponent 8 /Length ${data.length} >>`, data);
+    const xref = out.length;
+    let table = 'xref\n0 6\n0000000000 65535 f \n';
+    for (let i = 1; i <= 5; i++) table += `${String(offsets[i]).padStart(10, '0')} 00000 n \n`;
+    return Buffer.concat([
+        out,
+        Buffer.from(table),
+        Buffer.from(`trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF`),
+    ]);
+}
+
+describe('input size budget', () => {
+    it('admits a document at the cap and refuses one past it', () => {
+        // A ceiling, not a fence: exactly at the cap still extracts.
+        expect(withinByteBudget(MAX_PDF_BYTES)).toBe(true);
+        expect(withinByteBudget(MAX_PDF_BYTES + 1)).toBe(false);
+    });
+
+    it('admits the ordinary case', () => {
+        expect(withinByteBudget(12 * 1024 * 1024)).toBe(true);
+        expect(withinByteBudget(0)).toBe(true);
+    });
+
+    it('refuses nonsense sizes rather than trusting them', () => {
+        expect(withinByteBudget(-1)).toBe(false);
+        expect(withinByteBudget(Number.NaN)).toBe(false);
+    });
+
+    it("declines 'too-large' before handing anything to the parser", async () => {
+        // `allocUnsafe` deliberately: only `.length` is read before the
+        // decline, so the pages are never touched and the test does not carry
+        // 200 MB of resident memory to ask a question about a number.
+        const oversized = Buffer.allocUnsafe(MAX_PDF_BYTES + 1);
+        const out = await EXTRACTORS['pdf-text-layer']!.extract(oversized, 'application/pdf');
+        expect(out).toEqual({ declined: 'too-large' });
+    });
+});
+
+describe('per-image pixel budget', () => {
+    it('admits a page-sized scan', () => {
+        // US Letter at 300dpi — 2550×3300, the ordinary case this must not reject.
+        expect(withinPixelBudget(2550, 3300)).toBe(true);
+    });
+
+    it('admits a large-format scan', () => {
+        // A0 at 300dpi is around 35 megapixels: big, legitimate, still allowed.
+        expect(withinPixelBudget(9933, 3509)).toBe(true);
+    });
+
+    it('rejects an image that would allocate more than the budget', () => {
+        expect(withinPixelBudget(20_000, 20_000)).toBe(false);
+    });
+
+    it('rejects nonsense dimensions rather than trusting them', () => {
+        expect(withinPixelBudget(0, 100)).toBe(false);
+        expect(withinPixelBudget(-1, 100)).toBe(false);
+        expect(withinPixelBudget(Number.NaN, 100)).toBe(false);
+    });
+
+    it('extracts an image inside the budget', async () => {
+        // The control: a genuine 2×2 DeviceRGB image, 12 bytes of raw samples.
+        // It resolves and comes back — so the guard is not rejecting wholesale.
+        const byPage = await extractPageImages(pdfDeclaringImage(2, 2, Buffer.alloc(12)));
+        expect(byPage.size).toBe(1);
+        expect(byPage.get(1)![0]).toMatchObject({ width: 2, height: 2 });
+    });
+
+    it('yields nothing for a page whose image declares oversized dimensions', async () => {
+        // Pins the OUTCOME — the page is left unread rather than decoded. Note
+        // it does not isolate the mechanism: without the guard this file also
+        // yields nothing, because 20000×20000 with three bytes of data cannot
+        // resolve either. What the guard buys is that we never ask: the
+        // dimensions come from the paint operator, so the refusal is free.
+        const byPage = await extractPageImages(pdfDeclaringImage(20_000, 20_000, Buffer.alloc(3)));
+        expect(byPage.size).toBe(0);
+    });
+
+    it('states its budget in pixels, so the RGB cost is derivable', () => {
+        // Three bytes per pixel: the constant is the number that matters when
+        // sizing the worker, so it is asserted rather than left implicit.
+        expect(MAX_IMAGE_PIXELS * 3).toBeLessThanOrEqual(256 * 1024 * 1024);
+    });
+});

--- a/packages/content/src/__tests__/extraction-limits.test.ts
+++ b/packages/content/src/__tests__/extraction-limits.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect } from 'vitest';
 import { EXTRACTORS } from '../content-extractor';
 import { MAX_PDF_BYTES, withinByteBudget } from '../pdf-extractor';
-import { MAX_IMAGE_PIXELS, withinPixelBudget, extractPageImages } from '../pdf-page-images';
+import { MAX_IMAGE_PIXELS, PEAK_BYTES_PER_PIXEL, withinPixelBudget, extractPageImages } from '../pdf-page-images';
 
 /**
  * A one-page PDF whose image XObject *declares* enormous dimensions while
@@ -81,10 +81,14 @@ describe('input size budget', () => {
     });
 
     it("declines 'too-large' before handing anything to the parser", async () => {
-        // `allocUnsafe` deliberately: only `.length` is read before the
-        // decline, so the pages are never touched and the test does not carry
-        // 200 MB of resident memory to ask a question about a number.
-        const oversized = Buffer.allocUnsafe(MAX_PDF_BYTES + 1);
+        // An empty buffer reporting an oversized length. The guard reads
+        // `.length` and nothing else before declining, so that is the entire
+        // input this needs — allocating 200 MB to ask a question about a
+        // number would only make the suite slower and fragile under a
+        // constrained CI memory limit.
+        const oversized = Buffer.alloc(0);
+        Object.defineProperty(oversized, 'length', { value: MAX_PDF_BYTES + 1 });
+
         const out = await EXTRACTORS['pdf-text-layer']!.extract(oversized, 'application/pdf');
         expect(out).toEqual({ declined: 'too-large' });
     });
@@ -99,6 +103,12 @@ describe('per-image pixel budget', () => {
     it('admits a large-format scan', () => {
         // A0 at 300dpi is around 35 megapixels: big, legitimate, still allowed.
         expect(withinPixelBudget(9933, 3509)).toBe(true);
+    });
+
+    it('admits an ordinary page scanned at high resolution', () => {
+        // US Letter at 600dpi — 5100×6600, ~34 MP. Reachable with a normal
+        // page and a good scanner, so the budget must not reject it.
+        expect(withinPixelBudget(5100, 6600)).toBe(true);
     });
 
     it('rejects an image that would allocate more than the budget', () => {
@@ -129,9 +139,13 @@ describe('per-image pixel budget', () => {
         expect(byPage.size).toBe(0);
     });
 
-    it('states its budget in pixels, so the RGB cost is derivable', () => {
-        // Three bytes per pixel: the constant is the number that matters when
-        // sizing the worker, so it is asserted rather than left implicit.
-        expect(MAX_IMAGE_PIXELS * 3).toBeLessThanOrEqual(256 * 1024 * 1024);
+    it('bounds the whole allocation chain, not just the decoded raster', () => {
+        // Reading one image holds several copies at once — decoded samples,
+        // the RGB conversion, and the PNG scanline buffer — so the cost per
+        // pixel is ~10 bytes, not 3. Asserting against the real multiplier
+        // keeps the budget honest: a future rise in the cap has to reckon
+        // with the peak it actually implies.
+        const peak = MAX_IMAGE_PIXELS * PEAK_BYTES_PER_PIXEL;
+        expect(peak).toBeLessThanOrEqual(512 * 1024 * 1024);
     });
 });

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -33,6 +33,29 @@ interface OcrPageResult {
   confidences: number[];
 }
 
+/**
+ * Largest PDF this will attempt, in bytes.
+ *
+ * A PDF is a compressed container, so input size bounds nothing on its own —
+ * but it is the one number available before the parser touches the file, and
+ * refusing here means a hostile or pathological document never gets to expand
+ * inside pdf.js. Chosen to sit above real corpora (a few hundred pages of
+ * scanned FOIA material runs tens of megabytes) while still being a ceiling.
+ *
+ * A starting point, not a measured optimum — revisit against a real corpus
+ * (SMELTER-MEDIA-TYPES, live-testing follow-up). The per-image budget in
+ * `pdf-page-images` guards the decoded side, which is where the unbounded
+ * growth actually lives.
+ */
+export const MAX_PDF_BYTES = 200 * 1024 * 1024;
+
+/** Whether a document is small enough to attempt. Exported because the
+ *  threshold is a judgement, and judgements deserve tests that do not have to
+ *  materialize two hundred megabytes to ask the question. */
+export function withinByteBudget(bytes: number): boolean {
+  return Number.isFinite(bytes) && bytes >= 0 && bytes <= MAX_PDF_BYTES;
+}
+
 /** Words below this are worth an operator's attention. Tesseract reports
  *  0–100; readable text on a clean scan sits well above this. */
 const LOW_CONFIDENCE = 60;
@@ -177,6 +200,11 @@ function shapeTables(layer: PdfTextLayer): ExtractedText | null {
 
 export const pdfExtractor: ContentExtractor = {
   async extract(content) {
+    // Before the parser sees it: everything downstream — parse, image decode,
+    // OCR — expands from these bytes, so this is the only gate that costs
+    // nothing to enforce.
+    if (!withinByteBudget(content.length)) return { declined: 'too-large' };
+
     let layer;
     try {
       layer = await extractPdfTextLayer(content);

--- a/packages/content/src/pdf-page-images.ts
+++ b/packages/content/src/pdf-page-images.ts
@@ -27,16 +27,38 @@ const RGBA_32BPP = 3;
 const IDENTITY: readonly number[] = [1, 0, 0, 1, 0, 0];
 
 /**
- * Largest decoded image this will hold, in pixels. At three bytes per pixel
- * that is ~192 MB of raster for a single page — generous enough for a
- * large-format scan (A0 at 300dpi is ~35 MP) and far above the ordinary case
- * (US Letter at 300dpi is ~8 MP), while refusing an image whose dimensions
- * would allocate without bound.
+ * Largest image this will read, in pixels.
  *
- * A starting point, not a measured optimum: it should be revisited against a
- * real scanned corpus (SMELTER-MEDIA-TYPES, live-testing follow-up).
+ * Sizing this needs the WHOLE allocation chain, not just the decoded raster —
+ * reading one image can hold several copies at once:
+ *
+ *   pdf.js decoded samples   4 bytes/px worst case (RGBA; RGB is 3)
+ *   + `toRgb` conversion     3 bytes/px (RGBA and 1-bit both allocate a copy;
+ *                              plain RGB is passed through, no copy)
+ *   + `encodePng` scanlines  3 bytes/px (`raw`, plus a filter byte per row)
+ *   + deflate output         smaller, but live alongside the above
+ *   ────────────────────────────────────────────────────────────────────
+ *   ≈ 10 bytes/px transient peak for a single image
+ *
+ * So the budget below implies roughly half a gigabyte of transient peak for
+ * one pathological page — the number to size a worker against. Stating three
+ * bytes per pixel here (as an earlier revision did) understated it by ~3× and
+ * gave a false sense of safety.
+ *
+ * Chosen to admit the legitimate large cases with headroom: US Letter at
+ * 600dpi is ~34 MP and A0 at 300dpi is ~35 MP, against an ordinary US Letter
+ * at 300dpi of ~8 MP.
+ *
+ * A starting point, not a measured optimum: revisit against a real scanned
+ * corpus (SMELTER-MEDIA-TYPES, live-testing follow-up). Lowering the peak
+ * itself means removing copies from the chain — passing the decoded samples
+ * straight to the encoder — which is a refactor, not a smaller constant.
  */
-export const MAX_IMAGE_PIXELS = 64_000_000;
+export const MAX_IMAGE_PIXELS = 48_000_000;
+
+/** Worst-case bytes held per pixel while reading one image — the chain above.
+ *  Exported so the budget's real cost is asserted rather than assumed. */
+export const PEAK_BYTES_PER_PIXEL = 10;
 
 /** Whether an image's dimensions are sane and inside the budget. Exported
  *  because the threshold is a judgement, and judgements deserve tests. */

--- a/packages/content/src/pdf-page-images.ts
+++ b/packages/content/src/pdf-page-images.ts
@@ -26,6 +26,26 @@ const RGBA_32BPP = 3;
 
 const IDENTITY: readonly number[] = [1, 0, 0, 1, 0, 0];
 
+/**
+ * Largest decoded image this will hold, in pixels. At three bytes per pixel
+ * that is ~192 MB of raster for a single page — generous enough for a
+ * large-format scan (A0 at 300dpi is ~35 MP) and far above the ordinary case
+ * (US Letter at 300dpi is ~8 MP), while refusing an image whose dimensions
+ * would allocate without bound.
+ *
+ * A starting point, not a measured optimum: it should be revisited against a
+ * real scanned corpus (SMELTER-MEDIA-TYPES, live-testing follow-up).
+ */
+export const MAX_IMAGE_PIXELS = 64_000_000;
+
+/** Whether an image's dimensions are sane and inside the budget. Exported
+ *  because the threshold is a judgement, and judgements deserve tests. */
+export function withinPixelBudget(width: number, height: number): boolean {
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return false;
+    if (width <= 0 || height <= 0) return false;
+    return width * height <= MAX_IMAGE_PIXELS;
+}
+
 /** An image painted on a page, with the matrix that placed it. */
 export interface PlacedImage {
     ref: string;
@@ -172,6 +192,10 @@ export async function extractPageImages(
 
             const images: PageImage[] = [];
             for (const placement of findPlacedImages(ops.fnArray, ops.argsArray)) {
+                // Checked from the paint operator's own dimensions, BEFORE the
+                // image is resolved — refusing after decoding would already
+                // have paid the allocation this guards against.
+                if (!withinPixelBudget(placement.width, placement.height)) continue;
                 const rgb = toRgb(await resolveImage(page, placement.ref));
                 if (!rgb) continue;
                 images.push({


### PR DESCRIPTION
`'too-large'` has been in the decline vocabulary since Phase 0 and nothing ever emitted it. That dead value was the visible half of a real gap: **nothing bounded what extraction would allocate.**

Deleting it would have papered over the problem. A PDF is a compressed container, so input size implies nothing about decoded size — a few megabytes of JPEG can decode into gigabytes of raster, and since #1123 the OCR path decodes every scanned page. The fix is the limit the reason was declared for.

## Two bounds, deliberately different in kind

**A whole-document input cap that declines.** Nothing safe can be done with a document this size, and the operator should be told why — so it returns `{ declined: 'too-large' }` before the parser ever sees the bytes.

**A per-image pixel cap that skips.** One pathological page must not cost a document its other forty, so an over-budget image is skipped and its page is simply left unread — the partial-coverage story class C already tells (`unreadPages`).

The pixel check reads the dimensions **the paint operator itself reports, before the image is resolved**. Refusing after decoding would already have paid the allocation being guarded against; refusing beforehand costs nothing.

## Why this is worth having

Removing the byte guard does not fail a test — it ends the process:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
  Allocation failed - JavaScript heap out of memory
```

That is what the guard converts into a clean decline, and it is the clearest available statement of the behavior change.

## Nothing else needed plumbing

`'too-large'` was already in the `smelt:settled` reason enum, already in the Smelter's `SkipReason`, and already had a user-facing string in the worker's `DECLINE_MESSAGES` ("This document is too large to extract text from"). The vocabulary was complete end to end and had been waiting for an emitter — so this PR is three files and no wire change.

## Thresholds

Starting points, not measured optima, and they say so in their own comments:

- `MAX_PDF_BYTES` = 200 MB — above real corpora (a few hundred scanned FOIA pages run tens of megabytes) while still a ceiling.
- `MAX_IMAGE_PIXELS` = 64 MP — above a large-format scan (A0 at 300dpi ≈ 35 MP) and far above the ordinary case (US Letter at 300dpi ≈ 8 MP). At three bytes per pixel that is ~192 MB of raster for one page.

Both want revisiting against a real scanned corpus, alongside the other live-testing follow-ups.

## Testing

Thresholds are numbers, so they are tested as pure predicates — `withinByteBudget` / `withinPixelBudget` — including the boundary and nonsense inputs. Two integration tests cover the wiring: an oversized buffer declines before parsing (`allocUnsafe`, since only `.length` is read, so the test does not carry 200 MB of resident memory to ask a question about a number), and a hand-built PDF that *declares* 20000×20000 while carrying three bytes of data yields nothing. That file is impossible via pdf-lib, which is the point — it is the shape that makes a pre-resolution check observable. Its control is a genuine 2×2 image that comes back, proving the guard is not rejecting wholesale.

content 125/125 (13 files); make-meaning smelter + axioms 47/47; typechecks clean for content, make-meaning, jobs.

## Still unbounded, named rather than fixed

OCR batches every page image before recognizing, so peak retention scales with page count. Bounding that means interleaving extraction and recognition rather than adding a third threshold — a restructuring, not a constant, and it wants the same corpus measurement.
