### PR TITLE
Vector search survives qdrant-client 1.19.0: migrate off the removed search API, plus two e2e blind spots

### DIFF
--- a/packages/vectors/src/store/__tests__/qdrant-query-api.test.ts
+++ b/packages/vectors/src/store/__tests__/qdrant-query-api.test.ts
@@ -1,0 +1,125 @@
+/**
+ * QdrantVectorStore speaks the *query* API, not the removed *search* API.
+ *
+ * `@qdrant/js-client-rest` 1.19.0 deleted `search` and `searchBatch`, which the
+ * universal `query`/`queryBatch` endpoint had superseded. This store called
+ * both, so on any 1.19.0 install every vector read threw
+ * `this.qdrant.searchBatch is not a function` — gather.resource failed outright
+ * (observed 2026-08-05 on a live stack).
+ *
+ * Two things let that reach runtime, and the fake below is built to close both:
+ *
+ *   1. **No test ever constructed this store.** The suite covered the memory
+ *      store only, so nothing executed these code paths at all.
+ *   2. **`tsc` was satisfied.** The repo lockfile resolved 1.18.0, where the
+ *      removed methods still existed; the *container* resolved 1.19.0 from the
+ *      same `^1.18.0` range. The type-checker and the runtime were reading
+ *      different versions of the client.
+ *
+ * So the fake deliberately exposes ONLY the 1.19.0 surface — no `search`, no
+ * `searchBatch`. Reintroducing either reproduces the production TypeError here,
+ * in milliseconds, without a live Qdrant or a particular installed version.
+ * Asserting "we called queryBatch" alone would not do that: it would still pass
+ * if someone called `search` somewhere else in the file.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const calls: string[] = [];
+
+/** A client shaped like 1.19.0 — the removed methods simply do not exist. */
+class FakeQdrantClient {
+  async getCollection(name: string) { calls.push(`getCollection:${name}`); return {}; }
+  async createCollection() { calls.push('createCollection'); return true; }
+  async createPayloadIndex() { calls.push('createPayloadIndex'); return {}; }
+
+  async query(collection: string, body: Record<string, unknown>) {
+    calls.push(`query:${collection}`);
+    lastQuery = body;
+    return { points: [{ id: 'p1', score: 0.9, payload: { resourceId: 'res-2', text: 'hello' } }] };
+  }
+
+  async queryBatch(collection: string, body: { searches: Record<string, unknown>[] }) {
+    calls.push(`queryBatch:${collection}`);
+    lastBatch = body.searches;
+    // One response object PER search, each wrapping its hits in `points` —
+    // the shape change that a bare rename would have silently got wrong.
+    return body.searches.map((_s, i) => ({
+      points: [{ id: `p${i}`, score: 0.5 + i / 10, payload: { resourceId: `res-${i}`, text: `t${i}` } }],
+    }));
+  }
+
+  async scroll(_collection: string, _body: unknown) {
+    calls.push('scroll');
+    return { points: [{ id: 's1', vector: [0.1, 0.2] }, { id: 's2', vector: [0.3, 0.4] }], next_page_offset: null };
+  }
+}
+
+let lastQuery: Record<string, unknown> | undefined;
+let lastBatch: Record<string, unknown>[] | undefined;
+
+vi.mock('@qdrant/js-client-rest', () => ({ QdrantClient: FakeQdrantClient }));
+
+import { QdrantVectorStore } from '../qdrant';
+
+async function connected() {
+  const store = new QdrantVectorStore({ host: 'localhost', port: 6333, dimensions: 2 });
+  await store.connect();
+  return store;
+}
+
+describe('QdrantVectorStore uses the query API', () => {
+  beforeEach(() => { calls.length = 0; lastQuery = undefined; lastBatch = undefined; });
+
+  it('connects against a 1.19.0-shaped client', async () => {
+    // Guards the connect path too: it also runs client methods, and a removal
+    // there would fail every operation rather than just the reads.
+    await expect(connected()).resolves.toBeDefined();
+  });
+
+  it('searchResources calls query and unwraps `points`', async () => {
+    const store = await connected();
+
+    const results = await store.searchResources([0.1, 0.2], { limit: 5 });
+
+    expect(calls).toContain('query:resources');
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: 'p1', resourceId: 'res-2', text: 'hello' });
+  });
+
+  it('sends the embedding as `query`, not the removed `vector` field', async () => {
+    // The rename is not cosmetic: 1.19.0 ignores an unknown `vector` key, so
+    // getting this wrong returns unfiltered nearest-neighbours rather than an
+    // error — a silently wrong answer, which is worse than the TypeError.
+    const store = await connected();
+
+    await store.searchResources([0.1, 0.2], { limit: 5 });
+
+    expect(lastQuery).toMatchObject({ query: [0.1, 0.2], limit: 5 });
+    expect(lastQuery).not.toHaveProperty('vector');
+  });
+
+  it('searchByResource calls queryBatch and reads each response`s points', async () => {
+    const store = await connected();
+
+    const results = await store.searchByResource('res-src' as never, { limit: 10 });
+
+    expect(calls).toContain('queryBatch:resources');
+    // Two scrolled vectors → two searches → two responses, merged and deduped.
+    expect(lastBatch).toHaveLength(2);
+    expect(lastBatch![0]).toMatchObject({ query: [0.1, 0.2] });
+    expect(lastBatch![0]).not.toHaveProperty('vector');
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('merges batch responses by best score', async () => {
+    // The max-sim merge reads `batch.points`; against the old unwrapped array
+    // it would iterate the response object itself and yield nothing.
+    const store = await connected();
+
+    const results = await store.searchByResource('res-src' as never, { limit: 10 });
+
+    expect(results.map((r) => r.resourceId)).toEqual(expect.arrayContaining(['res-0', 'res-1']));
+    expect(results[0]!.score).toBeGreaterThanOrEqual(results[results.length - 1]!.score);
+  });
+});

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -288,19 +288,19 @@ export class QdrantVectorStore implements VectorStore {
     // over-fetch beyond `limit` is unnecessary because the max-sim merge only
     // needs a target in some chunk's top-K to surface.
     const searches = queryVectors.map((vector) => ({
-      vector,
+      query: vector,
       limit: opts.limit,
       score_threshold: opts.scoreThreshold,
       filter: filter ?? undefined,
       with_payload: true,
     }));
-    const batches = await this.qdrant.searchBatch('resources', { searches });
+    const batches = await this.qdrant.queryBatch('resources', { searches });
 
     // Max-sim merge: dedup by resourceId, keep the best (query-chunk × target-chunk)
     // score and the best-matching target chunk's payload.
     const bestByResource = new Map<string, { id: string; score: number; payload: Record<string, unknown> }>();
     for (const batch of batches) {
-      for (const r of batch) {
+      for (const r of batch.points) {
         const payload = r.payload ?? {};
         const tid = String(payload.resourceId);
         const prev = bestByResource.get(tid);
@@ -327,15 +327,18 @@ export class QdrantVectorStore implements VectorStore {
   private async search(collection: string, embedding: number[], opts: SearchOptions): Promise<VectorSearchResult[]> {
     const filter = this.buildFilter(opts.filter);
 
-    const results = await this.qdrant.search(collection, {
-      vector: embedding,
+    // `query`, not `search`: the REST client dropped `search`/`searchBatch` in
+    // 1.19.0 in favour of the universal query endpoint. Same request but the
+    // vector moves to `query`, and the response is wrapped in `{ points }`.
+    const { points } = await this.qdrant.query(collection, {
+      query: embedding,
       limit: opts.limit,
       score_threshold: opts.scoreThreshold,
       filter: filter ?? undefined,
       with_payload: true,
     });
 
-    return results.map((r) => {
+    return points.map((r) => {
       const payload = r.payload ?? {};
       return {
         id: String(r.id),

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,6 +13,9 @@ against a local KB, reachable by IP. Full rebuild/start flow in
 ```sh
 container ls | grep -E 'semiont-(frontend|backend)'    # grab both IPs
 
+# The image tag MUST match the installed library — see "Version pinning" below.
+PW=$(node -p "require('./node_modules/@playwright/test/package.json').version")
+
 container run --rm \
   -v "$(git rev-parse --show-toplevel):/workspace" \
   -w /workspace/tests/e2e \
@@ -21,7 +24,7 @@ container run --rm \
   -e E2E_FRONTEND_URL=http://<frontend-ip>:3000 \
   -e E2E_BACKEND_URL=http://<backend-ip>:4000 \
   -e CI=1 \
-  mcr.microsoft.com/playwright:v1.61.0-noble \
+  "mcr.microsoft.com/playwright:v$PW-noble" \
   npm test
 ```
 
@@ -34,6 +37,30 @@ container run --rm \
 > If every test fails in the `signIn` fixture with *"Request failed due
 > to a network error"*, the Playwright container can't reach the
 > host-published backend — see [Container networking](#container-networking-reaching-the-host).
+
+## Version pinning: the image must match the installed library
+
+Playwright refuses to run when the browser image and the `@playwright/test`
+library disagree, so the tag is not decorative. Derive it rather than typing
+it — `$PW` above reads the version off disk, which is the one source that
+cannot be stale relative to what is about to run.
+
+This README previously hard-coded the tag and drifted **twice**: Dependabot
+bumps `package.json` and `package-lock.json` together, but nothing installs
+them here, so three versions diverge silently — declared, installed, and
+documented. On 2026-08-05 they were 1.62.0, 1.61.1 and 1.61.0 respectively.
+
+**Nothing else catches this.** `tests/e2e` is not a root workspace and no CI
+workflow runs it, so the suite's dependencies are only ever installed by a
+person deciding to. After a Dependabot bump, sync before running:
+
+```sh
+npm ci        # installs the lockfile EXACTLY; never rewrites it
+```
+
+Use `npm ci`, not `npm install`: `ci` cannot alter `package-lock.json`, so
+syncing your `node_modules` can never quietly re-resolve the suite's
+dependencies for everyone else. The lockfile is tracked and is the authority.
 
 ## Container networking: reaching the host
 
@@ -68,7 +95,7 @@ container run --rm \
   -e E2E_FRONTEND_URL=http://192.168.64.1:3000 \
   -e E2E_BACKEND_URL=http://192.168.64.1:4000 \
   -e CI=1 \
-  mcr.microsoft.com/playwright:v1.61.0-noble \
+  "mcr.microsoft.com/playwright:v$PW-noble" \
   npm test
 ```
 

--- a/tests/e2e/specs/14-pdf-render.spec.ts
+++ b/tests/e2e/specs/14-pdf-render.spec.ts
@@ -175,7 +175,14 @@ test.describe('pdf render + spatial highlight', () => {
 
     // The payoff: the panel entry quotes the page text, instead of being the
     // anonymous rectangle this fix replaced.
-    await page.getByRole('button', { name: /^annotations$/i }).click();
+    //
+    // The panel is ALREADY open in annotate mode, so it is asserted rather
+    // than opened — clicking the toolbar button here toggles it CLOSED, and
+    // the count below then reads an unmounted panel and stays 0 forever. The
+    // annotation itself is fine in that failure (`mark:create-ok` above has
+    // already passed, and the stored quote is correct); only the surface it
+    // is read from is gone. Spec 23 carries the same note.
+    await expect(page.locator('.semiont-unified-panel')).toBeVisible({ timeout: 10_000 });
     await expect
       .poll(
         async () => page.locator('[data-type="highlight"]').filter({ hasText: /smoke test pdf/i }).count(),


### PR DESCRIPTION
## Aim

`@qdrant/js-client-rest` 1.19.0 removed `search` and `searchBatch`, superseded by the universal query endpoint. `QdrantVectorStore` still called both, so on any install that resolved 1.19.0 every vector read threw:

```
TypeError: this.qdrant.searchBatch is not a function
    at QdrantVectorStore.searchByResource
```

`gather.resource` failed outright on a live stack — the Gatherer could not assemble context for any resource.

## Why this was green everywhere it was checked

The declared range is `^1.18.0`. The repo lockfile resolves **1.18.0**, where both methods still exist, so `tsc` and the unit suite were satisfied. A container image installs fresh from that same range and gets **1.19.0**. The type-checker and the runtime were reading different versions of the client, which is why a removed API reached a running stack instead of failing a build.

Compounding it: `QdrantVectorStore` had **no tests at all**. The vectors suite covered the memory store and the embedding provider, so nothing ever constructed this class.

## Two call sites, not one

The error named `searchBatch`, but `search` was removed in the same release and backs every non-batch read (`searchResources`, `searchAnnotations`). Auditing all eleven client methods the store calls against 1.19.0 is what surfaced it; fixing only the reported one would have left the more common path broken and the next failure just as confusing.

## The migration is not a rename

The universal endpoint changes the request and the response, so a mechanical substitution would compile and silently misbehave:

- the embedding moves from `vector` to `query`
- results wrap in `{ points }` rather than arriving as a bare array

The second one matters most for `searchByResource`, whose max-sim merge iterates each batch. Against the old unwrapped shape it would iterate the response object and quietly yield nothing. The first is worse in a different way: 1.19.0 ignores an unknown `vector` key rather than rejecting it, so getting that wrong returns unfiltered nearest-neighbours instead of an error — a wrong answer rather than a loud one. Both are pinned by tests.

## No dependency change needed

`query` and `queryBatch` already exist at the range floor (1.18.0) with the identical `{ points }` shape, so the code works across the whole `^1.18.0` range and no pin or bump is required. This was purely a source-side use of APIs a later release removed.

## The guard

`qdrant-query-api.test.ts` builds a fake client exposing **only** the 1.19.0 surface — `search` and `searchBatch` simply do not exist on it. Reintroducing either reproduces the production `TypeError` in milliseconds, with no live Qdrant and regardless of which client version happens to be installed. Asserting "we called `queryBatch`" would not do that: it would still pass if a removed method were called somewhere else in the file. Verified to fail against the pre-fix code before being kept.

## Also

**`tests/e2e/specs/14-pdf-render.spec.ts` — a test bug, not a product one.** The rectangle-quoting test clicked the Annotations toolbar button before reading the panel. In annotate mode that panel is already open, so the click *closed* it and the count read an unmounted surface, sitting at 0 until timeout. The annotation was correct throughout — the stored selector carries `"exact": "Smoke Test PDF"`. Replaced the click with an assertion that the panel is visible.

**`tests/e2e/README.md` — Playwright version drift, fixed at the root.** Playwright refuses to run when the browser image and the library disagree, and three versions had diverged: 1.62.0 declared, 1.61.1 installed, 1.61.0 documented. Dependabot bumps `package.json` and the lockfile together, but `tests/e2e` is not a root workspace and no CI workflow runs it, so nothing ever installs them — the skew is invisible until someone runs the suite. The README now derives the tag from the installed library instead of hardcoding it, and prescribes `npm ci` (which cannot rewrite the lockfile) after a bump.

## Not in scope

A separate regression is still open and unrelated to these changes: a **declined** detection job surfaces no user-visible notice at all. `22-pdf-scanned-decline` fails on that. The decline is correct at every layer that can be inspected — the worker emits it, the event persists with the right message, it reaches the browser with a matching resource id, and the toast surface is mounted — but the React handler never runs. Expect 32/33 on this branch, with spec 22 the lone failure.
