### PR TITLE
Restore the lost invocation in the history-click test (fixes Package Tests on main)

### DIFF
--- a/packages/react-ui/src/features/resource-viewer/__tests__/ResourceViewerPage.test.tsx
+++ b/packages/react-ui/src/features/resource-viewer/__tests__/ResourceViewerPage.test.tsx
@@ -250,6 +250,7 @@ describe('ResourceViewerPage', () => {
       const sub = stubClient.bus.get('beckon:focus').subscribe(({ annotationId }: any) => focused.push(annotationId));
 
       expect(capturedHistory.props?.onEventClick).toBeTypeOf('function');
+      capturedHistory.props!.onEventClick('ann-42');
       expect(focused).toEqual(['ann-42']);
 
       sub.unsubscribe();


### PR DESCRIPTION
Fixes the `Package Tests` failure on `main` at 6206b936 ([run](https://github.com/The-AI-Alliance/semiont/actions/runs/30728483325/job/91444420024)).

## What broke

One line was lost while applying review feedback to #1125. The test subscribed to `beckon:focus` and asserted the emission, but no longer performed the click that produces it:

```ts
expect(capturedHistory.props?.onEventClick).toBeTypeOf('function');
// ← the invocation used to be here
expect(focused).toEqual(['ann-42']);
```

so it failed with `expected [] to deeply equal [ 'ann-42' ]`.

Worth being precise about what that means: the assertion is *correct* and the production wiring is *fine*. The test had simply stopped exercising the thing it asserts — which is the failure mode a green suite can't warn you about, and here it happened to fail loudly only because the assertion was strict.

## The fix

Restores the invocation. The review feedback that prompted the edit — resetting `capturedHistory.props` before rendering and asserting it was populated by this run — is kept, since the point of it stands: module-level capture state could otherwise let this test pass on props left behind by an earlier test.

`capturedHistory.props!` rather than `?.` is deliberate. Optional chaining would silently no-op if the capture were ever null, which is exactly the "passes without testing anything" failure this file just demonstrated; the non-null assertion throws instead, and the `expect(capturedHistory.props).not.toBeNull()` two lines above justifies it.

## Verification

Run locally in a `node:24` container against this change:

- `vitest run src/features` — the exact split that failed in CI: **30 files, 544 tests passing**
- full react-ui suite: **2525 passing / 38 pre-existing skips**
- `tsc --noEmit`: clean

## Type of change

- [x] Bug fix (test-only; no production code touched)

## Areas changed

- [x] React UI (`packages/react-ui`) — one line, in a test file
