### PR TITLE
Assist surface: translate every progress string, unify the entity log, make the history-row click work

### DIFF
--- a/packages/react-ui/src/components/AssistProgress.tsx
+++ b/packages/react-ui/src/components/AssistProgress.tsx
@@ -4,23 +4,34 @@ import type { components } from '@semiont/core';
 
 type JobProgress = components['schemas']['JobProgress'];
 
+/**
+ * Every string this component renders. Required by default and with NO
+ * English fallbacks (ASSIST-SURFACE-WARTS Lane A): a `tr.x || 'X'` default
+ * turns a forgotten key into English text in a Japanese UI, silently and
+ * only at runtime. Required keys make the same mistake a type error at the
+ * call site. Only genuinely conditional copy is optional.
+ */
 export interface AssistProgressTranslations {
   /** Header title (e.g. "Annotating Entity References" / "Generating Resource"). Omit for the headerless inline style. */
   title?: string;
   /** Cancel-button title attribute. */
-  cancel?: string;
+  cancel: string;
   /** Default in-progress status message (used when the job sends no `message`). */
-  inProgress?: string;
+  inProgress: string;
   /** Status copy for the terminal 'complete' stage. */
-  complete?: string;
+  complete: string;
   /** Fallback status copy for the terminal 'error' stage. */
-  failed?: string;
-  /** Completed entity-type log line (reference flow). */
+  failed: string;
+  /** Request-parameters block heading. */
+  paramsTitle: string;
+  /** Current-work detail line — the generic form, used by every flow. */
+  processing: (label: string) => string;
+  /** Completed entity-type log line (reference flow only). */
   found?: (count: number) => string;
-  /** Current-work detail line (reference flow). */
+  /** Current-work detail line, reference-flow wording; falls back to `processing`. */
   current?: (label: string) => string;
   /** Dismiss-button label. */
-  close?: string;
+  close: string;
 }
 
 export interface AssistProgressProps {
@@ -37,7 +48,7 @@ export interface AssistProgressProps {
   onDismiss?: () => void;
   /** Render the percentage bar (tag flow's visual; percentage itself comes from `progress`). */
   showPercentBar?: boolean;
-  translations?: AssistProgressTranslations;
+  translations: AssistProgressTranslations;
 }
 
 /**
@@ -55,9 +66,12 @@ export function AssistProgress({
   onCancel,
   onDismiss,
   showPercentBar = false,
-  translations: tr = {},
+  translations: tr,
 }: AssistProgressProps) {
   const terminal = progress.stage === 'complete' || progress.stage === 'error';
+  // The reference flow words this line its own way; everyone else gets the
+  // generic one. Both are translated — there is no untranslated branch.
+  const currentLabel = tr.current ?? tr.processing;
 
   return (
     <div className="semiont-annotation-progress" data-status={progress.stage} data-type={dataType}>
@@ -72,8 +86,8 @@ export function AssistProgress({
             <button
               onClick={onCancel}
               className="semiont-annotation-cancel"
-              title={tr.cancel || 'Cancel'}
-              aria-label={tr.cancel || 'Cancel'}
+              title={tr.cancel}
+              aria-label={tr.cancel}
               type="button"
             >
               ✕
@@ -85,7 +99,7 @@ export function AssistProgress({
       {/* Request parameters */}
       {progress.requestParams && progress.requestParams.length > 0 && (
         <div className="semiont-annotation-progress__params" data-type={dataType}>
-          <div className="semiont-annotation-progress__params-title">Request Parameters:</div>
+          <div className="semiont-annotation-progress__params-title">{tr.paramsTitle}</div>
           {progress.requestParams.map((param, idx) => (
             <div key={idx} className="semiont-annotation-progress__param">
               <span className="semiont-annotation-progress__param-label">{param.label}:</span> <span>{param.value}</span>
@@ -113,19 +127,19 @@ export function AssistProgress({
           <div className="semiont-annotation-progress__message">
             <span className="semiont-annotation-progress__icon">✅</span>
             {/* JobProgress.message is required but may be '' — never blank a terminal line. */}
-            <span>{tr.complete || progress.message || 'Complete'}</span>
+            <span>{tr.complete}</span>
           </div>
         ) : progress.stage === 'error' ? (
           <div className="semiont-annotation-progress__message">
             <span className="semiont-annotation-progress__icon">❌</span>
-            <span>{progress.message || tr.failed || 'Failed'}</span>
+            <span>{progress.message || tr.failed}</span>
           </div>
         ) : (
           <div className="semiont-annotation-progress__message">
             <span className="semiont-annotation-progress__icon">✨</span>
             <span>
               {progress.message
-                || (progress.currentEntityType && tr.current ? tr.current(progress.currentEntityType) : tr.inProgress)}
+                || (progress.currentEntityType ? currentLabel(progress.currentEntityType) : tr.inProgress)}
             </span>
           </div>
         )}
@@ -133,12 +147,12 @@ export function AssistProgress({
         {/* Current-work detail while running */}
         {!terminal && progress.currentEntityType && (
           <div className="semiont-annotation-progress__details">
-            {tr.current ? tr.current(progress.currentEntityType) : `Processing: ${progress.currentEntityType}`}
+            {currentLabel(progress.currentEntityType)}
           </div>
         )}
         {!terminal && progress.currentCategory && (
           <div className="semiont-annotation-progress__details">
-            Processing: {progress.currentCategory}
+            {tr.processing(progress.currentCategory)}
             {progress.processedCategories !== undefined && progress.totalCategories !== undefined && (
               <> ({progress.processedCategories}/{progress.totalCategories})</>
             )}
@@ -150,8 +164,8 @@ export function AssistProgress({
           <button
             onClick={onDismiss}
             className="semiont-annotation-progress__close"
-            aria-label={tr.close || 'Dismiss'}
-            title={tr.close || 'Dismiss'}
+            aria-label={tr.close}
+            title={tr.close}
             type="button"
           >
             ×

--- a/packages/react-ui/src/components/AssistProgress.tsx
+++ b/packages/react-ui/src/components/AssistProgress.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { components } from '@semiont/core';
+import { EntityFoundLog } from './EntityFoundLog';
 
 type JobProgress = components['schemas']['JobProgress'];
 
@@ -109,16 +110,8 @@ export function AssistProgress({
       )}
 
       {/* Completed entity-type log (reference flow) */}
-      {tr.found && progress.completedEntityTypes && progress.completedEntityTypes.length > 0 && (
-        <div className="semiont-annotation-log">
-          {progress.completedEntityTypes.map((item, index) => (
-            <div key={index} className="semiont-annotation-log-item">
-              <span className="semiont-annotation-check">✓</span>
-              <span className="semiont-annotation-entity-type">{item.entityType}:</span>
-              <span>{tr.found!(item.foundCount)}</span>
-            </div>
-          ))}
-        </div>
+      {tr.found && progress.completedEntityTypes && (
+        <EntityFoundLog entries={progress.completedEntityTypes} formatFound={tr.found} />
       )}
 
       {/* Status line with stage branching */}
@@ -126,8 +119,13 @@ export function AssistProgress({
         {progress.stage === 'complete' ? (
           <div className="semiont-annotation-progress__message">
             <span className="semiont-annotation-progress__icon">✅</span>
-            {/* JobProgress.message is required but may be '' — never blank a terminal line. */}
-            <span>{tr.complete}</span>
+            {/* Same precedence as 'error' below: the job's own message carries
+                detail no static string can ("Created 14 highlights"), and
+                `tr.complete` covers the required-but-possibly-'' case so a
+                terminal line is never blank. NOTE: job messages are composed
+                backend-side and are not localized — a real gap, but a backend
+                one; see ASSIST-SURFACE-WARTS watch-items. */}
+            <span>{progress.message || tr.complete}</span>
           </div>
         ) : progress.stage === 'error' ? (
           <div className="semiont-annotation-progress__message">

--- a/packages/react-ui/src/components/EntityFoundLog.tsx
+++ b/packages/react-ui/src/components/EntityFoundLog.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+export interface EntityFoundEntry {
+  entityType: string;
+  foundCount: number;
+}
+
+export interface EntityFoundLogProps {
+  entries: EntityFoundEntry[];
+  /** Formats the per-entity count line, e.g. `(n) => t('found', { count: n })`. */
+  formatFound: (count: number) => string;
+}
+
+/**
+ * "✓ Person: 5 found" — the completed entity-type log.
+ *
+ * One markup for one concept (ASSIST-SURFACE-WARTS Lane B). This was two
+ * class families a single panel apart: the live progress display used
+ * `semiont-annotation-log*` while ReferencesPanel's post-run form log used
+ * `semiont-assist-widget__log*`, with the same rows rendered by hand in both.
+ * Presentational and provider-free, like AssistProgress — the caller brings
+ * the formatter.
+ */
+export function EntityFoundLog({ entries, formatFound }: EntityFoundLogProps) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="semiont-annotation-log">
+      {entries.map((item, index) => (
+        <div key={index} className="semiont-annotation-log-item">
+          <span className="semiont-annotation-check">✓</span>
+          <span className="semiont-annotation-entity-type">{item.entityType}:</span>
+          <span>{formatFound(item.foundCount)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/react-ui/src/components/__tests__/AssistProgress.test.tsx
+++ b/packages/react-ui/src/components/__tests__/AssistProgress.test.tsx
@@ -7,18 +7,36 @@
  * cancel/dismiss arrive as callbacks the caller wires (job.cancelRequest /
  * mark.dismissProgress). Feature blocks are data-presence-driven so each call
  * site keeps its current visuals by passing what it always had.
+ *
+ * i18n contract (ASSIST-SURFACE-WARTS Lane A): every string this component
+ * renders comes from `translations`. There are NO English fallbacks — a
+ * missing key must be a type error at the call site, not a silent English
+ * leak in a Japanese UI. Tests use key-echo strings ('tr.complete') so an
+ * assertion failing means "rendered something other than what was passed".
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import type { components } from '@semiont/core';
-import { AssistProgress } from '../AssistProgress';
+import { AssistProgress, type AssistProgressTranslations } from '../AssistProgress';
 
 type JobProgress = components['schemas']['JobProgress'];
 
 const running = (over: Partial<JobProgress> = {}): JobProgress => ({
   stage: 'analyzing', percentage: 40, message: 'working on it', ...over,
+});
+
+/** Every required key, echoing its own name; override per test. */
+const T = (over: Partial<AssistProgressTranslations> = {}): AssistProgressTranslations => ({
+  cancel: 'tr.cancel',
+  inProgress: 'tr.inProgress',
+  complete: 'tr.complete',
+  failed: 'tr.failed',
+  close: 'tr.close',
+  paramsTitle: 'tr.paramsTitle',
+  processing: (label: string) => `tr.processing(${label})`,
+  ...over,
 });
 
 describe('AssistProgress', () => {
@@ -27,7 +45,8 @@ describe('AssistProgress', () => {
       <AssistProgress
         progress={running({ requestParams: [{ label: 'Density', value: '5' }] })}
         dataType="comment"
-             />,
+        translations={T()}
+      />,
     );
     expect(screen.getByText('working on it')).toBeInTheDocument();
     expect(screen.getByText(/Density/)).toBeInTheDocument();
@@ -37,12 +56,24 @@ describe('AssistProgress', () => {
     expect(root).toHaveAttribute('data-status', 'analyzing');
   });
 
+  it('renders the request-parameters title from translations, never a literal', () => {
+    render(
+      <AssistProgress
+        progress={running({ requestParams: [{ label: 'Density', value: '5' }] })}
+        dataType="comment"
+        translations={T()}
+      />,
+    );
+    expect(screen.getByText('tr.paramsTitle')).toBeInTheDocument();
+    expect(screen.queryByText('Request Parameters:')).not.toBeInTheDocument();
+  });
+
   it('renders a title header only when given one', () => {
     const { rerender } = render(
-      <AssistProgress progress={running()} dataType="reference" translations={{ title: 'Annotating Entity References' }} />,
+      <AssistProgress progress={running()} dataType="reference" translations={T({ title: 'Annotating Entity References' })} />,
     );
     expect(screen.getByText('Annotating Entity References')).toBeInTheDocument();
-    rerender(<AssistProgress progress={running()} dataType="comment" />);
+    rerender(<AssistProgress progress={running()} dataType="comment" translations={T()} />);
     expect(screen.queryByText('Annotating Entity References')).not.toBeInTheDocument();
   });
 
@@ -50,7 +81,7 @@ describe('AssistProgress', () => {
     // Cancel lives in the title header — both flows that offer cancel
     // (reference detection, generation) render the titled profile.
     const onCancel = vi.fn();
-    const tr = { title: 'Generating Resource', cancel: 'Cancel Job' };
+    const tr = T({ title: 'Generating Resource', cancel: 'Cancel Job' });
     const { rerender } = render(
       <AssistProgress progress={running()} dataType="generation" onCancel={onCancel} translations={tr} />,
     );
@@ -70,11 +101,11 @@ describe('AssistProgress', () => {
 
   it('stage branching: complete shows ✅ + complete copy, error shows ❌ + message', () => {
     const { rerender } = render(
-      <AssistProgress progress={running({ stage: 'complete' })} dataType="reference" translations={{ complete: 'All done!' }} />,
+      <AssistProgress progress={running({ stage: 'complete' })} dataType="reference" translations={T({ complete: 'All done!' })} />,
     );
     expect(screen.getByText('All done!')).toBeInTheDocument();
     rerender(
-      <AssistProgress progress={running({ stage: 'error', message: 'it broke' })} dataType="reference" translations={{ failed: 'Failed' }} />,
+      <AssistProgress progress={running({ stage: 'error', message: 'it broke' })} dataType="reference" translations={T({ failed: 'Failed' })} />,
     );
     expect(screen.getByText('it broke')).toBeInTheDocument();
   });
@@ -83,7 +114,7 @@ describe('AssistProgress', () => {
     render(
       <AssistProgress
         progress={running({ completedEntityTypes: [{ entityType: 'Person', foundCount: 3 }] })}
-        dataType="reference" translations={{ found: (n) => `Found ${n}` }}
+        dataType="reference" translations={T({ found: (n) => `Found ${n}` })}
       />,
     );
     expect(screen.getByText('Person:')).toBeInTheDocument();
@@ -94,55 +125,75 @@ describe('AssistProgress', () => {
     const { rerender } = render(
       <AssistProgress
         progress={running({ currentEntityType: 'Location' })}
-        dataType="reference" translations={{ current: (l) => `Processing: ${l}` }}
+        dataType="reference" translations={T({ current: (l) => `Current: ${l}` })}
       />,
     );
-    expect(screen.getByText('Processing: Location')).toBeInTheDocument();
+    expect(screen.getByText('Current: Location')).toBeInTheDocument();
     rerender(
       <AssistProgress
         progress={running({ currentCategory: 'Rule', processedCategories: 2, totalCategories: 5 })}
-        dataType="tag"      />,
+        dataType="tag" translations={T()}
+      />,
     );
     expect(screen.getByText(/Rule/)).toBeInTheDocument();
     expect(screen.getByText(/2\/5/)).toBeInTheDocument();
   });
 
+  it('falls back to the generic processing formatter — never the English literal', () => {
+    // The reference flow passes its own `current` wording; every other flow
+    // (tag categories, and any flow without one) uses `processing`. Neither
+    // path may render a hardcoded "Processing: ".
+    const { rerender } = render(
+      <AssistProgress progress={running({ currentEntityType: 'Location' })} dataType="reference" translations={T()} />,
+    );
+    expect(screen.getByText('tr.processing(Location)')).toBeInTheDocument();
+    rerender(
+      <AssistProgress progress={running({ currentCategory: 'Rule' })} dataType="tag" translations={T()} />,
+    );
+    expect(screen.getByText(/tr\.processing\(Rule\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/^Processing: /)).not.toBeInTheDocument();
+  });
+
   it('renders the percentage bar only when opted in', () => {
     const { container, rerender } = render(
-      <AssistProgress progress={running({ percentage: 40 })} dataType="tag" showPercentBar />,
+      <AssistProgress progress={running({ percentage: 40 })} dataType="tag" showPercentBar translations={T()} />,
     );
     const fill = container.querySelector('.semiont-progress-bar__fill');
     expect(fill).toBeInTheDocument();
     expect(fill).toHaveStyle({ width: '40%' });
     rerender(
-      <AssistProgress progress={running({ percentage: 40 })} dataType="reference" />,
+      <AssistProgress progress={running({ percentage: 40 })} dataType="reference" translations={T()} />,
     );
     expect(container.querySelector('.semiont-progress-bar__fill')).not.toBeInTheDocument();
   });
 
-  it('cancel and dismiss carry accessible names, with safe fallbacks when untranslated', () => {
-    // ✕ / × glyphs alone are meaningless to screen readers; the controls must
-    // have an accessible name even when a caller forgets the translations.
+  it('cancel and dismiss take their accessible names from translations', () => {
+    // ✕ / × glyphs alone are meaningless to screen readers, and an English
+    // fallback is meaningless to a non-English reader. The labels are
+    // required keys, so there is nothing to fall back TO.
     render(
       <AssistProgress progress={running()} dataType="generation"
         onCancel={vi.fn()} onDismiss={vi.fn()}
-        translations={{ title: 'Generating' }} />,
+        translations={T({ title: 'Generating' })} />,
     );
-    expect(screen.getByLabelText('Cancel')).toBeInTheDocument();
-    expect(screen.getByLabelText('Dismiss')).toBeInTheDocument();
+    expect(screen.getByLabelText('tr.cancel')).toBeInTheDocument();
+    expect(screen.getByLabelText('tr.close')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Cancel')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Dismiss')).not.toBeInTheDocument();
   });
 
-  it('terminal stages never render a blank status line', () => {
+  it('terminal stages never render a blank status line, and never an English one', () => {
     // JobProgress.message is required but can be '' — a terminal display with
-    // no text at all is worse than a generic word.
+    // no text at all is worse than a generic word, but that word must be the
+    // caller's translated one.
     const { rerender } = render(
-      <AssistProgress progress={running({ stage: 'complete', message: '' })} dataType="reference" />,
+      <AssistProgress progress={running({ stage: 'complete', message: '' })} dataType="reference" translations={T()} />,
     );
-    expect(screen.getByText('Complete')).toBeInTheDocument();
+    expect(screen.getByText('tr.complete')).toBeInTheDocument();
     rerender(
-      <AssistProgress progress={running({ stage: 'error', message: '' })} dataType="reference" />,
+      <AssistProgress progress={running({ stage: 'error', message: '' })} dataType="reference" translations={T()} />,
     );
-    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText('tr.failed')).toBeInTheDocument();
   });
 
   it('renders dismiss whenever the caller offers it (WHEN is the caller\'s policy)', async () => {
@@ -151,12 +202,12 @@ describe('AssistProgress', () => {
     // "callback present → affordance rendered".
     const onDismiss = vi.fn();
     const { rerender } = render(
-      <AssistProgress progress={running()} dataType="highlight" translations={{ close: 'Close' }} />,
+      <AssistProgress progress={running()} dataType="highlight" translations={T({ close: 'Close' })} />,
     );
     expect(screen.queryByLabelText('Close')).not.toBeInTheDocument();
     rerender(
       <AssistProgress progress={running()} dataType="highlight"
-        onDismiss={onDismiss} translations={{ close: 'Close' }} />,
+        onDismiss={onDismiss} translations={T({ close: 'Close' })} />,
     );
     await userEvent.click(screen.getByLabelText('Close'));
     expect(onDismiss).toHaveBeenCalledOnce();

--- a/packages/react-ui/src/components/__tests__/AssistProgress.test.tsx
+++ b/packages/react-ui/src/components/__tests__/AssistProgress.test.tsx
@@ -99,9 +99,16 @@ describe('AssistProgress', () => {
     expect(screen.queryByTitle('Cancel Job')).not.toBeInTheDocument();
   });
 
-  it('stage branching: complete shows ✅ + complete copy, error shows ❌ + message', () => {
+  it('stage branching: both terminal stages prefer the job message, then the translated copy', () => {
+    // The job composes detail no static string can ("Created 14 highlights"),
+    // so it wins on BOTH terminal stages; the translated copy covers the
+    // required-but-empty message case (pinned below).
     const { rerender } = render(
       <AssistProgress progress={running({ stage: 'complete' })} dataType="reference" translations={T({ complete: 'All done!' })} />,
+    );
+    expect(screen.getByText('working on it')).toBeInTheDocument();
+    rerender(
+      <AssistProgress progress={running({ stage: 'complete', message: '' })} dataType="reference" translations={T({ complete: 'All done!' })} />,
     );
     expect(screen.getByText('All done!')).toBeInTheDocument();
     rerender(

--- a/packages/react-ui/src/components/resource/AnnotateView.tsx
+++ b/packages/react-ui/src/components/resource/AnnotateView.tsx
@@ -8,6 +8,7 @@ import { defaultAnnotateRenderers, type AnnotateMediaRenderers } from './annotat
 import type { EditorView } from '@codemirror/view';
 import type { SemiontSession } from '@semiont/sdk';
 import { useSessionEventSubscriptions } from '../../hooks/useSessionEventSubscriptions';
+import { scrollAnnotationIntoView } from '../../lib/scroll-utils';
 
 // Type augmentation for custom DOM properties
 interface EnrichedHTMLElement extends HTMLElement {
@@ -51,6 +52,7 @@ interface Props {
  *
  * @emits mark:requested - User requested to create annotation. Payload: { selector: Selector | Selector[], motivation: SelectionMotivation }
  * @subscribes beckon:hover - Annotation hovered. Payload: { annotationId: string | null }
+ * @subscribes beckon:focus - Scroll to and highlight annotation. Payload: { annotationId: string }
  */
 export function AnnotateView({
   content,
@@ -104,10 +106,20 @@ export function AnnotateView({
     onUIStateChangeRef.current?.({ hoveredAnnotationId: annotationId });
   }, []);
 
+  // "Scroll to and highlight this annotation" — the same contract BrowseView
+  // serves, so the behaviour no longer depends on which view mode is active.
+  // The `scrollToAnnotationId` prop path (uiState → renderer) stays as the
+  // host-facing capability it is; this is the in-app producer's route.
+  const handleAnnotationFocus = useCallback(({ annotationId }: { annotationId?: string | null }) => {
+    if (!containerRef.current) return;
+    scrollAnnotationIntoView(annotationId ?? null, containerRef.current, { pulse: true });
+  }, []);
+
   // Annotation hover (session-scoped). Toolbar preference changes flow through
   // props/callbacks, not the bus (TOOLBAR-PREFS-AS-PROPS).
   useSessionEventSubscriptions(session, {
     'beckon:hover': handleAnnotationHover,
+    'beckon:focus': handleAnnotationFocus,
   });
 
   // Handle text annotation with sparkle or immediate creation

--- a/packages/react-ui/src/components/resource/__tests__/AnnotateView.focus.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/AnnotateView.focus.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ASSIST-SURFACE-WARTS Lane D — in-content scroll on `beckon:focus`.
+ *
+ * `beckon:focus` is the established "scroll to and highlight this annotation"
+ * contract; BrowseView has subscribed to it all along. AnnotateView did not,
+ * so the same event scrolled the content in browse mode and did nothing in
+ * annotate mode. With the history panel now producing the event, that asymmetry
+ * becomes user-visible: the same click works or doesn't depending on the mode.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { AnnotationUIState } from '../../../types/annotation-props';
+import { createTestSemiontWrapper } from '../../../test-utils';
+
+const scrollSpy = vi.hoisted(() => vi.fn());
+vi.mock('../../../lib/scroll-utils', () => ({
+  scrollAnnotationIntoView: scrollSpy,
+}));
+vi.mock('../../CodeMirrorRenderer', () => ({
+  CodeMirrorRenderer: () => <div data-annotation-id="ann-7">cm-mock</div>,
+}));
+
+import { AnnotateView } from '../AnnotateView';
+
+const emptyAnnotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
+const uiState: AnnotationUIState = {
+  selectedMotivation: 'linking',
+  selectedClick: 'detail',
+  selectedShape: 'rectangle',
+  hoveredAnnotationId: null,
+  scrollToAnnotationId: null,
+};
+
+describe('AnnotateView — beckon:focus scrolls the content', () => {
+  beforeEach(() => scrollSpy.mockClear());
+
+  it('scrolls to the annotation when the session emits beckon:focus', () => {
+    const { session, client } = createTestSemiontWrapper();
+
+    render(
+      <AnnotateView
+        content="hello world"
+        mimeType="text/plain"
+        resourceUri="res-1"
+        annotations={emptyAnnotations}
+        uiState={uiState}
+        session={session}
+        annotateMode
+      />,
+    );
+
+    client.bus.get('beckon:focus').next({ annotationId: 'ann-7' });
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy.mock.calls[0]?.[0]).toBe('ann-7');
+  });
+});

--- a/packages/react-ui/src/components/resource/panels/AssistSection.css
+++ b/packages/react-ui/src/components/resource/panels/AssistSection.css
@@ -126,49 +126,6 @@
    Detection Log (Completed Results)
    ============================================ */
 
-.semiont-assist-widget__log {
-  background-color: var(--semiont-bg-primary);
-  border-radius: 0.5rem;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-[data-theme="dark"] .semiont-assist-widget__log {
-  background-color: var(--semiont-color-gray-800);
-}
-
-.semiont-assist-widget__log-items {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.semiont-assist-widget__log-item {
-  font-size: 0.75rem;
-  color: var(--semiont-color-gray-600);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-[data-theme="dark"] .semiont-assist-widget__log-item {
-  color: var(--semiont-color-gray-400);
-}
-
-.semiont-assist-widget__log-check {
-  color: var(--semiont-color-green-600);
-}
-
-[data-theme="dark"] .semiont-assist-widget__log-check {
-  color: var(--semiont-color-green-400);
-}
-
-.semiont-assist-widget__log-type {
-  font-weight: 500;
-}
 
 /* ============================================
    Detection Progress Display

--- a/packages/react-ui/src/components/resource/panels/AssistSection.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssistSection.tsx
@@ -43,6 +43,7 @@ export function AssistSection({
                      annotationType === 'assessment' ? 'AssessmentPanel' :
                      'CommentsPanel';
   const t = useTranslations(panelName);
+  const ta = useTranslations('AssistProgress');
   const [instructions, setInstructions] = useState('');
   type ToneValue = 'scholarly' | 'explanatory' | 'conversational' | 'technical' | 'analytical' | 'critical' | 'balanced' | 'constructive' | '';
   const [tone, setTone] = useState<ToneValue>('');
@@ -89,7 +90,15 @@ export function AssistSection({
       progress={progress}
       progressProps={{
         onDismiss: handleDismissProgress,
-        translations: { close: t('closeProgress') },
+        translations: {
+          cancel: t('cancel'),
+          inProgress: t('annotating'),
+          complete: t('complete'),
+          failed: t('failed'),
+          paramsTitle: ta('paramsTitle'),
+          processing: (label) => ta('processing', { label }),
+          close: ta('close'),
+        },
       }}
       form={
         <>
@@ -157,7 +166,7 @@ export function AssistSection({
                 <span>{t('densityLabel')}</span>
               </label>
               {useDensity && (
-                <span className="semiont-form-field__info">{density} per 2000 words</span>
+                <span className="semiont-form-field__info">{t('densityPerWords', { density })}</span>
               )}
             </div>
 

--- a/packages/react-ui/src/components/resource/panels/AssistShell.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssistShell.tsx
@@ -19,8 +19,12 @@ export interface AssistShellProps {
    * Pass-through config for the progress renderer (cancel/dismiss wiring,
    * translations, percent bar). Dismiss policy lives HERE: the shell forwards
    * `onDismiss` only once the assist is no longer running.
+   *
+   * Required because `translations` is: the shell renders the progress display
+   * itself, so a caller that omitted this would render untranslated chrome —
+   * the failure Lane A exists to make impossible.
    */
-  progressProps?: Omit<AssistProgressProps, 'progress' | 'dataType'>;
+  progressProps: Omit<AssistProgressProps, 'progress' | 'dataType'>;
 }
 
 /**

--- a/packages/react-ui/src/components/resource/panels/ReferencesPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/ReferencesPanel.tsx
@@ -6,6 +6,7 @@ import type { SemiontSession } from '@semiont/sdk';
 import { useSessionEventSubscriptions } from '../../../hooks/useSessionEventSubscriptions';
 import type { RouteBuilder, LinkComponentProps } from '../../../contexts/RoutingContext';
 import { AssistShell } from './AssistShell';
+import { EntityFoundLog } from '../../EntityFoundLog';
 import { ReferenceEntry } from './ReferenceEntry';
 import type { components, Selector } from '@semiont/core';
 import { getTextPositionSelector, getTargetSelector } from '@semiont/core';
@@ -121,6 +122,9 @@ export function ReferencesPanel({
   sourceLanguage,
 }: Props) {
   const t = useTranslations('ReferencesPanel');
+  // Chrome shared by every assist surface (heading, current-work line, dismiss)
+  // lives in one namespace so the same words aren't re-translated per panel.
+  const ta = useTranslations('AssistProgress');
   const [selectedEntityTypes, setSelectedEntityTypes] = useState<string[]>([]);
   const [lastAnnotationLog, setLastDetectionLog] = useState<Array<{ entityType: string; foundCount: number }> | null>(null);
   const [pendingEntityTypes, setPendingEntityTypes] = useState<string[]>([]);
@@ -375,24 +379,19 @@ export function ReferencesPanel({
                 failed: t('failed'),
                 found: (count) => t('found', { count }),
                 current: (entityType) => t('current', { entityType }),
-                close: t('closeProgress'),
+                paramsTitle: ta('paramsTitle'),
+                processing: (label) => ta('processing', { label }),
+                close: ta('close'),
               },
             }}
             form={
               <>
                 {/* Completed annotation log - shown after completion */}
-                {lastAnnotationLog && lastAnnotationLog.length > 0 && (
-                  <div className="semiont-assist-widget__log">
-                    <div className="semiont-assist-widget__log-items">
-                      {lastAnnotationLog.map((item, index) => (
-                        <div key={index} className="semiont-assist-widget__log-item">
-                          <span className="semiont-assist-widget__log-check">✓</span>
-                          <span className="semiont-assist-widget__log-type">{item.entityType}:</span>
-                          <span>{t('found', { count: item.foundCount })}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
+                {lastAnnotationLog && (
+                  <EntityFoundLog
+                    entries={lastAnnotationLog}
+                    formatFound={(count) => t('found', { count })}
+                  />
                 )}
 
                 {/* Entity Types Selection */}

--- a/packages/react-ui/src/components/resource/panels/TaggingPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/TaggingPanel.tsx
@@ -82,6 +82,14 @@ export function TaggingPanel({
   sourceLanguage,
 }: TaggingPanelProps) {
   const t = useTranslations('TaggingPanel');
+  const ta = useTranslations('AssistProgress');
+
+  // Dismiss parity: tag was the one assist surface with no way to clear a
+  // finished progress display, because it had no `closeProgress` key to
+  // label the control. Same wiring as every other surface.
+  const handleDismissProgress = useCallback(() => {
+    session?.client.mark.dismissProgress();
+  }, [session]);
 
   // Subscribe to the per-KB tag-schema registry. Schemas are runtime-
   // registered by the KB at session start (see frame.addTagSchema).
@@ -355,7 +363,19 @@ export function TaggingPanel({
             title={t('annotateTags')}
             isAssisting={isAssisting}
             progress={progress}
-            progressProps={{ showPercentBar: true }}
+            progressProps={{
+              showPercentBar: true,
+              onDismiss: handleDismissProgress,
+              translations: {
+                cancel: t('cancel'),
+                inProgress: t('annotating'),
+                complete: t('complete'),
+                failed: t('failed'),
+                paramsTitle: ta('paramsTitle'),
+                processing: (label) => ta('processing', { label }),
+                close: ta('close'),
+              },
+            }}
             form={
               <>
                   {/* Empty-state — registry has resolved with no schemas. */}

--- a/packages/react-ui/src/components/resource/panels/__tests__/AssistSection.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/AssistSection.test.tsx
@@ -126,7 +126,7 @@ describe('AssistSection', () => {
         />
       );
 
-      expect(screen.getByText('Request Parameters:')).toBeInTheDocument();
+      expect(screen.getByText('paramsTitle')).toBeInTheDocument();
       expect(screen.getByText('Find important points')).toBeInTheDocument();
       expect(screen.getByText(/Instructions:/)).toBeInTheDocument();
       expect(screen.getByText('5')).toBeInTheDocument();
@@ -506,7 +506,7 @@ describe('AssistSection', () => {
         />
       );
 
-      expect(screen.queryByText('Request Parameters:')).not.toBeInTheDocument();
+      expect(screen.queryByText('paramsTitle')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/react-ui/src/components/resource/panels/__tests__/AssistShell.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/AssistShell.test.tsx
@@ -13,6 +13,11 @@ import { AssistShell } from '../AssistShell';
 
 const progress = { stage: 'analyzing', percentage: 50, message: 'working' };
 
+/** AssistProgress requires a full translation set; the shell just passes it through. */
+const TR = { cancel: 'tr.cancel', inProgress: 'tr.inProgress', complete: 'tr.complete',
+  failed: 'tr.failed', close: 'tr.close', paramsTitle: 'tr.paramsTitle',
+  processing: (l: string) => `tr.processing(${l})` };
+
 describe('AssistShell', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -21,12 +26,12 @@ describe('AssistShell', () => {
   it('renders the form when there is no progress, the progress when there is', () => {
     const { rerender } = render(
       <AssistShell assistType="tag" title="Annotate Tags" isAssisting={false} progress={null}
-        form={<button type="button">the form</button>} />,
+        form={<button type="button">the form</button>} progressProps={{ translations: TR }} />,
     );
     expect(screen.getByText('the form')).toBeInTheDocument();
     rerender(
       <AssistShell assistType="tag" title="Annotate Tags" isAssisting={true} progress={progress}
-        form={<button type="button">the form</button>} />,
+        form={<button type="button">the form</button>} progressProps={{ translations: TR }} />,
     );
     expect(screen.queryByText('the form')).not.toBeInTheDocument();
     expect(screen.getByText('working')).toBeInTheDocument();
@@ -37,7 +42,7 @@ describe('AssistShell', () => {
     const props = {
       assistType: 'highlight', title: 'Annotate Highlights', progress,
       form: <span>form</span>,
-      progressProps: { onDismiss, translations: { close: 'Close' } },
+      progressProps: { onDismiss, translations: { ...TR, close: 'Close' } },
     };
     const { rerender } = render(<AssistShell {...props} isAssisting={true} />);
     expect(screen.queryByLabelText('Close')).not.toBeInTheDocument();
@@ -50,7 +55,7 @@ describe('AssistShell', () => {
   it('persists the expand state per assist type', async () => {
     render(
       <AssistShell assistType="reference" title="Annotate References" isAssisting={false} progress={null}
-        form={<span>form</span>} />,
+        form={<span>form</span>} progressProps={{ translations: TR }} />,
     );
     await userEvent.click(screen.getByRole('button', { name: /Annotate References/ }));
     expect(screen.queryByText('form')).not.toBeInTheDocument();

--- a/packages/react-ui/src/components/resource/panels/__tests__/HighlightPanel.annotationProgress.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/HighlightPanel.annotationProgress.test.tsx
@@ -169,7 +169,7 @@ describe('HighlightPanel + AssistSection Integration', () => {
         />
       );
 
-      expect(screen.getByText('Request Parameters:')).toBeInTheDocument();
+      expect(screen.getByText('paramsTitle')).toBeInTheDocument();
       expect(screen.getByText('Find important points')).toBeInTheDocument();
       expect(screen.getByText('5')).toBeInTheDocument();
     });

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.test.tsx
@@ -409,6 +409,32 @@ describe('ReferencesPanel Component', () => {
       expect(screen.getByText('Organization:')).toBeInTheDocument();
     });
 
+    it('renders the entity log with the SAME markup the progress display uses', () => {
+      // ASSIST-SURFACE-WARTS Lane B: this form-side log and AssistProgress's
+      // completed-entity log are the same concept. They had two class families
+      // (semiont-assist-widget__log* here, semiont-annotation-log* there) one
+      // panel apart — one concept, one markup.
+      const { container, rerender } = renderWithEventBus(
+        <ReferencesPanel
+          {...panelProps()}
+          isAssisting={false}
+          progress={{
+            stage: 'complete',
+            percentage: 100,
+            message: 'Annotation complete',
+            completedEntityTypes: [{ entityType: 'Person', foundCount: 5 }],
+          }}
+        />
+      );
+      rerender(
+        <ReferencesPanel {...panelProps()} isAssisting={false} progress={null} />
+      );
+
+      expect(container.querySelector('.semiont-annotation-log')).toBeInTheDocument();
+      expect(container.querySelector('.semiont-annotation-log-item')).toBeInTheDocument();
+      expect(container.querySelector('.semiont-assist-widget__log')).not.toBeInTheDocument();
+    });
+
     it('should hide entity type selection during detection', () => {
       renderWithEventBus(
         <ReferencesPanel

--- a/packages/react-ui/src/features/resource-viewer/__tests__/ResourceViewerPage.test.tsx
+++ b/packages/react-ui/src/features/resource-viewer/__tests__/ResourceViewerPage.test.tsx
@@ -41,7 +41,7 @@ vi.mock('../../../hooks/useResourceContent', () => ({
 // SemiontClient (wired to a dummy baseUrl). The real client surface lets
 // createResourceViewerPageStateUnit run against the full namespace API without us
 // hand-stubbing every method it touches.
-const { stubBrowser } = vi.hoisted(() => {
+const { stubBrowser, stubClient } = vi.hoisted(() => {
   const { BehaviorSubject } = require('rxjs');
   const { SemiontClient, HttpTransport, HttpContentTransport } = require('@semiont/sdk');
   const { baseUrl } = require('@semiont/core');
@@ -63,7 +63,7 @@ const { stubBrowser } = vi.hoisted(() => {
     on: vi.fn(() => () => {}),
     stream: vi.fn(() => ({ subscribe: () => ({ unsubscribe: () => {} }) })),
   };
-  return { stubBrowser };
+  return { stubBrowser, stubClient: client };
 });
 
 vi.mock('../../../session/SemiontProvider', async () => {
@@ -76,6 +76,8 @@ vi.mock('../../../session/SemiontProvider', async () => {
   };
 });
 
+const capturedHistory = vi.hoisted(() => ({ props: null as any }));
+
 vi.mock('@semiont/react-ui', async () => {
   const actual = await vi.importActual('@semiont/react-ui');
   return {
@@ -84,7 +86,10 @@ vi.mock('@semiont/react-ui', async () => {
     Toolbar: () => <div data-testid="toolbar">Toolbar</div>,
     ToolbarPanels: ({ children }: any) => <div data-testid="toolbar-panels">{children}</div>,
     UnifiedAnnotationsPanel: () => <div data-testid="annotations-panel">Annotations</div>,
-    AnnotationHistory: () => <div data-testid="history-panel">History</div>,
+    AnnotationHistory: (props: any) => {
+      capturedHistory.props = props;
+      return <div data-testid="history-panel">History</div>;
+    },
     ResourceInfoPanel: () => <div data-testid="info-panel">Info</div>,
     CollaborationPanel: () => <div data-testid="collaboration-panel">Collaboration</div>,
     JsonLdPanel: () => <div data-testid="jsonld-panel">JSON-LD</div>,
@@ -225,6 +230,27 @@ describe('ResourceViewerPage', () => {
       renderWithProviders(<ResourceViewerPage {...props} />);
 
       expect(screen.getByTestId('annotations-panel')).toBeInTheDocument();
+      localStorage.clear();
+    });
+
+    it('clicking a history event focuses that annotation in the content', () => {
+      // ASSIST-SURFACE-WARTS Lane D. `handleEventClick` used to be a no-op with
+      // a stale comment, while HistoryEvent still rendered a focusable button
+      // labelled "View annotation" — a promise to screen-reader users that
+      // nothing kept. `beckon:focus` is the existing "scroll to and highlight"
+      // contract (BrowseView already subscribes); this makes the page a producer.
+      localStorage.setItem('activeToolbarPanel', 'history');
+      const props = createMockProps();
+      renderWithProviders(<ResourceViewerPage {...props} />);
+
+      const focused: Array<string | null> = [];
+      const sub = stubClient.bus.get('beckon:focus').subscribe(({ annotationId }: any) => focused.push(annotationId));
+
+      expect(capturedHistory.props.onEventClick).toBeDefined();
+      capturedHistory.props.onEventClick('ann-42');
+      expect(focused).toEqual(['ann-42']);
+
+      sub.unsubscribe();
       localStorage.clear();
     });
 

--- a/packages/react-ui/src/features/resource-viewer/__tests__/ResourceViewerPage.test.tsx
+++ b/packages/react-ui/src/features/resource-viewer/__tests__/ResourceViewerPage.test.tsx
@@ -240,14 +240,16 @@ describe('ResourceViewerPage', () => {
       // nothing kept. `beckon:focus` is the existing "scroll to and highlight"
       // contract (BrowseView already subscribes); this makes the page a producer.
       localStorage.setItem('activeToolbarPanel', 'history');
+      capturedHistory.props = null;
       const props = createMockProps();
       renderWithProviders(<ResourceViewerPage {...props} />);
+
+      expect(capturedHistory.props).not.toBeNull();
 
       const focused: Array<string | null> = [];
       const sub = stubClient.bus.get('beckon:focus').subscribe(({ annotationId }: any) => focused.push(annotationId));
 
-      expect(capturedHistory.props.onEventClick).toBeDefined();
-      capturedHistory.props.onEventClick('ann-42');
+      expect(capturedHistory.props?.onEventClick).toBeTypeOf('function');
       expect(focused).toEqual(['ann-42']);
 
       sub.unsubscribe();

--- a/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
+++ b/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
@@ -139,6 +139,7 @@ export function ResourceViewerPage({
   // Translations
   const tw = useTranslations('ReferenceWizard');
   const tg = useTranslations('ResourceGenerate');
+  const ta = useTranslations('AssistProgress');
 
   const browser = useSemiont();
   const session = useObservable(browser.activeSession$);
@@ -444,9 +445,17 @@ export function ResourceViewerPage({
     }
   }, [session]);
 
-  const handleEventClick = useCallback((_annotationId: string | null) => {
-    // ResourceViewer now manages scroll state internally
-  }, []);
+  // Clicking a history row reveals that annotation in the content. HistoryEvent
+  // renders these rows as buttons labelled "View annotation", so this used to be
+  // a focusable, screen-reader-announced control wired to a no-op.
+  // `beckon:focus` is the existing "scroll to and highlight" contract rather
+  // than a new prop chain — BrowseView already subscribed to it, AnnotateView
+  // now does too. See .plans/ASSIST-SURFACE-WARTS.md Lane D.
+  const handleEventClick = useCallback((id: string | null) => {
+    if (id) {
+      stateUnit?.beckon.focus(annotationId(id));
+    }
+  }, [stateUnit]);
 
   // Document rendering
   return (
@@ -475,6 +484,9 @@ export function ResourceViewerPage({
                 inProgress: tg('progressInProgress'),
                 complete: tg('progressComplete'),
                 failed: tg('progressFailed'),
+                paramsTitle: ta('paramsTitle'),
+                processing: (label) => ta('processing', { label }),
+                close: ta('close'),
               }}
             />
           )}

--- a/packages/react-ui/translations/ar.json
+++ b/packages/react-ui/translations/ar.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "إغلاق",
+    "paramsTitle": "معاملات الطلب:",
+    "processing": "الحالي: {{label}}"
+  },
   "Toolbar": {
     "annotations": "التعليقات التوضيحية",
     "history": "السجل",
@@ -105,7 +110,9 @@
     "densityDense": "كثيف",
     "fragmentSelected": "تم تحديد جزء",
     "imageRegionSelected": "تم تحديد منطقة من الصورة",
-    "closeProgress": "إغلاق"
+    "complete": "اكتمل التوضيح!",
+    "failed": "فشل التوضيح",
+    "densityPerWords": "{{density}} لكل 2000 كلمة"
   },
   "HighlightPanel": {
     "title": "التمييزات",
@@ -120,7 +127,9 @@
     "densityLabel": "الكثافة",
     "densitySparse": "متفرق",
     "densityDense": "كثيف",
-    "closeProgress": "إغلاق"
+    "complete": "اكتمل التوضيح!",
+    "failed": "فشل التوضيح",
+    "densityPerWords": "{{density}} لكل 2000 كلمة"
   },
   "AssessmentPanel": {
     "title": "التقييمات",
@@ -145,7 +154,9 @@
     "densityDense": "كثيف",
     "fragmentSelected": "تم تحديد جزء",
     "imageRegionSelected": "تم تحديد منطقة من الصورة",
-    "closeProgress": "إغلاق"
+    "complete": "اكتمل التوضيح!",
+    "failed": "فشل التوضيح",
+    "densityPerWords": "{{density}} لكل 2000 كلمة"
   },
   "TaggingPanel": {
     "title": "العلامات",
@@ -164,7 +175,9 @@
     "selectCategory": "اختيار الفئة",
     "chooseCategory": "اختر فئة...",
     "fragmentSelected": "تم تحديد جزء",
-    "imageRegionSelected": "تم تحديد منطقة من الصورة"
+    "imageRegionSelected": "تم تحديد منطقة من الصورة",
+    "complete": "اكتمل التوضيح!",
+    "failed": "فشل التوضيح"
   },
   "UnifiedAnnotationsPanel": {
     "title": "التعليقات التوضيحية",
@@ -220,7 +233,6 @@
     "complete": "اكتمل التوضيح!",
     "failed": "فشل التوضيح",
     "current": "الحالي: {{entityType}}",
-    "closeProgress": "إغلاق",
     "loading": "جارٍ التحميل...",
     "loadingEllipsis": "جارٍ التحميل...",
     "untitledResource": "مورد بدون عنوان",

--- a/packages/react-ui/translations/bn.json
+++ b/packages/react-ui/translations/bn.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "বন্ধ করুন",
+    "paramsTitle": "অনুরোধের প্যারামিটার:",
+    "processing": "বর্তমান: {{label}}"
+  },
   "Toolbar": {
     "annotations": "টীকাসমূহ",
     "history": "ইতিহাস",
@@ -105,7 +110,9 @@
     "densityDense": "ঘন",
     "fragmentSelected": "অংশ নির্বাচিত",
     "imageRegionSelected": "ছবির অঞ্চল নির্বাচিত",
-    "closeProgress": "বন্ধ করুন"
+    "complete": "টীকাকরণ সম্পূর্ণ!",
+    "failed": "টীকাকরণ ব্যর্থ",
+    "densityPerWords": "প্রতি ২০০০ শব্দে {{density}}"
   },
   "HighlightPanel": {
     "title": "হাইলাইটসমূহ",
@@ -120,7 +127,9 @@
     "densityLabel": "ঘনত্ব",
     "densitySparse": "বিরল",
     "densityDense": "ঘন",
-    "closeProgress": "বন্ধ করুন"
+    "complete": "টীকাকরণ সম্পূর্ণ!",
+    "failed": "টীকাকরণ ব্যর্থ",
+    "densityPerWords": "প্রতি ২০০০ শব্দে {{density}}"
   },
   "AssessmentPanel": {
     "title": "মূল্যায়নসমূহ",
@@ -145,7 +154,9 @@
     "densityDense": "ঘন",
     "fragmentSelected": "অংশ নির্বাচিত",
     "imageRegionSelected": "ছবির অঞ্চল নির্বাচিত",
-    "closeProgress": "বন্ধ করুন"
+    "complete": "টীকাকরণ সম্পূর্ণ!",
+    "failed": "টীকাকরণ ব্যর্থ",
+    "densityPerWords": "প্রতি ২০০০ শব্দে {{density}}"
   },
   "TaggingPanel": {
     "title": "ট্যাগসমূহ",
@@ -164,7 +175,9 @@
     "selectCategory": "বিভাগ নির্বাচন করুন",
     "chooseCategory": "একটি বিভাগ বেছে নিন...",
     "fragmentSelected": "অংশ নির্বাচিত",
-    "imageRegionSelected": "ছবির অঞ্চল নির্বাচিত"
+    "imageRegionSelected": "ছবির অঞ্চল নির্বাচিত",
+    "complete": "টীকাকরণ সম্পূর্ণ!",
+    "failed": "টীকাকরণ ব্যর্থ"
   },
   "UnifiedAnnotationsPanel": {
     "title": "টীকাসমূহ",
@@ -220,7 +233,6 @@
     "complete": "টীকাকরণ সম্পূর্ণ!",
     "failed": "টীকাকরণ ব্যর্থ",
     "current": "বর্তমান: {{entityType}}",
-    "closeProgress": "বন্ধ করুন",
     "loading": "লোড হচ্ছে...",
     "loadingEllipsis": "লোড হচ্ছে...",
     "untitledResource": "শিরোনামবিহীন সম্পদ",

--- a/packages/react-ui/translations/cs.json
+++ b/packages/react-ui/translations/cs.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Zavřít",
+    "paramsTitle": "Parametry požadavku:",
+    "processing": "Aktuální: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Anotace",
     "history": "Historie",
@@ -105,7 +110,9 @@
     "densityDense": "Hustá",
     "fragmentSelected": "Fragment vybrán",
     "imageRegionSelected": "Oblast obrázku vybrána",
-    "closeProgress": "Zavřít"
+    "complete": "Anotace dokončena!",
+    "failed": "Anotace selhala",
+    "densityPerWords": "{{density}} na 2000 slov"
   },
   "HighlightPanel": {
     "title": "Zvýraznění",
@@ -120,7 +127,9 @@
     "densityLabel": "Hustota",
     "densitySparse": "Řídká",
     "densityDense": "Hustá",
-    "closeProgress": "Zavřít"
+    "complete": "Anotace dokončena!",
+    "failed": "Anotace selhala",
+    "densityPerWords": "{{density}} na 2000 slov"
   },
   "AssessmentPanel": {
     "title": "Hodnocení",
@@ -145,7 +154,9 @@
     "densityDense": "Hustá",
     "fragmentSelected": "Fragment vybrán",
     "imageRegionSelected": "Oblast obrázku vybrána",
-    "closeProgress": "Zavřít"
+    "complete": "Anotace dokončena!",
+    "failed": "Anotace selhala",
+    "densityPerWords": "{{density}} na 2000 slov"
   },
   "TaggingPanel": {
     "title": "Štítky",
@@ -164,7 +175,9 @@
     "selectCategory": "Vybrat kategorii",
     "chooseCategory": "Zvolte kategorii...",
     "fragmentSelected": "Fragment vybrán",
-    "imageRegionSelected": "Oblast obrázku vybrána"
+    "imageRegionSelected": "Oblast obrázku vybrána",
+    "complete": "Anotace dokončena!",
+    "failed": "Anotace selhala"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Anotace",
@@ -220,7 +233,6 @@
     "complete": "Anotace dokončena!",
     "failed": "Anotace selhala",
     "current": "Aktuální: {{entityType}}",
-    "closeProgress": "Zavřít",
     "loading": "načítání...",
     "loadingEllipsis": "Načítání...",
     "untitledResource": "Zdroj bez názvu",

--- a/packages/react-ui/translations/da.json
+++ b/packages/react-ui/translations/da.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Luk",
+    "paramsTitle": "Anmodningsparametre:",
+    "processing": "Aktuel: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annoteringer",
     "history": "Historik",
@@ -105,7 +110,9 @@
     "densityDense": "Tæt",
     "fragmentSelected": "Fragment markeret",
     "imageRegionSelected": "Billedområde markeret",
-    "closeProgress": "Luk"
+    "complete": "Annotering færdig!",
+    "failed": "Annotering mislykkedes",
+    "densityPerWords": "{{density}} pr. 2000 ord"
   },
   "HighlightPanel": {
     "title": "Fremhævninger",
@@ -120,7 +127,9 @@
     "densityLabel": "Tæthed",
     "densitySparse": "Sparsom",
     "densityDense": "Tæt",
-    "closeProgress": "Luk"
+    "complete": "Annotering færdig!",
+    "failed": "Annotering mislykkedes",
+    "densityPerWords": "{{density}} pr. 2000 ord"
   },
   "AssessmentPanel": {
     "title": "Vurderinger",
@@ -145,7 +154,9 @@
     "densityDense": "Tæt",
     "fragmentSelected": "Fragment markeret",
     "imageRegionSelected": "Billedområde markeret",
-    "closeProgress": "Luk"
+    "complete": "Annotering færdig!",
+    "failed": "Annotering mislykkedes",
+    "densityPerWords": "{{density}} pr. 2000 ord"
   },
   "TaggingPanel": {
     "title": "Tags",
@@ -164,7 +175,9 @@
     "selectCategory": "Vælg kategori",
     "chooseCategory": "Vælg en kategori...",
     "fragmentSelected": "Fragment markeret",
-    "imageRegionSelected": "Billedområde markeret"
+    "imageRegionSelected": "Billedområde markeret",
+    "complete": "Annotering færdig!",
+    "failed": "Annotering mislykkedes"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annoteringer",
@@ -220,7 +233,6 @@
     "complete": "Annotering færdig!",
     "failed": "Annotering mislykkedes",
     "current": "Aktuel: {{entityType}}",
-    "closeProgress": "Luk",
     "loading": "indlæser...",
     "loadingEllipsis": "Indlæser...",
     "untitledResource": "Unavngivet ressource",

--- a/packages/react-ui/translations/de.json
+++ b/packages/react-ui/translations/de.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Schließen",
+    "paramsTitle": "Anfrageparameter:",
+    "processing": "Aktuell: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annotationen",
     "history": "Verlauf",
@@ -105,7 +110,9 @@
     "densityDense": "Hoch",
     "fragmentSelected": "Fragment ausgewählt",
     "imageRegionSelected": "Bildbereich ausgewählt",
-    "closeProgress": "Schließen"
+    "complete": "Annotation abgeschlossen!",
+    "failed": "Annotation fehlgeschlagen",
+    "densityPerWords": "{{density}} pro 2000 Wörter"
   },
   "HighlightPanel": {
     "title": "Hervorhebungen",
@@ -120,7 +127,9 @@
     "densityLabel": "Dichte",
     "densitySparse": "Gering",
     "densityDense": "Hoch",
-    "closeProgress": "Schließen"
+    "complete": "Annotation abgeschlossen!",
+    "failed": "Annotation fehlgeschlagen",
+    "densityPerWords": "{{density}} pro 2000 Wörter"
   },
   "AssessmentPanel": {
     "title": "Bewertungen",
@@ -145,7 +154,9 @@
     "densityDense": "Hoch",
     "fragmentSelected": "Fragment ausgewählt",
     "imageRegionSelected": "Bildbereich ausgewählt",
-    "closeProgress": "Schließen"
+    "complete": "Annotation abgeschlossen!",
+    "failed": "Annotation fehlgeschlagen",
+    "densityPerWords": "{{density}} pro 2000 Wörter"
   },
   "TaggingPanel": {
     "title": "Tags",
@@ -164,7 +175,9 @@
     "selectCategory": "Kategorie auswählen",
     "chooseCategory": "Kategorie wählen...",
     "fragmentSelected": "Fragment ausgewählt",
-    "imageRegionSelected": "Bildbereich ausgewählt"
+    "imageRegionSelected": "Bildbereich ausgewählt",
+    "complete": "Annotation abgeschlossen!",
+    "failed": "Annotation fehlgeschlagen"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annotationen",
@@ -220,7 +233,6 @@
     "complete": "Annotation abgeschlossen!",
     "failed": "Annotation fehlgeschlagen",
     "current": "Aktuell: {{entityType}}",
-    "closeProgress": "Schließen",
     "loading": "Wird geladen...",
     "loadingEllipsis": "Wird geladen...",
     "untitledResource": "Unbenannte Ressource",

--- a/packages/react-ui/translations/el.json
+++ b/packages/react-ui/translations/el.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Κλείσιμο",
+    "paramsTitle": "Παράμετροι αιτήματος:",
+    "processing": "Τρέχον: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Σχολιασμοί",
     "history": "Ιστορικό",
@@ -105,7 +110,9 @@
     "densityDense": "Πυκνή",
     "fragmentSelected": "Επιλέχθηκε τμήμα",
     "imageRegionSelected": "Επιλέχθηκε περιοχή εικόνας",
-    "closeProgress": "Κλείσιμο"
+    "complete": "Ο σχολιασμός ολοκληρώθηκε!",
+    "failed": "Ο σχολιασμός απέτυχε",
+    "densityPerWords": "{{density}} ανά 2000 λέξεις"
   },
   "HighlightPanel": {
     "title": "Επισημάνσεις",
@@ -120,7 +127,9 @@
     "densityLabel": "Πυκνότητα",
     "densitySparse": "Αραιή",
     "densityDense": "Πυκνή",
-    "closeProgress": "Κλείσιμο"
+    "complete": "Ο σχολιασμός ολοκληρώθηκε!",
+    "failed": "Ο σχολιασμός απέτυχε",
+    "densityPerWords": "{{density}} ανά 2000 λέξεις"
   },
   "AssessmentPanel": {
     "title": "Αξιολογήσεις",
@@ -145,7 +154,9 @@
     "densityDense": "Πυκνή",
     "fragmentSelected": "Επιλέχθηκε τμήμα",
     "imageRegionSelected": "Επιλέχθηκε περιοχή εικόνας",
-    "closeProgress": "Κλείσιμο"
+    "complete": "Ο σχολιασμός ολοκληρώθηκε!",
+    "failed": "Ο σχολιασμός απέτυχε",
+    "densityPerWords": "{{density}} ανά 2000 λέξεις"
   },
   "TaggingPanel": {
     "title": "Ετικέτες",
@@ -164,7 +175,9 @@
     "selectCategory": "Επιλογή Κατηγορίας",
     "chooseCategory": "Επιλέξτε μια κατηγορία...",
     "fragmentSelected": "Επιλέχθηκε τμήμα",
-    "imageRegionSelected": "Επιλέχθηκε περιοχή εικόνας"
+    "imageRegionSelected": "Επιλέχθηκε περιοχή εικόνας",
+    "complete": "Ο σχολιασμός ολοκληρώθηκε!",
+    "failed": "Ο σχολιασμός απέτυχε"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Σχολιασμοί",
@@ -220,7 +233,6 @@
     "complete": "Ο σχολιασμός ολοκληρώθηκε!",
     "failed": "Ο σχολιασμός απέτυχε",
     "current": "Τρέχον: {{entityType}}",
-    "closeProgress": "Κλείσιμο",
     "loading": "φόρτωση...",
     "loadingEllipsis": "Φόρτωση...",
     "untitledResource": "Πόρος Χωρίς Τίτλο",

--- a/packages/react-ui/translations/en.json
+++ b/packages/react-ui/translations/en.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Close",
+    "paramsTitle": "Request Parameters:",
+    "processing": "Current: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annotations",
     "history": "History",
@@ -105,7 +110,9 @@
     "densityDense": "Dense",
     "fragmentSelected": "Fragment selected",
     "imageRegionSelected": "Image region selected",
-    "closeProgress": "Close"
+    "complete": "Annotation complete!",
+    "failed": "Annotation failed",
+    "densityPerWords": "{{density}} per 2000 words"
   },
   "HighlightPanel": {
     "title": "Highlights",
@@ -120,7 +127,9 @@
     "densityLabel": "Density",
     "densitySparse": "Sparse",
     "densityDense": "Dense",
-    "closeProgress": "Close"
+    "complete": "Annotation complete!",
+    "failed": "Annotation failed",
+    "densityPerWords": "{{density}} per 2000 words"
   },
   "AssessmentPanel": {
     "title": "Assessments",
@@ -145,7 +154,9 @@
     "densityDense": "Dense",
     "fragmentSelected": "Fragment selected",
     "imageRegionSelected": "Image region selected",
-    "closeProgress": "Close"
+    "complete": "Annotation complete!",
+    "failed": "Annotation failed",
+    "densityPerWords": "{{density}} per 2000 words"
   },
   "TaggingPanel": {
     "title": "Tags",
@@ -164,7 +175,9 @@
     "selectCategory": "Select Category",
     "chooseCategory": "Choose a category...",
     "fragmentSelected": "Fragment selected",
-    "imageRegionSelected": "Image region selected"
+    "imageRegionSelected": "Image region selected",
+    "complete": "Annotation complete!",
+    "failed": "Annotation failed"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annotations",
@@ -220,7 +233,6 @@
     "complete": "Annotation complete!",
     "failed": "Annotation failed",
     "current": "Current: {{entityType}}",
-    "closeProgress": "Close",
     "loading": "loading...",
     "loadingEllipsis": "Loading...",
     "untitledResource": "Untitled Resource",

--- a/packages/react-ui/translations/es.json
+++ b/packages/react-ui/translations/es.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Cerrar",
+    "paramsTitle": "Parámetros de la solicitud:",
+    "processing": "Actual: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Anotaciones",
     "history": "Historial",
@@ -105,7 +110,9 @@
     "densityDense": "Densa",
     "fragmentSelected": "Fragmento seleccionado",
     "imageRegionSelected": "Región de imagen seleccionada",
-    "closeProgress": "Cerrar"
+    "complete": "¡Anotación completa!",
+    "failed": "Anotación fallida",
+    "densityPerWords": "{{density}} por cada 2000 palabras"
   },
   "HighlightPanel": {
     "title": "Destacados",
@@ -120,7 +127,9 @@
     "densityLabel": "Densidad",
     "densitySparse": "Escasa",
     "densityDense": "Densa",
-    "closeProgress": "Cerrar"
+    "complete": "¡Anotación completa!",
+    "failed": "Anotación fallida",
+    "densityPerWords": "{{density}} por cada 2000 palabras"
   },
   "AssessmentPanel": {
     "title": "Evaluaciones",
@@ -145,7 +154,9 @@
     "densityDense": "Densa",
     "fragmentSelected": "Fragmento seleccionado",
     "imageRegionSelected": "Región de imagen seleccionada",
-    "closeProgress": "Cerrar"
+    "complete": "¡Anotación completa!",
+    "failed": "Anotación fallida",
+    "densityPerWords": "{{density}} por cada 2000 palabras"
   },
   "TaggingPanel": {
     "title": "Etiquetas",
@@ -164,7 +175,9 @@
     "selectCategory": "Seleccionar Categoría",
     "chooseCategory": "Elegir una categoría...",
     "fragmentSelected": "Fragmento seleccionado",
-    "imageRegionSelected": "Región de imagen seleccionada"
+    "imageRegionSelected": "Región de imagen seleccionada",
+    "complete": "¡Anotación completa!",
+    "failed": "Anotación fallida"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Anotaciones",
@@ -220,7 +233,6 @@
     "complete": "¡Anotación completa!",
     "failed": "Anotación fallida",
     "current": "Actual: {{entityType}}",
-    "closeProgress": "Cerrar",
     "loading": "cargando...",
     "loadingEllipsis": "Cargando...",
     "untitledResource": "Recurso Sin Título",

--- a/packages/react-ui/translations/fa.json
+++ b/packages/react-ui/translations/fa.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "بستن",
+    "paramsTitle": "پارامترهای درخواست:",
+    "processing": "فعلی: {{label}}"
+  },
   "Toolbar": {
     "annotations": "حاشیه‌نویسی‌ها",
     "history": "تاریخچه",
@@ -105,7 +110,9 @@
     "densityDense": "متراکم",
     "fragmentSelected": "قطعه انتخاب شد",
     "imageRegionSelected": "ناحیه تصویر انتخاب شد",
-    "closeProgress": "بستن"
+    "complete": "حاشیه‌نویسی تکمیل شد!",
+    "failed": "حاشیه‌نویسی ناموفق بود",
+    "densityPerWords": "{{density}} در هر ۲۰۰۰ کلمه"
   },
   "HighlightPanel": {
     "title": "برجسته‌سازی‌ها",
@@ -120,7 +127,9 @@
     "densityLabel": "تراکم",
     "densitySparse": "پراکنده",
     "densityDense": "متراکم",
-    "closeProgress": "بستن"
+    "complete": "حاشیه‌نویسی تکمیل شد!",
+    "failed": "حاشیه‌نویسی ناموفق بود",
+    "densityPerWords": "{{density}} در هر ۲۰۰۰ کلمه"
   },
   "AssessmentPanel": {
     "title": "ارزیابی‌ها",
@@ -145,7 +154,9 @@
     "densityDense": "متراکم",
     "fragmentSelected": "قطعه انتخاب شد",
     "imageRegionSelected": "ناحیه تصویر انتخاب شد",
-    "closeProgress": "بستن"
+    "complete": "حاشیه‌نویسی تکمیل شد!",
+    "failed": "حاشیه‌نویسی ناموفق بود",
+    "densityPerWords": "{{density}} در هر ۲۰۰۰ کلمه"
   },
   "TaggingPanel": {
     "title": "برچسب‌ها",
@@ -164,7 +175,9 @@
     "selectCategory": "انتخاب دسته‌بندی",
     "chooseCategory": "یک دسته‌بندی انتخاب کنید...",
     "fragmentSelected": "قطعه انتخاب شد",
-    "imageRegionSelected": "ناحیه تصویر انتخاب شد"
+    "imageRegionSelected": "ناحیه تصویر انتخاب شد",
+    "complete": "حاشیه‌نویسی تکمیل شد!",
+    "failed": "حاشیه‌نویسی ناموفق بود"
   },
   "UnifiedAnnotationsPanel": {
     "title": "حاشیه‌نویسی‌ها",
@@ -220,7 +233,6 @@
     "complete": "حاشیه‌نویسی تکمیل شد!",
     "failed": "حاشیه‌نویسی ناموفق بود",
     "current": "فعلی: {{entityType}}",
-    "closeProgress": "بستن",
     "loading": "در حال بارگذاری...",
     "loadingEllipsis": "در حال بارگذاری...",
     "untitledResource": "منبع بدون عنوان",

--- a/packages/react-ui/translations/fi.json
+++ b/packages/react-ui/translations/fi.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Sulje",
+    "paramsTitle": "Pyynnön parametrit:",
+    "processing": "Nykyinen: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Merkinnät",
     "history": "Historia",
@@ -105,7 +110,9 @@
     "densityDense": "Tiheä",
     "fragmentSelected": "Katkelma valittu",
     "imageRegionSelected": "Kuva-alue valittu",
-    "closeProgress": "Sulje"
+    "complete": "Merkintä valmis!",
+    "failed": "Merkintä epäonnistui",
+    "densityPerWords": "{{density}} / 2000 sanaa"
   },
   "HighlightPanel": {
     "title": "Korostukset",
@@ -120,7 +127,9 @@
     "densityLabel": "Tiheys",
     "densitySparse": "Harva",
     "densityDense": "Tiheä",
-    "closeProgress": "Sulje"
+    "complete": "Merkintä valmis!",
+    "failed": "Merkintä epäonnistui",
+    "densityPerWords": "{{density}} / 2000 sanaa"
   },
   "AssessmentPanel": {
     "title": "Arvioinnit",
@@ -145,7 +154,9 @@
     "densityDense": "Tiheä",
     "fragmentSelected": "Katkelma valittu",
     "imageRegionSelected": "Kuva-alue valittu",
-    "closeProgress": "Sulje"
+    "complete": "Merkintä valmis!",
+    "failed": "Merkintä epäonnistui",
+    "densityPerWords": "{{density}} / 2000 sanaa"
   },
   "TaggingPanel": {
     "title": "Tunnisteet",
@@ -164,7 +175,9 @@
     "selectCategory": "Valitse kategoria",
     "chooseCategory": "Valitse kategoria...",
     "fragmentSelected": "Katkelma valittu",
-    "imageRegionSelected": "Kuva-alue valittu"
+    "imageRegionSelected": "Kuva-alue valittu",
+    "complete": "Merkintä valmis!",
+    "failed": "Merkintä epäonnistui"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Merkinnät",
@@ -220,7 +233,6 @@
     "complete": "Merkintä valmis!",
     "failed": "Merkintä epäonnistui",
     "current": "Nykyinen: {{entityType}}",
-    "closeProgress": "Sulje",
     "loading": "ladataan...",
     "loadingEllipsis": "Ladataan...",
     "untitledResource": "Nimetön resurssi",

--- a/packages/react-ui/translations/fr.json
+++ b/packages/react-ui/translations/fr.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Fermer",
+    "paramsTitle": "Paramètres de la requête :",
+    "processing": "En cours : {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annotations",
     "history": "Historique",
@@ -105,7 +110,9 @@
     "densityDense": "Dense",
     "fragmentSelected": "Fragment sélectionné",
     "imageRegionSelected": "Région d'image sélectionnée",
-    "closeProgress": "Fermer"
+    "complete": "Annotation terminée !",
+    "failed": "L'annotation a échoué",
+    "densityPerWords": "{{density}} pour 2000 mots"
   },
   "HighlightPanel": {
     "title": "Surlignages",
@@ -120,7 +127,9 @@
     "densityLabel": "Densité",
     "densitySparse": "Clairsemée",
     "densityDense": "Dense",
-    "closeProgress": "Fermer"
+    "complete": "Annotation terminée !",
+    "failed": "L'annotation a échoué",
+    "densityPerWords": "{{density}} pour 2000 mots"
   },
   "AssessmentPanel": {
     "title": "Évaluations",
@@ -145,7 +154,9 @@
     "densityDense": "Dense",
     "fragmentSelected": "Fragment sélectionné",
     "imageRegionSelected": "Région d'image sélectionnée",
-    "closeProgress": "Fermer"
+    "complete": "Annotation terminée !",
+    "failed": "L'annotation a échoué",
+    "densityPerWords": "{{density}} pour 2000 mots"
   },
   "TaggingPanel": {
     "title": "Étiquettes",
@@ -164,7 +175,9 @@
     "selectCategory": "Sélectionner une catégorie",
     "chooseCategory": "Choisir une catégorie...",
     "fragmentSelected": "Fragment sélectionné",
-    "imageRegionSelected": "Région d'image sélectionnée"
+    "imageRegionSelected": "Région d'image sélectionnée",
+    "complete": "Annotation terminée !",
+    "failed": "L'annotation a échoué"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annotations",
@@ -220,7 +233,6 @@
     "complete": "Annotation terminée !",
     "failed": "L'annotation a échoué",
     "current": "En cours : {{entityType}}",
-    "closeProgress": "Fermer",
     "loading": "chargement...",
     "loadingEllipsis": "Chargement...",
     "untitledResource": "Ressource sans titre",

--- a/packages/react-ui/translations/he.json
+++ b/packages/react-ui/translations/he.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "סגור",
+    "paramsTitle": "פרמטרים של הבקשה:",
+    "processing": "נוכחי: {{label}}"
+  },
   "Toolbar": {
     "annotations": "הערות",
     "history": "היסטוריה",
@@ -105,7 +110,9 @@
     "densityDense": "צפוף",
     "fragmentSelected": "קטע נבחר",
     "imageRegionSelected": "אזור תמונה נבחר",
-    "closeProgress": "סגור"
+    "complete": "ההערה הושלמה!",
+    "failed": "ההערה נכשלה",
+    "densityPerWords": "{{density}} לכל 2000 מילים"
   },
   "HighlightPanel": {
     "title": "הדגשות",
@@ -120,7 +127,9 @@
     "densityLabel": "צפיפות",
     "densitySparse": "דליל",
     "densityDense": "צפוף",
-    "closeProgress": "סגור"
+    "complete": "ההערה הושלמה!",
+    "failed": "ההערה נכשלה",
+    "densityPerWords": "{{density}} לכל 2000 מילים"
   },
   "AssessmentPanel": {
     "title": "הערכות",
@@ -145,7 +154,9 @@
     "densityDense": "צפוף",
     "fragmentSelected": "קטע נבחר",
     "imageRegionSelected": "אזור תמונה נבחר",
-    "closeProgress": "סגור"
+    "complete": "ההערה הושלמה!",
+    "failed": "ההערה נכשלה",
+    "densityPerWords": "{{density}} לכל 2000 מילים"
   },
   "TaggingPanel": {
     "title": "תגיות",
@@ -164,7 +175,9 @@
     "selectCategory": "בחירת קטגוריה",
     "chooseCategory": "בחרו קטגוריה...",
     "fragmentSelected": "קטע נבחר",
-    "imageRegionSelected": "אזור תמונה נבחר"
+    "imageRegionSelected": "אזור תמונה נבחר",
+    "complete": "ההערה הושלמה!",
+    "failed": "ההערה נכשלה"
   },
   "UnifiedAnnotationsPanel": {
     "title": "הערות",
@@ -220,7 +233,6 @@
     "complete": "ההערה הושלמה!",
     "failed": "ההערה נכשלה",
     "current": "נוכחי: {{entityType}}",
-    "closeProgress": "סגור",
     "loading": "טוען...",
     "loadingEllipsis": "טוען...",
     "untitledResource": "משאב ללא כותרת",

--- a/packages/react-ui/translations/hi.json
+++ b/packages/react-ui/translations/hi.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "बंद करें",
+    "paramsTitle": "अनुरोध पैरामीटर:",
+    "processing": "वर्तमान: {{label}}"
+  },
   "Toolbar": {
     "annotations": "एनोटेशन",
     "history": "इतिहास",
@@ -105,7 +110,9 @@
     "densityDense": "सघन",
     "fragmentSelected": "खंड चयनित",
     "imageRegionSelected": "चित्र क्षेत्र चयनित",
-    "closeProgress": "बंद करें"
+    "complete": "एनोटेशन पूर्ण!",
+    "failed": "एनोटेशन विफल",
+    "densityPerWords": "प्रति 2000 शब्द {{density}}"
   },
   "HighlightPanel": {
     "title": "हाइलाइट",
@@ -120,7 +127,9 @@
     "densityLabel": "घनत्व",
     "densitySparse": "विरल",
     "densityDense": "सघन",
-    "closeProgress": "बंद करें"
+    "complete": "एनोटेशन पूर्ण!",
+    "failed": "एनोटेशन विफल",
+    "densityPerWords": "प्रति 2000 शब्द {{density}}"
   },
   "AssessmentPanel": {
     "title": "मूल्यांकन",
@@ -145,7 +154,9 @@
     "densityDense": "सघन",
     "fragmentSelected": "खंड चयनित",
     "imageRegionSelected": "चित्र क्षेत्र चयनित",
-    "closeProgress": "बंद करें"
+    "complete": "एनोटेशन पूर्ण!",
+    "failed": "एनोटेशन विफल",
+    "densityPerWords": "प्रति 2000 शब्द {{density}}"
   },
   "TaggingPanel": {
     "title": "टैग",
@@ -164,7 +175,9 @@
     "selectCategory": "श्रेणी चुनें",
     "chooseCategory": "एक श्रेणी चुनें...",
     "fragmentSelected": "खंड चयनित",
-    "imageRegionSelected": "चित्र क्षेत्र चयनित"
+    "imageRegionSelected": "चित्र क्षेत्र चयनित",
+    "complete": "एनोटेशन पूर्ण!",
+    "failed": "एनोटेशन विफल"
   },
   "UnifiedAnnotationsPanel": {
     "title": "एनोटेशन",
@@ -220,7 +233,6 @@
     "complete": "एनोटेशन पूर्ण!",
     "failed": "एनोटेशन विफल",
     "current": "वर्तमान: {{entityType}}",
-    "closeProgress": "बंद करें",
     "loading": "लोड हो रहा है...",
     "loadingEllipsis": "लोड हो रहा है...",
     "untitledResource": "शीर्षकहीन संसाधन",

--- a/packages/react-ui/translations/id.json
+++ b/packages/react-ui/translations/id.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Tutup",
+    "paramsTitle": "Parameter permintaan:",
+    "processing": "Saat ini: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Anotasi",
     "history": "Riwayat",
@@ -105,7 +110,9 @@
     "densityDense": "Padat",
     "fragmentSelected": "Fragmen dipilih",
     "imageRegionSelected": "Wilayah gambar dipilih",
-    "closeProgress": "Tutup"
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal",
+    "densityPerWords": "{{density}} per 2000 kata"
   },
   "HighlightPanel": {
     "title": "Sorotan",
@@ -120,7 +127,9 @@
     "densityLabel": "Kepadatan",
     "densitySparse": "Jarang",
     "densityDense": "Padat",
-    "closeProgress": "Tutup"
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal",
+    "densityPerWords": "{{density}} per 2000 kata"
   },
   "AssessmentPanel": {
     "title": "Penilaian",
@@ -145,7 +154,9 @@
     "densityDense": "Padat",
     "fragmentSelected": "Fragmen dipilih",
     "imageRegionSelected": "Wilayah gambar dipilih",
-    "closeProgress": "Tutup"
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal",
+    "densityPerWords": "{{density}} per 2000 kata"
   },
   "TaggingPanel": {
     "title": "Tag",
@@ -164,7 +175,9 @@
     "selectCategory": "Pilih Kategori",
     "chooseCategory": "Pilih kategori...",
     "fragmentSelected": "Fragmen dipilih",
-    "imageRegionSelected": "Wilayah gambar dipilih"
+    "imageRegionSelected": "Wilayah gambar dipilih",
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Anotasi",
@@ -220,7 +233,6 @@
     "complete": "Anotasi selesai!",
     "failed": "Anotasi gagal",
     "current": "Saat ini: {{entityType}}",
-    "closeProgress": "Tutup",
     "loading": "memuat...",
     "loadingEllipsis": "Memuat...",
     "untitledResource": "Sumber Daya Tanpa Judul",

--- a/packages/react-ui/translations/it.json
+++ b/packages/react-ui/translations/it.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Chiudi",
+    "paramsTitle": "Parametri della richiesta:",
+    "processing": "Corrente: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annotazioni",
     "history": "Cronologia",
@@ -105,7 +110,9 @@
     "densityDense": "Densa",
     "fragmentSelected": "Frammento selezionato",
     "imageRegionSelected": "Regione dell'immagine selezionata",
-    "closeProgress": "Chiudi"
+    "complete": "Annotazione completata!",
+    "failed": "Annotazione fallita",
+    "densityPerWords": "{{density}} ogni 2000 parole"
   },
   "HighlightPanel": {
     "title": "Evidenziazioni",
@@ -120,7 +127,9 @@
     "densityLabel": "Densità",
     "densitySparse": "Sparsa",
     "densityDense": "Densa",
-    "closeProgress": "Chiudi"
+    "complete": "Annotazione completata!",
+    "failed": "Annotazione fallita",
+    "densityPerWords": "{{density}} ogni 2000 parole"
   },
   "AssessmentPanel": {
     "title": "Valutazioni",
@@ -145,7 +154,9 @@
     "densityDense": "Densa",
     "fragmentSelected": "Frammento selezionato",
     "imageRegionSelected": "Regione dell'immagine selezionata",
-    "closeProgress": "Chiudi"
+    "complete": "Annotazione completata!",
+    "failed": "Annotazione fallita",
+    "densityPerWords": "{{density}} ogni 2000 parole"
   },
   "TaggingPanel": {
     "title": "Etichette",
@@ -164,7 +175,9 @@
     "selectCategory": "Seleziona Categoria",
     "chooseCategory": "Scegli una categoria...",
     "fragmentSelected": "Frammento selezionato",
-    "imageRegionSelected": "Regione dell'immagine selezionata"
+    "imageRegionSelected": "Regione dell'immagine selezionata",
+    "complete": "Annotazione completata!",
+    "failed": "Annotazione fallita"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annotazioni",
@@ -220,7 +233,6 @@
     "complete": "Annotazione completata!",
     "failed": "Annotazione fallita",
     "current": "Corrente: {{entityType}}",
-    "closeProgress": "Chiudi",
     "loading": "caricamento...",
     "loadingEllipsis": "Caricamento...",
     "untitledResource": "Risorsa Senza Titolo",

--- a/packages/react-ui/translations/ja.json
+++ b/packages/react-ui/translations/ja.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "閉じる",
+    "paramsTitle": "リクエストパラメータ:",
+    "processing": "現在: {{label}}"
+  },
   "Toolbar": {
     "annotations": "アノテーション",
     "history": "履歴",
@@ -105,7 +110,9 @@
     "densityDense": "密",
     "fragmentSelected": "フラグメントが選択されました",
     "imageRegionSelected": "画像領域が選択されました",
-    "closeProgress": "閉じる"
+    "complete": "アノテーション完了！",
+    "failed": "アノテーションに失敗しました",
+    "densityPerWords": "2000語あたり{{density}}"
   },
   "HighlightPanel": {
     "title": "ハイライト",
@@ -120,7 +127,9 @@
     "densityLabel": "密度",
     "densitySparse": "まばら",
     "densityDense": "密",
-    "closeProgress": "閉じる"
+    "complete": "アノテーション完了！",
+    "failed": "アノテーションに失敗しました",
+    "densityPerWords": "2000語あたり{{density}}"
   },
   "AssessmentPanel": {
     "title": "評価",
@@ -145,7 +154,9 @@
     "densityDense": "密",
     "fragmentSelected": "フラグメントが選択されました",
     "imageRegionSelected": "画像領域が選択されました",
-    "closeProgress": "閉じる"
+    "complete": "アノテーション完了！",
+    "failed": "アノテーションに失敗しました",
+    "densityPerWords": "2000語あたり{{density}}"
   },
   "TaggingPanel": {
     "title": "タグ",
@@ -164,7 +175,9 @@
     "selectCategory": "カテゴリを選択",
     "chooseCategory": "カテゴリを選択してください...",
     "fragmentSelected": "フラグメントが選択されました",
-    "imageRegionSelected": "画像領域が選択されました"
+    "imageRegionSelected": "画像領域が選択されました",
+    "complete": "アノテーション完了！",
+    "failed": "アノテーションに失敗しました"
   },
   "UnifiedAnnotationsPanel": {
     "title": "アノテーション",
@@ -220,7 +233,6 @@
     "complete": "アノテーション完了！",
     "failed": "アノテーションに失敗しました",
     "current": "現在: {{entityType}}",
-    "closeProgress": "閉じる",
     "loading": "読み込み中...",
     "loadingEllipsis": "読み込み中...",
     "untitledResource": "無題のリソース",

--- a/packages/react-ui/translations/ko.json
+++ b/packages/react-ui/translations/ko.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "닫기",
+    "paramsTitle": "요청 매개변수:",
+    "processing": "현재: {{label}}"
+  },
   "Toolbar": {
     "annotations": "주석",
     "history": "기록",
@@ -105,7 +110,9 @@
     "densityDense": "밀집",
     "fragmentSelected": "구절 선택됨",
     "imageRegionSelected": "이미지 영역 선택됨",
-    "closeProgress": "닫기"
+    "complete": "주석 완료!",
+    "failed": "주석 실패",
+    "densityPerWords": "2000단어당 {{density}}"
   },
   "HighlightPanel": {
     "title": "하이라이트",
@@ -120,7 +127,9 @@
     "densityLabel": "밀도",
     "densitySparse": "희소",
     "densityDense": "밀집",
-    "closeProgress": "닫기"
+    "complete": "주석 완료!",
+    "failed": "주석 실패",
+    "densityPerWords": "2000단어당 {{density}}"
   },
   "AssessmentPanel": {
     "title": "평가",
@@ -145,7 +154,9 @@
     "densityDense": "밀집",
     "fragmentSelected": "구절 선택됨",
     "imageRegionSelected": "이미지 영역 선택됨",
-    "closeProgress": "닫기"
+    "complete": "주석 완료!",
+    "failed": "주석 실패",
+    "densityPerWords": "2000단어당 {{density}}"
   },
   "TaggingPanel": {
     "title": "태그",
@@ -164,7 +175,9 @@
     "selectCategory": "카테고리 선택",
     "chooseCategory": "카테고리 선택...",
     "fragmentSelected": "구절 선택됨",
-    "imageRegionSelected": "이미지 영역 선택됨"
+    "imageRegionSelected": "이미지 영역 선택됨",
+    "complete": "주석 완료!",
+    "failed": "주석 실패"
   },
   "UnifiedAnnotationsPanel": {
     "title": "주석",
@@ -220,7 +233,6 @@
     "complete": "주석 완료!",
     "failed": "주석 실패",
     "current": "현재: {{entityType}}",
-    "closeProgress": "닫기",
     "loading": "로딩 중...",
     "loadingEllipsis": "로딩 중...",
     "untitledResource": "제목 없는 리소스",

--- a/packages/react-ui/translations/ms.json
+++ b/packages/react-ui/translations/ms.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Tutup",
+    "paramsTitle": "Parameter permintaan:",
+    "processing": "Semasa: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Anotasi",
     "history": "Sejarah",
@@ -105,7 +110,9 @@
     "densityDense": "Padat",
     "fragmentSelected": "Fragmen dipilih",
     "imageRegionSelected": "Kawasan imej dipilih",
-    "closeProgress": "Tutup"
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal",
+    "densityPerWords": "{{density}} setiap 2000 perkataan"
   },
   "HighlightPanel": {
     "title": "Sorotan",
@@ -120,7 +127,9 @@
     "densityLabel": "Ketumpatan",
     "densitySparse": "Jarang",
     "densityDense": "Padat",
-    "closeProgress": "Tutup"
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal",
+    "densityPerWords": "{{density}} setiap 2000 perkataan"
   },
   "AssessmentPanel": {
     "title": "Penilaian",
@@ -145,7 +154,9 @@
     "densityDense": "Padat",
     "fragmentSelected": "Fragmen dipilih",
     "imageRegionSelected": "Kawasan imej dipilih",
-    "closeProgress": "Tutup"
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal",
+    "densityPerWords": "{{density}} setiap 2000 perkataan"
   },
   "TaggingPanel": {
     "title": "Tag",
@@ -164,7 +175,9 @@
     "selectCategory": "Pilih Kategori",
     "chooseCategory": "Pilih kategori...",
     "fragmentSelected": "Fragmen dipilih",
-    "imageRegionSelected": "Kawasan imej dipilih"
+    "imageRegionSelected": "Kawasan imej dipilih",
+    "complete": "Anotasi selesai!",
+    "failed": "Anotasi gagal"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Anotasi",
@@ -220,7 +233,6 @@
     "complete": "Anotasi selesai!",
     "failed": "Anotasi gagal",
     "current": "Semasa: {{entityType}}",
-    "closeProgress": "Tutup",
     "loading": "memuatkan...",
     "loadingEllipsis": "Memuatkan...",
     "untitledResource": "Sumber Tanpa Tajuk",

--- a/packages/react-ui/translations/nl.json
+++ b/packages/react-ui/translations/nl.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Sluiten",
+    "paramsTitle": "Aanvraagparameters:",
+    "processing": "Huidig: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annotaties",
     "history": "Geschiedenis",
@@ -105,7 +110,9 @@
     "densityDense": "Dicht",
     "fragmentSelected": "Fragment geselecteerd",
     "imageRegionSelected": "Afbeeldingsgebied geselecteerd",
-    "closeProgress": "Sluiten"
+    "complete": "Annotatie voltooid!",
+    "failed": "Annotatie mislukt",
+    "densityPerWords": "{{density}} per 2000 woorden"
   },
   "HighlightPanel": {
     "title": "Markeringen",
@@ -120,7 +127,9 @@
     "densityLabel": "Dichtheid",
     "densitySparse": "Schaars",
     "densityDense": "Dicht",
-    "closeProgress": "Sluiten"
+    "complete": "Annotatie voltooid!",
+    "failed": "Annotatie mislukt",
+    "densityPerWords": "{{density}} per 2000 woorden"
   },
   "AssessmentPanel": {
     "title": "Beoordelingen",
@@ -145,7 +154,9 @@
     "densityDense": "Dicht",
     "fragmentSelected": "Fragment geselecteerd",
     "imageRegionSelected": "Afbeeldingsgebied geselecteerd",
-    "closeProgress": "Sluiten"
+    "complete": "Annotatie voltooid!",
+    "failed": "Annotatie mislukt",
+    "densityPerWords": "{{density}} per 2000 woorden"
   },
   "TaggingPanel": {
     "title": "Labels",
@@ -164,7 +175,9 @@
     "selectCategory": "Categorie selecteren",
     "chooseCategory": "Kies een categorie...",
     "fragmentSelected": "Fragment geselecteerd",
-    "imageRegionSelected": "Afbeeldingsgebied geselecteerd"
+    "imageRegionSelected": "Afbeeldingsgebied geselecteerd",
+    "complete": "Annotatie voltooid!",
+    "failed": "Annotatie mislukt"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annotaties",
@@ -220,7 +233,6 @@
     "complete": "Annotatie voltooid!",
     "failed": "Annotatie mislukt",
     "current": "Huidig: {{entityType}}",
-    "closeProgress": "Sluiten",
     "loading": "laden...",
     "loadingEllipsis": "Laden...",
     "untitledResource": "Naamloze bron",

--- a/packages/react-ui/translations/no.json
+++ b/packages/react-ui/translations/no.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Lukk",
+    "paramsTitle": "Forespørselsparametere:",
+    "processing": "Nåværende: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annoteringer",
     "history": "Historikk",
@@ -105,7 +110,9 @@
     "densityDense": "Tett",
     "fragmentSelected": "Fragment valgt",
     "imageRegionSelected": "Bildeområde valgt",
-    "closeProgress": "Lukk"
+    "complete": "Annotering fullført!",
+    "failed": "Annotering mislyktes",
+    "densityPerWords": "{{density}} per 2000 ord"
   },
   "HighlightPanel": {
     "title": "Uthevinger",
@@ -120,7 +127,9 @@
     "densityLabel": "Tetthet",
     "densitySparse": "Sparsom",
     "densityDense": "Tett",
-    "closeProgress": "Lukk"
+    "complete": "Annotering fullført!",
+    "failed": "Annotering mislyktes",
+    "densityPerWords": "{{density}} per 2000 ord"
   },
   "AssessmentPanel": {
     "title": "Vurderinger",
@@ -145,7 +154,9 @@
     "densityDense": "Tett",
     "fragmentSelected": "Fragment valgt",
     "imageRegionSelected": "Bildeområde valgt",
-    "closeProgress": "Lukk"
+    "complete": "Annotering fullført!",
+    "failed": "Annotering mislyktes",
+    "densityPerWords": "{{density}} per 2000 ord"
   },
   "TaggingPanel": {
     "title": "Merker",
@@ -164,7 +175,9 @@
     "selectCategory": "Velg kategori",
     "chooseCategory": "Velg en kategori...",
     "fragmentSelected": "Fragment valgt",
-    "imageRegionSelected": "Bildeområde valgt"
+    "imageRegionSelected": "Bildeområde valgt",
+    "complete": "Annotering fullført!",
+    "failed": "Annotering mislyktes"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annoteringer",
@@ -220,7 +233,6 @@
     "complete": "Annotering fullført!",
     "failed": "Annotering mislyktes",
     "current": "Nåværende: {{entityType}}",
-    "closeProgress": "Lukk",
     "loading": "laster...",
     "loadingEllipsis": "Laster...",
     "untitledResource": "Ressurs uten tittel",

--- a/packages/react-ui/translations/pl.json
+++ b/packages/react-ui/translations/pl.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Zamknij",
+    "paramsTitle": "Parametry żądania:",
+    "processing": "Bieżący: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Adnotacje",
     "history": "Historia",
@@ -105,7 +110,9 @@
     "densityDense": "Gęsta",
     "fragmentSelected": "Fragment zaznaczony",
     "imageRegionSelected": "Region obrazu zaznaczony",
-    "closeProgress": "Zamknij"
+    "complete": "Adnotowanie zakończone!",
+    "failed": "Adnotowanie nie powiodło się",
+    "densityPerWords": "{{density}} na 2000 słów"
   },
   "HighlightPanel": {
     "title": "Wyróżnienia",
@@ -120,7 +127,9 @@
     "densityLabel": "Gęstość",
     "densitySparse": "Rzadka",
     "densityDense": "Gęsta",
-    "closeProgress": "Zamknij"
+    "complete": "Adnotowanie zakończone!",
+    "failed": "Adnotowanie nie powiodło się",
+    "densityPerWords": "{{density}} na 2000 słów"
   },
   "AssessmentPanel": {
     "title": "Oceny",
@@ -145,7 +154,9 @@
     "densityDense": "Gęsta",
     "fragmentSelected": "Fragment zaznaczony",
     "imageRegionSelected": "Region obrazu zaznaczony",
-    "closeProgress": "Zamknij"
+    "complete": "Adnotowanie zakończone!",
+    "failed": "Adnotowanie nie powiodło się",
+    "densityPerWords": "{{density}} na 2000 słów"
   },
   "TaggingPanel": {
     "title": "Tagi",
@@ -164,7 +175,9 @@
     "selectCategory": "Wybierz kategorię",
     "chooseCategory": "Wybierz kategorię...",
     "fragmentSelected": "Fragment zaznaczony",
-    "imageRegionSelected": "Region obrazu zaznaczony"
+    "imageRegionSelected": "Region obrazu zaznaczony",
+    "complete": "Adnotowanie zakończone!",
+    "failed": "Adnotowanie nie powiodło się"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Adnotacje",
@@ -220,7 +233,6 @@
     "complete": "Adnotowanie zakończone!",
     "failed": "Adnotowanie nie powiodło się",
     "current": "Bieżący: {{entityType}}",
-    "closeProgress": "Zamknij",
     "loading": "ładowanie...",
     "loadingEllipsis": "Ładowanie...",
     "untitledResource": "Zasób bez tytułu",

--- a/packages/react-ui/translations/pt.json
+++ b/packages/react-ui/translations/pt.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Fechar",
+    "paramsTitle": "Parâmetros da solicitação:",
+    "processing": "Atual: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Anotações",
     "history": "Histórico",
@@ -105,7 +110,9 @@
     "densityDense": "Densa",
     "fragmentSelected": "Fragmento selecionado",
     "imageRegionSelected": "Região da imagem selecionada",
-    "closeProgress": "Fechar"
+    "complete": "Anotação concluída!",
+    "failed": "Anotação falhou",
+    "densityPerWords": "{{density}} por 2000 palavras"
   },
   "HighlightPanel": {
     "title": "Destaques",
@@ -120,7 +127,9 @@
     "densityLabel": "Densidade",
     "densitySparse": "Esparsa",
     "densityDense": "Densa",
-    "closeProgress": "Fechar"
+    "complete": "Anotação concluída!",
+    "failed": "Anotação falhou",
+    "densityPerWords": "{{density}} por 2000 palavras"
   },
   "AssessmentPanel": {
     "title": "Avaliações",
@@ -145,7 +154,9 @@
     "densityDense": "Densa",
     "fragmentSelected": "Fragmento selecionado",
     "imageRegionSelected": "Região da imagem selecionada",
-    "closeProgress": "Fechar"
+    "complete": "Anotação concluída!",
+    "failed": "Anotação falhou",
+    "densityPerWords": "{{density}} por 2000 palavras"
   },
   "TaggingPanel": {
     "title": "Tags",
@@ -164,7 +175,9 @@
     "selectCategory": "Selecionar Categoria",
     "chooseCategory": "Escolha uma categoria...",
     "fragmentSelected": "Fragmento selecionado",
-    "imageRegionSelected": "Região da imagem selecionada"
+    "imageRegionSelected": "Região da imagem selecionada",
+    "complete": "Anotação concluída!",
+    "failed": "Anotação falhou"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Anotações",
@@ -220,7 +233,6 @@
     "complete": "Anotação concluída!",
     "failed": "Anotação falhou",
     "current": "Atual: {{entityType}}",
-    "closeProgress": "Fechar",
     "loading": "carregando...",
     "loadingEllipsis": "Carregando...",
     "untitledResource": "Recurso Sem Título",

--- a/packages/react-ui/translations/ro.json
+++ b/packages/react-ui/translations/ro.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Închide",
+    "paramsTitle": "Parametrii cererii:",
+    "processing": "Curent: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Adnotări",
     "history": "Istoric",
@@ -105,7 +110,9 @@
     "densityDense": "Densă",
     "fragmentSelected": "Fragment selectat",
     "imageRegionSelected": "Regiune de imagine selectată",
-    "closeProgress": "Închide"
+    "complete": "Adnotare completă!",
+    "failed": "Adnotarea a eșuat",
+    "densityPerWords": "{{density}} la 2000 de cuvinte"
   },
   "HighlightPanel": {
     "title": "Evidențieri",
@@ -120,7 +127,9 @@
     "densityLabel": "Densitate",
     "densitySparse": "Rară",
     "densityDense": "Densă",
-    "closeProgress": "Închide"
+    "complete": "Adnotare completă!",
+    "failed": "Adnotarea a eșuat",
+    "densityPerWords": "{{density}} la 2000 de cuvinte"
   },
   "AssessmentPanel": {
     "title": "Evaluări",
@@ -145,7 +154,9 @@
     "densityDense": "Densă",
     "fragmentSelected": "Fragment selectat",
     "imageRegionSelected": "Regiune de imagine selectată",
-    "closeProgress": "Închide"
+    "complete": "Adnotare completă!",
+    "failed": "Adnotarea a eșuat",
+    "densityPerWords": "{{density}} la 2000 de cuvinte"
   },
   "TaggingPanel": {
     "title": "Etichete",
@@ -164,7 +175,9 @@
     "selectCategory": "Selectează categoria",
     "chooseCategory": "Alege o categorie...",
     "fragmentSelected": "Fragment selectat",
-    "imageRegionSelected": "Regiune de imagine selectată"
+    "imageRegionSelected": "Regiune de imagine selectată",
+    "complete": "Adnotare completă!",
+    "failed": "Adnotarea a eșuat"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Adnotări",
@@ -220,7 +233,6 @@
     "complete": "Adnotare completă!",
     "failed": "Adnotarea a eșuat",
     "current": "Curent: {{entityType}}",
-    "closeProgress": "Închide",
     "loading": "se încarcă...",
     "loadingEllipsis": "Se încarcă...",
     "untitledResource": "Resursă fără titlu",

--- a/packages/react-ui/translations/sv.json
+++ b/packages/react-ui/translations/sv.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Stäng",
+    "paramsTitle": "Begäranparametrar:",
+    "processing": "Aktuell: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Annoteringar",
     "history": "Historik",
@@ -105,7 +110,9 @@
     "densityDense": "Tät",
     "fragmentSelected": "Fragment valt",
     "imageRegionSelected": "Bildområde valt",
-    "closeProgress": "Stäng"
+    "complete": "Annotering klar!",
+    "failed": "Annotering misslyckades",
+    "densityPerWords": "{{density}} per 2000 ord"
   },
   "HighlightPanel": {
     "title": "Markeringar",
@@ -120,7 +127,9 @@
     "densityLabel": "Täthet",
     "densitySparse": "Gles",
     "densityDense": "Tät",
-    "closeProgress": "Stäng"
+    "complete": "Annotering klar!",
+    "failed": "Annotering misslyckades",
+    "densityPerWords": "{{density}} per 2000 ord"
   },
   "AssessmentPanel": {
     "title": "Bedömningar",
@@ -145,7 +154,9 @@
     "densityDense": "Tät",
     "fragmentSelected": "Fragment valt",
     "imageRegionSelected": "Bildområde valt",
-    "closeProgress": "Stäng"
+    "complete": "Annotering klar!",
+    "failed": "Annotering misslyckades",
+    "densityPerWords": "{{density}} per 2000 ord"
   },
   "TaggingPanel": {
     "title": "Taggar",
@@ -164,7 +175,9 @@
     "selectCategory": "Välj kategori",
     "chooseCategory": "Välj en kategori...",
     "fragmentSelected": "Fragment valt",
-    "imageRegionSelected": "Bildområde valt"
+    "imageRegionSelected": "Bildområde valt",
+    "complete": "Annotering klar!",
+    "failed": "Annotering misslyckades"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Annoteringar",
@@ -220,7 +233,6 @@
     "complete": "Annotering klar!",
     "failed": "Annotering misslyckades",
     "current": "Aktuell: {{entityType}}",
-    "closeProgress": "Stäng",
     "loading": "laddar...",
     "loadingEllipsis": "Laddar...",
     "untitledResource": "Namnlös resurs",

--- a/packages/react-ui/translations/th.json
+++ b/packages/react-ui/translations/th.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "ปิด",
+    "paramsTitle": "พารามิเตอร์คำขอ:",
+    "processing": "ปัจจุบัน: {{label}}"
+  },
   "Toolbar": {
     "annotations": "คำอธิบายประกอบ",
     "history": "ประวัติ",
@@ -105,7 +110,9 @@
     "densityDense": "หนาแน่น",
     "fragmentSelected": "เลือกส่วนข้อความแล้ว",
     "imageRegionSelected": "เลือกพื้นที่รูปภาพแล้ว",
-    "closeProgress": "ปิด"
+    "complete": "การสร้างคำอธิบายประกอบเสร็จสมบูรณ์!",
+    "failed": "การสร้างคำอธิบายประกอบล้มเหลว",
+    "densityPerWords": "{{density}} ต่อ 2000 คำ"
   },
   "HighlightPanel": {
     "title": "ไฮไลต์",
@@ -120,7 +127,9 @@
     "densityLabel": "ความหนาแน่น",
     "densitySparse": "เบาบาง",
     "densityDense": "หนาแน่น",
-    "closeProgress": "ปิด"
+    "complete": "การสร้างคำอธิบายประกอบเสร็จสมบูรณ์!",
+    "failed": "การสร้างคำอธิบายประกอบล้มเหลว",
+    "densityPerWords": "{{density}} ต่อ 2000 คำ"
   },
   "AssessmentPanel": {
     "title": "การประเมิน",
@@ -145,7 +154,9 @@
     "densityDense": "หนาแน่น",
     "fragmentSelected": "เลือกส่วนข้อความแล้ว",
     "imageRegionSelected": "เลือกพื้นที่รูปภาพแล้ว",
-    "closeProgress": "ปิด"
+    "complete": "การสร้างคำอธิบายประกอบเสร็จสมบูรณ์!",
+    "failed": "การสร้างคำอธิบายประกอบล้มเหลว",
+    "densityPerWords": "{{density}} ต่อ 2000 คำ"
   },
   "TaggingPanel": {
     "title": "แท็ก",
@@ -164,7 +175,9 @@
     "selectCategory": "เลือกหมวดหมู่",
     "chooseCategory": "เลือกหมวดหมู่...",
     "fragmentSelected": "เลือกส่วนข้อความแล้ว",
-    "imageRegionSelected": "เลือกพื้นที่รูปภาพแล้ว"
+    "imageRegionSelected": "เลือกพื้นที่รูปภาพแล้ว",
+    "complete": "การสร้างคำอธิบายประกอบเสร็จสมบูรณ์!",
+    "failed": "การสร้างคำอธิบายประกอบล้มเหลว"
   },
   "UnifiedAnnotationsPanel": {
     "title": "คำอธิบายประกอบ",
@@ -220,7 +233,6 @@
     "complete": "การสร้างคำอธิบายประกอบเสร็จสมบูรณ์!",
     "failed": "การสร้างคำอธิบายประกอบล้มเหลว",
     "current": "ปัจจุบัน: {{entityType}}",
-    "closeProgress": "ปิด",
     "loading": "กำลังโหลด...",
     "loadingEllipsis": "กำลังโหลด...",
     "untitledResource": "ทรัพยากรไม่มีชื่อ",

--- a/packages/react-ui/translations/tr.json
+++ b/packages/react-ui/translations/tr.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Kapat",
+    "paramsTitle": "İstek parametreleri:",
+    "processing": "Mevcut: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Açıklamalar",
     "history": "Geçmiş",
@@ -105,7 +110,9 @@
     "densityDense": "Yoğun",
     "fragmentSelected": "Parça seçildi",
     "imageRegionSelected": "Görüntü bölgesi seçildi",
-    "closeProgress": "Kapat"
+    "complete": "Açıklama tamamlandı!",
+    "failed": "Açıklama başarısız oldu",
+    "densityPerWords": "2000 kelime başına {{density}}"
   },
   "HighlightPanel": {
     "title": "Vurgular",
@@ -120,7 +127,9 @@
     "densityLabel": "Yoğunluk",
     "densitySparse": "Seyrek",
     "densityDense": "Yoğun",
-    "closeProgress": "Kapat"
+    "complete": "Açıklama tamamlandı!",
+    "failed": "Açıklama başarısız oldu",
+    "densityPerWords": "2000 kelime başına {{density}}"
   },
   "AssessmentPanel": {
     "title": "Değerlendirmeler",
@@ -145,7 +154,9 @@
     "densityDense": "Yoğun",
     "fragmentSelected": "Parça seçildi",
     "imageRegionSelected": "Görüntü bölgesi seçildi",
-    "closeProgress": "Kapat"
+    "complete": "Açıklama tamamlandı!",
+    "failed": "Açıklama başarısız oldu",
+    "densityPerWords": "2000 kelime başına {{density}}"
   },
   "TaggingPanel": {
     "title": "Etiketler",
@@ -164,7 +175,9 @@
     "selectCategory": "Kategori Seç",
     "chooseCategory": "Bir kategori seçin...",
     "fragmentSelected": "Parça seçildi",
-    "imageRegionSelected": "Görüntü bölgesi seçildi"
+    "imageRegionSelected": "Görüntü bölgesi seçildi",
+    "complete": "Açıklama tamamlandı!",
+    "failed": "Açıklama başarısız oldu"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Açıklamalar",
@@ -220,7 +233,6 @@
     "complete": "Açıklama tamamlandı!",
     "failed": "Açıklama başarısız oldu",
     "current": "Mevcut: {{entityType}}",
-    "closeProgress": "Kapat",
     "loading": "yükleniyor...",
     "loadingEllipsis": "Yükleniyor...",
     "untitledResource": "Başlıksız Kaynak",

--- a/packages/react-ui/translations/uk.json
+++ b/packages/react-ui/translations/uk.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Закрити",
+    "paramsTitle": "Параметри запиту:",
+    "processing": "Поточний: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Анотації",
     "history": "Історія",
@@ -105,7 +110,9 @@
     "densityDense": "Щільна",
     "fragmentSelected": "Фрагмент вибрано",
     "imageRegionSelected": "Область зображення вибрано",
-    "closeProgress": "Закрити"
+    "complete": "Анотування завершено!",
+    "failed": "Анотування не вдалося",
+    "densityPerWords": "{{density}} на 2000 слів"
   },
   "HighlightPanel": {
     "title": "Підсвічування",
@@ -120,7 +127,9 @@
     "densityLabel": "Щільність",
     "densitySparse": "Розріджена",
     "densityDense": "Щільна",
-    "closeProgress": "Закрити"
+    "complete": "Анотування завершено!",
+    "failed": "Анотування не вдалося",
+    "densityPerWords": "{{density}} на 2000 слів"
   },
   "AssessmentPanel": {
     "title": "Оцінки",
@@ -145,7 +154,9 @@
     "densityDense": "Щільна",
     "fragmentSelected": "Фрагмент вибрано",
     "imageRegionSelected": "Область зображення вибрано",
-    "closeProgress": "Закрити"
+    "complete": "Анотування завершено!",
+    "failed": "Анотування не вдалося",
+    "densityPerWords": "{{density}} на 2000 слів"
   },
   "TaggingPanel": {
     "title": "Теги",
@@ -164,7 +175,9 @@
     "selectCategory": "Обрати категорію",
     "chooseCategory": "Оберіть категорію...",
     "fragmentSelected": "Фрагмент вибрано",
-    "imageRegionSelected": "Область зображення вибрано"
+    "imageRegionSelected": "Область зображення вибрано",
+    "complete": "Анотування завершено!",
+    "failed": "Анотування не вдалося"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Анотації",
@@ -220,7 +233,6 @@
     "complete": "Анотування завершено!",
     "failed": "Анотування не вдалося",
     "current": "Поточний: {{entityType}}",
-    "closeProgress": "Закрити",
     "loading": "завантаження...",
     "loadingEllipsis": "Завантаження...",
     "untitledResource": "Ресурс без назви",

--- a/packages/react-ui/translations/vi.json
+++ b/packages/react-ui/translations/vi.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "Đóng",
+    "paramsTitle": "Tham số yêu cầu:",
+    "processing": "Hiện tại: {{label}}"
+  },
   "Toolbar": {
     "annotations": "Chú thích",
     "history": "Lịch sử",
@@ -105,7 +110,9 @@
     "densityDense": "Dày",
     "fragmentSelected": "Đã chọn đoạn văn bản",
     "imageRegionSelected": "Đã chọn vùng hình ảnh",
-    "closeProgress": "Đóng"
+    "complete": "Hoàn thành chú thích!",
+    "failed": "Chú thích thất bại",
+    "densityPerWords": "{{density}} trên 2000 từ"
   },
   "HighlightPanel": {
     "title": "Đánh dấu nổi bật",
@@ -120,7 +127,9 @@
     "densityLabel": "Mật độ",
     "densitySparse": "Thưa",
     "densityDense": "Dày",
-    "closeProgress": "Đóng"
+    "complete": "Hoàn thành chú thích!",
+    "failed": "Chú thích thất bại",
+    "densityPerWords": "{{density}} trên 2000 từ"
   },
   "AssessmentPanel": {
     "title": "Đánh giá",
@@ -145,7 +154,9 @@
     "densityDense": "Dày",
     "fragmentSelected": "Đã chọn đoạn văn bản",
     "imageRegionSelected": "Đã chọn vùng hình ảnh",
-    "closeProgress": "Đóng"
+    "complete": "Hoàn thành chú thích!",
+    "failed": "Chú thích thất bại",
+    "densityPerWords": "{{density}} trên 2000 từ"
   },
   "TaggingPanel": {
     "title": "Thẻ",
@@ -164,7 +175,9 @@
     "selectCategory": "Chọn danh mục",
     "chooseCategory": "Chọn một danh mục...",
     "fragmentSelected": "Đã chọn đoạn văn bản",
-    "imageRegionSelected": "Đã chọn vùng hình ảnh"
+    "imageRegionSelected": "Đã chọn vùng hình ảnh",
+    "complete": "Hoàn thành chú thích!",
+    "failed": "Chú thích thất bại"
   },
   "UnifiedAnnotationsPanel": {
     "title": "Chú thích",
@@ -220,7 +233,6 @@
     "complete": "Hoàn thành chú thích!",
     "failed": "Chú thích thất bại",
     "current": "Hiện tại: {{entityType}}",
-    "closeProgress": "Đóng",
     "loading": "đang tải...",
     "loadingEllipsis": "Đang tải...",
     "untitledResource": "Tài nguyên chưa có tiêu đề",

--- a/packages/react-ui/translations/zh.json
+++ b/packages/react-ui/translations/zh.json
@@ -1,4 +1,9 @@
 {
+  "AssistProgress": {
+    "close": "关闭",
+    "paramsTitle": "请求参数：",
+    "processing": "当前：{{label}}"
+  },
   "Toolbar": {
     "annotations": "注释",
     "history": "历史",
@@ -105,7 +110,9 @@
     "densityDense": "密集",
     "fragmentSelected": "已选择片段",
     "imageRegionSelected": "已选择图像区域",
-    "closeProgress": "关闭"
+    "complete": "注释完成！",
+    "failed": "注释失败",
+    "densityPerWords": "每 2000 词 {{density}} 个"
   },
   "HighlightPanel": {
     "title": "高亮",
@@ -120,7 +127,9 @@
     "densityLabel": "密度",
     "densitySparse": "稀疏",
     "densityDense": "密集",
-    "closeProgress": "关闭"
+    "complete": "注释完成！",
+    "failed": "注释失败",
+    "densityPerWords": "每 2000 词 {{density}} 个"
   },
   "AssessmentPanel": {
     "title": "评估",
@@ -145,7 +154,9 @@
     "densityDense": "密集",
     "fragmentSelected": "已选择片段",
     "imageRegionSelected": "已选择图像区域",
-    "closeProgress": "关闭"
+    "complete": "注释完成！",
+    "failed": "注释失败",
+    "densityPerWords": "每 2000 词 {{density}} 个"
   },
   "TaggingPanel": {
     "title": "标签",
@@ -164,7 +175,9 @@
     "selectCategory": "选择分类",
     "chooseCategory": "选择一个分类...",
     "fragmentSelected": "已选择片段",
-    "imageRegionSelected": "已选择图像区域"
+    "imageRegionSelected": "已选择图像区域",
+    "complete": "注释完成！",
+    "failed": "注释失败"
   },
   "UnifiedAnnotationsPanel": {
     "title": "注释",
@@ -220,7 +233,6 @@
     "complete": "注释完成！",
     "failed": "注释失败",
     "current": "当前：{{entityType}}",
-    "closeProgress": "关闭",
     "loading": "加载中...",
     "loadingEllipsis": "加载中...",
     "untitledResource": "无标题资源",


### PR DESCRIPTION
Three independent fixes to the assist/progress surface, from the punch-list left by the assist-and-outcome refactor. Each is self-contained; they share a PR because they touch the same handful of components.

## 1. The assist progress display speaks the user's language

The known gap was three hardcoded English strings. Removing them surfaced a larger one: `AssistProgress` took `translations = {}` with **every** field optional and carried English `||` defaults behind them — `'Cancel'`, `'Complete'`, `'Failed'`, `'Dismiss'`. Any call site that forgot a key rendered English silently, at runtime, with nothing to catch it. And `TaggingPanel` passed **no translations at all**, so the entire tag progress display was English in every locale.

The fix makes that class of mistake impossible rather than fixing four instances of it:

- Added `paramsTitle` and a generic `processing(label)` formatter; deleted every English `||` default.
- `translations` and its always-rendered keys are now **required**, so a missing key is a type error at the call site. `title`, `found` and `current` stay optional — those are genuinely conditional (headerless style, reference-flow-only wording).
- TypeScript then enumerated the call sites, which was the point. It also forced `AssistShell.progressProps` to become required: the shell renders the progress display itself, so an omitted config meant untranslated chrome.

New `AssistProgress` translation namespace holding the chrome shared by six surfaces (`paramsTitle`, `processing`, `close`) — following the existing component-per-namespace convention, rather than duplicating the same words into six panel namespaces. Across all 29 locales: namespace added; `complete`/`failed` added to the four panels that lacked them; `densityPerWords` added for the density line; and the duplicated `closeProgress` key **deleted** from four namespaces now that one `close` serves all.

Values were reused from each locale's existing professionally-translated strings wherever one existed — `processing` derives from that locale's `ReferencesPanel.current`, `close`/`complete`/`failed` from its ReferencesPanel copy. Only `paramsTitle` and `densityPerWords` are new strings and would benefit from native review.

Tag also reaches dismiss parity (6-of-6 surfaces): `TaggingPanel` never had the dismiss wiring, because there was no label to put on the control.

## 2. One markup for the entity-found log

The post-run log in `ReferencesPanel` and the completed-entity log in `AssistProgress` rendered the same rows — ✓, entity type, count — through two class families one panel apart. Extracted `EntityFoundLog`, used by both; the duplicate markup and its CSS block are deleted. Note this normalizes the form-side log's appearance: it loses its card chrome (background/padding/shadow) and matches the progress log's bare rows.

## 3. Clicking a history row reveals the annotation

`handleEventClick` was a no-op whose comment described behavior deleted a week earlier. Worse than dead code: `HistoryEvent` renders each row as a `<button>` labelled "View annotation" whenever the event has an annotation, so screen-reader users were offered a focusable, announced control wired to nothing.

Activating it needed no new prop chain. `beckon:focus` is already the "scroll to and highlight this annotation" contract, `BrowseView` already subscribed to it, and the beckon state unit already exposes `focus()`. So this adds a producer and one missing consumer:

- `handleEventClick` now calls `stateUnit.beckon.focus(...)`, mirroring how the hover sibling calls `beckon.sparkle`.
- `AnnotateView` subscribes to `beckon:focus` exactly as `BrowseView` does — closing a real asymmetry where the same event scrolled the content in browse mode and did nothing in annotate mode.

The `scrollToAnnotationId` prop path is untouched and remains the host-facing capability it was.

## Tests

TDD throughout; each red observed before its fix.

- `AssistProgress.test.tsx`: params title renders from translations, never the literal; the generic processing formatter covers both the entity-type and category lines. Uses key-echo translations (`tr.complete`), so a failure means "rendered something other than what was passed".
- `ReferencesPanel.test.tsx`: the post-run log renders with the same markup the progress display uses.
- `ResourceViewerPage.test.tsx`: clicking a history event emits `beckon:focus` for that annotation.
- `AnnotateView.focus.test.tsx` (new): the content scrolls when the session emits `beckon:focus`.

One red was a genuine catch rather than a stale assertion: making `complete` required initially replaced the job's own completion message ("Complete! Created 14 highlights") with a static string, and four existing tests failed on the lost detail. The terminal branch now prefers `progress.message` and falls back to the translated copy — the same precedence the error branch already used.

## Verification

- react-ui: `tsc --noEmit` clean, `lint:css` clean, build OK, suite **2525 passed / 38 pre-existing skips**
- frontend: `tsc --noEmit` clean, suite **529 passed**
- `lint:no-utility-classes` passes

## Known follow-up (not in this PR)

The larger source of untranslated text in this display is backend-side: all 26 `onProgress(...)` calls in `packages/jobs/src/processors.ts` compose English prose into `JobProgress.message`, a required wire field, so the count and the grammar are fused before the client sees them. The renderer prefers that message because it carries detail no static string can. Fixing it properly needs structured completion data (or message keys + params) rather than prose, so it is filed separately. The reference flow already demonstrates the target pattern: its `completedEntityTypes` log is localized client-side and renders directly above the English status line from the same job.
