### PR TITLE
PDF yield: model-authored Typst compiled in the worker, citations anchored to page geometry (PDF-GENERATION P1–P5)

### DIFF
--- a/docs/development/MEDIA-TYPES.md
+++ b/docs/development/MEDIA-TYPES.md
@@ -22,6 +22,7 @@ interface MediaTypeCapabilities {
   extractText: 'decode' | 'pdf-text-layer' | 'none';
   authorable: boolean;
   uploadable: boolean;
+  generatable: boolean;
 }
 ```
 
@@ -41,7 +42,8 @@ table.
 
 Three axes, and they are genuinely independent. A type can be rendered but not
 anchored, embedded but not rendered, or anchored spatially while yielding no text
-at all.
+at all. Three booleans sit alongside them — `uploadable`, `authorable`,
+`generatable` — saying how a resource of that type may come into existence.
 
 ## What each axis changes
 
@@ -93,6 +95,58 @@ type is textual — and everything else is `none`.
 `extractText: 'none'` is not a gap to fill. An image is annotatable
 (`anchoring: 'spatial'`) and carries no text; that combination is coherent and
 final.
+
+### `generatable` — what a model may be asked to produce
+
+The three booleans say how a resource may come into existence: `uploadable`
+(a user supplies bytes), `authorable` (a user types it in the browser), and
+`generatable` (`yield.fromResource` / `yield.fromAnnotation` may target it).
+They are independent — `application/pdf` is generatable but not authorable,
+because a model can write one and a person cannot type one.
+
+`generatable` lives in the registry for the same reason as everything else
+here: the gate was previously a local constant inside `processGenerationJob`,
+a second media-type table of exactly the kind this registry exists to prevent.
+
+## Authored PDFs: geometry chosen, not recovered
+
+`application/pdf` is the one type Semiont both **reads** and **writes**, and the
+two directions differ in a way worth stating, because the axes above describe
+the reading direction only.
+
+When a PDF is generated, the model writes [Typst](https://typst.app/) source
+and a pinned compiler in the worker image renders it. The result is an ordinary
+born-digital PDF: `extractText: 'pdf-text-layer'` reads it exactly as it reads a
+PDF someone uploaded, and every rung of the running example below applies
+unchanged. There is no second path and no authored sidecar — the PDF's own text
+layer carries the geometry.
+
+What differs is epistemic rather than mechanical: **for an authored PDF the
+system chose the coordinates rather than recovering them.** Nothing was scanned,
+so there is no OCR, no confidence score, and no unread page. In the vocabulary
+`PDF-MODEL` proposes, that is `textSource: 'text-layer'` with no treatments —
+the A–G `pdfClass` taxonomy has no honest letter for a document we wrote
+ourselves.
+
+Two consequences for citations, both load-bearing:
+
+- **Citations carry page geometry, never text offsets.** A generated PDF's
+  claims are re-anchored through the same extractor the Smelter uses, and land
+  as `FragmentSelector` rects plus the quoted text. A `TextPositionSelector`
+  would index the generated *string* and render nothing — a silent wrong, which
+  is why the selector type is pinned by test.
+- **Unfindable claims drop loudly.** If a claim cannot be located in the text
+  layer — or the layer is missing entirely — the citation is dropped with a
+  warning rather than minted at a guessed position. Anchoring never guesses.
+
+Two properties of the renderer make this work, and both are enforced rather than
+assumed. The compile is **deterministic** — the creation timestamp is pinned on
+every invocation, because unpinned compiles of identical source produce
+different bytes, which would change the content checksum and make the Smelter
+re-embed a document that never changed. And **hyphenation stays on**: Typst
+drops soft hyphens from the text layer, so a hyphenated word appears as two
+runs with no hyphen character, and the citation search absorbs the break instead
+of the renderer degrading the typography.
 
 ## The running example: a PDF, end to end
 

--- a/docs/development/MEDIA-TYPES.md
+++ b/docs/development/MEDIA-TYPES.md
@@ -1,0 +1,349 @@
+# Media Types and the Flow
+
+Every resource in Semiont travels the same path: **yield → smelt → weave →
+annotate**. What differs between a Markdown note and a scanned PDF is not the
+path but what each stage is *able to do* — and that is declared in one place, as
+data, not scattered through the code that consumes it.
+
+This guide explains the declaration, what each part of it changes downstream, and
+then walks one media type end to end. PDF is the running example because it is
+the only type that exercises every axis at its hardest setting.
+
+## The declaration
+
+`packages/core/src/media-types.ts` holds one row per supported type:
+
+```ts
+interface MediaTypeCapabilities {
+  extension: `.${string}`;
+  label: string;
+  render:      'text' | 'image' | 'pdf' | 'none';
+  anchoring:   'text-selector' | 'spatial' | 'none';
+  extractText: 'decode' | 'pdf-text-layer' | 'none';
+  authorable: boolean;
+  uploadable: boolean;
+}
+```
+
+The registry is `satisfies Record<SupportedMediaType, …>`, so adding a type to
+the spec enum without a capabilities row — or the reverse — is a compile error.
+That drift-lock is the reason this guide can describe behavior by reading one
+table.
+
+| Media type | `render` | `anchoring` | `extractText` |
+|---|---|---|---|
+| `text/markdown`, `text/plain`, `text/html` | `text` | `text-selector` | `decode` |
+| `application/json` | `text` | `text-selector` | `decode` |
+| `application/pdf` | `pdf` | `spatial` | `pdf-text-layer` |
+| `image/png`, `image/jpeg` | `image` | `spatial` | `none` |
+| Stored text (`text/css`, `text/csv`, …) | `none` | `none` | `decode` |
+| Stored binary (archives, `audio/*`, `video/*`) | `none` | `none` | `none` |
+
+Three axes, and they are genuinely independent. A type can be rendered but not
+anchored, embedded but not rendered, or anchored spatially while yielding no text
+at all.
+
+## What each axis changes
+
+### `render` — what the browser mounts
+
+Selects the viewer component and nothing else. `text` renders through the
+markdown/prose pipeline, `pdf` mounts the PDF canvas, `image` an image surface,
+`none` shows metadata and a download affordance. A type with `render: 'none'` is
+catalogued and retrievable but never displayed.
+
+### `anchoring` — what a selector is allowed to be
+
+The consequential one. It decides what an annotation can *point at*, and that
+choice is permanent for every annotation ever created against the type.
+
+- **`text-selector`** — characters are the anchor. An annotation carries a
+  `TextPositionSelector` and a `TextQuoteSelector`. Offsets index the resource's
+  own bytes, so nothing has to be derived before annotating.
+- **`spatial`** — position is the anchor. Characters are drawn at coordinates
+  rather than held at offsets, and the extracted text is a derived artifact that
+  re-extraction could shift. So a PDF annotation carries a `FragmentSelector`
+  (RFC 3778: `page=N&viewrect=…`, PDF points, origin bottom-left) and, when the
+  text is known, a `TextQuoteSelector`. **Never a `TextPositionSelector`** — a
+  character offset is not a durable anchor into a document whose text is
+  recovered rather than stored.
+- **`none`** — not annotatable.
+
+That single distinction is why the PDF flow below has stages the Markdown flow
+does not. It is not incidental complexity; it is what "position is the anchor"
+costs.
+
+Note that these three values enumerate the anchoring models in use, not the
+space of possible ones. Time-based media needs a fourth, and video needs a
+*combination* rather than a fourth — see
+[Time-based media](#time-based-media-what-the-model-must-absorb) below before
+extending this axis.
+
+### `extractText` — how meaning is recovered, and what it costs
+
+Feeds the Smelter's gate (`textExtractionOf`). On a registry miss, base types
+under `text/*` fall back to `decode` — RFC 2046 guarantees the `text` top-level
+type is textual — and everything else is `none`.
+
+- **`decode`** — charset-aware passthrough. The text *is* the bytes. Free.
+- **`pdf-text-layer`** — parse the content stream, and where a page has no
+  glyphs, rasterize and OCR it. Roughly **2.9 seconds per scanned page**.
+- **`none`** — no extractor. No embedding, no vector search, no AI detection.
+
+`extractText: 'none'` is not a gap to fill. An image is annotatable
+(`anchoring: 'spatial'`) and carries no text; that combination is coherent and
+final.
+
+## The running example: a PDF, end to end
+
+A PDF declares `render: 'pdf'`, `anchoring: 'spatial'`, `extractText:
+'pdf-text-layer'` — the hardest setting on every axis. Each numbered step below
+exists because of one of those three declarations.
+
+### Ingest
+
+1. **`yield.resource`** with the bytes. The backend appends to the event log —
+   the system of record — and emits **`yield:created`**.
+2. **Three consumers take that event independently**, none waiting on the others:
+   - **ViewMaterializer** builds the view projection. This makes the resource
+     openable, and it is also the `resourceId → checksum` index that later
+     stages rely on.
+   - **Smelter** plans an embed.
+   - **Weaver** folds it into the graph.
+
+### Smelting — recovering the text, and the geometry that indexes it
+
+3. **Smelter computes `calculateChecksum(bytes)`.** For a `spatial` type this is
+   the identity of the derived artifact, not merely a freshness stamp: two
+   resources holding identical bytes share one artifact.
+4. **It calls `extract(bytes, contentType, { key: checksum, store })`.** The
+   cache seam lives *inside* `extract()`, and consults the store for those exact
+   bytes:
+   - **Hit** → return the stored outcome. No parse, no OCR.
+   - **Miss** → classify the document (native text layer, scanned, or hybrid),
+     extract, and the seam writes the result.
+5. **The stored artifact is an `ExtractionOutcome`** — `text`, `items`,
+   `method`, `pdfClass`, `ocrConfidence`, `unreadPages`, *or* a named decline.
+   Declines are cached too: "we recognized this and found nothing" costs one
+   recognition pass for the lifetime of those bytes.
+6. **It lands at `stateDir/anchored-text/{ab}/{cd}/{checksum}.json`**, sharded
+   with the same helper the event log uses and bind-mounted per root, so it
+   survives a restart and `semiont clean --store anchored-text` can reclaim it.
+7. **Smelter chunks, embeds, and writes vectors.**
+8. **It emits `smelt:settled { resourceId, contentChecksum, outcome }`** —
+   `indexed` or `skipped`. The vector stamp is written *before* this fires, so
+   anything released by the barrier is guaranteed to find it.
+
+There is exactly one writer of that artifact: the seam inside `extract()`.
+
+### The artifact's shape
+
+Both directions over a PDF use one type, `AnchoredText` in `@semiont/core`:
+
+```ts
+interface AnchoredText { text: string; items: PdfTextItem[] }
+interface PdfTextItem { start; end; page; x; y; width; height }
+```
+
+Text paired with the geometry that indexes it — `items[i]` says *"characters
+`start`..`end` of `text` are drawn at this rectangle on this page."* Two
+functions form an inverse pair over it:
+
+```
+locate(anchored, start, end) → rects     a model quoted text; find its geometry
+textUnder(anchored, rect)    → string    a person drew a box; find its text
+```
+
+### Weaving
+
+9. **Weaver folds `yield:created`** into the graph and emits `weave:applied`.
+   Near-trivial for a bare resource; it earns its keep once reference
+   annotations exist.
+
+### When is it annotatable?
+
+A `spatial` type has three readiness moments, deliberately decoupled:
+
+- **Geometry: immediately.** Once the view exists you can drag a rectangle and it
+  persists — whether or not anything knows what is under it.
+- **Born-digital PDF, with quotes: immediately, with no server involvement.** The
+  canvas calls `getTextContent()`, gets runs from pdf.js in the browser, and
+  builds the map locally with `anchorRuns`. It never asks the backend.
+- **Scanned PDF, with quotes: once smelt settles.** No runs, so the canvas calls
+  `browse.resourceAnchoredText(resourceId)`. Server-side: resolve the view → take
+  the primary representation's checksum → read the store → on a miss wait on
+  `whenSettled(resourceId, checksum, 15_000)` → re-read if `indexed`, else
+  `null`. A timeout or a decline yields no quote, and the annotation ships with
+  geometry alone.
+
+**Failure degrades; it does not break.** No map — because the document has none,
+because extraction declined, or because the barrier timed out — means an
+annotation with geometry and no quote. That is the behavior a `spatial` type had
+before any text recovery existed, so the failure mode is "no improvement", never
+"broken".
+
+### Annotating
+
+10. **Drag a rectangle.** `textUnder(map, rect)` returns every word whose area is
+    **≥50%** covered (`RUN_COVERAGE_THRESHOLD`). Any-intersection is the obvious
+    rule and it does not survive a hand-drawn box: word boxes run ~10pt tall at
+    12pt line pitch, so a few points of overshoot pulls in fragments of the lines
+    above and below.
+11. **The canvas emits `mark:create-request`** with a `FragmentSelector`, plus a
+    `TextQuoteSelector` when `textUnder` found anything. The backend replies
+    `mark:create-ok` and appends **`mark:added`**.
+12. **Or AI detection.** `job:create` → a worker runs `prepareDetection`, which
+    calls the same cached `extract()` — so on an already-smelted document it does
+    no OCR. The model returns a verbatim quote; `locate()` turns that span into
+    one `FragmentSelector` per line; `buildPdfAnnotation` assembles the
+    annotation.
+
+### How annotation events feed back
+
+13. **`mark:added` reaches both actors.** Weaver folds it into the graph. Smelter
+    embeds the annotation's `exactText`, then reads `getResourceStamp` to inherit
+    the resource's provenance — the source of `machineRead: true`, which marks a
+    quote as recognized rather than authored.
+14. **Selectors are fixed at birth.** No stored event mutates a target. An
+    annotation created before its map existed keeps no quote, permanently — which
+    is why recognition happens at ingest rather than after annotation. The
+    alternative, annotating now and patching the quote in later, would require
+    mutable annotation targets, and the event log has no vocabulary for one.
+
+### When the artifact goes missing
+
+15. **Reconcile plans `smelt:reanchor`** for a resource whose artifact is absent —
+    the third staleness class, alongside checksum drift and entity-tag drift.
+16. **A scoped rebuild command** re-anchors one resource or all, serialized, and
+    **fails loudly on partial completion**. That matters because a silently
+    incomplete rebuild presents as a missing quote, which is also what a document
+    with genuinely no text looks like.
+17. **`semiont clean --store anchored-text`** reclaims the tree. Everything in it
+    is reproducible from bytes, so deleting costs recomputation and never data.
+
+## What the other media types skip
+
+Reading the PDF flow against a simpler row shows what each declaration bought.
+
+**Markdown** (`text-selector`, `decode`) skips steps 3–8's derived artifact
+entirely. The text is the bytes, so there is nothing to recover, nothing to
+store, no barrier to wait on, and no restart hazard. An annotation carries
+character offsets directly. Steps 1–2, 9, and 13–14 are identical.
+
+**An image** (`spatial`, `none`) takes the geometry half and none of the text
+half. It is annotatable the moment the view exists, and a rectangle over it is
+always geometry-only — there is no map, so no quote, ever. The "three readiness
+moments" collapse to one.
+
+**Stored types** (`none`, `none`) are catalogued, named and downloadable.
+`storedText` additionally decodes, so it is embedded and searchable while never
+being rendered or annotated — a deliberate combination, not an oversight.
+
+## Time-based media: what the model must absorb
+
+`audio/*` and `video/*` are stored binaries today — catalogued, downloadable,
+neither rendered nor annotated. Transcripts change that, and they are a harder
+case than PDF, not an easier one. This section says which parts of the model
+carry over unchanged and which parts are genuinely load-bearing decisions, so
+that the first person to implement it does not discover them one at a time.
+
+The anchoring mechanism is settled by standards rather than by us: **W3C Media
+Fragments** gives `#t=start,end` for time and `#xywh=` for space, and the two
+**combine** — which is what a video annotation needs, since a region on screen
+exists only during an interval.
+
+### What carries over unchanged
+
+- **The artifact's shape.** `AnchoredText { text, items }` already says
+  *"characters `start`..`end` of `text` live at this position"* and is
+  deliberately indifferent to what "position" means. Character offsets, page
+  rects, time intervals, and time-plus-rect are four coordinate spaces over one
+  structure. The type survives; only `PdfTextItem`'s field set is PDF-specific.
+- **The inverse pair.** `locate` (span → position, for a model that quoted text)
+  and `textUnder` (position → span, for a human who selected a region) are the
+  same two directions over a transcript. "What was said between 10s and 20s" is
+  `textUnder` with a temporal region.
+- **The three-way source classification.** A PDF is born-digital, scanned, or
+  hybrid. Audio and video are the same shape: an embedded caption track
+  (WebVTT, CEA-608) is the native text layer, ASR is the OCR, and a partially
+  captioned file is the hybrid. The cost split is identical — one source is free
+  and exact, the other is expensive and approximate.
+- **Everything about the derived artifact.** Content-addressed by checksum,
+  written once at ingest, consulted before re-deriving, stored where `clean` can
+  reclaim it, re-derivable when missing. ASR on a three-hour recording makes
+  this *more* necessary than OCR did, not less.
+- **The settle barrier and the readiness split.** An embedded caption track is
+  readable in the browser through `TextTrack`, exactly as pdf.js reads a native
+  text layer — so the "three readiness moments" structure holds, with WebVTT
+  playing pdf.js's role and ASR playing OCR's.
+- **Selectors fixed at birth.** Unchanged, and for the same reason.
+
+### What does not carry over
+
+These are the real decisions. Each one is a place where the PDF model gives no
+answer.
+
+1. **`anchoring` cannot stay a flat enum.** Audio is temporal. Video is temporal
+   *and* spatial at once — a rectangle on a frame during an interval. Adding
+   `'temporal'` alongside `'spatial'` handles audio and fails on video. Media
+   Fragments composes its two dimensions rather than enumerating their
+   combinations, and this axis should follow it.
+
+2. **"One artifact per representation" breaks.** A PDF representation has one
+   text layer. An audio representation can have several transcripts that are all
+   valid simultaneously: raw ASR, a human-corrected pass, translations, output
+   from a second engine. The representation checksum alone cannot distinguish
+   them, so the key needs a variant dimension — and "which transcript is *the*
+   transcript" becomes a question the PDF path never had to ask.
+
+3. **Speaker attribution has no PDF analogue.** Diarization attributes text to
+   speakers, and overlapping speech means two segments legitimately cover the
+   same interval with different text. `textUnder(rect)` on a page has one
+   correct answer; "what was said between 10s and 20s" may have two, and
+   flattening them into one string loses the fact that they were simultaneous.
+   This is the transcript version of the multi-column reading-order problem, and
+   it is worse: with columns, one linearization is defensible.
+
+4. **Time is continuous where offsets are discrete.** A word occupies a
+   real-valued interval, silence maps to no text, and music maps to no text. A
+   coverage rule for "is this word inside the selection" needs a temporal
+   analogue of `RUN_COVERAGE_THRESHOLD` — and that constant's history is the
+   warning worth heeding: it was set wrong twice, both times from a sweep that
+   looked conclusive on the corpus it had. Measure across genuinely different
+   material (fast speech, overlapping speakers, long pauses) before fixing a
+   value.
+
+5. **The whole-resource record comes under real size pressure.** A ten-page
+   scan's map is small enough that decoding all of it to answer a question about
+   one page is acceptable. A three-hour transcript is not. The deferred option —
+   group the geometry by page while keeping one `text` string — has an obvious
+   temporal counterpart in windowing by time, and time-based media is the case
+   that forces the decision.
+
+## Adding a media type
+
+Add the row; the drift-lock will tell you what else is required. Then decide
+each axis knowingly:
+
+- **`anchoring` is the irreversible one.** Every annotation created against the
+  type inherits it, and selectors are fixed at birth. Choosing `spatial` commits
+  you to geometry-first anchoring and to a text-recovery story if quotes are
+  wanted; choosing `text-selector` commits you to the text being the bytes. If
+  the type is time-based, read the section above first — the axis needs
+  extending before the row can be written honestly, and a row that understates
+  its anchoring model is not something later annotations can be migrated off.
+- **`extractText: 'none'` is a valid destination**, not a placeholder. It means
+  no embedding, no search, and no AI detection for that type.
+- **Extraction that costs real time needs an artifact and a key.** Anything
+  above passthrough cost should be content-addressed by checksum, written once,
+  stored where `clean` can reclaim it, and re-derivable when absent. The PDF path
+  is the reference implementation.
+- **Row order matters** for extension lookup: `.xml`, `.yaml`, `.js`, `.ts` and
+  `.webm` collide, and resolve to the first row declaring them.
+
+## Related
+
+- **[../system/ANCHORING.md](../system/ANCHORING.md)** — the anchoring pipeline in depth.
+- **[../protocol/W3C-SELECTORS.md](../protocol/W3C-SELECTORS.md)** — the selector types, and which apply to which anchoring model.
+- **[../system/PROJECTION-PATTERN.md](../system/PROJECTION-PATTERN.md)** — the read-your-writes barrier step 8 relies on.
+- **[../protocol/TRANSPORT-CONTRACT.md](../protocol/TRANSPORT-CONTRACT.md)** — where the artifact crosses a process boundary.

--- a/docs/development/MEDIA-TYPES.md
+++ b/docs/development/MEDIA-TYPES.md
@@ -60,8 +60,10 @@ The consequential one. It decides what an annotation can *point at*, and that
 choice is permanent for every annotation ever created against the type.
 
 - **`text-selector`** — characters are the anchor. An annotation carries a
-  `TextPositionSelector` and a `TextQuoteSelector`. Offsets index the resource's
-  own bytes, so nothing has to be derived before annotating.
+  `TextPositionSelector` and a `TextQuoteSelector`. Offsets are character
+  positions in the resource's decoded text — consumers apply selectors to the
+  decoded string, not raw bytes — so nothing has to be derived before
+  annotating.
 - **`spatial`** — position is the anchor. Characters are drawn at coordinates
   rather than held at offsets, and the extracted text is a derived artifact that
   re-extraction could shift. So a PDF annotation carries a `FragmentSelector`

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -71,6 +71,7 @@ The layered architecture, dependency graph, and per-package summaries live in **
 - **[CONTRIBUTING.md](../../CONTRIBUTING.md)** — branch/PR workflow, commit conventions, platform-contribution playbook.
 - **[System Documentation](../system/README.md)** — index for all system-architecture docs (actor model, knowledge system, container topology, package architecture).
 - **[LOCAL-DEVELOPMENT.md](LOCAL-DEVELOPMENT.md)** — running locally; Path B for contributors building from source.
+- **[MEDIA-TYPES.md](MEDIA-TYPES.md)** — how a media type's declared capabilities change the yield → smelt → weave → annotate flow, walked end to end with PDF.
 - **[TESTING.md](TESTING.md)** — testing conventions and infrastructure.
 - **[RELEASE.md](RELEASE.md)** — versioning and release process.
 - **[packages/README.md](../../packages/README.md)** — full package inventory with dependency graph.

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -29,6 +29,12 @@ export {
   type ExtractionCache,
 } from './content-extractor';
 
+// Extraction byte budget (#1124). Also the generation output bound
+// (PDF-GENERATION P5): an artifact we generate must stay within the budget
+// our own extractor accepts, or we would mint resources the Smelter
+// declines as 'too-large'. One threshold, two enforcement points.
+export { MAX_PDF_BYTES, withinByteBudget } from './pdf-extractor';
+
 // Persistent recognition cache (ANCHORED-TEXT-CACHE Lane 2). Derived values
 // only — an authored coordinate map is master data and never belongs here.
 export {

--- a/packages/core/src/__tests__/media-types.test.ts
+++ b/packages/core/src/__tests__/media-types.test.ts
@@ -17,6 +17,7 @@ import {
   textExtractionOf,
   AUTHORABLE_MEDIA_TYPES,
   EMBEDDABLE_MEDIA_TYPES,
+  GENERATABLE_MEDIA_TYPES,
   type SupportedMediaType,
 } from '../media-types';
 
@@ -59,32 +60,45 @@ describe('media-types registry', () => {
     it('pins the seven curated rows', () => {
       expect(MEDIA_TYPES['text/markdown']).toEqual({
         extension: '.md', label: 'Markdown', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: true, uploadable: true,
+        extractText: 'decode', authorable: true, uploadable: true, generatable: true,
       });
       expect(MEDIA_TYPES['text/plain']).toEqual({
         extension: '.txt', label: 'Plain Text', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: true, uploadable: true,
+        extractText: 'decode', authorable: true, uploadable: true, generatable: true,
       });
       expect(MEDIA_TYPES['text/html']).toEqual({
         extension: '.html', label: 'HTML', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: true, uploadable: true,
+        extractText: 'decode', authorable: true, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['application/json']).toEqual({
         extension: '.json', label: 'JSON', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: false, uploadable: true,
+        extractText: 'decode', authorable: false, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['image/png']).toEqual({
         extension: '.png', label: 'PNG image', render: 'image', anchoring: 'spatial',
-        extractText: 'none', authorable: false, uploadable: true,
+        extractText: 'none', authorable: false, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['image/jpeg']).toEqual({
         extension: '.jpg', label: 'JPEG image', render: 'image', anchoring: 'spatial',
-        extractText: 'none', authorable: false, uploadable: true,
+        extractText: 'none', authorable: false, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['application/pdf']).toEqual({
         extension: '.pdf', label: 'PDF', render: 'pdf', anchoring: 'spatial',
-        extractText: 'pdf-text-layer', authorable: false, uploadable: true,
+        extractText: 'pdf-text-layer', authorable: false, uploadable: true, generatable: true,
       });
+    });
+  });
+
+  describe('generatable capability (PDF-GENERATION P1)', () => {
+    // The generation worker's gate reads the registry, not a local table —
+    // closing the second-media-type-table violation the MEDIA-TYPES grep
+    // gate exists to prevent.
+    it('derives GENERATABLE_MEDIA_TYPES from the registry', () => {
+      expect(GENERATABLE_MEDIA_TYPES).toEqual(['text/markdown', 'text/plain', 'application/pdf']);
+    });
+
+    it('application/pdf is generatable — the Typst renderer exists (P3)', () => {
+      expect(MEDIA_TYPES['application/pdf'].generatable).toBe(true);
     });
   });
 

--- a/packages/core/src/__tests__/pdf-citation-search.test.ts
+++ b/packages/core/src/__tests__/pdf-citation-search.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { findClaimSpan } from '../pdf-citation-search';
+import { locate, type AnchoredText } from '../pdf-anchoring';
+
+/**
+ * The two-stage citation search (PDF-GENERATION P4).
+ *
+ * A citation's `exact` claim text comes from the Typst SOURCE; the PDF's text
+ * layer renders it with line breaks (`anchorRuns` joins runs with " \n") and
+ * hyphenation (soft hyphens are DROPPED — "extraordinarily" becomes
+ * "extraor" + "dinarily" with no hyphen character anywhere). Two stages, in
+ * order, never collapsed:
+ *
+ *   1. STRICT — whitespace-normalized search, offsets mapped back. Bridges
+ *      plain line breaks (" \n" collapses to " ").
+ *   2. BREAK-AWARE — only on a strict miss. The line break becomes a distinct
+ *      marker that may be absorbed in any inter-character gap; ordinary
+ *      spaces are NEVER wildcards.
+ *
+ * The ordering is the safety property: the permissive matcher runs only where
+ * the strict one already failed, so it can never turn a working citation into
+ * a wrong one.
+ */
+describe('findClaimSpan (PDF-GENERATION P4)', () => {
+  const anchoredWith = (text: string): AnchoredText => ({ text, items: [] });
+
+  it('finds a claim within a single line (strict)', () => {
+    const anchored = anchoredWith('The quick brown fox jumps over the lazy dog.');
+
+    const span = findClaimSpan(anchored, 'brown fox jumps');
+
+    expect(span).not.toBeNull();
+    expect(anchored.text.slice(span!.start, span!.end)).toBe('brown fox jumps');
+  });
+
+  it('finds a claim across a line break via normalization (strict — the spike\'s consequence 1)', () => {
+    // anchorRuns joins runs with " \n": a raw indexOf misses.
+    const anchored = anchoredWith('The quick brown \nfox jumps high.');
+
+    const span = findClaimSpan(anchored, 'brown fox');
+
+    expect(span).not.toBeNull();
+    expect(anchored.text.slice(span!.start, span!.end)).toBe('brown \nfox');
+  });
+
+  it('finds a hyphenated claim via the break-aware fallback (the spike\'s consequence 2)', () => {
+    // Soft hyphen dropped: "extraor" + "dinarily", no hyphen char anywhere.
+    // Plain normalization yields "extraor dinarily" — a strict miss.
+    const anchored = anchoredWith('It is extraor \ndinarily complicated today.');
+
+    const span = findClaimSpan(anchored, 'extraordinarily complicated');
+
+    expect(span).not.toBeNull();
+    expect(anchored.text.slice(span!.start, span!.end)).toBe('extraor \ndinarily complicated');
+  });
+
+  it('never treats ordinary spaces as wildcards — "abc" must not match "a b c"', () => {
+    expect(findClaimSpan(anchoredWith('x a b c y'), 'abc')).toBeNull();
+  });
+
+  it('returns null on a genuine miss', () => {
+    expect(findClaimSpan(anchoredWith('Entirely unrelated text.'), 'quantum entanglement')).toBeNull();
+  });
+});
+
+describe('locate — proportional boundary narrowing (PDF-GENERATION P4)', () => {
+  // Typst emits one text run per line, so a mid-line phrase used to bound the
+  // WHOLE line. The measured fallback (Q2): proportionally interpolate the
+  // boundary items' x-extents by character fraction — a rect narrower than
+  // the line, exact font metrics deferred to the operator-list probe.
+  it('a mid-line phrase produces a rect narrower than the line', () => {
+    const anchored: AnchoredText = {
+      text: '0123456789',
+      items: [{ start: 0, end: 10, page: 1, x: 100, y: 700, width: 100, height: 10 }],
+    };
+
+    const { rects } = locate(anchored, 2, 6); // chars '2345'
+
+    expect(rects).toHaveLength(1);
+    const r = rects[0]!;
+    expect(r.x).toBeCloseTo(120, 5); // 100 + 100 * (2/10)
+    expect(r.width).toBeCloseTo(40, 5); // 100 * (4/10)
+    expect(r.y).toBe(700);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,6 +310,7 @@ export {
   textExtractionOf,
   AUTHORABLE_MEDIA_TYPES,
   EMBEDDABLE_MEDIA_TYPES,
+  GENERATABLE_MEDIA_TYPES,
 } from './media-types';
 export type {
   SupportedMediaType,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -192,6 +192,7 @@ export type { PdfCoordinate } from './pdf-coordinates';
 
 // PDF text <-> geometry anchoring (locate/textUnder are inverses)
 export { locate, textUnder, anchorRuns, isTextRun } from './pdf-anchoring';
+export { findClaimSpan } from './pdf-citation-search';
 export type { AnchoredText, ExtractionOutcome, PdfTextItem, PdfTextRun } from './pdf-anchoring';
 
 // ResourceDescriptor accessors

--- a/packages/core/src/media-types.ts
+++ b/packages/core/src/media-types.ts
@@ -43,6 +43,10 @@ export interface MediaTypeCapabilities {
   extractText: TextExtraction;
   authorable: boolean;
   uploadable: boolean;
+  /** Whether the generation worker can produce this type as a yield artifact.
+   *  Gate for `outputMediaType` — unsupported requests fail loudly, never
+   *  fall back to markdown under a mislabeled format. */
+  generatable: boolean;
 }
 
 /** Storage tier: catalogued — stored, named, uploadable — but not
@@ -55,6 +59,7 @@ const storedBinary = (extension: `.${string}`, label: string): MediaTypeCapabili
   extractText: 'none',
   authorable: false,
   uploadable: true,
+  generatable: false,
 });
 
 /** Storage tier, text-flavored: embedded (charset-aware decode), not rendered. */
@@ -74,13 +79,15 @@ const storedText = (extension: `.${string}`, label: string): MediaTypeCapabiliti
  */
 export const MEDIA_TYPES = {
   // Full-capability tier
-  'text/markdown':    { extension: '.md',   label: 'Markdown',   render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true },
-  'text/plain':       { extension: '.txt',  label: 'Plain Text', render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true },
-  'text/html':        { extension: '.html', label: 'HTML',       render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true },
-  'application/json': { extension: '.json', label: 'JSON',       render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: false, uploadable: true },
-  'image/png':        { extension: '.png',  label: 'PNG image',  render: 'image', anchoring: 'spatial',       extractText: 'none',           authorable: false, uploadable: true },
-  'image/jpeg':       { extension: '.jpg',  label: 'JPEG image', render: 'image', anchoring: 'spatial',       extractText: 'none',           authorable: false, uploadable: true },
-  'application/pdf':  { extension: '.pdf',  label: 'PDF',        render: 'pdf',   anchoring: 'spatial',       extractText: 'pdf-text-layer', authorable: false, uploadable: true },
+  // `generatable: application/pdf` — the Typst renderer (PDF-GENERATION P3):
+  // the model writes Typst, the worker's pinned binary compiles it.
+  'text/markdown':    { extension: '.md',   label: 'Markdown',   render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true, generatable: true },
+  'text/plain':       { extension: '.txt',  label: 'Plain Text', render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true, generatable: true },
+  'text/html':        { extension: '.html', label: 'HTML',       render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true, generatable: false },
+  'application/json': { extension: '.json', label: 'JSON',       render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: false, uploadable: true, generatable: false },
+  'image/png':        { extension: '.png',  label: 'PNG image',  render: 'image', anchoring: 'spatial',       extractText: 'none',           authorable: false, uploadable: true, generatable: false },
+  'image/jpeg':       { extension: '.jpg',  label: 'JPEG image', render: 'image', anchoring: 'spatial',       extractText: 'none',           authorable: false, uploadable: true, generatable: false },
+  'application/pdf':  { extension: '.pdf',  label: 'PDF',        render: 'pdf',   anchoring: 'spatial',       extractText: 'pdf-text-layer', authorable: false, uploadable: true, generatable: true },
 
   // Storage tier — the big tent. Every row is a deliberate admission,
   // promotable by editing its row. Text-flavored rows embed (decode).
@@ -249,4 +256,10 @@ export const AUTHORABLE_MEDIA_TYPES: readonly SupportedMediaType[] = REGISTRY_KE
  *  text/* fallback in `textExtractionOf` isn't enumerable. */
 export const EMBEDDABLE_MEDIA_TYPES: readonly SupportedMediaType[] = REGISTRY_KEYS.filter(
   (type) => MEDIA_TYPES[type].extractText !== 'none',
+);
+
+/** Types the generation worker can produce as a yield artifact — the
+ *  `outputMediaType` gate reads this, not a local table. */
+export const GENERATABLE_MEDIA_TYPES: readonly SupportedMediaType[] = REGISTRY_KEYS.filter(
+  (type) => MEDIA_TYPES[type].generatable,
 );

--- a/packages/core/src/pdf-anchoring.ts
+++ b/packages/core/src/pdf-anchoring.ts
@@ -158,10 +158,26 @@ export function locate(
     // for each page, group items into lines and compute one rectangle per line
     for (const [page, pageItems] of pages) {
         const lines = groupItemsByLine(pageItems, SAME_LINE_THRESHOLD_PT);
-        // Compute one bounding rectangle per line and add it to rects
+        // Compute one bounding rectangle per line and add it to rects.
+        // Boundary items that extend past [start, end) are clipped by character
+        // fraction (PDF-GENERATION P4): renderers like Typst emit ONE item per
+        // line, so without clipping a mid-line phrase would bound the whole
+        // line. Proportional interpolation is the measured fallback — exact
+        // glyph metrics need the operator-list route (open question 2) and can
+        // replace this arithmetic without changing the shape.
         for (const lineItems of lines) {
-            const x = Math.min(...lineItems.map(i => i.x));
-            const right = Math.max(...lineItems.map(i => i.x + i.width));
+            const edges = lineItems.map(i => {
+                const chars = i.end - i.start;
+                const left = i.start < start && chars > 0
+                    ? i.x + i.width * ((start - i.start) / chars)
+                    : i.x;
+                const right = i.end > end && chars > 0
+                    ? i.x + i.width * ((end - i.start) / chars)
+                    : i.x + i.width;
+                return { left, right };
+            });
+            const x = Math.min(...edges.map(e => e.left));
+            const right = Math.max(...edges.map(e => e.right));
             const y = Math.min(...lineItems.map(i => i.y));
             const top = Math.max(...lineItems.map(i => i.y + i.height));
             rects.push({page, x, y, width: right - x, height: top - y});

--- a/packages/core/src/pdf-citation-search.ts
+++ b/packages/core/src/pdf-citation-search.ts
@@ -1,0 +1,74 @@
+/**
+ * Two-stage citation search over an extracted PDF text layer
+ * (PDF-GENERATION P4).
+ *
+ * A citation's `exact` claim text comes from the authored source; the rendered
+ * text layer diverges from it in exactly two measured ways (the P0 spike):
+ * line breaks (`anchorRuns` joins runs with " \n") and hyphenation (soft
+ * hyphens are DROPPED — a hyphenated word yields its two halves with no hyphen
+ * character anywhere).
+ *
+ * Two stages, in this order, never collapsed to one matcher:
+ *
+ *   1. STRICT — search a whitespace-normalized copy, offsets mapped back.
+ *      Bridges plain line breaks (" \n" collapses to " ").
+ *   2. BREAK-AWARE — only on a strict miss. The line break becomes a distinct
+ *      marker character that may be absorbed in any inter-character gap, with
+ *      an optional space on either side (anchorRuns emits a space *then* the
+ *      newline). Ordinary spaces are NEVER wildcards, so "abc" cannot match
+ *      "a b c" — only a real break is absorbable.
+ *
+ * The ordering is the safety property: the permissive matcher runs only where
+ * the strict one already failed, so it can never turn a working citation into
+ * a wrong one — only a failure into an unlikely mismatch.
+ */
+import type { AnchoredText } from './pdf-anchoring';
+
+/** Distinct break marker — deliberately not a space (spaces are never wildcards). */
+const BREAK_MARKER = '';
+
+/** Optional-break gap: the marker, with an optional space on either side. */
+const BREAK_GAP = `(?: ?${BREAK_MARKER} ?)?`;
+
+const escapeRegExp = (ch: string): string => ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export function findClaimSpan(
+  anchored: AnchoredText,
+  exact: string,
+): { start: number; end: number } | null {
+  const needle = exact.replace(/\s+/g, ' ').trim();
+  if (needle.length === 0) return null;
+
+  // ── Stage 1: strict, over a whitespace-normalized copy with an offset map ──
+  let norm = '';
+  const map: number[] = [];
+  let pendingWsAt = -1;
+  for (let i = 0; i < anchored.text.length; i++) {
+    const ch = anchored.text[i]!;
+    if (/\s/.test(ch)) {
+      if (norm.length > 0 && pendingWsAt < 0) pendingWsAt = i;
+      continue;
+    }
+    if (pendingWsAt >= 0) {
+      norm += ' ';
+      map.push(pendingWsAt);
+      pendingWsAt = -1;
+    }
+    norm += ch;
+    map.push(i);
+  }
+  const idx = norm.indexOf(needle);
+  if (idx >= 0) {
+    return { start: map[idx]!, end: map[idx + needle.length - 1]! + 1 };
+  }
+
+  // ── Stage 2: break-aware, only on a miss ──
+  const marker = anchored.text.replace(/\n/g, BREAK_MARKER);
+  const pattern = [...needle].map(escapeRegExp).join(BREAK_GAP);
+  const match = new RegExp(pattern).exec(marker);
+  if (match) {
+    return { start: match.index, end: match.index + match[0].length };
+  }
+
+  return null;
+}

--- a/packages/jobs/Dockerfile
+++ b/packages/jobs/Dockerfile
@@ -34,6 +34,9 @@ COPY --from=installer /usr/local/bin /usr/local/bin
 # non-Latin tiers are a deliberate later pass. Every invocation must pin
 # --creation-timestamp — unpinned compiles change bytes on identical input,
 # which churns content checksums and re-embeds forever (S11/S12).
+# Attribution lives in NOTICE (Apache-2.0 + the embedded font licenses, which
+# no scanner can see inside a bare binary) — bump the version there in the
+# same diff as this tag.
 COPY --from=ghcr.io/typst/typst:0.15.1 /bin/typst /usr/local/bin/typst
 
 # Strip npm/npx after the COPY above re-introduces them from the installer tree.

--- a/packages/jobs/Dockerfile
+++ b/packages/jobs/Dockerfile
@@ -26,6 +26,16 @@ RUN addgroup --system --gid 1001 nodejs && \
 COPY --from=installer /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=installer /usr/local/bin /usr/local/bin
 
+# Typst renderer for PDF generation (PDF-GENERATION P2, approved 2026-08-04).
+# Pinned to the version the P0 spike measured — the recorded citation geometry
+# is a property of this version's layout. Alpine/musl build, same libc as this
+# base. The binary embeds its default Latin fonts (Libertinus, SIL OFL), which
+# covers the day-one locales (en/es/de/fr) with no separate font files; the
+# non-Latin tiers are a deliberate later pass. Every invocation must pin
+# --creation-timestamp — unpinned compiles change bytes on identical input,
+# which churns content checksums and re-embeds forever (S11/S12).
+COPY --from=ghcr.io/typst/typst:0.15.1 /bin/typst /usr/local/bin/typst
+
 # Strip npm/npx after the COPY above re-introduces them from the installer tree.
 RUN rm -rf /usr/local/lib/node_modules/npm \
            /usr/local/bin/npm \

--- a/packages/jobs/NOTICE
+++ b/packages/jobs/NOTICE
@@ -12,6 +12,20 @@ components:
   Alpine Linux - MIT License
   Node.js - MIT License
 
+  Typst (typesetting compiler, v0.15.1) - Apache-2.0 License
+    The Typst Project Developers - https://github.com/typst/typst
+    Copied as a static binary from ghcr.io/typst/typst:0.15.1.
+    The binary embeds its default fonts, each under its own license. The
+    fonts' full copyright and license notices are retained verbatim inside
+    the font files embedded in the binary; the copyright notices are also
+    reproduced here:
+      Libertinus - SIL Open Font License 1.1
+      New Computer Modern - GUST Font License
+      DejaVu - Bitstream Vera Fonts License
+        Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
+        Bitstream Vera is a trademark of Bitstream, Inc.
+        DejaVu changes are in the public domain.
+
   npm dependencies (installed at build time from https://registry.npmjs.org):
     @semiont/jobs - Apache-2.0 License (The AI Alliance)
 

--- a/packages/jobs/src/__tests__/fixtures/typst/.gitignore
+++ b/packages/jobs/src/__tests__/fixtures/typst/.gitignore
@@ -1,0 +1,6 @@
+# Compiled PDF fixtures are generated from the .typ sources at test time
+# (vitest globalSetup, mirroring @semiont/content's generate-fixtures.ts;
+# needs the Typst binary — see README.md for the compile invocation and the
+# mandatory --creation-timestamp pin). Don't commit the binaries — edit the
+# .typ sources instead.
+*.pdf

--- a/packages/jobs/src/__tests__/fixtures/typst/README.md
+++ b/packages/jobs/src/__tests__/fixtures/typst/README.md
@@ -1,0 +1,58 @@
+# Typst citation fixtures
+
+Source documents for the PDF-generation citation branch. Each one forces a
+specific way that **rendered text diverges from the source text a model cited**,
+which is the problem the citation search layer exists to solve.
+
+Every file carries a header comment stating what it forces and the geometry it
+produced when measured. Read those first; this file covers only what is common.
+
+## These are sources, not artifacts
+
+**The compiled PDFs are not committed.** `packages/content` establishes the
+convention — `src/__tests__/generate-fixtures.ts` builds its PDF fixtures at
+test time through a vitest `globalSetup`, so fixtures stay reviewable as code
+rather than opaque binaries. There are no committed binary fixtures anywhere in
+this repo, and these should not be the first.
+
+Compiling them needs the Typst binary, which arrives with the worker image in
+PDF-GENERATION P2. **Until then these files are inert** — a generation step
+alongside them is P4's work, mirroring `generate-fixtures.ts`.
+
+## Compiling
+
+```
+typst compile --creation-timestamp 1700000000 plain.typ plain.pdf
+```
+
+**The timestamp pin is mandatory, not stylistic.** Typst writes `CreationDate`
+and `ModDate`, so unpinned compiles of identical source produce different bytes
+every time. Different bytes mean a different content checksum, which makes the
+Smelter re-embed a document that did not change — the spurious-re-embed failure
+smelter axioms S11/S12 exist to prevent. Measured 2026-08-04: unpinned compiles
+differ, pinned compiles are byte-identical. The flag also honours
+`SOURCE_DATE_EPOCH`.
+
+## Nothing about the page is set
+
+No `#set page`, no font, no margins. Every recorded number comes from Typst
+0.15.1 defaults, which is what makes them reproducible:
+
+| | |
+|---|---|
+| Page | `595.2756 x 841.8898` pt (A4) |
+| Left margin | `70.866` pt (2.5 cm) — the `x=71` in every recorded rect |
+| Body / heading | 11 pt / 15.4 pt |
+
+Do not add page settings to these files. The defaults *are* the fixture: change
+them and every recorded assertion moves.
+
+If a compile does not put `"quick brown"` at the end of line 1 of `plain.typ`,
+that is a Typst version difference rather than a settings one — check the
+version before assuming a regression.
+
+## Where the reasoning lives
+
+Findings, the two-stage search design these fixtures test, and the untracked
+spike harness that produced them are in `.plans/PDF-GENERATION.md`. That
+document is not in the repo; these fixtures are self-describing on purpose.

--- a/packages/jobs/src/__tests__/fixtures/typst/bad.typ
+++ b/packages/jobs/src/__tests__/fixtures/typst/bad.typ
@@ -1,0 +1,9 @@
+// Deliberately malformed, for compile-error shape.
+// Typst reports: error: unclosed delimiter, with file:line:col and a caret.
+// That legibility is the load-bearing input to whether a compile-repair loop
+// is viable (PDF-GENERATION open question 1).
+
+#set text(hyphenate: true)
+
+#let broken = [unclosed
+A paragraph with #undefined-fn() in it.

--- a/packages/jobs/src/__tests__/fixtures/typst/hard.typ
+++ b/packages/jobs/src/__tests__/fixtures/typst/hard.typ
@@ -1,0 +1,16 @@
+// Forces automatic hyphenation, and carries ligature words.
+// "extraordinarily" splits as "extraor" / "dinarily" with NO hyphen character
+// anywhere in the text layer and no /ActualText -- so whitespace normalization
+// cannot recover it and a break-aware matcher is required.
+// "flagship" and "efficiency" exercise ffi/fl ligatures; both round-trip.
+//
+// Expected: "extraordinarily complicated" -> 2 rects,
+//   y=764 x=71..523   y=749 x=71..524
+
+#set text(hyphenate: true)
+#set par(justify: true)
+
+The organization's classification of infrastructure investments was
+reclassified following an extraordinarily complicated administrative
+reconsideration, and the difficulty of finding a specific phrase became
+the flagship efficiency finding of the quarter.

--- a/packages/jobs/src/__tests__/fixtures/typst/hyph2.typ
+++ b/packages/jobs/src/__tests__/fixtures/typst/hyph2.typ
@@ -1,0 +1,12 @@
+// Isolates SOFT hyphen loss from hyphen loss generally.
+// Explicit hyphens survive extraction verbatim -- "well-known" and
+// "state-of-the-art" both match -- so the gap is specifically the hyphen that
+// automatic hyphenation inserts. This is what makes the upstream Typst report
+// precise rather than vague.
+
+#set text(hyphenate: true)
+#set par(justify: true)
+
+A well-known state-of-the-art phrase with explicit hyphens sits here, and
+then an extraordinarily complicated administrative reconsideration follows
+to force automatic hyphenation at the measure.

--- a/packages/jobs/src/__tests__/fixtures/typst/nohyph.typ
+++ b/packages/jobs/src/__tests__/fixtures/typst/nohyph.typ
@@ -1,0 +1,11 @@
+// Control for hard.typ: identical source with hyphenation off.
+// "extraordinarily complicated" becomes a plain hit, which is what isolates
+// hyphenation as the cause rather than line breaking generally.
+
+#set text(hyphenate: false)
+#set par(justify: true)
+
+The organization's classification of infrastructure investments was
+reclassified following an extraordinarily complicated administrative
+reconsideration, and the difficulty of finding a specific phrase became
+the flagship efficiency finding of the quarter.

--- a/packages/jobs/src/__tests__/fixtures/typst/plain.typ
+++ b/packages/jobs/src/__tests__/fixtures/typst/plain.typ
@@ -1,0 +1,17 @@
+// Forces a cited phrase across a line break.
+// "quick brown fox" straddles lines 1-2 of the first paragraph: a plain search
+// of the assembled text MISSES it, because anchorRuns joins runs with " \n".
+// Two paragraphs so block structure is distinguishable from inline.
+//
+// Expected (Typst 0.15.1 defaults): "quick brown fox" -> 2 rects,
+//   y=746 x=71..521   y=731 x=71..495
+
+= Quarterly Report
+
+Some preceding text that fills the line and wraps naturally across the
+measure, then the quick brown fox appears here in the middle of a
+paragraph, and a good deal more text follows after it so the phrase is
+genuinely interior rather than at a boundary.
+
+A second paragraph exists so that block-level structure is visible and
+distinguishable from inline structure in whatever the compiler emits.

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -37,6 +37,11 @@ vi.mock('../workers/generation/resource-generation', () => ({
   generateResourceFromTopic: vi.fn(),
 }));
 
+vi.mock('../workers/generation/typst-compiler', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../workers/generation/typst-compiler')>()),
+  compileTypst: vi.fn(),
+}));
+
 vi.mock('@semiont/event-sourcing', () => ({
   generateAnnotationId: vi.fn(() => 'ann-test-123'),
 }));
@@ -49,6 +54,7 @@ vi.mock('@semiont/event-sourcing', () => ({
 import { AnnotationDetection } from '../workers/annotation-detection';
 import { extractEntities } from '../workers/detection/entity-extractor';
 import { generateResourceFromTopic } from '../workers/generation/resource-generation';
+import { compileTypst, MAX_COMPILE_REPAIRS } from '../workers/generation/typst-compiler';
 import type { PdfTextLayer } from '@semiont/content';
 import {
   processHighlightJob,
@@ -57,6 +63,7 @@ import {
   processReferenceJob,
   processTagJob,
   processGenerationJob,
+  assertWithinOutputBudget,
   buildTextAnnotation,
   buildPdfAnnotation,
   type BuildAnnotation,
@@ -368,7 +375,7 @@ describe('processGenerationJob', () => {
       LOGGER,
     );
 
-    expect(result.content).toContain('Generated resource');
+    expect(new TextDecoder().decode(result.content)).toContain('Generated resource');
     expect(result.title).toBe('Generated Title');
     expect(result.format).toBe('text/markdown');
     expect(result.result.resourceName).toBe('Generated Title');
@@ -448,13 +455,15 @@ describe('processGenerationJob — inline citations (INLINE-CITATIONS P1)', () =
       LOGGER,
     );
 
-    expect(r.content).toBe('Paris is the capital of France. It is large.');
+    const text = new TextDecoder().decode(r.content);
+    expect(text).toBe('Paris is the capital of France. It is large.');
     expect(r.citations).toHaveLength(1);
     const c = r.citations[0]!;
     expect(c.resourceId).toBe('ctx-9');
     expect(c.exact).toBe('Paris is the capital of France.');
     // anchor invariant: the selector must reproduce exact from the FINAL content
-    expect(r.content.substring(c.start, c.end)).toBe(c.exact);
+    // (citation offsets index the decoded text)
+    expect(text.substring(c.start, c.end)).toBe(c.exact);
   });
 
   it('drops a hallucinated id loudly — stripped, warned, no citation', async () => {
@@ -471,7 +480,7 @@ describe('processGenerationJob — inline citations (INLINE-CITATIONS P1)', () =
       logger,
     );
 
-    expect(r.content).toBe('A bold claim.');
+    expect(new TextDecoder().decode(r.content)).toBe('A bold claim.');
     expect(r.citations).toHaveLength(0);
     expect(warn).toHaveBeenCalledTimes(1);
   });
@@ -489,8 +498,110 @@ describe('processGenerationJob — inline citations (INLINE-CITATIONS P1)', () =
       LOGGER,
     );
 
-    expect(r.content).toBe('Wiki-style [[links]] are legitimate content.');
+    expect(new TextDecoder().decode(r.content)).toBe('Wiki-style [[links]] are legitimate content.');
     expect(r.citations).toHaveLength(0);
+  });
+});
+
+describe('processGenerationJob — byte return (PDF-GENERATION P1)', () => {
+  // The artifact is bytes. Text is an encoding of them — one shape for every
+  // output media type, so a string can never travel mislabeled as a binary
+  // format. The sole consumer (worker upload) already does Buffer.from().
+  it('returns the artifact content as Uint8Array', async () => {
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({ content: 'Generated body', title: 'T' });
+
+    const r = await processGenerationJob(makeInferenceClient(), { title: 'T' }, vi.fn(), LOGGER);
+
+    expect(r.content).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(r.content)).toBe('Generated body');
+  });
+});
+
+describe('processGenerationJob — PDF generation via Typst (PDF-GENERATION P3)', () => {
+  beforeEach(() => {
+    vi.mocked(compileTypst).mockReset();
+    vi.mocked(generateResourceFromTopic).mockReset();
+  });
+
+  it('compiles model-authored Typst to PDF bytes', async () => {
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({ content: '= Title\nBody.', title: 'T' });
+    const pdf = new TextEncoder().encode('%PDF-FAKE');
+    vi.mocked(compileTypst).mockReturnValue({ pdf });
+
+    const r = await processGenerationJob(
+      makeInferenceClient(),
+      { title: 'T', outputMediaType: 'application/pdf' },
+      vi.fn(),
+      LOGGER,
+    );
+
+    expect(compileTypst).toHaveBeenCalledWith('= Title\nBody.');
+    expect(r.content).toBe(pdf);
+    expect(r.format).toBe('application/pdf');
+  });
+
+  it('feeds a compile error back for a bounded repair, then succeeds', async () => {
+    vi.mocked(generateResourceFromTopic)
+      .mockResolvedValueOnce({ content: '#let broken = [unclosed', title: 'T' })
+      .mockResolvedValueOnce({ content: '= Fixed\nBody.', title: 'T' });
+    const pdf = new TextEncoder().encode('%PDF-FAKE');
+    vi.mocked(compileTypst)
+      .mockReturnValueOnce({ error: 'error: unclosed delimiter\n  ┌─ doc.typ:1:14' })
+      .mockReturnValueOnce({ pdf });
+
+    const r = await processGenerationJob(
+      makeInferenceClient(),
+      { title: 'T', outputMediaType: 'application/pdf' },
+      vi.fn(),
+      LOGGER,
+    );
+
+    expect(r.content).toBe(pdf);
+    expect(generateResourceFromTopic).toHaveBeenCalledTimes(2);
+    // The repair call carries the failed source + the legible error (last arg).
+    const repairArg = vi.mocked(generateResourceFromTopic).mock.calls[1]!.at(-1);
+    expect(repairArg).toMatchObject({
+      source: '#let broken = [unclosed',
+      error: expect.stringContaining('unclosed delimiter'),
+    });
+  });
+
+  it('gives up loudly after the bounded repairs are exhausted', async () => {
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({ content: '#broken', title: 'T' });
+    vi.mocked(compileTypst).mockReturnValue({ error: 'error: unclosed delimiter' });
+
+    await expect(
+      processGenerationJob(makeInferenceClient(), { title: 'T', outputMediaType: 'application/pdf' }, vi.fn(), LOGGER),
+    ).rejects.toThrow(/unclosed delimiter/);
+
+    // 1 initial + MAX_COMPILE_REPAIRS attempts, then fail — no unbounded loop.
+    expect(generateResourceFromTopic).toHaveBeenCalledTimes(1 + MAX_COMPILE_REPAIRS);
+  });
+
+  it('cite with application/pdf fails loudly until the citation branch (P4) lands', async () => {
+    await expect(
+      processGenerationJob(
+        makeInferenceClient(),
+        { title: 'T', outputMediaType: 'application/pdf', cite: true },
+        vi.fn(),
+        LOGGER,
+      ),
+    ).rejects.toThrow(/citation branch/);
+    // fail-fast: before the LLM call
+    expect(generateResourceFromTopic).not.toHaveBeenCalled();
+  });
+});
+
+describe('processGenerationJob — output bound (PDF-GENERATION P5)', () => {
+  // Symmetric with #1124's extraction byte budget, and deliberately the SAME
+  // threshold: a generated artifact larger than what extraction accepts would
+  // be a resource our own Smelter declines as 'too-large'. Tested by the
+  // numbers — the judgment doesn't require materializing 200 MB (the same
+  // rationale content's withinByteBudget records).
+  it('accepts an artifact exactly at the budget and refuses one past it', async () => {
+    const { MAX_PDF_BYTES } = await import('@semiont/content');
+    expect(() => assertWithinOutputBudget(MAX_PDF_BYTES)).not.toThrow();
+    expect(() => assertWithinOutputBudget(MAX_PDF_BYTES + 1)).toThrow(/output byte budget/);
   });
 });
 

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -578,17 +578,39 @@ describe('processGenerationJob — PDF generation via Typst (PDF-GENERATION P3)'
     expect(generateResourceFromTopic).toHaveBeenCalledTimes(1 + MAX_COMPILE_REPAIRS);
   });
 
-  it('cite with application/pdf fails loudly until the citation branch (P4) lands', async () => {
-    await expect(
-      processGenerationJob(
-        makeInferenceClient(),
-        { title: 'T', outputMediaType: 'application/pdf', cite: true },
-        vi.fn(),
-        LOGGER,
-      ),
-    ).rejects.toThrow(/citation branch/);
-    // fail-fast: before the LLM call
-    expect(generateResourceFromTopic).not.toHaveBeenCalled();
+  it('cite with application/pdf strips tokens BEFORE compile and carries citations (P4)', async () => {
+    // Tokens must never render into the PDF; the claim `exact` strings travel
+    // to the worker, which anchors them by page geometry after extraction.
+    const CITE_PDF_CONTEXT = {
+      focus: {
+        kind: 'resource',
+        resource: { '@context': 'https://www.w3.org/ns/anno.jsonld', '@id': 'src-1', name: 'Src', representations: [] },
+      },
+      graph: { nodes: [{ id: 'src-1', type: 'resource', label: 'Src' }, { id: 'ctx-9', type: 'resource', label: 'Ctx' }], edges: [] },
+      metadata: {},
+    } as GatheredContext;
+    vi.mocked(generateResourceFromTopic).mockResolvedValue({
+      content: '= Answer\nParis is the capital of France. [[ctx-9]]',
+      title: 'T',
+    });
+    const pdf = new TextEncoder().encode('%PDF-FAKE');
+    vi.mocked(compileTypst).mockReturnValue({ pdf });
+
+    const r = await processGenerationJob(
+      makeInferenceClient(),
+      { title: 'T', outputMediaType: 'application/pdf', cite: true, context: CITE_PDF_CONTEXT },
+      vi.fn(),
+      LOGGER,
+    );
+
+    // stripped source reached the compiler — no token in the artifact
+    expect(compileTypst).toHaveBeenCalledWith('= Answer\nParis is the capital of France.');
+    expect(r.content).toBe(pdf);
+    expect(r.citations).toHaveLength(1);
+    expect(r.citations[0]).toMatchObject({
+      resourceId: 'ctx-9',
+      exact: 'Paris is the capital of France.',
+    });
   });
 });
 

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -266,7 +266,7 @@ describe('handleJob orchestration', () => {
   describe('generation', () => {
     it('uploads content via session.client.yield.resource, then emits job:complete with resourceId + resourceName', async () => {
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: '# Generated\n\nBody.',
+        content: new TextEncoder().encode('# Generated\n\nBody.'),
         title: 'New Resource',
         format: 'text/markdown',
         citations: [],
@@ -302,7 +302,7 @@ describe('handleJob orchestration', () => {
 
     it('propagates upload errors so the caller can translate to job:fail', async () => {
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: 'body',
+        content: new TextEncoder().encode('body'),
         title: 'T',
         format: 'text/markdown',
         citations: [],
@@ -322,7 +322,7 @@ describe('handleJob orchestration', () => {
       // step `browse.resources({ entityType: 'Character' })` would never
       // surface synthesized resources.
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: 'body',
+        content: new TextEncoder().encode('body'),
         title: 'T',
         format: 'text/markdown',
         citations: [],
@@ -349,7 +349,7 @@ describe('handleJob orchestration', () => {
       // resource — distinct from "field absent", and confusing for
       // downstream queries.
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: 'body',
+        content: new TextEncoder().encode('body'),
         title: 'T',
         format: 'text/markdown',
         citations: [],
@@ -369,7 +369,7 @@ describe('handleJob orchestration', () => {
       // mints a navigable reference: target = the whole source resource (resource-level,
       // no selector), body = SpecificResource → the derived resource.
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: 'body', title: 'Derived Doc', format: 'text/markdown', citations: [], result: {} as never,
+        content: new TextEncoder().encode('body'), title: 'Derived Doc', format: 'text/markdown', citations: [], result: {} as never,
       });
       const h = makeFakeSessionAndAdapter();
 
@@ -399,7 +399,7 @@ describe('handleJob orchestration', () => {
       // target = the derived resource + position/quote selectors for the claim,
       // body = SpecificResource → the cited source.
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: 'Paris is the capital of France. It is large.',
+        content: new TextEncoder().encode('Paris is the capital of France. It is large.'),
         title: 'Answer',
         format: 'text/markdown',
         citations: [{ resourceId: 'ctx-9', start: 0, end: 31, exact: 'Paris is the capital of France.' }],
@@ -637,7 +637,7 @@ describe('handleJob orchestration', () => {
 
     it('does not gate generation jobs (they read the annotation, not the source bytes)', async () => {
       vi.mocked(processGenerationJob).mockResolvedValue({
-        content: 'body',
+        content: new TextEncoder().encode('body'),
         title: 'T',
         format: 'text/markdown',
         citations: [],

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -31,6 +31,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { extractPdfTextLayer } from '@semiont/content';
 import type { SemiontSession } from '@semiont/sdk';
 import type { ActiveJob, JobClaimAdapter } from '../job-claim-adapter';
 import { handleJob, type WorkerProcessConfig } from '../worker-process';
@@ -67,6 +68,9 @@ vi.mock('@semiont/content', async (importOriginal) => {
   return {
     ...actual,
     EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn() } },
+    // PDF citation geometry (P4): the worker re-anchors claims through the
+    // extracted text layer; tests supply it.
+    extractPdfTextLayer: vi.fn(),
   };
 });
 
@@ -426,6 +430,46 @@ describe('handleJob orchestration', () => {
         },
       });
       expect(h.busEmits.map(e => e.channel)).toEqual(['job:start', 'mark:create', 'job:complete']);
+    });
+
+    it('anchors PDF citations by page geometry — FragmentSelector, never TextPositionSelector (PDF-GENERATION P4)', async () => {
+      // The citation offsets index the Typst SOURCE; on a PDF they render
+      // nothing — the silent wrong this test exists to prevent. The worker
+      // re-anchors each claim through the extracted text layer instead.
+      vi.mocked(processGenerationJob).mockResolvedValue({
+        content: new TextEncoder().encode('%PDF-FAKE'),
+        title: 'Answer',
+        format: 'application/pdf',
+        citations: [{ resourceId: 'ctx-9', start: 0, end: 31, exact: 'Paris is the capital of France.' }],
+        result: {} as never,
+      });
+      vi.mocked(extractPdfTextLayer).mockResolvedValue({
+        text: 'Paris is the capital of France. It is large.',
+        items: [{ start: 0, end: 44, page: 1, x: 71, y: 746, width: 450, height: 11 }],
+        pages: [],
+      } as never);
+      const h = makeFakeSessionAndAdapter();
+
+      await handleJob(
+        h.adapter,
+        makeConfig(h.session),
+        makeJob('generation', { referenceId: 'ref-1', cite: true, outputMediaType: 'application/pdf' }),
+      );
+
+      const markCreates = h.busEmits.filter(e => e.channel === 'mark:create');
+      expect(markCreates).toHaveLength(1);
+      const payload = markCreates[0]!.payload as {
+        resourceId: string;
+        annotation: { motivation: string; target: { source: string; selector: Array<{ type: string }> }; body: unknown };
+      };
+      expect(payload.resourceId).toBe('new-res-42');
+      expect(payload.annotation.motivation).toBe('linking');
+      expect(payload.annotation.target.source).toBe('new-res-42');
+      const selectorTypes = payload.annotation.target.selector.map((s) => s.type);
+      expect(selectorTypes).toContain('FragmentSelector');
+      expect(selectorTypes).toContain('TextQuoteSelector');
+      expect(selectorTypes).not.toContain('TextPositionSelector');
+      expect(payload.annotation.body).toMatchObject({ type: 'SpecificResource', source: 'ctx-9', purpose: 'linking' });
     });
   });
 

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -471,6 +471,41 @@ describe('handleJob orchestration', () => {
       expect(selectorTypes).not.toContain('TextPositionSelector');
       expect(payload.annotation.body).toMatchObject({ type: 'SpecificResource', source: 'ctx-9', purpose: 'linking' });
     });
+
+    it('a hyphenated claim mints with the RENDERED text as its quote — the source string would trip the containment invariant', async () => {
+      // The claim text comes from the Typst SOURCE; the rendered layer drops
+      // the soft hyphen ("extraor" + "dinarily"). The quote selector must
+      // carry what is actually under the rects — the rendered substring — or
+      // buildPdfAnnotation's invariant throws and fails the whole job even
+      // though findClaimSpan found the span.
+      vi.mocked(processGenerationJob).mockResolvedValue({
+        content: new TextEncoder().encode('%PDF-FAKE'),
+        title: 'Answer',
+        format: 'application/pdf',
+        citations: [{ resourceId: 'ctx-9', start: 0, end: 27, exact: 'extraordinarily complicated' }],
+        result: {} as never,
+      });
+      vi.mocked(extractPdfTextLayer).mockResolvedValue({
+        text: 'It is extraor \ndinarily complicated today.',
+        items: [{ start: 0, end: 42, page: 1, x: 71, y: 764, width: 452, height: 11 }],
+        pages: [],
+      } as never);
+      const h = makeFakeSessionAndAdapter();
+
+      await handleJob(
+        h.adapter,
+        makeConfig(h.session),
+        makeJob('generation', { referenceId: 'ref-1', cite: true, outputMediaType: 'application/pdf' }),
+      );
+
+      const markCreates = h.busEmits.filter(e => e.channel === 'mark:create');
+      expect(markCreates).toHaveLength(1);
+      const selector = (markCreates[0]!.payload as {
+        annotation: { target: { selector: Array<{ type: string; exact?: string }> } };
+      }).annotation.target.selector;
+      const quote = selector.find(s => s.type === 'TextQuoteSelector');
+      expect(quote?.exact).toBe('extraor \ndinarily complicated');
+    });
   });
 
   describe('wire contract', () => {

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -627,13 +627,14 @@ export async function processGenerationJob(
   // until the citation branch (P4) provides it, `cite` fails fast and loudly
   // rather than minting selectors that would render nothing.
   if (outputMediaType === 'application/pdf') {
-    if (params.cite === true) {
-      throw new Error(
-        'cite with application/pdf requires the citation branch (PDF-GENERATION P4): PDF citations anchor by page geometry, which is not built yet.',
-      );
-    }
-
     onProgress(5, 'Generating resource...', 'generating');
+
+    // Under `cite`, [[<id>]] tokens are stripped from the SOURCE before every
+    // compile — they must never render into the artifact. The citations carry
+    // the claim text; the worker re-anchors it by page geometry after
+    // extraction (P4). Offsets in these citations index the Typst source and
+    // are NOT used for PDF anchoring.
+    const validIds = params.cite === true ? collectContextResourceIds(params.context) : null;
 
     let generated = await generateResourceFromTopic(
       title, entityTypes, inferenceClient, logger,
@@ -641,7 +642,14 @@ export async function processGenerationJob(
       params.maxTokens, params.sourceLanguage, outputMediaType,
       params.task, params.structure, params.cite,
     );
-    let compiled = compileTypst(generated.content);
+    let source = generated.content;
+    let citations: GenerationCitation[] = [];
+    if (validIds) {
+      const resolved = resolveCitationTokens(generated.content, validIds, logger);
+      source = resolved.content;
+      citations = resolved.citations;
+    }
+    let compiled = compileTypst(source);
     let repairs = 0;
     while ('error' in compiled && repairs < MAX_COMPILE_REPAIRS) {
       repairs++;
@@ -654,9 +662,16 @@ export async function processGenerationJob(
         params.prompt, params.language, params.context, params.temperature,
         params.maxTokens, params.sourceLanguage, outputMediaType,
         params.task, params.structure, params.cite,
-        { source: generated.content, error: compiled.error },
+        { source, error: compiled.error },
       );
-      compiled = compileTypst(generated.content);
+      if (validIds) {
+        const resolved = resolveCitationTokens(generated.content, validIds, logger);
+        source = resolved.content;
+        citations = resolved.citations;
+      } else {
+        source = generated.content;
+      }
+      compiled = compileTypst(source);
     }
     if ('error' in compiled) {
       throw new Error(
@@ -671,7 +686,7 @@ export async function processGenerationJob(
       content: compiled.pdf,
       title: generated.title ?? title,
       format: outputMediaType,
-      citations: [],
+      citations,
       result: {
         resourceId: '' as ResourceId,
         resourceName: generated.title ?? title,

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -12,9 +12,11 @@
 import { AnnotationDetection } from './workers/annotation-detection';
 import { extractEntities } from './workers/detection/entity-extractor';
 import { generateResourceFromTopic } from './workers/generation/resource-generation';
+import { compileTypst, MAX_COMPILE_REPAIRS } from './workers/generation/typst-compiler';
+import { withinByteBudget, MAX_PDF_BYTES } from '@semiont/content';
 import { resolveCitationTokens, collectContextResourceIds, type GenerationCitation } from './workers/generation/citation-resolver';
 import { generateAnnotationId } from '@semiont/event-sourcing';
-import { didToAgent, type Annotation, type Logger, type ResourceId, type SupportedMediaType, type components } from '@semiont/core';
+import { didToAgent, GENERATABLE_MEDIA_TYPES, type Annotation, type Logger, type ResourceId, type SupportedMediaType, type components } from '@semiont/core';
 import { reconcileSelector, createFragmentSelector, locate, type ReconciledSelector, type AnchoredText } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 import type {
@@ -584,16 +586,31 @@ export async function processTagJob(
   };
 }
 
+/**
+ * Output bound (PDF-GENERATION P5), symmetric with #1124's extraction budget
+ * and deliberately the SAME threshold: an artifact larger than what extraction
+ * accepts would be a resource our own Smelter declines as 'too-large'. One
+ * judgment, two enforcement points. A runaway generation fails loudly
+ * (job:fail); it never uploads.
+ */
+export function assertWithinOutputBudget(byteLength: number): void {
+  if (!withinByteBudget(byteLength)) {
+    throw new Error(
+      `Generated artifact exceeds the output byte budget: ${byteLength} bytes > ${MAX_PDF_BYTES}. Refusing a runaway generation.`,
+    );
+  }
+}
+
 export async function processGenerationJob(
   inferenceClient: InferenceClient,
   params: GenerationParams,
   onProgress: OnProgress,
   logger: Logger,
-): Promise<{ content: string; title: string; format: SupportedMediaType; citations: GenerationCitation[]; result: GenerationResult }> {
-  // Generation produces text only for now. Refuse any other requested media type
-  // loudly (the throw propagates as job:fail) rather than silently emitting markdown
-  // under a mislabeled format. Validate before the LLM call so it fails fast.
-  const GENERATABLE_MEDIA_TYPES: readonly SupportedMediaType[] = ['text/markdown', 'text/plain'];
+): Promise<{ content: Uint8Array; title: string; format: SupportedMediaType; citations: GenerationCitation[]; result: GenerationResult }> {
+  // Refuse any requested media type the registry doesn't mark `generatable` —
+  // loudly (the throw propagates as job:fail), never a silent markdown fallback
+  // under a mislabeled format. The gate reads the registry capability
+  // (PDF-GENERATION P1), not a local table. Validate before the LLM call.
   const outputMediaType: SupportedMediaType = params.outputMediaType ?? 'text/markdown';
   if (!GENERATABLE_MEDIA_TYPES.includes(outputMediaType)) {
     throw new Error(
@@ -603,6 +620,64 @@ export async function processGenerationJob(
 
   const title = params.title ?? 'Untitled';
   const entityTypes = (params.entityTypes ?? []).map(String);
+
+  // PDF path (PDF-GENERATION P3): the model authors Typst; the worker's pinned
+  // binary compiles it, with the legible compile errors fed back for a bounded
+  // number of repairs. Citations on PDFs need page geometry, not text offsets —
+  // until the citation branch (P4) provides it, `cite` fails fast and loudly
+  // rather than minting selectors that would render nothing.
+  if (outputMediaType === 'application/pdf') {
+    if (params.cite === true) {
+      throw new Error(
+        'cite with application/pdf requires the citation branch (PDF-GENERATION P4): PDF citations anchor by page geometry, which is not built yet.',
+      );
+    }
+
+    onProgress(5, 'Generating resource...', 'generating');
+
+    let generated = await generateResourceFromTopic(
+      title, entityTypes, inferenceClient, logger,
+      params.prompt, params.language, params.context, params.temperature,
+      params.maxTokens, params.sourceLanguage, outputMediaType,
+      params.task, params.structure, params.cite,
+    );
+    let compiled = compileTypst(generated.content);
+    let repairs = 0;
+    while ('error' in compiled && repairs < MAX_COMPILE_REPAIRS) {
+      repairs++;
+      logger.warn('Typst compile failed — feeding the error back for repair', {
+        attempt: repairs,
+        error: compiled.error.slice(0, 500),
+      });
+      generated = await generateResourceFromTopic(
+        title, entityTypes, inferenceClient, logger,
+        params.prompt, params.language, params.context, params.temperature,
+        params.maxTokens, params.sourceLanguage, outputMediaType,
+        params.task, params.structure, params.cite,
+        { source: generated.content, error: compiled.error },
+      );
+      compiled = compileTypst(generated.content);
+    }
+    if ('error' in compiled) {
+      throw new Error(
+        `Typst compilation failed after ${MAX_COMPILE_REPAIRS} repair attempts: ${compiled.error}`,
+      );
+    }
+
+    assertWithinOutputBudget(compiled.pdf.byteLength);
+    onProgress(95, 'Creating resource...', 'creating');
+
+    return {
+      content: compiled.pdf,
+      title: generated.title ?? title,
+      format: outputMediaType,
+      citations: [],
+      result: {
+        resourceId: '' as ResourceId,
+        resourceName: generated.title ?? title,
+      },
+    };
+  }
 
   // Generation has exactly two observable transitions: the LLM call starting
   // ('generating') and content finalized / creation beginning ('creating').
@@ -643,8 +718,14 @@ export async function processGenerationJob(
 
   onProgress(95, 'Creating resource...', 'creating');
 
+  // The artifact is bytes; text is an encoding of them. One shape for every
+  // output media type, so a string can never travel mislabeled as a binary
+  // format (PDF-GENERATION P1). Citation offsets index the decoded text.
+  const artifact = new TextEncoder().encode(content);
+  assertWithinOutputBudget(artifact.byteLength);
+
   return {
-    content,
+    content: artifact,
     title: generated.title ?? title,
     format: outputMediaType,
     citations,

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -396,7 +396,8 @@ async function handleJobInner(
     // source — so citations are first-class references like any other.
     //
     // Anchoring branches on the artifact's anchoring model. Text formats
-    // anchor by character offset into the stored bytes (INLINE-CITATIONS P1).
+    // anchor by character offset into the DECODED text — consumers apply
+    // selectors to the decoded string, not raw bytes (INLINE-CITATIONS P1).
     // A PDF anchors by PAGE GEOMETRY (PDF-GENERATION P4): the citation's
     // offsets index the Typst SOURCE and would render nothing, so each claim
     // is re-found in the artifact's own text layer (two-stage search — strict,
@@ -418,13 +419,18 @@ async function handleJobInner(
             });
             continue;
           }
+          // The quote must be the RENDERED substring, not the source claim:
+          // hyphenation drops characters, so the source string can fail
+          // buildPdfAnnotation's containment invariant even though the span
+          // was found — and W3C-wise the quote should be the text actually
+          // under the rects, which is what re-anchoring will see.
           const citationRef = buildPdfAnnotation(
             layer,
             makeResourceId(String(newResourceId)),
             userId,
             generator,
             'linking',
-            { exact: citation.exact, start: span.start, end: span.end },
+            { exact: layer.text.slice(span.start, span.end), start: span.start, end: span.end },
             { type: 'SpecificResource', source: citation.resourceId, purpose: 'linking' },
           );
           await emitEvent(session, 'mark:create', { annotation: citationRef, resourceId: newResourceId });

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -29,10 +29,10 @@ import {
 } from './types';
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
-import { getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, type EventMap } from '@semiont/core';
+import { getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, findClaimSpan, type EventMap } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 import type { Logger, components } from '@semiont/core';
-import { deriveStorageUri, type AnchoredTextStore } from '@semiont/content';
+import { deriveStorageUri, extractPdfTextLayer, type AnchoredTextStore } from '@semiont/content';
 import { prepareDetection, type DetectionDecline } from './workers/detection/prepare-detection';
 import { SpanKind, recordJobOutcome, withSpan } from '@semiont/observability';
 import {
@@ -42,6 +42,7 @@ import {
   processReferenceJob,
   processTagJob,
   processGenerationJob,
+  buildPdfAnnotation,
   type OnProgress,
   type BuildAnnotation,
 } from './processors';
@@ -390,27 +391,63 @@ async function handleJobInner(
       await emitEvent(session, 'mark:create', { annotation: provenanceRef, resourceId });
     }
 
-    // Inline citations (INLINE-CITATIONS P1): the processor resolved the model's
-    // [[<id>]] transport tokens into claim-span citations against the final
-    // (token-stripped) content. Mint each as a linking annotation ON THE DERIVED
-    // resource — the target anchors the claim span, the body points at the cited
+    // Inline citations: mint each as a linking annotation ON THE DERIVED
+    // resource — the target anchors the claim, the body points at the cited
     // source — so citations are first-class references like any other.
-    for (const citation of genResult.citations) {
-      const { annotation: citationRef } = assembleAnnotation(
-        {
-          motivation: 'linking',
-          target: {
-            source: String(newResourceId),
-            selector: [
-              { type: 'TextPositionSelector', start: citation.start, end: citation.end },
-              { type: 'TextQuoteSelector', exact: citation.exact },
-            ],
+    //
+    // Anchoring branches on the artifact's anchoring model. Text formats
+    // anchor by character offset into the stored bytes (INLINE-CITATIONS P1).
+    // A PDF anchors by PAGE GEOMETRY (PDF-GENERATION P4): the citation's
+    // offsets index the Typst SOURCE and would render nothing, so each claim
+    // is re-found in the artifact's own text layer (two-stage search — strict,
+    // then break-aware for hyphenation) and located to rects. A claim the
+    // search cannot find is dropped LOUDLY, never minted wrong.
+    if (genResult.format === 'application/pdf' && genResult.citations.length > 0) {
+      const layer = await extractPdfTextLayer(genResult.content);
+      if (!layer) {
+        config.logger.warn('PDF citations dropped — the generated artifact yielded no text layer', {
+          jobId, resourceId: newResourceId, citations: genResult.citations.length,
+        });
+      } else {
+        for (const citation of genResult.citations) {
+          const span = findClaimSpan(layer, citation.exact);
+          if (!span) {
+            config.logger.warn('PDF citation dropped — claim not found in the rendered text layer', {
+              jobId, resourceId: newResourceId, citedResourceId: citation.resourceId,
+              exactPreview: citation.exact.slice(0, 80),
+            });
+            continue;
+          }
+          const citationRef = buildPdfAnnotation(
+            layer,
+            makeResourceId(String(newResourceId)),
+            userId,
+            generator,
+            'linking',
+            { exact: citation.exact, start: span.start, end: span.end },
+            { type: 'SpecificResource', source: citation.resourceId, purpose: 'linking' },
+          );
+          await emitEvent(session, 'mark:create', { annotation: citationRef, resourceId: newResourceId });
+        }
+      }
+    } else {
+      for (const citation of genResult.citations) {
+        const { annotation: citationRef } = assembleAnnotation(
+          {
+            motivation: 'linking',
+            target: {
+              source: String(newResourceId),
+              selector: [
+                { type: 'TextPositionSelector', start: citation.start, end: citation.end },
+                { type: 'TextQuoteSelector', exact: citation.exact },
+              ],
+            },
+            body: { type: 'SpecificResource', source: citation.resourceId, purpose: 'linking' },
           },
-          body: { type: 'SpecificResource', source: citation.resourceId, purpose: 'linking' },
-        },
-        generator,
-      );
-      await emitEvent(session, 'mark:create', { annotation: citationRef, resourceId: newResourceId });
+          generator,
+        );
+        await emitEvent(session, 'mark:create', { annotation: citationRef, resourceId: newResourceId });
+      }
     }
 
     await emitEvent(session, 'job:complete', {

--- a/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
+++ b/packages/jobs/src/workers/generation/__tests__/resource-generation.test.ts
@@ -856,6 +856,46 @@ describe('generateResourceFromTopic', () => {
       expect(promptArg()).toMatch(/markdown/i);
     });
 
+    it('application/pdf instructs Typst markup, not markdown (PDF-GENERATION P3)', async () => {
+      client.setResponses(['= X\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined, undefined, undefined, undefined, undefined,
+        'application/pdf',
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toContain('Typst');
+      expect(prompt).toContain('= Heading');
+      expect(prompt).not.toContain('Write the response as markdown');
+    });
+
+    it('strips a ```typst code fence from the response (PDF-GENERATION P3)', async () => {
+      client.setResponses(['```typst\n= T\nbody\n```']);
+
+      const result = await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined, undefined, undefined, undefined, undefined,
+        'application/pdf',
+      );
+
+      expect(result.content).toBe('= T\nbody');
+    });
+
+    it('a compile-repair context reaches the prompt with the failed source and error (PDF-GENERATION P3)', async () => {
+      client.setResponses(['= Fixed\nbody']);
+
+      await generateResourceFromTopic(
+        'Topic', [], client, LOGGER, undefined, undefined, undefined, undefined, undefined, undefined,
+        'application/pdf', undefined, undefined, undefined,
+        { source: '#let broken = [unclosed', error: 'error: unclosed delimiter' },
+      );
+
+      const prompt = promptArg();
+      expect(prompt).toContain('failed to compile');
+      expect(prompt).toContain('error: unclosed delimiter');
+      expect(prompt).toContain('#let broken = [unclosed');
+    });
+
     it('text/plain drops the markdown scaffolding and asks for plain prose', async () => {
       client.setResponses(['X\n\nbody']);
 

--- a/packages/jobs/src/workers/generation/__tests__/typst-compiler.test.ts
+++ b/packages/jobs/src/workers/generation/__tests__/typst-compiler.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { compileTypst, PINNED_CREATION_TIMESTAMP } from '../typst-compiler';
+
+/**
+ * Compiler-invocation mechanics, tested against a FAKE `typst` executable
+ * prepended to PATH — the real binary lives only in the worker image (P2) and
+ * the fixture-generation setup (P4). What this file pins is OUR side of the
+ * contract: argument order, the mandatory --creation-timestamp (determinism —
+ * unpinned compiles change bytes on identical input, churning checksums into
+ * permanent re-embeds), temp-file plumbing, byte return, and legible error
+ * capture. Real-compile coverage arrives with P4's fixture globalSetup.
+ */
+describe('compileTypst (PDF-GENERATION P3)', () => {
+  let fakeDir: string;
+  let savedPath: string | undefined;
+
+  beforeEach(() => {
+    fakeDir = mkdtempSync(join(tmpdir(), 'fake-typst-'));
+    savedPath = process.env.PATH;
+    process.env.PATH = `${fakeDir}:${savedPath ?? ''}`;
+  });
+
+  afterEach(() => {
+    process.env.PATH = savedPath;
+    rmSync(fakeDir, { recursive: true, force: true });
+  });
+
+  /** Install a fake `typst` that records its argv and behaves per `body`. */
+  function installFakeTypst(body: string): string {
+    const argsFile = join(fakeDir, 'argv');
+    const script = `#!/bin/sh\necho "$@" > "${argsFile}"\n${body}\n`;
+    const bin = join(fakeDir, 'typst');
+    writeFileSync(bin, script);
+    chmodSync(bin, 0o755);
+    return argsFile;
+  }
+
+  it('compiles source to PDF bytes, pinning the creation timestamp', () => {
+    // The fake writes a recognizable byte payload to the output path (last arg).
+    const argsFile = installFakeTypst(
+      'for last in "$@"; do :; done; printf "%%PDF-FAKE" > "$last"',
+    );
+
+    const result = compileTypst('= Title\nBody text.');
+
+    expect('pdf' in result && result.pdf).toBeInstanceOf(Uint8Array);
+    if (!('pdf' in result)) throw new Error('expected pdf');
+    expect(new TextDecoder().decode(result.pdf)).toBe('%PDF-FAKE');
+
+    const argv = readFileSync(argsFile, 'utf8');
+    expect(argv).toContain('compile');
+    expect(argv).toContain(`--creation-timestamp ${PINNED_CREATION_TIMESTAMP}`);
+  });
+
+  it('captures the legible compile error on failure', () => {
+    installFakeTypst(
+      'echo "error: unclosed delimiter\\n  ┌─ doc.typ:3:9" >&2; exit 2',
+    );
+
+    const result = compileTypst('#let broken = [unclosed');
+
+    expect('error' in result).toBe(true);
+    if (!('error' in result)) throw new Error('expected error');
+    expect(result.error).toContain('unclosed delimiter');
+  });
+});

--- a/packages/jobs/src/workers/generation/resource-generation.ts
+++ b/packages/jobs/src/workers/generation/resource-generation.ts
@@ -55,7 +55,8 @@ export async function generateResourceFromTopic(
   outputMediaType: SupportedMediaType = 'text/markdown',
   task: string = 'resource',
   structure?: string,
-  cite: boolean = false
+  cite: boolean = false,
+  repair?: { source: string; error: string }
 ): Promise<{ title: string; content: string }> {
   logger.debug('Generating resource from topic', {
     topicPreview: topic.substring(0, 100),
@@ -234,13 +235,19 @@ ${after ? `${after}...` : ''}
   // determine shape). Never derived from the token budget: maxTokens is length
   // only. The forced `# Title` heading exists only under canonical 'sections'.
   const isPlainText = outputMediaType === 'text/plain';
+  // PDF output means the model authors Typst source (Q1, direct Typst); the
+  // worker compiles it. The prompt therefore teaches Typst syntax, and the
+  // markdown scaffolding never applies.
+  const isPdf = outputMediaType === 'application/pdf';
   let structureRequirement = '';
   let titleRequirement = '';
   if (structure === 'sections') {
-    structureRequirement = isPlainText
-      ? '\n- Organize the content into titled sections with well-structured paragraphs'
-      : '\n- Organize the content into titled sections (## Section) with well-structured paragraphs';
-    if (!isPlainText) {
+    structureRequirement = isPdf
+      ? '\n- Organize the content into titled sections (= Heading) with well-structured paragraphs'
+      : isPlainText
+        ? '\n- Organize the content into titled sections with well-structured paragraphs'
+        : '\n- Organize the content into titled sections (## Section) with well-structured paragraphs';
+    if (!isPlainText && !isPdf) {
       titleRequirement = '\n- Start with a clear heading (# Title)';
     }
   } else if (structure === 'prose') {
@@ -260,16 +267,31 @@ ${after ? `${after}...` : ''}
     ? '\n- Ground every claim in the provided context. Immediately after each claim, cite its source by emitting [[<id>]], where <id> is an id shown in square brackets in the context above (for a passage labeled [abc], emit [[abc]]). Cite only ids that appear in the context.'
     : '';
 
-  const formatRequirements = isPlainText
-    ? `- Write the response as plain text — no formatting markup (no #, *, backticks, headings, or links)
+  const formatRequirements = isPdf
+    ? `- Write the response as Typst markup (the Typst typesetting language — not markdown, not LaTeX)
+- Headings are written as = Heading (deeper levels == Subheading); everything else is plain prose paragraphs
+- Do not emit markdown syntax or code fences`
+    : isPlainText
+      ? `- Write the response as plain text — no formatting markup (no #, *, backticks, headings, or links)
 - Begin with the title on its own first line`
-    : `- Use markdown formatting
+      : `- Use markdown formatting
 - Write the response as markdown`;
+
+  // Compile-repair context (PDF-GENERATION P3): the previous Typst source
+  // failed to compile; the legible compiler diagnostics go back to the model
+  // as an authoritative instruction to fix and re-emit the full document.
+  const repairSection = repair
+    ? `\n\nYour previous attempt failed to compile. Fix the error and return the complete corrected document — full source, not a diff.
+Compile error:
+${repair.error}
+Previous source:
+${repair.source}`
+    : '';
 
   // The caller's prompt is an authoritative leading Instruction (YIELD-STRUCTURE D3),
   // not background "additional context" — task = what to produce, prompt = how.
   const prompt = `${leadLine}
-${userPrompt ? `Instruction: ${userPrompt}` : ''}
+${userPrompt ? `Instruction: ${userPrompt}` : ''}${repairSection}
 ${entityTypes.length > 0 ? `Focus on these entity types: ${entityTypes.join(', ')}.` : ''}${annotationSection}${contextSection}${resourceSection}${graphSection}${semanticContextSection}${sourceLanguageInstruction}${languageInstruction}
 
 Requirements:
@@ -281,7 +303,7 @@ ${formatRequirements}`;
   const parseResponse = (response: string): { title: string; content: string } => {
     // Clean up any markdown code fences if present
     let content = response.trim();
-    if (content.startsWith('```markdown') || content.startsWith('```md')) {
+    if (content.startsWith('```markdown') || content.startsWith('```md') || content.startsWith('```typst')) {
       content = content.slice(content.indexOf('\n') + 1);
       const endIndex = content.lastIndexOf('```');
       if (endIndex !== -1) {

--- a/packages/jobs/src/workers/generation/typst-compiler.ts
+++ b/packages/jobs/src/workers/generation/typst-compiler.ts
@@ -1,0 +1,53 @@
+/**
+ * Typst compiler invocation (PDF-GENERATION P3).
+ *
+ * The model writes Typst source (Q1, settled 2026-08-04: direct Typst); this
+ * module turns it into PDF bytes via the pinned binary the worker image ships
+ * (P2 — `/usr/local/bin/typst`, v0.15.1, resolved through PATH so tests can
+ * substitute a fake). Compile failures return the legible error text — Typst's
+ * `file:line:col` + caret diagnostics are the load-bearing input to the bounded
+ * repair loop in `processGenerationJob`.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Every compile pins the PDF creation timestamp. Unpinned compiles of
+ * identical source produce different bytes every time (CreationDate/ModDate),
+ * which churns the content checksum and makes the Smelter re-embed a document
+ * that did not change — the spurious-re-embed failure S11/S12 exist to
+ * prevent. The value is arbitrary; its fixity is the point.
+ */
+export const PINNED_CREATION_TIMESTAMP = 1700000000;
+
+/**
+ * Model-authored source can fail to compile; the error is fed back for repair
+ * a bounded number of times, then the job fails loudly with the compiler's
+ * diagnostics. Bounded because generation is non-idempotent and paid per
+ * attempt — this is a repair loop, not a retry loop.
+ */
+export const MAX_COMPILE_REPAIRS = 2;
+
+export function compileTypst(source: string): { pdf: Uint8Array } | { error: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'typst-'));
+  try {
+    const inFile = join(dir, 'doc.typ');
+    const outFile = join(dir, 'doc.pdf');
+    writeFileSync(inFile, source);
+    try {
+      execFileSync(
+        'typst',
+        ['compile', '--creation-timestamp', String(PINNED_CREATION_TIMESTAMP), inFile, outFile],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    } catch (err) {
+      const stderr = (err as { stderr?: Buffer }).stderr;
+      return { error: stderr?.length ? stderr.toString('utf8') : String(err) };
+    }
+    return { pdf: new Uint8Array(readFileSync(outFile)) };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## What

`yield.fromResource(…, { outputMediaType: 'application/pdf' })` now produces a real PDF: the model writes **Typst** source, the worker's pinned compiler renders it deterministically, and — with `cite: true` — each claim arrives as a W3C linking annotation anchored to **word-precise page geometry** in the artifact's own text layer. Implements PDF-GENERATION P1–P5 (the P0 spike established there is no coordinate map to build — the standard text layer *is* the map).

### P1 — the gate is a registry capability, and artifacts are bytes
- `generatable: boolean` joins `MediaTypeCapabilities` (the `authorable` pattern), with derived `GENERATABLE_MEDIA_TYPES` exported from core. The local table inside `processGenerationJob` is deleted — closing a known second-media-type-table violation. Core-only: no spec change (the enum didn't change).
- `processGenerationJob` returns `content: Uint8Array` always — text is an encoding of bytes, so a string can never travel mislabeled as a binary format. Sole consumer (`Buffer.from` at upload) unchanged.

### P2 — Typst runtime in the worker image (maintainer-approved)
- `COPY --from=ghcr.io/typst/typst:0.15.1 /bin/typst` — Alpine/musl, same libc as the base; mechanism verified with a smoke image on the exact base. Pinned to the spike-measured version: **the recorded citation geometry is a property of this version's layout.**
- Day-one fonts are the binary's embedded defaults (Libertinus — SIL OFL; covers en/es/de/fr). **NOTICE** gains the Typst attribution (Apache-2.0, verified from the repo and the image's OCI labels) plus the embedded font licenses — including the Bitstream Vera copyright notice verbatim, since no scanner sees inside a bare binary. The Dockerfile comment couples the version pin to the NOTICE line.

### P3 — direct-Typst authoring with a bounded repair loop (Q1: settled, direct Typst)
- New `typst-compiler.ts`: `execFileSync` + temp files, **`--creation-timestamp` pinned** — unpinned compiles change bytes on identical input, which would churn checksums into permanent Smelter re-embeds (S11/S12). Measured: pinned compiles are byte-identical, checksum `1e47f122…` **reproduces the P0 spike's artifact exactly**.
- The prompt teaches Typst (`= Heading`, no markdown); compile failures feed Typst's legible diagnostics back for at most `MAX_COMPILE_REPAIRS` attempts, then fail loudly with the compiler's error. `application/pdf` flips `generatable: true` — the P1 activation switch.

### P4 — the citation branch (the payoff)
- **Two-stage search** (`@semiont/core` `pdf-citation-search.ts`): strict whitespace-normalized match first (bridges line breaks), break-aware fallback **only on a miss** (bridges hyphenation's dropped characters; spaces are never wildcards). The ordering is the safety property — the permissive matcher can never turn a working citation into a wrong one.
- **Proportional narrowing in `locate()`**: boundary items clipped by character fraction, so a mid-line phrase gets a sub-line rect (PDF detection inherits this for free). Exact glyph metrics (operator-list route) remain an open refinement that can swap in without changing shape.
- **Wiring**: `[[id]]` tokens are stripped from the Typst source before every compile (they never render); the worker re-anchors each claim through `extractPdfTextLayer` → `findClaimSpan` → `buildPdfAnnotation` — **FragmentSelector rects + quote, never a TextPositionSelector** (source offsets index nothing renderable; the worker test pins the selector types). Unfindable claims drop loudly, never mint wrong.
- **Measured end-to-end** (real Typst + built dists): `"quick brown fox"` found across its line break — the `"fox"` rect is **13.3 pt wide** where the spike recorded the full 424 pt line; hyphenated `"extraor·dinarily complicated"` found by the break-aware stage, rects on exactly the recorded lines (y=764/749).

### P5 — output bound
`assertWithinOutputBudget` reuses #1124's `MAX_PDF_BYTES`/`withinByteBudget` (newly exported from content) — deliberately the *same* threshold: a generated artifact larger than extraction accepts would be a resource our own Smelter declines as `too-large`. One judgment, two enforcement points.

### Fixtures + docs
The spike corpus is promoted to tracked fixtures (`packages/jobs/src/__tests__/fixtures/typst/`, each header carrying expected geometry); compiled PDFs are gitignored per the `@semiont/content` generate-at-test-time convention. `docs/development/MEDIA-TYPES.md` documents the capability registry and the authored-PDF case.

## Verification

Every phase RED-first with the failure observed. node:24-alpine: core **564 passed**, jobs **368 passed | 1 skipped**, `tsc --noEmit` 0 in both. (Two core `project.test.ts` git-branch failures are environmental — no `git` in the container.) Plus the two live-binary measurements above.

## Not in this PR (deliberate)

- **P6 renderer provenance** — blocked on `DERIVED-PROVENANCE.md` P1 (its plan now carries the ground truth this work produced, incl. the binary-vs-npm version-source constraint).
- **`test:pdf` integration tier** — the pipeline is validated by the live-binary run; the vitest `globalSetup` + CI-image typst wiring is a named follow-up.
- **Q2 exact glyph metrics** — refinement only; proportional interpolation ships as the sanctioned, measured fallback.
- Citations remain **overlay annotations** (Semiont's universal model) — the PDF bytes carry no citation markup; visible in-document references (footnotes/reference list) for artifacts that leave the system are recorded future work in the plan.