### PR TITLE
PDF viewer: virtualized continuous scroll with a page rail (and a 46-variable CSS defect class it uncovered)

### DIFF
--- a/.github/workflows/architecture-compliance.yml
+++ b/.github/workflows/architecture-compliance.yml
@@ -40,6 +40,16 @@ jobs:
           ./scripts/compliance/audit-raw-bus.sh
           echo "::endgroup::"
 
+      - name: Run CSS Gates
+        run: |
+          echo "::group::CSS Gates (stylelint + every var() resolves + no utility frameworks)"
+          fail=0
+          npm run lint:css || fail=1
+          npm run lint:css-variables || fail=1
+          npm run lint:no-utility-classes || fail=1
+          echo "::endgroup::"
+          exit $fail
+
       - name: Run StateUnit Compliance Audit
         run: |
           echo "::group::StateUnit Compliance Audit (A1-static no-class / X3-static no-module-state / X5 fire-and-forget)"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:css": "stylelint '**/*.css' --ignore-path .gitignore",
     "lint:css:fix": "stylelint '**/*.css' --ignore-path .gitignore --fix",
     "lint:no-utility-classes": "node scripts/lint/check-no-utility-classes-in-react-ui.js",
+    "lint:css-variables": "node scripts/lint/check-css-variables-defined.js",
     "build:css": "node scripts/dev/build-css-with-sourcemaps.js",
     "build:css:watch": "node scripts/dev/build-css-with-sourcemaps.js --watch",
     "build:css:prod": "node scripts/dev/build-css-with-sourcemaps.js --production",

--- a/packages/react-ui/src/components/StatusDisplay.css
+++ b/packages/react-ui/src/components/StatusDisplay.css
@@ -161,7 +161,7 @@
 
 .semiont-toolbar-icon-large {
   font-size: 1.875rem; /* 30px - was 2xl/1.5rem */
-  font-weight: var(--semiont-font-weight-bold);
+  font-weight: var(--semiont-font-bold);
 }
 
 /* Dark mode for Toolbar - Fixed to respect data-theme attribute */
@@ -206,7 +206,7 @@
   color: var(--semiont-color-primary-700);
   border: 1px solid var(--semiont-color-primary-200);
   border-radius: var(--semiont-radius-base);
-  font-size: var(--semiont-font-size-xs);
+  font-size: var(--semiont-text-xs);
 }
 
 /* Editing affordances (RESOURCE-TAGS-INLINE-EDITING) */
@@ -217,7 +217,7 @@
   border: none;
   background: none;
   color: inherit;
-  font-size: var(--semiont-font-size-xs);
+  font-size: var(--semiont-text-xs);
   cursor: pointer;
   opacity: 0.7;
 }
@@ -279,8 +279,8 @@
 }
 
 .semiont-error-boundary-title {
-  font-size: var(--semiont-font-size-2xl);
-  font-weight: var(--semiont-font-weight-bold);
+  font-size: var(--semiont-text-2xl);
+  font-weight: var(--semiont-font-bold);
   color: var(--semiont-color-neutral-900);
   margin-bottom: var(--semiont-spacing-xs);
 }
@@ -290,30 +290,30 @@
 }
 
 .semiont-error-boundary-details {
-  background-color: var(--semiont-color-danger-50);
-  border: 1px solid var(--semiont-color-danger-200);
+  background-color: var(--semiont-color-red-50);
+  border: 1px solid var(--semiont-color-red-200);
   border-radius: var(--semiont-radius-md);
   padding: var(--semiont-spacing-md);
 }
 
 .semiont-error-boundary-details-title {
-  font-size: var(--semiont-font-size-sm);
-  font-weight: var(--semiont-font-weight-semibold);
-  color: var(--semiont-color-danger-800);
+  font-size: var(--semiont-text-sm);
+  font-weight: var(--semiont-font-semibold);
+  color: var(--semiont-color-red-800);
   margin-bottom: calc(var(--semiont-spacing-xs) / 2);
 }
 
 .semiont-error-boundary-details-message {
-  font-size: var(--semiont-font-size-xs);
-  color: var(--semiont-color-danger-700);
+  font-size: var(--semiont-text-xs);
+  color: var(--semiont-color-red-700);
   font-family: monospace;
   word-break: break-all;
 }
 
 .semiont-error-boundary-stack {
   margin-top: var(--semiont-spacing-xs);
-  font-size: var(--semiont-font-size-xs);
-  color: var(--semiont-color-danger-600);
+  font-size: var(--semiont-text-xs);
+  color: var(--semiont-color-red-600);
   overflow-x: auto;
 }
 
@@ -326,8 +326,8 @@
 /* AsyncErrorBoundary Component */
 .semiont-async-error-boundary {
   padding: var(--semiont-spacing-md);
-  background-color: var(--semiont-color-warning-50);
-  border: 1px solid var(--semiont-color-warning-200);
+  background-color: var(--semiont-color-amber-50);
+  border: 1px solid var(--semiont-color-amber-200);
   border-radius: var(--semiont-radius-md);
 }
 
@@ -343,7 +343,7 @@
 .semiont-icon-warning {
   height: 1.25rem;
   width: 1.25rem;
-  color: var(--semiont-color-warning-400);
+  color: var(--semiont-color-amber-400);
 }
 
 .semiont-async-error-details {
@@ -352,21 +352,21 @@
 }
 
 .semiont-async-error-title {
-  font-size: var(--semiont-font-size-sm);
-  font-weight: var(--semiont-font-weight-medium);
-  color: var(--semiont-color-warning-800);
+  font-size: var(--semiont-text-sm);
+  font-weight: var(--semiont-font-medium);
+  color: var(--semiont-color-amber-800);
 }
 
 .semiont-async-error-message {
   margin-top: calc(var(--semiont-spacing-xs) / 2);
-  font-size: var(--semiont-font-size-sm);
-  color: var(--semiont-color-warning-700);
+  font-size: var(--semiont-text-sm);
+  color: var(--semiont-color-amber-700);
 }
 
 .semiont-async-error-retry {
   margin-top: var(--semiont-spacing-xs);
-  font-size: var(--semiont-font-size-sm);
-  color: var(--semiont-color-warning-600);
+  font-size: var(--semiont-text-sm);
+  color: var(--semiont-color-amber-600);
   text-decoration: underline;
   background: none;
   border: none;
@@ -375,7 +375,7 @@
 }
 
 .semiont-async-error-retry:hover {
-  color: var(--semiont-color-warning-500);
+  color: var(--semiont-color-amber-500);
 }
 
 /* Dark mode for ErrorBoundary */
@@ -393,43 +393,43 @@
 
 [data-theme="dark"] .semiont-error-boundary-details {
   background-color: rgba(239, 68, 68, 0.2);
-  border-color: var(--semiont-color-danger-800);
+  border-color: var(--semiont-color-red-800);
 }
 
 [data-theme="dark"] .semiont-error-boundary-details-title {
-  color: var(--semiont-color-danger-300);
+  color: var(--semiont-color-red-300);
 }
 
 [data-theme="dark"] .semiont-error-boundary-details-message {
-  color: var(--semiont-color-danger-400);
+  color: var(--semiont-color-red-400);
 }
 
 [data-theme="dark"] .semiont-error-boundary-stack {
-  color: var(--semiont-color-danger-500);
+  color: var(--semiont-color-red-500);
 }
 
 [data-theme="dark"] .semiont-async-error-boundary {
   background-color: rgba(245, 158, 11, 0.2);
-  border-color: var(--semiont-color-warning-800);
+  border-color: var(--semiont-color-amber-800);
 }
 
 [data-theme="dark"] .semiont-icon-warning {
-  color: var(--semiont-color-warning-400);
+  color: var(--semiont-color-amber-400);
 }
 
 [data-theme="dark"] .semiont-async-error-title {
-  color: var(--semiont-color-warning-300);
+  color: var(--semiont-color-amber-300);
 }
 
 [data-theme="dark"] .semiont-async-error-message {
-  color: var(--semiont-color-warning-400);
+  color: var(--semiont-color-amber-400);
 }
 
 [data-theme="dark"] .semiont-async-error-retry {
-  color: var(--semiont-color-warning-400);
+  color: var(--semiont-color-amber-400);
 }
 
 [data-theme="dark"] .semiont-async-error-retry:hover {
-  color: var(--semiont-color-warning-300);
+  color: var(--semiont-color-amber-300);
 }
 

--- a/packages/react-ui/src/components/annotation/annotations.css
+++ b/packages/react-ui/src/components/annotation/annotations.css
@@ -45,7 +45,7 @@
  * or a position-fallback. The hover tooltip (added by
  * `getAnnotationDecorationMeta`) names the strategy. */
 .annotation-low-confidence {
-  text-decoration: underline dotted var(--semiont-color-warning-500, #d97706);
+  text-decoration: underline dotted var(--semiont-color-amber-500, #d97706);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }

--- a/packages/react-ui/src/components/modals/SearchModal.css
+++ b/packages/react-ui/src/components/modals/SearchModal.css
@@ -211,11 +211,11 @@
 }
 
 .semiont-search-modal__result-icon--entity {
-  color: var(--semiont-color-success-500);
+  color: var(--semiont-color-green-500);
 }
 
 [data-theme="dark"] .semiont-search-modal__result-icon--entity {
-  color: var(--semiont-color-success-400);
+  color: var(--semiont-color-green-400);
 }
 
 /* Result content */
@@ -244,13 +244,13 @@
   font-size: 0.75rem;
   font-weight: 500;
   border-radius: 9999px;
-  background-color: var(--semiont-color-success-100);
-  color: var(--semiont-color-success-700);
+  background-color: var(--semiont-color-green-100);
+  color: var(--semiont-color-green-700);
 }
 
 [data-theme="dark"] .semiont-search-modal__result-badge {
   background-color: rgba(34, 197, 94, 0.3);
-  color: var(--semiont-color-success-300);
+  color: var(--semiont-color-green-300);
 }
 
 .semiont-search-modal__result-description {

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
@@ -36,13 +36,41 @@
  * it the column grows to its content and the page scrolls instead, which
  * still works but defeats the windowing.
  */
+/*
+ * Viewport = the pages plus their strip, side by side. The strip sits AFTER
+ * the column so it lands against that column's scrollbar: two readings of the
+ * same position, adjacent.
+ */
+.semiont-pdf-annotation-canvas__viewport {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.semiont-pdf-annotation-canvas__viewport[data-axis="horizontal"] {
+  flex-direction: column;
+}
+
 .semiont-pdf-annotation-canvas__column {
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  flex: 1 1 auto;
   gap: 1rem;
+  align-items: center;
+}
+
+/*
+ * Both blocks below key off ONE attribute, so the strip can never end up
+ * running across the direction the document scrolls.
+ */
+.semiont-pdf-annotation-canvas__column[data-axis="vertical"] {
+  flex-direction: column;
   max-height: 80vh;
   overflow-y: auto;
+}
+
+.semiont-pdf-annotation-canvas__column[data-axis="horizontal"] {
+  flex-direction: row;
+  overflow-x: auto;
 }
 
 .semiont-pdf-annotation-canvas__slot {
@@ -57,10 +85,23 @@
  */
 .semiont-pdf-annotation-canvas__strip {
   display: flex;
-  align-items: flex-end;
+  flex: 0 0 auto;
   gap: 2px;
-  overflow-x: auto;
   padding: 0.5rem;
+}
+
+.semiont-pdf-annotation-canvas__strip[data-axis="vertical"] {
+  flex-direction: column;
+  align-items: center;
+  max-height: 80vh;
+  overflow-y: auto;
+  border-left: 1px solid var(--semiont-border-secondary);
+}
+
+.semiont-pdf-annotation-canvas__strip[data-axis="horizontal"] {
+  flex-direction: row;
+  align-items: flex-end;
+  overflow-x: auto;
   border-top: 1px solid var(--semiont-border-secondary);
 }
 

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
@@ -62,15 +62,18 @@
  * Both blocks below key off ONE attribute, so the strip can never end up
  * running across the direction the document scrolls.
  */
+/*
+ * The column does NOT scroll. The pane the viewer sits in already does
+ * (`flex: 1; min-height: 0`), and giving the column a viewport-relative
+ * height of its own produced a scroller inside a scroller — two bars along
+ * one axis, the inner one redundant with the page rail beside it.
+ */
 .semiont-pdf-annotation-canvas__column[data-axis="vertical"] {
   flex-direction: column;
-  max-height: 80vh;
-  overflow-y: auto;
 }
 
 .semiont-pdf-annotation-canvas__column[data-axis="horizontal"] {
   flex-direction: row;
-  overflow-x: auto;
 }
 
 .semiont-pdf-annotation-canvas__slot {
@@ -83,35 +86,60 @@
  * The page strip: the document's shape in miniature. Rectangles only — no
  * rasterization — so a 400-page scan costs 400 empty divs, not 400 renders.
  */
+/*
+ * The strip scrolls — a 70-page document cannot fit its numbered rectangles in
+ * one screen — but it must not show a scrollbar. Two scrollbars side by side
+ * read as two controls for one thing, and the strip's own moves the strip
+ * rather than the document, so it looks broken. Position is carried by the
+ * highlighted page, and the strip follows the reader on its own.
+ */
 .semiont-pdf-annotation-canvas__strip {
   display: flex;
   flex: 0 0 auto;
   gap: 2px;
   padding: 0.5rem;
+  scrollbar-width: none;
 }
 
+/*
+ * The rail hugs the leading edge of the content and stays put while the
+ * document scrolls past it — `sticky` rather than a fixed-height box, so it
+ * follows the reader without claiming a second scroll region in the layout.
+ */
 .semiont-pdf-annotation-canvas__strip[data-axis="vertical"] {
+  position: sticky;
+  top: 0;
   flex-direction: column;
+  align-self: flex-start;
   align-items: center;
-  max-height: 80vh;
+  max-height: 100vh;
   overflow-y: auto;
-  border-left: 1px solid var(--semiont-border-secondary);
+  border-right: 1px solid var(--semiont-border-secondary);
 }
 
 .semiont-pdf-annotation-canvas__strip[data-axis="horizontal"] {
+  position: sticky;
+  top: 0;
   flex-direction: row;
   align-items: flex-end;
+  max-width: 100%;
   overflow-x: auto;
-  border-top: 1px solid var(--semiont-border-secondary);
+  border-bottom: 1px solid var(--semiont-border-secondary);
 }
 
 .semiont-pdf-annotation-canvas__strip-page {
+  display: flex;
   flex: 0 0 auto;
-  width: 14px;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
   padding: 0;
   border: 1px solid var(--semiont-border-primary);
   border-radius: 1px;
   background: var(--semiont-bg-secondary);
+  color: var(--semiont-text-tertiary);
+  font-size: var(--semiont-text-2xs);
+  line-height: 1;
   cursor: pointer;
 }
 
@@ -123,6 +151,8 @@
 .semiont-pdf-annotation-canvas__strip-page[aria-current="page"] {
   border-color: var(--semiont-color-primary-600);
   background: var(--semiont-color-primary-500);
+  color: var(--semiont-color-neutral-0);
+  font-weight: var(--semiont-font-semibold);
 }
 
 .semiont-pdf-annotation-canvas__strip-page:focus-visible {

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
@@ -51,6 +51,44 @@
   width: 100%;
 }
 
+/*
+ * The page strip: the document's shape in miniature. Rectangles only — no
+ * rasterization — so a 400-page scan costs 400 empty divs, not 400 renders.
+ */
+.semiont-pdf-annotation-canvas__strip {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  overflow-x: auto;
+  padding: 0.5rem;
+  border-top: 1px solid var(--semiont-border-secondary);
+}
+
+.semiont-pdf-annotation-canvas__strip-page {
+  flex: 0 0 auto;
+  width: 14px;
+  padding: 0;
+  border: 1px solid var(--semiont-border-primary);
+  border-radius: 1px;
+  background: var(--semiont-bg-secondary);
+  cursor: pointer;
+}
+
+.semiont-pdf-annotation-canvas__strip-page:hover {
+  background: var(--semiont-bg-hover);
+}
+
+/* The reader's position, legible at a glance across a long strip. */
+.semiont-pdf-annotation-canvas__strip-page[aria-current="page"] {
+  border-color: var(--semiont-color-primary-600);
+  background: var(--semiont-color-primary-500);
+}
+
+.semiont-pdf-annotation-canvas__strip-page:focus-visible {
+  outline: 2px solid var(--semiont-focus-ring);
+  outline-offset: 1px;
+}
+
 .semiont-pdf-annotation-canvas__container {
   position: relative;
   display: inline-block;

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
@@ -20,11 +20,11 @@
 
 /* stylelint-disable semiont/accessibility -- Error indicator added by semantic-indicators.css */
 .semiont-pdf-annotation-canvas__error {
-  color: var(--error-color);
+  color: var(--semiont-color-error);
 }
 
 [data-theme="dark"] .semiont-pdf-annotation-canvas__error {
-  color: var(--error-color);
+  color: var(--semiont-color-error);
 }
 /* stylelint-enable semiont/accessibility */
 
@@ -106,12 +106,12 @@
   justify-content: center;
   gap: 1rem;
   padding: 1rem;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--semiont-border-primary);
 }
 
 .semiont-pdf-annotation-canvas__button {
   padding: 0.5rem 1rem;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--semiont-border-primary);
   border-radius: 4px;
   background: transparent;
   cursor: pointer;
@@ -124,11 +124,11 @@
 }
 
 .semiont-pdf-annotation-canvas__button:hover:not(:disabled) {
-  background-color: var(--hover-color, rgba(0, 0, 0, 0.05));
+  background-color: var(--semiont-bg-hover, rgba(0, 0, 0, 0.05));
 }
 
 .semiont-pdf-annotation-canvas__button:focus-visible {
-  outline: 2px solid var(--focus-color, #0066cc);
+  outline: 2px solid var(--semiont-focus-ring, #0066cc);
   outline-offset: 2px;
 }
 

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
@@ -28,6 +28,29 @@
 }
 /* stylelint-enable semiont/accessibility */
 
+/*
+ * The scrolling column (PDF-CONTINUOUS-SCROLL S1). Every page owns a slot so
+ * the scrollbar reflects the whole document; only pages near the viewport are
+ * mounted, and an unmounted slot holds its space with an estimated height set
+ * inline. `max-height` is what makes this a scroll container at all — without
+ * it the column grows to its content and the page scrolls instead, which
+ * still works but defeats the windowing.
+ */
+.semiont-pdf-annotation-canvas__column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.semiont-pdf-annotation-canvas__slot {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
 .semiont-pdf-annotation-canvas__container {
   position: relative;
   display: inline-block;

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
@@ -37,9 +37,9 @@
  * still works but defeats the windowing.
  */
 /*
- * Viewport = the pages plus their strip, side by side. The strip sits AFTER
- * the column so it lands against that column's scrollbar: two readings of the
- * same position, adjacent.
+ * Viewport = the pages plus their strip, side by side. The strip LEADS — it
+ * hugs the content's leading edge, where a page rail conventionally lives
+ * (Preview, Acrobat), so the reader's eye finds it before the page.
  */
 .semiont-pdf-annotation-canvas__viewport {
   display: flex;

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -6,6 +6,7 @@ import { resourceId as toResourceId } from '@semiont/core';
 import { toViewportAnchorRect } from '../../lib/anchor-rect';
 import { createFragmentSelector, anchorRuns, isTextRun, textUnder } from '@semiont/core';
 import { rectsForPage } from './rects-for-page';
+import { useTranslations } from '../../contexts/TranslationContext';
 import { createHoverHandlers, type SemiontSession } from '@semiont/sdk';
 import type { SelectionMotivation } from '../annotation/AnnotateToolbar';
 import {
@@ -113,7 +114,10 @@ function PdfPageView({
    */
   const [pageAnchored, setPageAnchored] = useState<AnchoredText | null>(null);
   const [displayDimensions, setDisplayDimensions] = useState<{ width: number; height: number } | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  /** Translation KEY, not text: `t` is a new closure each render, so keeping
+   *  it out of the load effect's deps is what stops a reload loop. */
+  const [errorKey, setErrorKey] = useState<string | null>(null);
+  const t = useTranslations('PdfViewer');
 
   const [isDrawing, setIsDrawing] = useState(false);
   const [selection, setSelection] = useState<CanvasRectangle | null>(null);
@@ -191,7 +195,7 @@ function PdfPageView({
         if (cancelled) return;
 
         console.error('Error loading page:', err);
-        setError('Failed to load page');
+        setErrorKey('pageLoadFailed');
       }
     }
 
@@ -397,8 +401,8 @@ function PdfPageView({
   // Calculate motivation color
   const { stroke, fill } = getMotivationColor(selectedMotivation ?? null);
 
-  if (error) {
-    return <div className="semiont-pdf-annotation-canvas__error">{error}</div>;
+  if (errorKey) {
+    return <div className="semiont-pdf-annotation-canvas__error">{t(errorKey)}</div>;
   }
 
   return (
@@ -556,7 +560,8 @@ export function PdfAnnotationCanvas({
   const [numPages, setNumPages] = useState<number>(0);
   const [pageNumber, setPageNumber] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState<string | null>(null);
+  const t = useTranslations('PdfViewer');
   /**
    * Page 1's rendered height, used to size the slots of pages that have not
    * been mounted yet. Uniform documents (the overwhelming case, and every
@@ -579,7 +584,7 @@ export function PdfAnnotationCanvas({
     async function loadPdf() {
       try {
         setIsLoading(true);
-        setError(null);
+        setErrorKey(null);
 
         const doc = await loadPdfDocument(pdfUrl);
 
@@ -602,7 +607,7 @@ export function PdfAnnotationCanvas({
         if (cancelled) return;
 
         console.error('Error loading PDF:', err);
-        setError('Failed to load PDF');
+        setErrorKey('loadFailed');
         setIsLoading(false);
       }
     }
@@ -719,13 +724,13 @@ export function PdfAnnotationCanvas({
     fetchResourceAnchored,
   };
 
-  if (error) {
-    return <div className="semiont-pdf-annotation-canvas__error">{error}</div>;
+  if (errorKey) {
+    return <div className="semiont-pdf-annotation-canvas__error">{t(errorKey)}</div>;
   }
 
   return (
     <div className="semiont-pdf-annotation-canvas">
-      {isLoading && <div className="semiont-pdf-annotation-canvas__loading">Loading PDF...</div>}
+      {isLoading && <div className="semiont-pdf-annotation-canvas__loading">{t('loading')}</div>}
 
       {pdfDoc && pageLayout === 'scroll' ? (
         <div className="semiont-pdf-annotation-canvas__column">
@@ -751,25 +756,31 @@ export function PdfAnnotationCanvas({
 
       {/* Page navigation controls */}
       {numPages > 0 && (
-        <div className="semiont-pdf-annotation-canvas__controls">
+        <nav className="semiont-pdf-annotation-canvas__controls" aria-label={t('pagination')}>
           <button
             disabled={currentPage <= 1}
             onClick={() => (pageLayout === 'scroll' ? scrollToPage(currentPage - 1) : setPageNumber(pageNumber - 1))}
             className="semiont-pdf-annotation-canvas__button"
           >
-            Previous
+            {t('previous')}
           </button>
-          <span className="semiont-pdf-annotation-canvas__page-info">
-            Page {currentPage} of {numPages}
+          {/*
+            aria-live: the page number is the only feedback a page change gives,
+            and in the scrolling column it changes without any control being
+            activated at all — so a screen-reader user who scrolls would
+            otherwise get silence.
+          */}
+          <span className="semiont-pdf-annotation-canvas__page-info" aria-live="polite">
+            {t('pageOf', { page: currentPage, total: numPages })}
           </span>
           <button
             disabled={currentPage >= numPages}
             onClick={() => (pageLayout === 'scroll' ? scrollToPage(currentPage + 1) : setPageNumber(pageNumber + 1))}
             className="semiont-pdf-annotation-canvas__button"
           >
-            Next
+            {t('next')}
           </button>
-        </div>
+        </nav>
       )}
     </div>
   );

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -42,6 +42,22 @@ export type PageLayout = 'paged' | 'scroll';
 /** How far outside the viewport a page starts loading, and stays loaded. */
 const PRELOAD_MARGIN = '100% 0px';
 
+/** Width of one page rectangle in the strip, in CSS px. Height follows the
+ *  document's own aspect ratio, so the strip looks like the document. */
+const STRIP_PAGE_WIDTH = 14;
+
+/**
+ * Scroll an element into view where the environment supports it.
+ *
+ * Same posture as this file's guarded observers: jsdom implements no layout
+ * and therefore no `scrollIntoView`, and a viewer that throws in a test
+ * harness (or an exotic embedding host) is worse than one that simply does
+ * not scroll.
+ */
+function scrollElementIntoView(el: Element | null | undefined, options: ScrollIntoViewOptions): void {
+  if (typeof el?.scrollIntoView === 'function') el.scrollIntoView(options);
+}
+
 /**
  * Get color for annotation based on motivation
  */
@@ -738,8 +754,11 @@ export function PdfAnnotationCanvas({
     }
   }, []);
 
+  /** Keeps the current page's rectangle in view as the reader scrolls. */
+  const currentTickRef = useRef<HTMLButtonElement>(null);
+
   const scrollToPage = useCallback((page: number) => {
-    slotRefs.current.get(page)?.scrollIntoView({ block: 'start' });
+    scrollElementIntoView(slotRefs.current.get(page), { block: 'start' });
   }, []);
 
   // In the column the reader decides which page they are on by scrolling, so
@@ -747,6 +766,40 @@ export function PdfAnnotationCanvas({
   const currentPage = pageLayout === 'scroll'
     ? (visiblePages.size > 0 ? Math.min(...visiblePages) : 1)
     : pageNumber;
+
+  /**
+   * Left/Right step pages (S1a).
+   *
+   * Bound to the window rather than a focusable wrapper so it works without
+   * the reader hunting for the viewer's focus — but that reach is exactly why
+   * the guards matter more than the feature: a viewer that eats arrow keys
+   * while someone is editing an annotation body, or mid-drag, is worse than
+   * one with no shortcut at all.
+   */
+  useEffect(() => {
+    if (numPages === 0) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return; // browser/OS navigation
+      const el = e.target as HTMLElement | null;
+      const tag = el?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable) return;
+
+      const next = e.key === 'ArrowRight' ? currentPage + 1 : currentPage - 1;
+      if (next < 1 || next > numPages) return;
+      e.preventDefault();
+      if (pageLayout === 'scroll') scrollToPage(next);
+      else setPageNumber(next);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [numPages, currentPage, pageLayout, scrollToPage]);
+
+  useEffect(() => {
+    // `nearest` so following the reader never yanks the strip around; it
+    // scrolls only when the current rectangle would otherwise leave view.
+    scrollElementIntoView(currentTickRef.current, { block: 'nearest', inline: 'nearest' });
+  }, [currentPage]);
 
   const pageProps = {
     scale,
@@ -793,6 +846,33 @@ export function PdfAnnotationCanvas({
         pdfDoc && !isLoading && (
           <PdfPageView doc={pdfDoc} pageNumber={pageNumber} {...pageProps} />
         )
+      )}
+
+      {/*
+        The page strip: one proportional rectangle per page, current
+        highlighted, click to jump. Rectangles, not thumbnails — it needs no
+        rasterization at all, only the page count and the aspect ratio the
+        slot reservation already measures, so it stays cheap on a 400-page
+        scan. It answers "where am I in this document", which neither the
+        pager nor the scrollbar does.
+      */}
+      {pageLayout === 'scroll' && numPages > 0 && pageShape && (
+        <div className="semiont-pdf-annotation-canvas__strip">
+          {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
+            <button
+              key={page}
+              type="button"
+              data-page={page}
+              className="semiont-pdf-annotation-canvas__strip-page"
+              // The page it represents, at the page's own proportions.
+              style={{ height: `${Math.round(STRIP_PAGE_WIDTH * pageShape.aspect)}px` }}
+              aria-label={t('pageOf', { page, total: numPages })}
+              {...(page === currentPage ? { 'aria-current': 'page' as const } : {})}
+              ref={page === currentPage ? currentTickRef : undefined}
+              onClick={() => scrollToPage(page)}
+            />
+          ))}
+        </div>
       )}
 
       {/* Page navigation controls */}

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -610,8 +610,13 @@ export function PdfAnnotationCanvas({
 
   /** Pages currently intersecting the viewport (plus the preload margin). */
   const [visiblePages, setVisiblePages] = useState<Set<number>>(new Set());
+  /** Pages genuinely in view — observed with NO preload margin, so it answers
+   *  "what is the reader looking at" rather than "what should be loaded".
+   *  Drives the indicator and the rail; never the mount window. */
+  const [onscreenPages, setOnscreenPages] = useState<Set<number>>(new Set());
   const slotRefs = useRef(new Map<number, HTMLElement>());
   const observerRef = useRef<IntersectionObserver | null>(null);
+  const onscreenRef = useRef<IntersectionObserver | null>(null);
 
   // Load PDF document on mount
   useEffect(() => {
@@ -752,18 +757,50 @@ export function PdfAnnotationCanvas({
     observerRef.current = observer;
     for (const el of slotRefs.current.values()) observer.observe(el);
 
+    // A SECOND observer, with no preload margin, answers a different question:
+    // which pages the reader can actually see. Two observers rather than one
+    // set doing both jobs, because widening the mount window must never move
+    // the page indicator.
+    let onscreen: IntersectionObserver | null = null;
+    try {
+      onscreen = new IntersectionObserver((entries) => {
+        setOnscreenPages((prev) => {
+          const next = new Set(prev);
+          for (const entry of entries) {
+            const page = Number((entry.target as HTMLElement).dataset.page);
+            if (!page) continue;
+            if (entry.isIntersecting) next.add(page);
+            else next.delete(page);
+          }
+          return next;
+        });
+      });
+      onscreenRef.current = onscreen;
+      for (const el of slotRefs.current.values()) onscreen.observe(el);
+    } catch {
+      // Without an observer there is no notion of "on screen"; fall back to
+      // page 1 so the indicator names something rather than nothing.
+      setOnscreenPages(new Set([1]));
+    }
+
     return () => {
       observer.disconnect();
       observerRef.current = null;
+      onscreen?.disconnect();
+      onscreenRef.current = null;
     };
   }, [pageLayout, numPages]);
 
   const registerSlot = useCallback((page: number) => (el: HTMLDivElement | null) => {
     const previous = slotRefs.current.get(page);
-    if (previous) observerRef.current?.unobserve(previous);
+    if (previous) {
+      observerRef.current?.unobserve(previous);
+      onscreenRef.current?.unobserve(previous);
+    }
     if (el) {
       slotRefs.current.set(page, el);
       observerRef.current?.observe(el);
+      onscreenRef.current?.observe(el);
     } else {
       slotRefs.current.delete(page);
     }
@@ -777,9 +814,12 @@ export function PdfAnnotationCanvas({
   }, []);
 
   // In the column the reader decides which page they are on by scrolling, so
-  // the indicator reports rather than controls: the topmost visible page.
+  // the indicator reports rather than controls: the topmost page actually ON
+  // SCREEN. NOT `visiblePages` — that set is deliberately widened by
+  // PRELOAD_MARGIN to mount pages before they are reached, so reading it here
+  // would name a page still a viewport away.
   const currentPage = pageLayout === 'scroll'
-    ? (visiblePages.size > 0 ? Math.min(...visiblePages) : 1)
+    ? (onscreenPages.size > 0 ? Math.min(...onscreenPages) : 1)
     : pageNumber;
 
   /**
@@ -910,7 +950,12 @@ export function PdfAnnotationCanvas({
         </div>
       ) : (
         pdfDoc && !isLoading && (
-          <PdfPageView doc={pdfDoc} pageNumber={pageNumber} {...pageProps} />
+          // `key` is load-bearing: without it React reuses this instance
+          // across page changes, so the previous page's raster, text map and
+          // load error survive into the next page — a stale overlay, a quote
+          // taken from the wrong page, and an error that never clears. Each
+          // page is a different thing; mounting it as one resets all of it.
+          <PdfPageView key={pageNumber} doc={pdfDoc} pageNumber={pageNumber} {...pageProps} />
         )
       )}
 

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -43,8 +43,10 @@ export type PageLayout = 'paged' | 'scroll';
 const PRELOAD_MARGIN = '100% 0px';
 
 /** Width of one page rectangle in the strip, in CSS px. Height follows the
- *  document's own aspect ratio, so the strip looks like the document. */
-const STRIP_PAGE_WIDTH = 14;
+ *  document's own aspect ratio, so the strip looks like the document — wide
+ *  enough to carry a three-digit page number, which is what makes the strip
+ *  useful rather than merely positional on a long document. */
+const STRIP_PAGE_WIDTH = 30;
 
 /**
  * The axis pages advance along.
@@ -791,14 +793,20 @@ export function PdfAnnotationCanvas({
    */
   useEffect(() => {
     if (numPages === 0) return;
+    const BACK = ['ArrowLeft', 'ArrowUp'];
+    const FORWARD = ['ArrowRight', 'ArrowDown'];
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      // All four arrows step pages. Up/Down is what a reader reaches for
+      // first, because pages advance downward and the rail is vertical;
+      // Left/Right keep working because they have no native meaning in a
+      // vertical layout, so accepting both costs nothing.
+      if (!BACK.includes(e.key) && !FORWARD.includes(e.key)) return;
       if (e.metaKey || e.ctrlKey || e.altKey) return; // browser/OS navigation
       const el = e.target as HTMLElement | null;
       const tag = el?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable) return;
 
-      const next = e.key === 'ArrowRight' ? currentPage + 1 : currentPage - 1;
+      const next = FORWARD.includes(e.key) ? currentPage + 1 : currentPage - 1;
       if (next < 1 || next > numPages) return;
       e.preventDefault();
       if (pageLayout === 'scroll') scrollToPage(next);
@@ -851,6 +859,32 @@ export function PdfAnnotationCanvas({
 
       {pdfDoc && pageLayout === 'scroll' ? (
         <div className="semiont-pdf-annotation-canvas__viewport" data-axis={SCROLL_AXIS}>
+        {numPages > 0 && pageShape && (
+          <div
+            className="semiont-pdf-annotation-canvas__strip"
+            data-axis={SCROLL_AXIS}
+            data-scroller="true"
+            aria-orientation={SCROLL_AXIS}
+            ref={stripRef}
+          >
+            {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
+              <button
+                key={page}
+                type="button"
+                data-page={page}
+                className="semiont-pdf-annotation-canvas__strip-page"
+                style={{ height: `${Math.round(STRIP_PAGE_WIDTH * pageShape.aspect)}px` }}
+                aria-label={t('pageOf', { page, total: numPages })}
+                tabIndex={page === currentPage ? 0 : -1}
+                {...(page === currentPage ? { 'aria-current': 'page' as const } : {})}
+                ref={page === currentPage ? currentTickRef : undefined}
+                onClick={() => scrollToPage(page)}
+              >
+                {page}
+              </button>
+            ))}
+          </div>
+        )}
         <div className="semiont-pdf-annotation-canvas__column" data-axis={SCROLL_AXIS} ref={columnRef}>
           {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
             <div
@@ -870,29 +904,6 @@ export function PdfAnnotationCanvas({
             </div>
           ))}
         </div>
-        {numPages > 0 && pageShape && (
-          <div
-            className="semiont-pdf-annotation-canvas__strip"
-            data-axis={SCROLL_AXIS}
-            aria-orientation={SCROLL_AXIS}
-            ref={stripRef}
-          >
-            {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
-              <button
-                key={page}
-                type="button"
-                data-page={page}
-                className="semiont-pdf-annotation-canvas__strip-page"
-                style={{ height: `${Math.round(STRIP_PAGE_WIDTH * pageShape.aspect)}px` }}
-                aria-label={t('pageOf', { page, total: numPages })}
-                tabIndex={page === currentPage ? 0 : -1}
-                {...(page === currentPage ? { 'aria-current': 'page' as const } : {})}
-                ref={page === currentPage ? currentTickRef : undefined}
-                onClick={() => scrollToPage(page)}
-              />
-            ))}
-          </div>
-        )}
         </div>
       ) : (
         pdfDoc && !isLoading && (

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -793,13 +793,16 @@ export function PdfAnnotationCanvas({
    */
   useEffect(() => {
     if (numPages === 0) return;
-    const BACK = ['ArrowLeft', 'ArrowUp'];
-    const FORWARD = ['ArrowRight', 'ArrowDown'];
+    const BACK = ['ArrowLeft', 'PageUp'];
+    const FORWARD = ['ArrowRight', 'PageDown'];
     const onKeyDown = (e: KeyboardEvent) => {
-      // All four arrows step pages. Up/Down is what a reader reaches for
-      // first, because pages advance downward and the rail is vertical;
-      // Left/Right keep working because they have no native meaning in a
-      // vertical layout, so accepting both costs nothing.
+      // PageUp/PageDown jump a page; Left/Right do too, because they have no
+      // native meaning in a vertical layout so taking them costs nothing.
+      //
+      // Up/Down are deliberately NOT here. They are the scroller's fine
+      // movement, and a page can be taller than the viewport — taking them
+      // would leave no keyboard way to reach the bottom of one. This is the
+      // split Preview, Chrome's PDF viewer and Acrobat all use.
       if (!BACK.includes(e.key) && !FORWARD.includes(e.key)) return;
       if (e.metaKey || e.ctrlKey || e.altKey) return; // browser/OS navigation
       const el = e.target as HTMLElement | null;

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -23,6 +23,24 @@ import './PdfAnnotationCanvas.css';
 export type DrawingMode = 'rectangle' | 'circle' | 'polygon' | null;
 
 /**
+ * How the document's pages are laid out.
+ *
+ * `paged` is one page with Previous/Next. `scroll` is a virtualized column:
+ * every page gets a slot so the scrollbar tells the truth about the
+ * document's length, but only the pages near the viewport are mounted.
+ *
+ * Declared explicitly rather than inferred from `drawingMode`, which does NOT
+ * distinguish the modes — AnnotateView passes `drawingMode={null}` whenever no
+ * motivation is selected, so keying layout on it would flip a reader between
+ * scrolling and paged views as they picked up and put down a tool.
+ * See .plans/PDF-CONTINUOUS-SCROLL.md D3.
+ */
+export type PageLayout = 'paged' | 'scroll';
+
+/** How far outside the viewport a page starts loading, and stays loaded. */
+const PRELOAD_MARGIN = '100% 0px';
+
+/**
  * Get color for annotation based on motivation
  */
 function getMotivationColor(motivation: SelectionMotivation | null): { stroke: string; fill: string } {
@@ -44,133 +62,66 @@ function getMotivationColor(motivation: SelectionMotivation | null): { stroke: s
   }
 }
 
-interface PdfAnnotationCanvasProps {
-  pdfUrl: string;
-  /** The '@id' of the annotated resource — stamped as `source` on mark:requested (multi-viewer routing). */
+interface PdfPageViewProps {
+  doc: PDFDocumentProxy;
+  pageNumber: number;
+  /** Raster scale. Display-only: the overlay's geometry never reads it. */
+  scale: number;
   resourceUri: string;
-  existingAnnotations?: Annotation[];
+  existingAnnotations: Annotation[];
   drawingMode: DrawingMode;
   selectedMotivation?: SelectionMotivation | null;
   session?: SemiontSession | null | undefined;
   hoveredAnnotationId?: string | null;
   selectedAnnotationId?: string | null;
-  hoverDelayMs?: number;
+  hoverDelayMs: number;
+  /** The document-wide server map, fetched once per resource by the parent. */
+  fetchResourceAnchored: () => Promise<AnchoredText | null>;
 }
 
 /**
- * PDF annotation canvas with page navigation and rectangle drawing
+ * One rendered page: its raster, its text map, its annotation overlay, and
+ * the drag that draws on it.
  *
- * @emits browse:click - Annotation clicked on PDF. Payload: { annotationId: string, motivation: Motivation }
- * @emits mark:requested - New annotation drawn on PDF. Payload: { selector: [FragmentSelector, TextQuoteSelector?], motivation: SelectionMotivation } — the quote is the text under the rectangle, omitted when the page has no text layer
- * @emits beckon:hover - Annotation hovered or unhovered. Payload: { annotationId: string | null }
+ * Everything a page needs lives HERE rather than in the parent, which is what
+ * makes a scrolling column possible: mounting a page loads it, and unmounting
+ * releases it. The raster is a data-URL string, so the last reference going
+ * away IS the memory release — no eviction bookkeeping, no object-URL revoke.
+ * The drag lives here too because it needs this page's display dimensions and
+ * this page's text; a drag can no more span pages than a rectangle can.
  */
-export function PdfAnnotationCanvas({
-  pdfUrl,
+function PdfPageView({
+  doc,
+  pageNumber,
+  scale,
   resourceUri,
-  existingAnnotations = [],
+  existingAnnotations,
   drawingMode,
   selectedMotivation,
   session,
   hoveredAnnotationId,
   selectedAnnotationId,
-  hoverDelayMs = 150
-}: PdfAnnotationCanvasProps) {
-  // PDF state
-  const [pdfDoc, setPdfDoc] = useState<PDFDocumentProxy | null>(null);
-  const [numPages, setNumPages] = useState<number>(0);
-  const [pageNumber, setPageNumber] = useState(1);
+  hoverDelayMs,
+  fetchResourceAnchored,
+}: PdfPageViewProps) {
   const [pageImageUrl, setPageImageUrl] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [pageDimensions, setPageDimensions] = useState<{ width: number; height: number } | null>(null);
   /**
-   * The current page's text and per-run geometry, read once when the page
-   * loads so a drag can be quoted without a round trip. Null while the page
-   * is loading; `items` is empty on a scanned page, which has no text layer
-   * for the browser to read.
+   * This page's text and per-run geometry, read once when the page loads so a
+   * drag can be quoted without a round trip. Null while loading; `items` is
+   * empty on a scanned page, which has no text layer for the browser to read.
    */
   const [pageAnchored, setPageAnchored] = useState<AnchoredText | null>(null);
   const [displayDimensions, setDisplayDimensions] = useState<{ width: number; height: number } | null>(null);
-  const [scale] = useState(1.5); // Fixed scale for better quality
+  const [error, setError] = useState<string | null>(null);
 
-  // Drawing state
   const [isDrawing, setIsDrawing] = useState(false);
   const [selection, setSelection] = useState<CanvasRectangle | null>(null);
 
-  const containerRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
 
-  // Load PDF document on mount
   useEffect(() => {
     let cancelled = false;
-
-    async function loadPdf() {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const doc = await loadPdfDocument(pdfUrl);
-
-        if (cancelled) return;
-
-        setPdfDoc(doc);
-        setNumPages(doc.numPages);
-        setIsLoading(false);
-      } catch (err) {
-        if (cancelled) return;
-
-        console.error('Error loading PDF:', err);
-        setError('Failed to load PDF');
-        setIsLoading(false);
-      }
-    }
-
-    loadPdf();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [pdfUrl]);
-
-  /**
-   * The server-derived map, fetched once per document rather than once per
-   * page-load effect (PERSIST-ANCHORS P4). The map is WHOLE-RESOURCE — one
-   * artifact covering every page — so re-reading it from the per-page effect
-   * meant a full refetch and re-decode on every page turn; on a 400-page scan
-   * that is one decode per interaction instead of one per document.
-   *
-   * The cache holds the in-flight promise so concurrent page loads share one
-   * fetch. Answers cache — including "no map" and a stored decline, which are
-   * definitive — but a transport failure clears the entry, so the next page
-   * load retries instead of pinning the whole document to geometry-only.
-   */
-  const resourceAnchoredRef = useRef<{ uri: string; outcome: Promise<AnchoredText | null> } | null>(null);
-  const fetchResourceAnchored = useCallback((): Promise<AnchoredText | null> => {
-    if (!session) return Promise.resolve(null); // no session yet — don't cache its absence
-    const cached = resourceAnchoredRef.current;
-    if (cached && cached.uri === resourceUri) return cached.outcome;
-
-    const uri = resourceUri;
-    const outcome = session.client.browse.resourceAnchoredText(toResourceId(uri)).then(
-      (served) => (served && !('declined' in served) ? served : null),
-      () => {
-        if (resourceAnchoredRef.current?.uri === uri) resourceAnchoredRef.current = null;
-        return null;
-      },
-    );
-    resourceAnchoredRef.current = { uri, outcome };
-    return outcome;
-  }, [session, resourceUri]);
-
-  // Load current page when page number changes
-  useEffect(() => {
-    if (!pdfDoc) return;
-
-    let cancelled = false;
-    const doc = pdfDoc;
-
-    // Never quote the previous page's text under this page's rectangles.
-    setPageAnchored(null);
 
     /**
      * The map a rectangle on this page quotes from, or null when there is
@@ -194,7 +145,7 @@ export function PdfAnnotationCanvas({
         // No runs means a scanned page: the characters exist only as pixels
         // and pdf.js has nothing to give. The server derived a map at ingest,
         // so ask for it rather than leaving the annotation anonymous.
-        // Whole-resource — served once per document via the cache above —
+        // Whole-resource — served once per document by the parent's cache —
         // and `textUnder` filters by page: the same shape the native branch
         // produces, so nothing downstream branches.
         //
@@ -204,8 +155,7 @@ export function PdfAnnotationCanvas({
         // this existed. The served record is the full extraction outcome
         // (PERSIST-ANCHORS D1); a stored decline means extraction ran and
         // found nothing to anchor — for this canvas the same degradation as
-        // no map at all. A success outcome IS the anchoring shape, plus
-        // provenance this canvas does not read.
+        // no map at all.
         return await fetchResourceAnchored();
       } catch {
         return null;
@@ -215,15 +165,11 @@ export function PdfAnnotationCanvas({
     async function loadPage() {
       try {
         const page = await doc.getPage(pageNumber);
-
         if (cancelled) return;
 
         // Get page dimensions (at scale 1.0)
         const viewport = page.getViewport({ scale: 1.0 });
-        setPageDimensions({
-          width: viewport.width,
-          height: viewport.height
-        });
+        setPageDimensions({ width: viewport.width, height: viewport.height });
 
         // Anchoring and rendering are independent, and only one of them the
         // reader is waiting on. Sequencing them put a network round-trip in
@@ -254,7 +200,7 @@ export function PdfAnnotationCanvas({
     return () => {
       cancelled = true;
     };
-  }, [pdfDoc, pageNumber, scale, fetchResourceAnchored]);
+  }, [doc, pageNumber, scale, fetchResourceAnchored]);
 
   // Update display dimensions on resize
   useEffect(() => {
@@ -438,8 +384,8 @@ export function PdfAnnotationCanvas({
     // It will be cleared when drawingMode changes or user starts new selection
   }, [isDrawing, selection, pageNumber, pageDimensions, displayDimensions, selectedMotivation, existingAnnotations, session, resourceUri, pageAnchored]);
 
-  // Every FragmentSelector rect on the current page — one per line for a
-  // multi-line (multi-selector) annotation, exactly one for a manual annotation.
+  // Every FragmentSelector rect on this page — one per line for a multi-line
+  // (multi-selector) annotation, exactly one for a manual annotation.
   const pageRects = rectsForPage(existingAnnotations, pageNumber);
 
   // Hover handlers with currentHover guard and dwell delay
@@ -456,140 +402,369 @@ export function PdfAnnotationCanvas({
   }
 
   return (
+    <div
+      className="semiont-pdf-annotation-canvas__container"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={() => {
+        if (isDrawing) {
+          setIsDrawing(false);
+          setSelection(null);
+        }
+      }}
+      data-drawing-mode={drawingMode || 'none'}
+    >
+      {/* PDF page rendered as image */}
+      {pageImageUrl && (
+        <img
+          ref={imageRef}
+          src={pageImageUrl}
+          alt={`PDF page ${pageNumber}`}
+          className="semiont-pdf-annotation-canvas__image"
+          draggable={false}
+          style={{ pointerEvents: 'none' }}
+          onLoad={() => {
+            // Use double RAF to ensure layout is complete even in onLoad
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                if (imageRef.current) {
+                  setDisplayDimensions({
+                    width: imageRef.current.clientWidth,
+                    height: imageRef.current.clientHeight
+                  });
+                }
+              });
+            });
+          }}
+        />
+      )}
+
+      {/* SVG overlay for annotations */}
+      {displayDimensions && pageDimensions && (
+        <div className="semiont-pdf-annotation-canvas__overlay-container">
+          <div className="semiont-pdf-annotation-canvas__overlay">
+            <svg
+              className="semiont-pdf-annotation-canvas__svg"
+              width={displayDimensions.width}
+              height={displayDimensions.height}
+            >
+              {/* Render existing annotations for this page */}
+              {pageRects.map(r => {
+                const rect = pdfToCanvasCoordinates(r.coord, pageDimensions.height, 1.0);
+
+                // Scale to display coordinates
+                const scaleX = displayDimensions.width / pageDimensions.width;
+                const scaleY = displayDimensions.height / pageDimensions.height;
+
+                const isHovered = r.annId === hoveredAnnotationId;
+                const isSelected = r.annId === selectedAnnotationId;
+
+                // Colour by the annotation's own motivation (not the toolbar's).
+                const annMotivation = r.annotation.motivation as SelectionMotivation | null;
+                const { stroke: annStroke, fill: annFill } = getMotivationColor(annMotivation);
+
+                return (
+                  <rect
+                    key={`${r.annId}:${r.selectorIndex}`}
+                    x={rect.x * scaleX}
+                    y={rect.y * scaleY}
+                    width={rect.width * scaleX}
+                    height={rect.height * scaleY}
+                    stroke={annStroke}
+                    strokeWidth={isSelected ? 4 : isHovered ? 3 : 2}
+                    fill={annFill}
+                    style={{
+                      pointerEvents: 'auto',
+                      cursor: 'pointer',
+                      opacity: isSelected ? 1 : isHovered ? 0.9 : 0.7
+                    }}
+                    onClick={(e) => session?.client.browse.click(r.annId, r.annotation.motivation, e.currentTarget.getBoundingClientRect())}
+                    onMouseEnter={() => handleMouseEnter(r.annId)}
+                    onMouseLeave={handleMouseLeave}
+                  />
+                );
+              })}
+
+              {/* Render current selection while drawing or awaiting save */}
+              {selection && (() => {
+                const rectX = Math.min(selection.startX, selection.endX);
+                const rectY = Math.min(selection.startY, selection.endY);
+                const rectWidth = Math.abs(selection.endX - selection.startX);
+                const rectHeight = Math.abs(selection.endY - selection.startY);
+
+                // PDF only supports rectangle shapes (FragmentSelector with viewrect)
+                // Circle/polygon are disabled in the UI for PDF media types
+                return (
+                  <rect
+                    x={rectX}
+                    y={rectY}
+                    width={rectWidth}
+                    height={rectHeight}
+                    stroke={stroke}
+                    strokeWidth={2}
+                    strokeDasharray="5,5"
+                    fill={fill}
+                    pointerEvents="none"
+                  />
+                );
+              })()}
+            </svg>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface PdfAnnotationCanvasProps {
+  pdfUrl: string;
+  /** The '@id' of the annotated resource — stamped as `source` on mark:requested (multi-viewer routing). */
+  resourceUri: string;
+  existingAnnotations?: Annotation[];
+  drawingMode: DrawingMode;
+  selectedMotivation?: SelectionMotivation | null;
+  session?: SemiontSession | null | undefined;
+  hoveredAnnotationId?: string | null;
+  selectedAnnotationId?: string | null;
+  hoverDelayMs?: number;
+  /** `paged` (default) or the virtualized `scroll` column. See `PageLayout`. */
+  pageLayout?: PageLayout;
+}
+
+/**
+ * PDF annotation canvas with page navigation and rectangle drawing
+ *
+ * @emits browse:click - Annotation clicked on PDF. Payload: { annotationId: string, motivation: Motivation }
+ * @emits mark:requested - New annotation drawn on PDF. Payload: { selector: [FragmentSelector, TextQuoteSelector?], motivation: SelectionMotivation } — the quote is the text under the rectangle, omitted when the page has no text layer
+ * @emits beckon:hover - Annotation hovered or unhovered. Payload: { annotationId: string | null }
+ */
+export function PdfAnnotationCanvas({
+  pdfUrl,
+  resourceUri,
+  existingAnnotations = [],
+  drawingMode,
+  selectedMotivation,
+  session,
+  hoveredAnnotationId,
+  selectedAnnotationId,
+  hoverDelayMs = 150,
+  pageLayout = 'paged'
+}: PdfAnnotationCanvasProps) {
+  // PDF state
+  const [pdfDoc, setPdfDoc] = useState<PDFDocumentProxy | null>(null);
+  const [numPages, setNumPages] = useState<number>(0);
+  const [pageNumber, setPageNumber] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  /**
+   * Page 1's rendered height, used to size the slots of pages that have not
+   * been mounted yet. Uniform documents (the overwhelming case, and every
+   * scan) get exactness for one `getPage`; a mixed-size document gets scroll
+   * drift in its unmeasured tail, which self-corrects as pages mount.
+   * See .plans/PDF-CONTINUOUS-SCROLL.md D4.
+   */
+  const [estimatedPageHeight, setEstimatedPageHeight] = useState<number | null>(null);
+  const [scale] = useState(1.5); // Fixed scale for better quality
+
+  /** Pages currently intersecting the viewport (plus the preload margin). */
+  const [visiblePages, setVisiblePages] = useState<Set<number>>(new Set());
+  const slotRefs = useRef(new Map<number, HTMLElement>());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  // Load PDF document on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadPdf() {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const doc = await loadPdfDocument(pdfUrl);
+
+        if (cancelled) return;
+
+        setPdfDoc(doc);
+        setNumPages(doc.numPages);
+        setIsLoading(false);
+
+        // One extra getPage, for slot sizing (D4). Failure is not fatal:
+        // unsized slots still scroll, just less faithfully.
+        try {
+          const first = await doc.getPage(1);
+          if (cancelled) return;
+          setEstimatedPageHeight(first.getViewport({ scale }).height);
+        } catch {
+          /* leave unsized */
+        }
+      } catch (err) {
+        if (cancelled) return;
+
+        console.error('Error loading PDF:', err);
+        setError('Failed to load PDF');
+        setIsLoading(false);
+      }
+    }
+
+    loadPdf();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pdfUrl, scale]);
+
+  /**
+   * The server-derived map, fetched once per document rather than once per
+   * page (PERSIST-ANCHORS P4). The map is WHOLE-RESOURCE — one artifact
+   * covering every page — so re-reading it per page meant a full refetch and
+   * re-decode on every page turn; on a 400-page scan that is one decode per
+   * interaction instead of one per document. Living on the parent is also
+   * what lets a scrolling column mount many pages against a single fetch.
+   *
+   * The cache holds the in-flight promise so concurrent page loads share one
+   * fetch. Answers cache — including "no map" and a stored decline, which are
+   * definitive — but a transport failure clears the entry, so the next page
+   * load retries instead of pinning the whole document to geometry-only.
+   */
+  const resourceAnchoredRef = useRef<{ uri: string; outcome: Promise<AnchoredText | null> } | null>(null);
+  const fetchResourceAnchored = useCallback((): Promise<AnchoredText | null> => {
+    if (!session) return Promise.resolve(null); // no session yet — don't cache its absence
+    const cached = resourceAnchoredRef.current;
+    if (cached && cached.uri === resourceUri) return cached.outcome;
+
+    const uri = resourceUri;
+    const outcome = session.client.browse.resourceAnchoredText(toResourceId(uri)).then(
+      (served) => (served && !('declined' in served) ? served : null),
+      () => {
+        if (resourceAnchoredRef.current?.uri === uri) resourceAnchoredRef.current = null;
+        return null;
+      },
+    );
+    resourceAnchoredRef.current = { uri, outcome };
+    return outcome;
+  }, [session, resourceUri]);
+
+  // The mount window. Slots report their own visibility; a page is mounted
+  // while its slot intersects (widened by PRELOAD_MARGIN so the next page is
+  // ready before it is reached), and unmounting is what frees its raster.
+  useEffect(() => {
+    if (pageLayout !== 'scroll' || numPages === 0) return;
+
+    let observer: IntersectionObserver | null = null;
+    try {
+      observer = new IntersectionObserver(
+        (entries) => {
+          setVisiblePages((prev) => {
+            const next = new Set(prev);
+            for (const entry of entries) {
+              const page = Number((entry.target as HTMLElement).dataset.page);
+              if (!page) continue;
+              if (entry.isIntersecting) next.add(page);
+              else next.delete(page);
+            }
+            return next;
+          });
+        },
+        { rootMargin: PRELOAD_MARGIN },
+      );
+    } catch {
+      // No IntersectionObserver: mount every page rather than none. Correct,
+      // simply not virtualized — the same posture as the ResizeObserver
+      // fallback in PdfPageView.
+      setVisiblePages(new Set(Array.from({ length: numPages }, (_, i) => i + 1)));
+      return;
+    }
+
+    observerRef.current = observer;
+    for (const el of slotRefs.current.values()) observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+    };
+  }, [pageLayout, numPages]);
+
+  const registerSlot = useCallback((page: number) => (el: HTMLDivElement | null) => {
+    const previous = slotRefs.current.get(page);
+    if (previous) observerRef.current?.unobserve(previous);
+    if (el) {
+      slotRefs.current.set(page, el);
+      observerRef.current?.observe(el);
+    } else {
+      slotRefs.current.delete(page);
+    }
+  }, []);
+
+  const scrollToPage = useCallback((page: number) => {
+    slotRefs.current.get(page)?.scrollIntoView({ block: 'start' });
+  }, []);
+
+  // In the column the reader decides which page they are on by scrolling, so
+  // the indicator reports rather than controls: the topmost visible page.
+  const currentPage = pageLayout === 'scroll'
+    ? (visiblePages.size > 0 ? Math.min(...visiblePages) : 1)
+    : pageNumber;
+
+  const pageProps = {
+    scale,
+    resourceUri,
+    existingAnnotations,
+    drawingMode,
+    selectedMotivation,
+    session,
+    hoveredAnnotationId,
+    selectedAnnotationId,
+    hoverDelayMs,
+    fetchResourceAnchored,
+  };
+
+  if (error) {
+    return <div className="semiont-pdf-annotation-canvas__error">{error}</div>;
+  }
+
+  return (
     <div className="semiont-pdf-annotation-canvas">
       {isLoading && <div className="semiont-pdf-annotation-canvas__loading">Loading PDF...</div>}
 
-      <div
-        ref={containerRef}
-        className="semiont-pdf-annotation-canvas__container"
-        style={{ display: isLoading ? 'none' : undefined }}
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={() => {
-          if (isDrawing) {
-            setIsDrawing(false);
-            setSelection(null);
-          }
-        }}
-        data-drawing-mode={drawingMode || 'none'}
-      >
-        {/* PDF page rendered as image */}
-        {pageImageUrl && (
-          <img
-            ref={imageRef}
-            src={pageImageUrl}
-            alt={`PDF page ${pageNumber}`}
-            className="semiont-pdf-annotation-canvas__image"
-            draggable={false}
-            style={{ pointerEvents: 'none' }}
-            onLoad={() => {
-              // Use double RAF to ensure layout is complete even in onLoad
-              requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                  if (imageRef.current) {
-                    setDisplayDimensions({
-                      width: imageRef.current.clientWidth,
-                      height: imageRef.current.clientHeight
-                    });
-                  }
-                });
-              });
-            }}
-          />
-        )}
-
-        {/* SVG overlay for annotations */}
-        {displayDimensions && pageDimensions && (
-          <div className="semiont-pdf-annotation-canvas__overlay-container">
-            <div className="semiont-pdf-annotation-canvas__overlay">
-              <svg
-                className="semiont-pdf-annotation-canvas__svg"
-                width={displayDimensions.width}
-                height={displayDimensions.height}
-              >
-                {/* Render existing annotations for this page */}
-                {pageRects.map(r => {
-                  const rect = pdfToCanvasCoordinates(r.coord, pageDimensions.height, 1.0);
-
-                  // Scale to display coordinates
-                  const scaleX = displayDimensions.width / pageDimensions.width;
-                  const scaleY = displayDimensions.height / pageDimensions.height;
-
-                  const isHovered = r.annId === hoveredAnnotationId;
-                  const isSelected = r.annId === selectedAnnotationId;
-
-                  // Colour by the annotation's own motivation (not the toolbar's).
-                  const annMotivation = r.annotation.motivation as SelectionMotivation | null;
-                  const { stroke: annStroke, fill: annFill } = getMotivationColor(annMotivation);
-
-                  return (
-                    <rect
-                      key={`${r.annId}:${r.selectorIndex}`}
-                      x={rect.x * scaleX}
-                      y={rect.y * scaleY}
-                      width={rect.width * scaleX}
-                      height={rect.height * scaleY}
-                      stroke={annStroke}
-                      strokeWidth={isSelected ? 4 : isHovered ? 3 : 2}
-                      fill={annFill}
-                      style={{
-                        pointerEvents: 'auto',
-                        cursor: 'pointer',
-                        opacity: isSelected ? 1 : isHovered ? 0.9 : 0.7
-                      }}
-                      onClick={(e) => session?.client.browse.click(r.annId, r.annotation.motivation, e.currentTarget.getBoundingClientRect())}
-                      onMouseEnter={() => handleMouseEnter(r.annId)}
-                      onMouseLeave={handleMouseLeave}
-                    />
-                  );
-                })}
-
-                {/* Render current selection while drawing or awaiting save */}
-                {selection && (() => {
-                  const rectX = Math.min(selection.startX, selection.endX);
-                  const rectY = Math.min(selection.startY, selection.endY);
-                  const rectWidth = Math.abs(selection.endX - selection.startX);
-                  const rectHeight = Math.abs(selection.endY - selection.startY);
-
-                  // PDF only supports rectangle shapes (FragmentSelector with viewrect)
-                  // Circle/polygon are disabled in the UI for PDF media types
-                  return (
-                    <rect
-                      x={rectX}
-                      y={rectY}
-                      width={rectWidth}
-                      height={rectHeight}
-                      stroke={stroke}
-                      strokeWidth={2}
-                      strokeDasharray="5,5"
-                      fill={fill}
-                      pointerEvents="none"
-                    />
-                  );
-                })()}
-              </svg>
+      {pdfDoc && pageLayout === 'scroll' ? (
+        <div className="semiont-pdf-annotation-canvas__column">
+          {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
+            <div
+              key={page}
+              ref={registerSlot(page)}
+              data-page={page}
+              className="semiont-pdf-annotation-canvas__slot"
+              style={visiblePages.has(page) || !estimatedPageHeight ? undefined : { height: estimatedPageHeight }}
+            >
+              {visiblePages.has(page) && (
+                <PdfPageView doc={pdfDoc} pageNumber={page} {...pageProps} />
+              )}
             </div>
-          </div>
-        )}
-      </div>
+          ))}
+        </div>
+      ) : (
+        pdfDoc && !isLoading && (
+          <PdfPageView doc={pdfDoc} pageNumber={pageNumber} {...pageProps} />
+        )
+      )}
 
       {/* Page navigation controls */}
       {numPages > 0 && (
         <div className="semiont-pdf-annotation-canvas__controls">
           <button
-            disabled={pageNumber <= 1}
-            onClick={() => setPageNumber(pageNumber - 1)}
+            disabled={currentPage <= 1}
+            onClick={() => (pageLayout === 'scroll' ? scrollToPage(currentPage - 1) : setPageNumber(pageNumber - 1))}
             className="semiont-pdf-annotation-canvas__button"
           >
             Previous
           </button>
           <span className="semiont-pdf-annotation-canvas__page-info">
-            Page {pageNumber} of {numPages}
+            Page {currentPage} of {numPages}
           </span>
           <button
-            disabled={pageNumber >= numPages}
-            onClick={() => setPageNumber(pageNumber + 1)}
+            disabled={currentPage >= numPages}
+            onClick={() => (pageLayout === 'scroll' ? scrollToPage(currentPage + 1) : setPageNumber(pageNumber + 1))}
             className="semiont-pdf-annotation-canvas__button"
           >
             Next

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -795,10 +795,24 @@ export function PdfAnnotationCanvas({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [numPages, currentPage, pageLayout, scrollToPage]);
 
+  const stripRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     // `nearest` so following the reader never yanks the strip around; it
     // scrolls only when the current rectangle would otherwise leave view.
     scrollElementIntoView(currentTickRef.current, { block: 'nearest', inline: 'nearest' });
+
+    // Move focus with the current page, but ONLY when the strip already owns
+    // focus. Otherwise a clicked rectangle keeps focus while the current-page
+    // marker moves on, and the focus ring — which appears as soon as the
+    // reader touches an arrow key and the browser switches to keyboard
+    // modality — sits on a page that is no longer current: two rectangles
+    // claiming to be "here". Guarding on ownership means scrolling with the
+    // mouse never snatches focus from whatever the reader was doing.
+    const active = typeof document !== 'undefined' ? document.activeElement : null;
+    if (active && stripRef.current?.contains(active) && active !== currentTickRef.current) {
+      currentTickRef.current?.focus();
+    }
   }, [currentPage]);
 
   const pageProps = {
@@ -857,7 +871,7 @@ export function PdfAnnotationCanvas({
         pager nor the scrollbar does.
       */}
       {pageLayout === 'scroll' && numPages > 0 && pageShape && (
-        <div className="semiont-pdf-annotation-canvas__strip">
+        <div className="semiont-pdf-annotation-canvas__strip" ref={stripRef}>
           {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
             <button
               key={page}
@@ -867,6 +881,10 @@ export function PdfAnnotationCanvas({
               // The page it represents, at the page's own proportions.
               style={{ height: `${Math.round(STRIP_PAGE_WIDTH * pageShape.aspect)}px` }}
               aria-label={t('pageOf', { page, total: numPages })}
+              // Roving tabindex: the strip is ONE tab stop. A 400-page
+              // document must not put 400 stops in the tab order; arrows
+              // move between pages, and they already do.
+              tabIndex={page === currentPage ? 0 : -1}
               {...(page === currentPage ? { 'aria-current': 'page' as const } : {})}
               ref={page === currentPage ? currentTickRef : undefined}
               onClick={() => scrollToPage(page)}

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -47,6 +47,19 @@ const PRELOAD_MARGIN = '100% 0px';
 const STRIP_PAGE_WIDTH = 14;
 
 /**
+ * The axis pages advance along.
+ *
+ * ONE source for two consumers: the column scrolls along it, and the page
+ * strip runs parallel to it. A strip that ran across the scroll direction
+ * would read as a control for a movement the document does not make.
+ *
+ * Constant today because scrolling is vertical. The horizontal-scrolling
+ * setting turns this into a value read from preferences — both consumers
+ * follow automatically, which is the point of routing them through one name.
+ */
+const SCROLL_AXIS: 'vertical' | 'horizontal' = 'vertical';
+
+/**
  * Scroll an element into view where the environment supports it.
  *
  * Same posture as this file's guarded observers: jsdom implements no layout
@@ -837,7 +850,8 @@ export function PdfAnnotationCanvas({
       {isLoading && <div className="semiont-pdf-annotation-canvas__loading">{t('loading')}</div>}
 
       {pdfDoc && pageLayout === 'scroll' ? (
-        <div className="semiont-pdf-annotation-canvas__column" ref={columnRef}>
+        <div className="semiont-pdf-annotation-canvas__viewport" data-axis={SCROLL_AXIS}>
+        <div className="semiont-pdf-annotation-canvas__column" data-axis={SCROLL_AXIS} ref={columnRef}>
           {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
             <div
               key={page}
@@ -856,41 +870,34 @@ export function PdfAnnotationCanvas({
             </div>
           ))}
         </div>
+        {numPages > 0 && pageShape && (
+          <div
+            className="semiont-pdf-annotation-canvas__strip"
+            data-axis={SCROLL_AXIS}
+            aria-orientation={SCROLL_AXIS}
+            ref={stripRef}
+          >
+            {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
+              <button
+                key={page}
+                type="button"
+                data-page={page}
+                className="semiont-pdf-annotation-canvas__strip-page"
+                style={{ height: `${Math.round(STRIP_PAGE_WIDTH * pageShape.aspect)}px` }}
+                aria-label={t('pageOf', { page, total: numPages })}
+                tabIndex={page === currentPage ? 0 : -1}
+                {...(page === currentPage ? { 'aria-current': 'page' as const } : {})}
+                ref={page === currentPage ? currentTickRef : undefined}
+                onClick={() => scrollToPage(page)}
+              />
+            ))}
+          </div>
+        )}
+        </div>
       ) : (
         pdfDoc && !isLoading && (
           <PdfPageView doc={pdfDoc} pageNumber={pageNumber} {...pageProps} />
         )
-      )}
-
-      {/*
-        The page strip: one proportional rectangle per page, current
-        highlighted, click to jump. Rectangles, not thumbnails — it needs no
-        rasterization at all, only the page count and the aspect ratio the
-        slot reservation already measures, so it stays cheap on a 400-page
-        scan. It answers "where am I in this document", which neither the
-        pager nor the scrollbar does.
-      */}
-      {pageLayout === 'scroll' && numPages > 0 && pageShape && (
-        <div className="semiont-pdf-annotation-canvas__strip" ref={stripRef}>
-          {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
-            <button
-              key={page}
-              type="button"
-              data-page={page}
-              className="semiont-pdf-annotation-canvas__strip-page"
-              // The page it represents, at the page's own proportions.
-              style={{ height: `${Math.round(STRIP_PAGE_WIDTH * pageShape.aspect)}px` }}
-              aria-label={t('pageOf', { page, total: numPages })}
-              // Roving tabindex: the strip is ONE tab stop. A 400-page
-              // document must not put 400 stops in the tab order; arrows
-              // move between pages, and they already do.
-              tabIndex={page === currentPage ? 0 : -1}
-              {...(page === currentPage ? { 'aria-current': 'page' as const } : {})}
-              ref={page === currentPage ? currentTickRef : undefined}
-              onClick={() => scrollToPage(page)}
-            />
-          ))}
-        </div>
       )}
 
       {/* Page navigation controls */}

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -6,6 +6,7 @@ import { resourceId as toResourceId } from '@semiont/core';
 import { toViewportAnchorRect } from '../../lib/anchor-rect';
 import { createFragmentSelector, anchorRuns, isTextRun, textUnder } from '@semiont/core';
 import { rectsForPage } from './rects-for-page';
+import { estimateSlotHeight } from './estimate-slot-height';
 import { useTranslations } from '../../contexts/TranslationContext';
 import { createHoverHandlers, type SemiontSession } from '@semiont/sdk';
 import type { SelectionMotivation } from '../annotation/AnnotateToolbar';
@@ -563,13 +564,17 @@ export function PdfAnnotationCanvas({
   const [errorKey, setErrorKey] = useState<string | null>(null);
   const t = useTranslations('PdfViewer');
   /**
-   * Page 1's rendered height, used to size the slots of pages that have not
-   * been mounted yet. Uniform documents (the overwhelming case, and every
-   * scan) get exactness for one `getPage`; a mixed-size document gets scroll
-   * drift in its unmeasured tail, which self-corrects as pages mount.
-   * See .plans/PDF-CONTINUOUS-SCROLL.md D4.
+   * Page 1's shape, for reserving space in slots that have not mounted yet:
+   * its aspect ratio and its raster width. NOT its raster height — the image
+   * renders under `max-width: 100%; height: auto`, so its displayed height
+   * depends on the column's width, and reserving raster pixels made the
+   * column's height lurch on every mount (S1b).
+   * See .plans/PDF-CONTINUOUS-SCROLL.md D4 + S1b.
    */
-  const [estimatedPageHeight, setEstimatedPageHeight] = useState<number | null>(null);
+  const [pageShape, setPageShape] = useState<{ aspect: number; rasterWidth: number } | null>(null);
+  /** Measured inner width of the column — the other half of the reservation. */
+  const [columnWidth, setColumnWidth] = useState<number | null>(null);
+  const columnRef = useRef<HTMLDivElement>(null);
   const [scale] = useState(1.5); // Fixed scale for better quality
 
   /** Pages currently intersecting the viewport (plus the preload margin). */
@@ -599,9 +604,13 @@ export function PdfAnnotationCanvas({
         try {
           const first = await doc.getPage(1);
           if (cancelled) return;
-          setEstimatedPageHeight(first.getViewport({ scale }).height);
+          const natural = first.getViewport({ scale: 1.0 });
+          setPageShape({
+            aspect: natural.height / natural.width,
+            rasterWidth: first.getViewport({ scale }).width,
+          });
         } catch {
-          /* leave unsized */
+          /* leave unsized — an unsized slot is stable; a mis-sized one moves */
         }
       } catch (err) {
         if (cancelled) return;
@@ -649,6 +658,34 @@ export function PdfAnnotationCanvas({
     resourceAnchoredRef.current = { uri, outcome };
     return outcome;
   }, [session, resourceUri]);
+
+  // The column's width decides every page's displayed height, so the
+  // reservation cannot be computed without it.
+  useEffect(() => {
+    if (pageLayout !== 'scroll') return;
+    const measure = () => {
+      if (columnRef.current) setColumnWidth(columnRef.current.clientWidth);
+    };
+    measure();
+    let observer: ResizeObserver | null = null;
+    try {
+      observer = new ResizeObserver(measure);
+      if (columnRef.current) observer.observe(columnRef.current);
+    } catch {
+      window.addEventListener('resize', measure);
+    }
+    return () => {
+      if (observer) observer.disconnect();
+      else window.removeEventListener('resize', measure);
+    };
+  }, [pageLayout]);
+
+  const slotHeight = estimateSlotHeight(columnWidth, pageShape?.rasterWidth ?? null, pageShape?.aspect ?? null)
+    // Before the column has been measured there is still a sane reservation:
+    // the raster's own height. Wrong in a narrow column, but every slot is
+    // wrong by the SAME amount, so the column is at least internally
+    // consistent until the first measurement lands.
+    ?? (pageShape ? Math.round(pageShape.rasterWidth * pageShape.aspect) : null);
 
   // The mount window. Slots report their own visibility; a page is mounted
   // while its slot intersects (widened by PRELOAD_MARGIN so the next page is
@@ -733,14 +770,18 @@ export function PdfAnnotationCanvas({
       {isLoading && <div className="semiont-pdf-annotation-canvas__loading">{t('loading')}</div>}
 
       {pdfDoc && pageLayout === 'scroll' ? (
-        <div className="semiont-pdf-annotation-canvas__column">
+        <div className="semiont-pdf-annotation-canvas__column" ref={columnRef}>
           {Array.from({ length: numPages }, (_, i) => i + 1).map((page) => (
             <div
               key={page}
               ref={registerSlot(page)}
               data-page={page}
               className="semiont-pdf-annotation-canvas__slot"
-              style={visiblePages.has(page) || !estimatedPageHeight ? undefined : { height: estimatedPageHeight }}
+              // min-height, and applied whether or not the page is mounted:
+              // releasing it on mount is what made the scrollbar jump. `min`
+              // rather than a fixed height so a page that renders slightly
+              // taller expands instead of clipping.
+              style={slotHeight ? { minHeight: slotHeight } : undefined}
             >
               {visiblePages.has(page) && (
                 <PdfPageView doc={pdfDoc} pageNumber={page} {...pageProps} />

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -11,6 +11,8 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PdfAnnotationCanvas } from '../PdfAnnotationCanvas';
+import { TranslationProvider } from '../../../contexts/TranslationContext';
+import { defaultMocks } from '../../../test-utils';
 import { resourceId, annotationId, parseFragmentSelector } from '@semiont/core';
 import { pdfToCanvasCoordinates } from '../../../lib/pdf-coordinates';
 import { loadPdfDocument, renderPdfPageToDataUrl } from '../../../lib/browser-pdfjs';
@@ -735,6 +737,44 @@ describe('PdfAnnotationCanvas', () => {
       });
       expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(0);
       expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    });
+  });
+
+  // PDF-CONTINUOUS-SCROLL S3. The viewer chrome was the last hardcoded-English
+  // surface in this component: Previous/Next, the page indicator, and both
+  // failure lines. The mock translation manager echoes "<namespace>.<key>",
+  // so asserting the echo proves the string came from translations rather
+  // than from a literal that happens to read the same in English.
+  describe('viewer chrome', () => {
+    const renderTranslated = (ui: React.ReactElement) =>
+      render(<TranslationProvider translationManager={defaultMocks.translationManager}>{ui}</TranslationProvider>);
+
+    test('takes its controls and page indicator from translations', async () => {
+      renderTranslated(
+        <PdfAnnotationCanvas resourceUri="res-1" pdfUrl={mockPdfUrl} drawingMode={null} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'PdfViewer.previous' })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: 'PdfViewer.next' })).toBeInTheDocument();
+      expect(screen.getByText(/PdfViewer\.pageOf/)).toBeInTheDocument();
+      expect(screen.queryByText('Previous')).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Page 1 of 3$/)).not.toBeInTheDocument();
+    });
+
+    test('announces page changes — a silent indicator is invisible to a screen reader', async () => {
+      renderTranslated(
+        <PdfAnnotationCanvas resourceUri="res-1" pdfUrl={mockPdfUrl} drawingMode={null} />
+      );
+
+      await waitFor(() => {
+        expect(document.querySelector('.semiont-pdf-annotation-canvas__page-info')).toBeInTheDocument();
+      });
+      const indicator = document.querySelector('.semiont-pdf-annotation-canvas__page-info')!;
+      expect(indicator).toHaveAttribute('aria-live', 'polite');
+      // The pager is a navigation landmark, not loose buttons in the page.
+      expect(screen.getByRole('navigation')).toBeInTheDocument();
     });
   });
 });

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -917,6 +917,69 @@ describe('PdfAnnotationCanvas', () => {
       input.remove();
     });
 
+    test('focus follows the current page when the strip owns focus', async () => {
+      // Reported: click a page in the strip, then arrow away — the focus ring
+      // stays behind on the clicked rectangle while the current-page marker
+      // moves, so two rectangles claim to be "here". (The ring only appears
+      // after the arrow press because that is when the browser switches to
+      // keyboard modality and the clicked button starts matching
+      // :focus-visible.) Focus must travel with the current page — but ONLY
+      // when the strip already had it, so scrolling with the mouse never
+      // snatches focus away from whatever the reader was doing.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      Element.prototype.scrollIntoView = vi.fn();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__strip-page')).toHaveLength(5);
+      });
+      io.fire([1]);
+      await waitFor(() => expect(mountedPages()).toEqual([1]));
+
+      const tick = (page: number) =>
+        document.querySelector(`.semiont-pdf-annotation-canvas__strip-page[data-page="${page}"]`) as HTMLButtonElement;
+
+      tick(2).focus();
+      fireEvent.click(tick(2));
+      io.fire([3]);
+
+      await waitFor(() => expect(tick(3)).toHaveAttribute('aria-current', 'page'));
+      expect(document.activeElement).toBe(tick(3));
+    });
+
+    test('the strip is one tab stop, not one per page', async () => {
+      // A 400-page document must not put 400 stops in the tab order. The
+      // ARIA pattern: the current item is tabbable, the rest are reachable
+      // with arrows (which already page the document).
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      Element.prototype.scrollIntoView = vi.fn();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__strip-page')).toHaveLength(5);
+      });
+      io.fire([1]);
+
+      const tabbable = [...document.querySelectorAll('.semiont-pdf-annotation-canvas__strip-page')]
+        .filter((el) => (el as HTMLElement).tabIndex === 0);
+      expect(tabbable).toHaveLength(1);
+      expect(tabbable[0]).toHaveAttribute('data-page', '1');
+    });
+
     test('keeps the paged layout when no layout is requested', async () => {
       render(
         <PdfAnnotationCanvas resourceUri="res-1"

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -884,6 +884,46 @@ describe('PdfAnnotationCanvas', () => {
 
     // S1a. Arrow keys step pages. The guards are the substance: a viewer that
     // steals arrow keys from a text field is worse than one with no shortcut.
+    test('Up/Down step pages too — they match the axis pages advance along', async () => {
+      // Pages move vertically and the rail is vertical, so Up/Down is the
+      // key a reader reaches for first. Left/Right keep working: they have no
+      // native meaning in a vertical layout, so accepting both costs nothing.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      const scrollIntoView = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+      io.fire([2]);
+      await waitFor(() => expect(mountedPages()).toEqual([2]));
+
+      scrollIntoView.mockClear();
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+      expect(scrollIntoView).toHaveBeenCalled();
+
+      scrollIntoView.mockClear();
+      fireEvent.keyDown(window, { key: 'ArrowUp' });
+      expect(scrollIntoView).toHaveBeenCalled();
+
+      // The same guard as the horizontal pair: never steal from a text field.
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.focus();
+      scrollIntoView.mockClear();
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      input.remove();
+    });
+
     test('Left/Right step pages, and never steal keys from a text field', async () => {
       const io = stubIntersectionObserver();
       scannedDoc();
@@ -1009,10 +1049,73 @@ describe('PdfAnnotationCanvas', () => {
       expect(strip).toHaveAttribute('data-axis', 'vertical');
       // Tells assistive tech which arrow keys apply to the strip.
       expect(strip).toHaveAttribute('aria-orientation', 'vertical');
-      // Adjacent: siblings in the viewport, strip after the column so it
-      // lands beside that column's scrollbar.
-      expect(strip.previousElementSibling).toBe(column);
+      // The strip leads: it hugs the left edge of the content, the
+      // conventional place for a page rail (Preview, Acrobat), and the
+      // reader's eye finds it before the page rather than after it.
+      expect(strip.nextElementSibling).toBe(column);
       expect(strip.parentElement).toHaveClass('semiont-pdf-annotation-canvas__viewport');
+    });
+
+    test('each strip rectangle shows its page number', async () => {
+      // At 70 pages the rectangles are indistinguishable from one another —
+      // the strip shows position but not WHICH page, which is most of what a
+      // reader wants from it on a long document.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      Element.prototype.scrollIntoView = vi.fn();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__strip-page')).toHaveLength(5);
+      });
+      io.fire([1]);
+
+      const tick = (page: number) =>
+        document.querySelector(`.semiont-pdf-annotation-canvas__strip-page[data-page="${page}"]`)!;
+      expect(tick(1)).toHaveTextContent('1');
+      expect(tick(5)).toHaveTextContent('5');
+
+      // The accessible name keeps the context the bare digit loses, and
+      // still contains the visible text (WCAG 2.5.3 Label in Name).
+      expect(tick(5)).toHaveAttribute('aria-label', expect.stringContaining('5'));
+    });
+
+
+    test('the column does not add a second scrollbar inside the scrolling pane', async () => {
+      // The strip and a nested column scrollbar were two controls for one
+      // movement. The pane the viewer sits in already scrolls (flex: 1;
+      // min-height: 0), so the column must not declare a viewport-relative
+      // height of its own — that is what produced scroll-within-scroll.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      Element.prototype.scrollIntoView = vi.fn();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+      io.fire([1]);
+
+      // jsdom applies no stylesheet, so assert the CONTRACT the CSS keys off:
+      // the column declares the axis but claims no scroll role of its own.
+      const column = document.querySelector('.semiont-pdf-annotation-canvas__column')!;
+      expect(column).toHaveAttribute('data-axis', 'vertical');
+      expect(column).not.toHaveAttribute('data-scroller');
+      // The strip is the one that scrolls independently, and silently.
+      expect(document.querySelector('.semiont-pdf-annotation-canvas__strip'))
+        .toHaveAttribute('data-scroller', 'true');
     });
 
     test('keeps the paged layout when no layout is requested', async () => {

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -828,6 +828,95 @@ describe('PdfAnnotationCanvas', () => {
         .toHaveAttribute('data-drawing-mode', 'rectangle');
     });
 
+    // S4. A strip of proportional rectangles — one per page, current
+    // highlighted, click to jump. Deliberately NOT thumbnails: it needs no
+    // rasterization, only the page count and the aspect ratio S1b already
+    // measures, so it costs nothing next to the document itself. It answers
+    // "where am I in this document", which neither the pager nor the
+    // scrollbar does.
+    test('renders one strip rectangle per page, marking the current one', async () => {
+      const io = stubIntersectionObserver();
+      scannedDoc();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+
+      const ticks = () => document.querySelectorAll('.semiont-pdf-annotation-canvas__strip-page');
+      await waitFor(() => expect(ticks()).toHaveLength(5));
+
+      io.fire([3, 4]);
+      await waitFor(() => {
+        expect(document.querySelector('[aria-current="page"]')).toHaveAttribute('data-page', '3');
+      });
+    });
+
+    test('clicking a strip rectangle jumps to that page', async () => {
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      const scrollIntoView = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__strip-page')).toHaveLength(5);
+      });
+      io.fire([1]);
+
+      const tick4 = document.querySelector('.semiont-pdf-annotation-canvas__strip-page[data-page="4"]')!;
+      fireEvent.click(tick4);
+
+      expect(scrollIntoView).toHaveBeenCalled();
+    });
+
+    // S1a. Arrow keys step pages. The guards are the substance: a viewer that
+    // steals arrow keys from a text field is worse than one with no shortcut.
+    test('Left/Right step pages, and never steal keys from a text field', async () => {
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      const scrollIntoView = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+      io.fire([1]);
+      await waitFor(() => expect(mountedPages()).toEqual([1]));
+
+      scrollIntoView.mockClear();
+      fireEvent.keyDown(window, { key: 'ArrowRight' });
+      expect(scrollIntoView).toHaveBeenCalled();
+
+      // Typing in an input must not page the document underneath it.
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.focus();
+      scrollIntoView.mockClear();
+      fireEvent.keyDown(input, { key: 'ArrowRight' });
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      input.remove();
+    });
+
     test('keeps the paged layout when no layout is requested', async () => {
       render(
         <PdfAnnotationCanvas resourceUri="res-1"

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -7,7 +7,7 @@
  * - Annotation display
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PdfAnnotationCanvas } from '../PdfAnnotationCanvas';
@@ -75,30 +75,58 @@ vi.mock('../../../lib/browser-pdfjs', () => ({
  * fire() rather than a simulated layout — jsdom has no layout either.
  */
 function stubIntersectionObserver() {
-  const observed = new Map<Element, IntersectionObserverCallback>();
+  // (element, callback) PAIRS, not a map keyed by element: the component runs
+  // two observers over the same slots — one widened for preloading, one bare
+  // for "what is on screen" — and a map would keep only the last registered.
+  const observed: Array<{ el: Element; cb: IntersectionObserverCallback }> = [];
+  const margins = new Map<IntersectionObserverCallback, string>();
   class FakeIO {
-    constructor(private cb: IntersectionObserverCallback) {}
-    observe(el: Element) { observed.set(el, this.cb); }
-    unobserve(el: Element) { observed.delete(el); }
-    disconnect() { observed.clear(); }
+    constructor(private cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+      margins.set(cb, options?.rootMargin ?? '0px');
+    }
+    observe(el: Element) { observed.push({ el, cb: this.cb }); }
+    unobserve(el: Element) {
+      for (let i = observed.length - 1; i >= 0; i--) {
+        if (observed[i]!.el === el && observed[i]!.cb === this.cb) observed.splice(i, 1);
+      }
+    }
+    disconnect() {
+      for (let i = observed.length - 1; i >= 0; i--) {
+        if (observed[i]!.cb === this.cb) observed.splice(i, 1);
+      }
+    }
     takeRecords() { return []; }
   }
   vi.stubGlobal('IntersectionObserver', FakeIO);
+
+  /** Fire only the observer that has no preload margin — the one that decides
+   *  which page the reader is actually looking at. */
+  function fireFor(visible: number[], match: (rootMargin: string) => boolean) {
+    const byCb = new Map<IntersectionObserverCallback, IntersectionObserverEntry[]>();
+    for (const { el, cb } of observed) {
+      if (!match(margins.get(cb) ?? '0px')) continue;
+      const page = Number((el as HTMLElement).dataset.page);
+      byCb.set(cb, [...(byCb.get(cb) ?? []), {
+        target: el, isIntersecting: visible.includes(page),
+      } as unknown as IntersectionObserverEntry]);
+    }
+    act(() => { for (const [cb, entries] of byCb) cb(entries, {} as IntersectionObserver); });
+  }
+
+  /** Only the bare observer — what the reader can actually see. */
+  function fireOnscreen(visible: number[]) {
+    fireFor(visible, (m) => m === '0px');
+  }
+
   return {
-    /** Fire intersection changes for the slots whose data-page is listed. */
+    fireOnscreen,
+    /**
+     * Fire both observers: these pages are mounted AND on screen — the
+     * ordinary case. A test that needs the two to differ (a page preloaded
+     * but not yet visible) calls `fireOnscreen` afterwards to narrow it.
+     */
     fire(visible: number[]) {
-      const byCb = new Map<IntersectionObserverCallback, IntersectionObserverEntry[]>();
-      for (const [el, cb] of observed) {
-        const page = Number((el as HTMLElement).dataset.page);
-        const entry = {
-          target: el,
-          isIntersecting: visible.includes(page),
-        } as unknown as IntersectionObserverEntry;
-        byCb.set(cb, [...(byCb.get(cb) ?? []), entry]);
-      }
-      act(() => {
-        for (const [cb, entries] of byCb) cb(entries, {} as IntersectionObserver);
-      });
+      fireFor(visible, () => true);
     },
   };
 }
@@ -106,6 +134,11 @@ function stubIntersectionObserver() {
 describe('PdfAnnotationCanvas', () => {
   const mockResourceId = resourceId('123');
   const mockPdfUrl = 'https://example.com/resources/123.pdf';
+
+  afterEach(() => {
+    // Stubs must not leak into other files sharing this Vitest environment.
+    vi.unstubAllGlobals();
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1123,6 +1156,143 @@ describe('PdfAnnotationCanvas', () => {
       // The strip is the one that scrolls independently, and silently.
       expect(document.querySelector('.semiont-pdf-annotation-canvas__strip'))
         .toHaveAttribute('data-scroller', 'true');
+    });
+
+    test('the indicator reports a page the reader can SEE, not a preloaded one', async () => {
+      // The mount window deliberately reaches a viewport beyond the view
+      // (PRELOAD_MARGIN) so pages arrive early. Deriving the current page
+      // from that same set makes the indicator name a page that is still
+      // off-screen — it must come from actual visibility.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      Element.prototype.scrollIntoView = vi.fn();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1" pdfUrl={mockPdfUrl}
+          drawingMode={null} pageLayout="scroll" />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+
+      // Pages 1-3 are within the preload window; only 3 is actually on screen.
+      io.fire([1, 2, 3]);
+      io.fireOnscreen([3]);
+
+      await waitFor(() => {
+        expect(document.querySelector('[aria-current="page"]')).toHaveAttribute('data-page', '3');
+      });
+    });
+
+    test('paged navigation does not carry one page\'s state onto the next', async () => {
+      // In the paged layout a single PdfPageView is reused as `pageNumber`
+      // changes, so its state survives the switch: the previous page's raster
+      // shows briefly under the new page's overlay, a drag could quote the
+      // previous page's text, and a load failure sticks forever because
+      // nothing clears it. Each page is a different thing and must mount as one.
+      // Reject by PAGE, not by call order: the parent also calls getPage(1)
+      // to measure the document's shape, so a `...Once` rejection would be
+      // consumed there and never reach the page view.
+      const failingDoc = {
+        numPages: 3,
+        getPage: vi.fn((n: number) => (n === 1
+          ? Promise.reject(new Error('page 1 is broken'))
+          : Promise.resolve(mockPage(MOCK_TEXT_ITEMS)))),
+      };
+      vi.mocked(loadPdfDocument).mockResolvedValueOnce(
+        failingDoc as unknown as Awaited<ReturnType<typeof loadPdfDocument>>,
+      );
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1" pdfUrl={mockPdfUrl} drawingMode={null} />
+      );
+
+      await waitFor(() => {
+        expect(document.querySelector('.semiont-pdf-annotation-canvas__error')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+      // Page 2 loads fine; the failure belonged to page 1 and must not persist.
+      await waitFor(() => {
+        expect(document.querySelector('.semiont-pdf-annotation-canvas__error')).not.toBeInTheDocument();
+      });
+    });
+
+    test('without IntersectionObserver every page mounts — degraded, not broken', async () => {
+      // The virtualization is an optimization, not a correctness requirement.
+      // An environment without the observer must show the whole document
+      // rather than nothing.
+      scannedDoc();
+      vi.stubGlobal('IntersectionObserver', undefined);
+      Element.prototype.scrollIntoView = vi.fn();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1" pdfUrl={mockPdfUrl}
+          drawingMode={null} pageLayout="scroll" />
+      );
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__image')).toHaveLength(5);
+      });
+    });
+
+    test('a failed map fetch is not cached — the next page retries', async () => {
+      // Answers cache, including "no map". A transport failure must not, or
+      // one bad moment pins the whole document to geometry-only.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      Element.prototype.scrollIntoView = vi.fn();
+
+      const resourceAnchoredText = vi.fn()
+        .mockRejectedValueOnce(new Error('transport down'))
+        .mockResolvedValue({ text: 'later', items: [] });
+      const session = {
+        client: { beckon: { hover: vi.fn() }, browse: { resourceAnchoredText } },
+      } as unknown as import('@semiont/sdk').SemiontSession;
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1" pdfUrl={mockPdfUrl}
+          drawingMode={null} pageLayout="scroll" session={session} />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+
+      io.fire([1]);
+      await waitFor(() => expect(resourceAnchoredText).toHaveBeenCalledTimes(1));
+
+      io.fire([2]);
+      await waitFor(() => expect(resourceAnchoredText).toHaveBeenCalledTimes(2));
+    });
+
+    test('the pager still works in the column, and modifiers are left alone', async () => {
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      const scrollIntoView = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1" pdfUrl={mockPdfUrl}
+          drawingMode={null} pageLayout="scroll" />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+      io.fire([3]);
+      await waitFor(() => {
+        expect(document.querySelector('[aria-current="page"]')).toHaveAttribute('data-page', '3');
+      });
+
+      scrollIntoView.mockClear();
+      fireEvent.click(screen.getByRole('button', { name: /previous/i }));
+      expect(scrollIntoView).toHaveBeenCalled();
+
+      // Cmd/Ctrl/Alt + arrow belongs to the browser and the OS.
+      scrollIntoView.mockClear();
+      fireEvent.keyDown(window, { key: 'ArrowRight', metaKey: true });
+      fireEvent.keyDown(window, { key: 'PageDown', ctrlKey: true });
+      expect(scrollIntoView).not.toHaveBeenCalled();
     });
 
     test('keeps the paged layout when no layout is requested', async () => {

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PdfAnnotationCanvas } from '../PdfAnnotationCanvas';
 import { resourceId, annotationId, parseFragmentSelector } from '@semiont/core';
@@ -65,6 +65,41 @@ vi.mock('../../../lib/browser-pdfjs', () => ({
     height: 792
   })
 }));
+
+
+/**
+ * jsdom has no IntersectionObserver. This stub records what the component
+ * observes and hands the test the callback, so a "scroll" is an explicit
+ * fire() rather than a simulated layout — jsdom has no layout either.
+ */
+function stubIntersectionObserver() {
+  const observed = new Map<Element, IntersectionObserverCallback>();
+  class FakeIO {
+    constructor(private cb: IntersectionObserverCallback) {}
+    observe(el: Element) { observed.set(el, this.cb); }
+    unobserve(el: Element) { observed.delete(el); }
+    disconnect() { observed.clear(); }
+    takeRecords() { return []; }
+  }
+  vi.stubGlobal('IntersectionObserver', FakeIO);
+  return {
+    /** Fire intersection changes for the slots whose data-page is listed. */
+    fire(visible: number[]) {
+      const byCb = new Map<IntersectionObserverCallback, IntersectionObserverEntry[]>();
+      for (const [el, cb] of observed) {
+        const page = Number((el as HTMLElement).dataset.page);
+        const entry = {
+          target: el,
+          isIntersecting: visible.includes(page),
+        } as unknown as IntersectionObserverEntry;
+        byCb.set(cb, [...(byCb.get(cb) ?? []), entry]);
+      }
+      act(() => {
+        for (const [cb, entries] of byCb) cb(entries, {} as IntersectionObserver);
+      });
+    },
+  };
+}
 
 describe('PdfAnnotationCanvas', () => {
   const mockResourceId = resourceId('123');
@@ -589,5 +624,117 @@ describe('PdfAnnotationCanvas', () => {
       // In jsdom this is not available, so we verify the component did not error.
       expect(container).toBeInTheDocument();
     }
+  });
+
+  // PDF-CONTINUOUS-SCROLL S1. Browse mode scrolls: every page has a slot so
+  // the scrollbar is honest about the document's length, but only a window of
+  // pages is MOUNTED — unmounting is what releases a page's raster, so the
+  // window IS the memory budget (D2).
+  describe('scroll layout (browse mode)', () => {
+    const scannedDoc = () =>
+      vi.mocked(loadPdfDocument).mockResolvedValueOnce({
+        numPages: 5,
+        getPage: vi.fn().mockResolvedValue(mockPage([])),
+      } as unknown as Awaited<ReturnType<typeof loadPdfDocument>>);
+
+    const mountedPages = () =>
+      [...document.querySelectorAll('.semiont-pdf-annotation-canvas__image')]
+        .map((img) => Number((img as HTMLImageElement).alt.replace(/\D+/g, '')))
+        .sort((a, b) => a - b);
+
+    test('gives every page a slot but mounts only the visible window', async () => {
+      const io = stubIntersectionObserver();
+      scannedDoc();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+      // Nothing rasterized before anything is visible.
+      expect(mountedPages()).toEqual([]);
+
+      io.fire([1, 2]);
+      await waitFor(() => expect(mountedPages()).toEqual([1, 2]));
+      expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+    });
+
+    test('releases a page that scrolls out of the window', async () => {
+      const io = stubIntersectionObserver();
+      scannedDoc();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+
+      io.fire([1, 2]);
+      await waitFor(() => expect(mountedPages()).toEqual([1, 2]));
+
+      io.fire([4, 5]);
+      await waitFor(() => expect(mountedPages()).toEqual([4, 5]));
+    });
+
+    test('still fetches the whole-resource map once, across many mounted pages (P4)', async () => {
+      // P4's invariant has to survive the move from one shared page-load
+      // effect into N independent page views.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+
+      const resourceAnchoredText = vi.fn().mockResolvedValue({
+        text: 'Hello world again',
+        items: [{ start: 0, end: 5, page: 1, x: 72, y: 700, width: 30, height: 12 }],
+      });
+      const session = {
+        client: { beckon: { hover: vi.fn() }, browse: { resourceAnchoredText } },
+      } as unknown as import('@semiont/sdk').SemiontSession;
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+          session={session}
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+
+      io.fire([1, 2, 3]);
+      await waitFor(() => expect(mountedPages()).toEqual([1, 2, 3]));
+      io.fire([3, 4, 5]);
+      await waitFor(() => expect(mountedPages()).toEqual([3, 4, 5]));
+
+      expect(resourceAnchoredText).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps the paged layout by default — annotate mode is untouched until S2', async () => {
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode="rectangle"
+          selectedMotivation="highlighting"
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/page 1 of 3/i)).toBeInTheDocument();
+      });
+      expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(0);
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -723,7 +723,112 @@ describe('PdfAnnotationCanvas', () => {
       expect(resourceAnchoredText).toHaveBeenCalledTimes(1);
     });
 
-    test('keeps the paged layout by default — annotate mode is untouched until S2', async () => {
+    test('a slot keeps its reserved height when its page mounts', async () => {
+      // S1b. Releasing the reservation on mount is what made the column's
+      // total height change on every scroll — the scrollbar jumped and
+      // resized under the cursor. The reservation must survive mounting so
+      // the column's geometry never depends on which pages are mounted.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+
+      const slotOf = (page: number) =>
+        document.querySelector(`.semiont-pdf-annotation-canvas__slot[data-page="${page}"]`) as HTMLElement;
+
+      // Read whichever property expresses the reservation, so the pin is
+      // about the CONTRACT (space is reserved, and mounting does not release
+      // it) rather than about which CSS property implements it.
+      const reserved = (el: HTMLElement) => el.style.minHeight || el.style.height;
+
+      io.fire([1]);
+      await waitFor(() => expect(mountedPages()).toEqual([1]));
+
+      // Page 5 is unmounted and must hold space open.
+      expect(reserved(slotOf(5))).not.toBe('');
+      // Page 1 is mounted and must hold exactly the same space, or the
+      // column's height changes as pages come and go.
+      expect(reserved(slotOf(1))).toBe(reserved(slotOf(5)));
+    });
+
+    test('a rectangle drawn on a scrolled page carries THAT page number', async () => {
+      // S2. The drag lives in the page view, so page identity comes from the
+      // component that owns the pixels rather than from a shared `pageNumber`
+      // — the invariant that makes a column safe to draw on at all.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+
+      const request = vi.fn();
+      const session = {
+        client: { mark: { request }, beckon: { hover: vi.fn() } },
+      } as unknown as import('@semiont/sdk').SemiontSession;
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode="rectangle"
+          selectedMotivation="highlighting"
+          session={session}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+
+      io.fire([2, 3]);
+      await waitFor(() => expect(mountedPages()).toEqual([2, 3]));
+
+      // Draw on page 3's container, not page 2's.
+      const slot3 = document.querySelector('.semiont-pdf-annotation-canvas__slot[data-page="3"]')!;
+      const img = slot3.querySelector('.semiont-pdf-annotation-canvas__image') as HTMLImageElement;
+      Object.defineProperty(img, 'clientWidth', { value: 612, configurable: true });
+      Object.defineProperty(img, 'clientHeight', { value: 792, configurable: true });
+      fireEvent.load(img);
+
+      const container = slot3.querySelector('.semiont-pdf-annotation-canvas__container')!;
+      fireEvent.mouseDown(container, { clientX: 40, clientY: 40 });
+      fireEvent.mouseMove(container, { clientX: 200, clientY: 160 });
+      fireEvent.mouseUp(container, { clientX: 200, clientY: 160 });
+
+      await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+      expect(request.mock.calls[0][1][0].value).toContain('page=3');
+    });
+
+    test('annotate mode scrolls too — the primary mode is not left on the pager', async () => {
+      // The registries are the seam: both now ask for the column.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode="rectangle"
+          selectedMotivation="highlighting"
+          pageLayout="scroll"
+        />
+      );
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__slot')).toHaveLength(5);
+      });
+      io.fire([1]);
+      await waitFor(() => expect(mountedPages()).toEqual([1]));
+      // Drawing still works in the column: the container is the page's own.
+      expect(document.querySelector('.semiont-pdf-annotation-canvas__container'))
+        .toHaveAttribute('data-drawing-mode', 'rectangle');
+    });
+
+    test('keeps the paged layout when no layout is requested', async () => {
       render(
         <PdfAnnotationCanvas resourceUri="res-1"
           pdfUrl={mockPdfUrl}

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -980,6 +980,41 @@ describe('PdfAnnotationCanvas', () => {
       expect(tabbable[0]).toHaveAttribute('data-page', '1');
     });
 
+    test('the strip runs along the same axis as the scrolling, beside the column', async () => {
+      // Pages scroll vertically, so a horizontal strip reads across a
+      // direction the document does not move in. The strip's axis follows the
+      // scroll axis — which is also what makes horizontal scrolling (a later
+      // phase) a change of one value rather than a second layout.
+      const io = stubIntersectionObserver();
+      scannedDoc();
+      Element.prototype.scrollIntoView = vi.fn();
+
+      render(
+        <PdfAnnotationCanvas resourceUri="res-1"
+          pdfUrl={mockPdfUrl}
+          drawingMode={null}
+          pageLayout="scroll"
+        />
+      );
+      await waitFor(() => {
+        expect(document.querySelectorAll('.semiont-pdf-annotation-canvas__strip-page')).toHaveLength(5);
+      });
+      io.fire([1]);
+
+      const column = document.querySelector('.semiont-pdf-annotation-canvas__column')!;
+      const strip = document.querySelector('.semiont-pdf-annotation-canvas__strip')!;
+
+      // One axis, declared in one place, read by both.
+      expect(column).toHaveAttribute('data-axis', 'vertical');
+      expect(strip).toHaveAttribute('data-axis', 'vertical');
+      // Tells assistive tech which arrow keys apply to the strip.
+      expect(strip).toHaveAttribute('aria-orientation', 'vertical');
+      // Adjacent: siblings in the viewport, strip after the column so it
+      // lands beside that column's scrollbar.
+      expect(strip.previousElementSibling).toBe(column);
+      expect(strip.parentElement).toHaveClass('semiont-pdf-annotation-canvas__viewport');
+    });
+
     test('keeps the paged layout when no layout is requested', async () => {
       render(
         <PdfAnnotationCanvas resourceUri="res-1"

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -884,10 +884,11 @@ describe('PdfAnnotationCanvas', () => {
 
     // S1a. Arrow keys step pages. The guards are the substance: a viewer that
     // steals arrow keys from a text field is worse than one with no shortcut.
-    test('Up/Down step pages too — they match the axis pages advance along', async () => {
-      // Pages move vertically and the rail is vertical, so Up/Down is the
-      // key a reader reaches for first. Left/Right keep working: they have no
-      // native meaning in a vertical layout, so accepting both costs nothing.
+    test('PageUp/PageDown step pages; Up/Down are left to scroll', async () => {
+      // The convention every mainstream viewer follows (Preview, Chrome's PDF
+      // viewer, Acrobat): PageUp/PageDown jump a page, Up/Down scroll finely.
+      // Taking Up/Down would leave no keyboard way to reach the bottom of a
+      // page taller than the viewport.
       const io = stubIntersectionObserver();
       scannedDoc();
       const scrollIntoView = vi.fn();
@@ -907,19 +908,25 @@ describe('PdfAnnotationCanvas', () => {
       await waitFor(() => expect(mountedPages()).toEqual([2]));
 
       scrollIntoView.mockClear();
-      fireEvent.keyDown(window, { key: 'ArrowDown' });
+      fireEvent.keyDown(window, { key: 'PageDown' });
       expect(scrollIntoView).toHaveBeenCalled();
 
       scrollIntoView.mockClear();
-      fireEvent.keyDown(window, { key: 'ArrowUp' });
+      fireEvent.keyDown(window, { key: 'PageUp' });
       expect(scrollIntoView).toHaveBeenCalled();
+
+      // Up/Down belong to the scroller, not to us.
+      scrollIntoView.mockClear();
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+      fireEvent.keyDown(window, { key: 'ArrowUp' });
+      expect(scrollIntoView).not.toHaveBeenCalled();
 
       // The same guard as the horizontal pair: never steal from a text field.
       const input = document.createElement('input');
       document.body.appendChild(input);
       input.focus();
       scrollIntoView.mockClear();
-      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyDown(input, { key: 'PageDown' });
       expect(scrollIntoView).not.toHaveBeenCalled();
       input.remove();
     });

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/estimate-slot-height.test.ts
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/estimate-slot-height.test.ts
@@ -1,0 +1,53 @@
+/**
+ * PDF-CONTINUOUS-SCROLL S1b.
+ *
+ * The scroll column reserves space for unmounted pages. If the reservation is
+ * wrong, every mount and unmount changes the column's height and the scrollbar
+ * jumps — which is what S1 shipped, by reserving the raster height rather than
+ * the displayed one.
+ *
+ * These pins hold the estimate to the CSS the image is actually under:
+ * `max-width: 100%; height: auto`.
+ */
+import { describe, it, expect } from 'vitest';
+import { estimateSlotHeight } from '../estimate-slot-height';
+
+// US Letter at scale 1.5: 918 × 1188 raster, aspect 792/612.
+const ASPECT = 792 / 612;
+const RASTER_W = 918;
+
+describe('estimateSlotHeight', () => {
+  it('scales to the column when the column is narrower than the raster', () => {
+    // The common case: `max-width: 100%` shrinks the image to the column.
+    expect(estimateSlotHeight(600, RASTER_W, ASPECT)).toBe(Math.round(600 * ASPECT));
+  });
+
+  it('never upscales past the raster — max-width shrinks only', () => {
+    // A column wider than the raster leaves the image at natural size, so the
+    // height stops growing. Reserving columnWidth * aspect here would over-
+    // reserve and leave a gap under every page.
+    expect(estimateSlotHeight(1600, RASTER_W, ASPECT)).toBe(Math.round(RASTER_W * ASPECT));
+  });
+
+  it('is exactly the raster height when the column matches the raster', () => {
+    expect(estimateSlotHeight(RASTER_W, RASTER_W, ASPECT)).toBe(Math.round(RASTER_W * ASPECT));
+  });
+
+  it('does NOT use the raster height as a width-independent constant', () => {
+    // The S1 defect, stated as a pin: the raster is 1188px tall, but in a
+    // 600px column the page occupies ~776px. Reserving 1188 is what made the
+    // column's height lurch on every mount.
+    const rasterHeight = Math.round(RASTER_W * ASPECT); // 1188
+    expect(estimateSlotHeight(600, RASTER_W, ASPECT)).not.toBe(rasterHeight);
+    expect(estimateSlotHeight(600, RASTER_W, ASPECT)).toBeLessThan(rasterHeight);
+  });
+
+  it('answers null until every measurement is in, rather than guessing', () => {
+    // A wrong reservation is worse than none: an unsized slot is stable, a
+    // mis-sized one moves when the page lands.
+    expect(estimateSlotHeight(null, RASTER_W, ASPECT)).toBeNull();
+    expect(estimateSlotHeight(600, null, ASPECT)).toBeNull();
+    expect(estimateSlotHeight(600, RASTER_W, null)).toBeNull();
+    expect(estimateSlotHeight(0, RASTER_W, ASPECT)).toBeNull();
+  });
+});

--- a/packages/react-ui/src/components/pdf-annotation/estimate-slot-height.ts
+++ b/packages/react-ui/src/components/pdf-annotation/estimate-slot-height.ts
@@ -1,0 +1,31 @@
+/**
+ * The height a page will occupy once rendered, computed BEFORE rendering it.
+ *
+ * The scrolling column reserves space for pages it has not mounted. If the
+ * reserved height differs from the height the page actually takes, every mount
+ * and unmount changes the column's total height and the scrollbar jumps under
+ * the reader's cursor — the defect S1 shipped by reserving the *raster* height
+ * (`getViewport({ scale }).height`) instead of the *displayed* one.
+ *
+ * This models the CSS the image is under exactly:
+ *
+ *   .semiont-pdf-annotation-canvas__image { max-width: 100%; height: auto; }
+ *
+ * `max-width` shrinks but never upscales, so the displayed width is
+ * `min(columnWidth, rasterWidth)` and the height follows the page's aspect
+ * ratio. Aspect is scale-invariant, so it can come from any viewport.
+ *
+ * @param columnWidth  Measured inner width of the scroll column, in CSS px.
+ * @param rasterWidth  Width of the rendered raster, in px (`viewport(scale).width`).
+ * @param aspect       Page height ÷ width, from any viewport scale.
+ * @returns Reserved height in CSS px, or null when a measurement is not in yet.
+ */
+export function estimateSlotHeight(
+  columnWidth: number | null,
+  rasterWidth: number | null,
+  aspect: number | null,
+): number | null {
+  if (!columnWidth || !rasterWidth || !aspect) return null;
+  if (columnWidth <= 0 || rasterWidth <= 0 || aspect <= 0) return null;
+  return Math.round(Math.min(columnWidth, rasterWidth) * aspect);
+}

--- a/packages/react-ui/src/components/resource/__tests__/browse-renderers.dispatch.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/browse-renderers.dispatch.test.tsx
@@ -109,5 +109,38 @@ describe('browse-renderers — annotation + session forwarding (dispatch contrac
     expect(props.existingAnnotations).toEqual([shapeAnnotation()]); // pinned — worked before
     expect(props.drawingMode).toBeNull();
     expect(props.session).toBe(session);                            // NEW — was a session-less no-op
+    // PDF-CONTINUOUS-SCROLL S1: browse asks for the scrolling column.
+    expect(props.pageLayout).toBe('scroll');
+  });
+
+  // S2. Annotate is the mode people actually work in
+  // (.plans/PDF-CONTINUOUS-SCROLL.md D3, second correction), so it gets the
+  // column too — leaving it on Previous/Next made the feature invisible to
+  // its primary audience.
+  it('the annotate registry asks for the column as well, with the live tool', async () => {
+    const session = fakeSession();
+    const { AnnotateView } = await import('../AnnotateView');
+    const { container } = render(
+      <AnnotateView
+        content="blob:pdf-url"
+        mimeType="application/pdf"
+        resourceUri="res-1"
+        annotations={emptyAnnotations}
+        uiState={{
+          selectedMotivation: 'highlighting',
+          selectedClick: 'detail',
+          selectedShape: 'rectangle',
+          hoveredAnnotationId: null,
+          scrollToAnnotationId: null,
+        }}
+        annotateMode
+        session={session}
+      />,
+    );
+
+    await within(container).findByText('pdf-canvas-mock');
+    const props = captured.pdf.at(-1)!;
+    expect(props.pageLayout).toBe('scroll');
+    expect(props.drawingMode).toBe('rectangle'); // the tool still reaches the pages
   });
 });

--- a/packages/react-ui/src/components/resource/annotate-renderers.tsx
+++ b/packages/react-ui/src/components/resource/annotate-renderers.tsx
@@ -145,6 +145,7 @@ export function PdfAnnotateRenderer({
         session={session}
         hoveredAnnotationId={hoveredAnnotationId || null}
         hoverDelayMs={hoverDelayMs}
+        pageLayout="scroll"
       />
     </Suspense>
   );

--- a/packages/react-ui/src/components/resource/annotate-renderers.tsx
+++ b/packages/react-ui/src/components/resource/annotate-renderers.tsx
@@ -7,10 +7,18 @@ import { SvgDrawingCanvas } from '../image-annotation/SvgDrawingCanvas';
 import { CodeMirrorRenderer } from '../CodeMirrorRenderer';
 import { segmentTextWithAnnotations } from '../../lib/text-segmentation';
 import type { SelectionMotivation, ShapeType } from '../annotation/AnnotateToolbar';
+import { useTranslations } from '../../contexts/TranslationContext';
 
 // Lazy-load the PDF component to avoid SSR issues with browser PDF.js loading.
 // Kept lazy here deliberately: hoisting it to a static import would make it
 // eager again and reintroduce the SSR problem this indirection exists for.
+/** The lazy chunk's fallback needs its own component: a hook cannot run
+ *  inside a `fallback` prop expression. */
+function PdfViewerLoading() {
+  const t = useTranslations('PdfViewer');
+  return <>{t('viewerLoading')}</>;
+}
+
 const PdfAnnotationCanvas = lazy(() =>
   import('../pdf-annotation/PdfAnnotationCanvas.client').then((mod) => ({ default: mod.PdfAnnotationCanvas })),
 );
@@ -127,7 +135,7 @@ export function PdfAnnotateRenderer({
 }: AnnotateMediaRendererProps) {
   if (!content) return null;
   return (
-    <Suspense fallback={<div className="semiont-annotate-view__loading">Loading PDF viewer...</div>}>
+    <Suspense fallback={<div className="semiont-annotate-view__loading"><PdfViewerLoading /></div>}>
       <PdfAnnotationCanvas
         pdfUrl={content}
         resourceUri={resourceUri}

--- a/packages/react-ui/src/components/resource/browse-renderers.tsx
+++ b/packages/react-ui/src/components/resource/browse-renderers.tsx
@@ -68,6 +68,7 @@ export function PdfBrowseRenderer({ content, resourceUri, annotations, session }
         drawingMode={null}
         selectedMotivation={null}
         session={session}
+        pageLayout="scroll"
       />
     </Suspense>
   );

--- a/packages/react-ui/src/components/resource/browse-renderers.tsx
+++ b/packages/react-ui/src/components/resource/browse-renderers.tsx
@@ -6,8 +6,16 @@ import remarkGfm from 'remark-gfm';
 import type { Annotation } from '@semiont/core';
 import type { SemiontSession } from '@semiont/sdk';
 import { SvgDrawingCanvas } from '../image-annotation/SvgDrawingCanvas';
+import { useTranslations } from '../../contexts/TranslationContext';
 
 // Lazy-load the PDF component to avoid SSR issues with browser PDF.js loading.
+/** The lazy chunk's fallback needs its own component: a hook cannot run
+ *  inside a `fallback` prop expression. */
+function PdfViewerLoading() {
+  const t = useTranslations('PdfViewer');
+  return <>{t('viewerLoading')}</>;
+}
+
 const PdfAnnotationCanvas = lazy(() => import('../pdf-annotation/PdfAnnotationCanvas.client').then(mod => ({ default: mod.PdfAnnotationCanvas })));
 
 /**
@@ -60,7 +68,7 @@ export function ImageBrowseRenderer({ content, resourceUri, annotations, session
 
 export function PdfBrowseRenderer({ content, resourceUri, annotations, session }: MediaRendererProps) {
   return (
-    <Suspense fallback={<div className="semiont-browse-view__loading">Loading PDF viewer...</div>}>
+    <Suspense fallback={<div className="semiont-browse-view__loading"><PdfViewerLoading /></div>}>
       <PdfAnnotationCanvas
         pdfUrl={content}
         resourceUri={resourceUri}

--- a/packages/react-ui/src/features/auth/auth.css
+++ b/packages/react-ui/src/features/auth/auth.css
@@ -345,27 +345,27 @@
 }
 
 .semiont-form__url-status--checking {
-  color: var(--semiont-text-muted, #888888);
+  color: var(--semiont-text-tertiary, #888888);
   animation: spin 1s linear infinite;
   display: inline-block;
 }
 
 [data-theme="dark"] .semiont-form__url-status--checking {
-  color: var(--semiont-text-muted, #888888);
+  color: var(--semiont-text-tertiary, #888888);
 }
 
 .semiont-form__url-status--ok {
-  color: var(--semiont-success, #22c55e);
+  color: var(--semiont-color-success, #22c55e);
 }
 
 [data-theme="dark"] .semiont-form__url-status--ok {
-  color: var(--semiont-success, #22c55e);
+  color: var(--semiont-color-success, #22c55e);
 }
 
 .semiont-form__url-status--error {
-  color: var(--semiont-error, #ef4444);
+  color: var(--semiont-color-error, #ef4444);
 }
 
 [data-theme="dark"] .semiont-form__url-status--error {
-  color: var(--semiont-error, #ef4444);
+  color: var(--semiont-color-error, #ef4444);
 }

--- a/packages/react-ui/src/styles/features/resource-viewer.css
+++ b/packages/react-ui/src/styles/features/resource-viewer.css
@@ -324,7 +324,7 @@
 }
 
 [data-theme="dark"] .semiont-browse-view__content tr:nth-child(even) td {
-  background: var(--semiont-color-gray-850, var(--semiont-color-gray-800));
+  background: var(--semiont-color-gray-800, var(--semiont-color-gray-800));
 }
 
 /* GFM task list checkboxes */

--- a/packages/react-ui/src/styles/features/static-pages.css
+++ b/packages/react-ui/src/styles/features/static-pages.css
@@ -412,8 +412,8 @@
 }
 
 .semiont-static-warning-box {
-  background: var(--semiont-color-warning-50);
-  border-left: 4px solid var(--semiont-color-warning-500);
+  background: var(--semiont-color-amber-50);
+  border-left: 4px solid var(--semiont-color-amber-500);
   border-radius: 0.375rem;
   padding: 1rem 1.25rem;
   margin: 1.5rem 0;
@@ -427,7 +427,7 @@
 
 [data-theme="dark"] .semiont-static-warning-box {
   background: rgba(251, 146, 60, 0.1);
-  border-left-color: var(--semiont-color-warning-400);
+  border-left-color: var(--semiont-color-amber-400);
 }
 
 /* ========================================
@@ -447,27 +447,27 @@
 
 .semiont-static-badge-planned {
   background: rgba(251, 146, 60, 0.1);
-  color: var(--semiont-color-warning-700);
-  border: 1px solid var(--semiont-color-warning-200);
+  color: var(--semiont-color-amber-700);
+  border: 1px solid var(--semiont-color-amber-200);
 }
 
 .semiont-static-badge-active {
   background: rgba(34, 197, 94, 0.1);
-  color: var(--semiont-color-success-700);
-  border: 1px solid var(--semiont-color-success-200);
+  color: var(--semiont-color-green-700);
+  border: 1px solid var(--semiont-color-green-200);
 }
 
 /* Dark mode */
 [data-theme="dark"] .semiont-static-badge-planned {
   background: rgba(251, 146, 60, 0.15);
-  color: var(--semiont-color-warning-400);
-  border-color: var(--semiont-color-warning-600);
+  color: var(--semiont-color-amber-400);
+  border-color: var(--semiont-color-amber-600);
 }
 
 [data-theme="dark"] .semiont-static-badge-active {
   background: rgba(34, 197, 94, 0.15);
-  color: var(--semiont-color-success-400);
-  border-color: var(--semiont-color-success-600);
+  color: var(--semiont-color-green-400);
+  border-color: var(--semiont-color-green-600);
 }
 
 /* ========================================

--- a/packages/react-ui/src/styles/motivations/motivation-comment.css
+++ b/packages/react-ui/src/styles/motivations/motivation-comment.css
@@ -33,8 +33,8 @@
   --semiont-motivation-comment-panel-bg-dark: rgba(55, 65, 81, 0.2);
 
   /* Button gradients */
-  --semiont-motivation-comment-button-bg: linear-gradient(to right, var(--semiont-color-purple-600), var(--semiont-color-indigo-600));
-  --semiont-motivation-comment-button-bg-hover: linear-gradient(to right, var(--semiont-color-purple-700), var(--semiont-color-indigo-700));
+  --semiont-motivation-comment-button-bg: linear-gradient(to right, var(--semiont-color-purple-600), var(--semiont-color-blue-600));
+  --semiont-motivation-comment-button-bg-hover: linear-gradient(to right, var(--semiont-color-purple-700), var(--semiont-color-blue-700));
 }
 
 /* ============================================

--- a/packages/react-ui/src/styles/utilities/motion.css
+++ b/packages/react-ui/src/styles/utilities/motion.css
@@ -165,19 +165,19 @@
 }
 
 .semiont-animate-slide-in-up {
-  animation: slideInUp var(--semiont-duration-moderate, 300ms) ease-out;
+  animation: slideInUp var(--semiont-duration-base, 300ms) ease-out;
 }
 
 .semiont-animate-slide-in-down {
-  animation: slideInDown var(--semiont-duration-moderate, 300ms) ease-out;
+  animation: slideInDown var(--semiont-duration-base, 300ms) ease-out;
 }
 
 .semiont-animate-slide-in-left {
-  animation: slideInLeft var(--semiont-duration-moderate, 300ms) ease-out;
+  animation: slideInLeft var(--semiont-duration-base, 300ms) ease-out;
 }
 
 .semiont-animate-slide-in-right {
-  animation: slideInRight var(--semiont-duration-moderate, 300ms) ease-out;
+  animation: slideInRight var(--semiont-duration-base, 300ms) ease-out;
 }
 
 .semiont-animate-scale-in {

--- a/packages/react-ui/src/styles/variables.css
+++ b/packages/react-ui/src/styles/variables.css
@@ -177,6 +177,14 @@
   --semiont-bg-tertiary: var(--semiont-color-neutral-100);
   --semiont-bg-inverse: var(--semiont-color-neutral-900);
 
+  /* Borders — the panel/card border every pattern file reaches for. */
+  --semiont-border-primary: var(--semiont-color-neutral-200);
+  --semiont-border-secondary: var(--semiont-color-neutral-100);
+
+  /* Interaction */
+  --semiont-bg-hover: var(--semiont-color-neutral-100);
+  --semiont-focus-ring: var(--semiont-color-blue-500);
+
   /* Text Colors */
   --semiont-text-primary: var(--semiont-color-neutral-900);
   --semiont-text-secondary: var(--semiont-color-neutral-600);
@@ -186,6 +194,8 @@
 
   /* Spacing */
   --semiont-spacing-0: 0;
+  --semiont-panel-gap-xs: 0.25rem;
+  --semiont-text-2xs: 0.625rem;
   --semiont-spacing-xs: 0.25rem;
   --semiont-spacing-sm: 0.5rem;
   --semiont-spacing-md: 1rem;
@@ -322,6 +332,11 @@
     --semiont-text-tertiary: var(--semiont-color-neutral-400);
     --semiont-text-disabled: var(--semiont-color-neutral-600);
     --semiont-text-inverse: var(--semiont-color-neutral-900);
+
+    --semiont-border-primary: var(--semiont-color-neutral-700);
+    --semiont-border-secondary: var(--semiont-color-neutral-800);
+    --semiont-bg-hover: var(--semiont-color-neutral-800);
+    --semiont-focus-ring: var(--semiont-color-blue-400);
   }
 }
 
@@ -337,6 +352,14 @@
   --semiont-text-tertiary: var(--semiont-color-neutral-500);
   --semiont-text-disabled: var(--semiont-color-neutral-400);
   --semiont-text-inverse: var(--semiont-color-neutral-0);
+
+  /* Borders — the panel/card border every pattern file reaches for. */
+  --semiont-border-primary: var(--semiont-color-neutral-200);
+  --semiont-border-secondary: var(--semiont-color-neutral-100);
+
+  /* Interaction */
+  --semiont-bg-hover: var(--semiont-color-neutral-100);
+  --semiont-focus-ring: var(--semiont-color-blue-500);
 }
 
 /* Allow manual dark mode override */
@@ -351,4 +374,9 @@
   --semiont-text-tertiary: var(--semiont-color-neutral-400);
   --semiont-text-disabled: var(--semiont-color-neutral-600);
   --semiont-text-inverse: var(--semiont-color-neutral-900);
+
+  --semiont-border-primary: var(--semiont-color-neutral-700);
+  --semiont-border-secondary: var(--semiont-color-neutral-800);
+  --semiont-bg-hover: var(--semiont-color-neutral-800);
+  --semiont-focus-ring: var(--semiont-color-blue-400);
 }

--- a/packages/react-ui/translations/ar.json
+++ b/packages/react-ui/translations/ar.json
@@ -4,6 +4,16 @@
     "paramsTitle": "معاملات الطلب:",
     "processing": "الحالي: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "فشل تحميل ملف PDF",
+    "loading": "جارٍ تحميل PDF...",
+    "next": "التالي",
+    "pageLoadFailed": "فشل تحميل الصفحة",
+    "pageOf": "صفحة {{page}} من {{total}}",
+    "pagination": "ترقيم الصفحات",
+    "previous": "السابق",
+    "viewerLoading": "جارٍ تحميل عارض PDF..."
+  },
   "Toolbar": {
     "annotations": "التعليقات التوضيحية",
     "history": "السجل",

--- a/packages/react-ui/translations/bn.json
+++ b/packages/react-ui/translations/bn.json
@@ -4,6 +4,16 @@
     "paramsTitle": "অনুরোধের প্যারামিটার:",
     "processing": "বর্তমান: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF লোড করা যায়নি",
+    "loading": "PDF লোড হচ্ছে...",
+    "next": "পরবর্তী",
+    "pageLoadFailed": "পৃষ্ঠা লোড করা যায়নি",
+    "pageOf": "পৃষ্ঠা {{page}} / {{total}}",
+    "pagination": "পৃষ্ঠা নেভিগেশন",
+    "previous": "পূর্ববর্তী",
+    "viewerLoading": "PDF ভিউয়ার লোড হচ্ছে..."
+  },
   "Toolbar": {
     "annotations": "টীকাসমূহ",
     "history": "ইতিহাস",

--- a/packages/react-ui/translations/cs.json
+++ b/packages/react-ui/translations/cs.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parametry požadavku:",
     "processing": "Aktuální: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Nepodařilo se načíst PDF",
+    "loading": "Načítání PDF...",
+    "next": "Další",
+    "pageLoadFailed": "Nepodařilo se načíst stránku",
+    "pageOf": "Strana {{page}} z {{total}}",
+    "pagination": "Stránkování",
+    "previous": "Předchozí",
+    "viewerLoading": "Načítání prohlížeče PDF..."
+  },
   "Toolbar": {
     "annotations": "Anotace",
     "history": "Historie",

--- a/packages/react-ui/translations/da.json
+++ b/packages/react-ui/translations/da.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Anmodningsparametre:",
     "processing": "Aktuel: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Kunne ikke indlæse PDF",
+    "loading": "Indlæser PDF...",
+    "next": "Næste",
+    "pageLoadFailed": "Kunne ikke indlæse siden",
+    "pageOf": "Side {{page}} af {{total}}",
+    "pagination": "Sidenavigation",
+    "previous": "Forrige",
+    "viewerLoading": "Indlæser PDF-fremviser..."
+  },
   "Toolbar": {
     "annotations": "Annoteringer",
     "history": "Historik",

--- a/packages/react-ui/translations/de.json
+++ b/packages/react-ui/translations/de.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Anfrageparameter:",
     "processing": "Aktuell: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF konnte nicht geladen werden",
+    "loading": "PDF wird geladen...",
+    "next": "Weiter",
+    "pageLoadFailed": "Seite konnte nicht geladen werden",
+    "pageOf": "Seite {{page}} von {{total}}",
+    "pagination": "Seitennavigation",
+    "previous": "Zurück",
+    "viewerLoading": "PDF-Betrachter wird geladen..."
+  },
   "Toolbar": {
     "annotations": "Annotationen",
     "history": "Verlauf",

--- a/packages/react-ui/translations/el.json
+++ b/packages/react-ui/translations/el.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Παράμετροι αιτήματος:",
     "processing": "Τρέχον: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Αποτυχία φόρτωσης PDF",
+    "loading": "Φόρτωση PDF...",
+    "next": "Επόμενη",
+    "pageLoadFailed": "Αποτυχία φόρτωσης σελίδας",
+    "pageOf": "Σελίδα {{page}} από {{total}}",
+    "pagination": "Πλοήγηση σελίδων",
+    "previous": "Προηγούμενη",
+    "viewerLoading": "Φόρτωση προβολής PDF..."
+  },
   "Toolbar": {
     "annotations": "Σχολιασμοί",
     "history": "Ιστορικό",

--- a/packages/react-ui/translations/en.json
+++ b/packages/react-ui/translations/en.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Request Parameters:",
     "processing": "Current: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Failed to load PDF",
+    "loading": "Loading PDF...",
+    "next": "Next",
+    "pageLoadFailed": "Failed to load page",
+    "pageOf": "Page {{page}} of {{total}}",
+    "pagination": "Page navigation",
+    "previous": "Previous",
+    "viewerLoading": "Loading PDF viewer..."
+  },
   "Toolbar": {
     "annotations": "Annotations",
     "history": "History",

--- a/packages/react-ui/translations/es.json
+++ b/packages/react-ui/translations/es.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parámetros de la solicitud:",
     "processing": "Actual: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "No se pudo cargar el PDF",
+    "loading": "Cargando PDF...",
+    "next": "Siguiente",
+    "pageLoadFailed": "No se pudo cargar la página",
+    "pageOf": "Página {{page}} de {{total}}",
+    "pagination": "Navegación de páginas",
+    "previous": "Anterior",
+    "viewerLoading": "Cargando visor de PDF..."
+  },
   "Toolbar": {
     "annotations": "Anotaciones",
     "history": "Historial",

--- a/packages/react-ui/translations/fa.json
+++ b/packages/react-ui/translations/fa.json
@@ -4,6 +4,16 @@
     "paramsTitle": "پارامترهای درخواست:",
     "processing": "فعلی: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "بارگذاری PDF ناموفق بود",
+    "loading": "در حال بارگذاری PDF...",
+    "next": "بعدی",
+    "pageLoadFailed": "بارگذاری صفحه ناموفق بود",
+    "pageOf": "صفحه {{page}} از {{total}}",
+    "pagination": "ناوبری صفحه",
+    "previous": "قبلی",
+    "viewerLoading": "در حال بارگذاری نمایشگر PDF..."
+  },
   "Toolbar": {
     "annotations": "حاشیه‌نویسی‌ها",
     "history": "تاریخچه",

--- a/packages/react-ui/translations/fi.json
+++ b/packages/react-ui/translations/fi.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Pyynnön parametrit:",
     "processing": "Nykyinen: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF-tiedoston lataus epäonnistui",
+    "loading": "Ladataan PDF-tiedostoa...",
+    "next": "Seuraava",
+    "pageLoadFailed": "Sivun lataus epäonnistui",
+    "pageOf": "Sivu {{page}} / {{total}}",
+    "pagination": "Sivunavigointi",
+    "previous": "Edellinen",
+    "viewerLoading": "Ladataan PDF-katselinta..."
+  },
   "Toolbar": {
     "annotations": "Merkinnät",
     "history": "Historia",

--- a/packages/react-ui/translations/fr.json
+++ b/packages/react-ui/translations/fr.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Paramètres de la requête :",
     "processing": "En cours : {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Échec du chargement du PDF",
+    "loading": "Chargement du PDF...",
+    "next": "Suivant",
+    "pageLoadFailed": "Échec du chargement de la page",
+    "pageOf": "Page {{page}} sur {{total}}",
+    "pagination": "Navigation des pages",
+    "previous": "Précédent",
+    "viewerLoading": "Chargement de la visionneuse PDF..."
+  },
   "Toolbar": {
     "annotations": "Annotations",
     "history": "Historique",

--- a/packages/react-ui/translations/he.json
+++ b/packages/react-ui/translations/he.json
@@ -4,6 +4,16 @@
     "paramsTitle": "פרמטרים של הבקשה:",
     "processing": "נוכחי: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "טעינת ה-PDF נכשלה",
+    "loading": "טוען PDF...",
+    "next": "הבא",
+    "pageLoadFailed": "טעינת העמוד נכשלה",
+    "pageOf": "עמוד {{page}} מתוך {{total}}",
+    "pagination": "ניווט בין עמודים",
+    "previous": "הקודם",
+    "viewerLoading": "טוען מציג PDF..."
+  },
   "Toolbar": {
     "annotations": "הערות",
     "history": "היסטוריה",

--- a/packages/react-ui/translations/hi.json
+++ b/packages/react-ui/translations/hi.json
@@ -4,6 +4,16 @@
     "paramsTitle": "अनुरोध पैरामीटर:",
     "processing": "वर्तमान: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF लोड नहीं हो सका",
+    "loading": "PDF लोड हो रहा है...",
+    "next": "अगला",
+    "pageLoadFailed": "पृष्ठ लोड नहीं हो सका",
+    "pageOf": "पृष्ठ {{page}} / {{total}}",
+    "pagination": "पृष्ठ नेविगेशन",
+    "previous": "पिछला",
+    "viewerLoading": "PDF व्यूअर लोड हो रहा है..."
+  },
   "Toolbar": {
     "annotations": "एनोटेशन",
     "history": "इतिहास",

--- a/packages/react-ui/translations/id.json
+++ b/packages/react-ui/translations/id.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parameter permintaan:",
     "processing": "Saat ini: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Gagal memuat PDF",
+    "loading": "Memuat PDF...",
+    "next": "Berikutnya",
+    "pageLoadFailed": "Gagal memuat halaman",
+    "pageOf": "Halaman {{page}} dari {{total}}",
+    "pagination": "Navigasi halaman",
+    "previous": "Sebelumnya",
+    "viewerLoading": "Memuat penampil PDF..."
+  },
   "Toolbar": {
     "annotations": "Anotasi",
     "history": "Riwayat",

--- a/packages/react-ui/translations/it.json
+++ b/packages/react-ui/translations/it.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parametri della richiesta:",
     "processing": "Corrente: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Impossibile caricare il PDF",
+    "loading": "Caricamento PDF...",
+    "next": "Successiva",
+    "pageLoadFailed": "Impossibile caricare la pagina",
+    "pageOf": "Pagina {{page}} di {{total}}",
+    "pagination": "Navigazione pagine",
+    "previous": "Precedente",
+    "viewerLoading": "Caricamento visualizzatore PDF..."
+  },
   "Toolbar": {
     "annotations": "Annotazioni",
     "history": "Cronologia",

--- a/packages/react-ui/translations/ja.json
+++ b/packages/react-ui/translations/ja.json
@@ -4,6 +4,16 @@
     "paramsTitle": "リクエストパラメータ:",
     "processing": "現在: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF を読み込めませんでした",
+    "loading": "PDF を読み込んでいます...",
+    "next": "次へ",
+    "pageLoadFailed": "ページを読み込めませんでした",
+    "pageOf": "{{total}} ページ中 {{page}} ページ",
+    "pagination": "ページナビゲーション",
+    "previous": "前へ",
+    "viewerLoading": "PDF ビューアを読み込んでいます..."
+  },
   "Toolbar": {
     "annotations": "アノテーション",
     "history": "履歴",

--- a/packages/react-ui/translations/ko.json
+++ b/packages/react-ui/translations/ko.json
@@ -4,6 +4,16 @@
     "paramsTitle": "요청 매개변수:",
     "processing": "현재: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF를 로드하지 못했습니다",
+    "loading": "PDF 로드 중...",
+    "next": "다음",
+    "pageLoadFailed": "페이지를 로드하지 못했습니다",
+    "pageOf": "{{total}}페이지 중 {{page}}페이지",
+    "pagination": "페이지 탐색",
+    "previous": "이전",
+    "viewerLoading": "PDF 뷰어 로드 중..."
+  },
   "Toolbar": {
     "annotations": "주석",
     "history": "기록",

--- a/packages/react-ui/translations/ms.json
+++ b/packages/react-ui/translations/ms.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parameter permintaan:",
     "processing": "Semasa: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Gagal memuatkan PDF",
+    "loading": "Memuatkan PDF...",
+    "next": "Seterusnya",
+    "pageLoadFailed": "Gagal memuatkan halaman",
+    "pageOf": "Halaman {{page}} daripada {{total}}",
+    "pagination": "Navigasi halaman",
+    "previous": "Sebelumnya",
+    "viewerLoading": "Memuatkan pemapar PDF..."
+  },
   "Toolbar": {
     "annotations": "Anotasi",
     "history": "Sejarah",

--- a/packages/react-ui/translations/nl.json
+++ b/packages/react-ui/translations/nl.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Aanvraagparameters:",
     "processing": "Huidig: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Kan de PDF niet laden",
+    "loading": "PDF laden...",
+    "next": "Volgende",
+    "pageLoadFailed": "Kan de pagina niet laden",
+    "pageOf": "Pagina {{page}} van {{total}}",
+    "pagination": "Paginanavigatie",
+    "previous": "Vorige",
+    "viewerLoading": "PDF-viewer laden..."
+  },
   "Toolbar": {
     "annotations": "Annotaties",
     "history": "Geschiedenis",

--- a/packages/react-ui/translations/no.json
+++ b/packages/react-ui/translations/no.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Forespørselsparametere:",
     "processing": "Nåværende: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Kunne ikke laste PDF",
+    "loading": "Laster PDF...",
+    "next": "Neste",
+    "pageLoadFailed": "Kunne ikke laste siden",
+    "pageOf": "Side {{page}} av {{total}}",
+    "pagination": "Sidenavigasjon",
+    "previous": "Forrige",
+    "viewerLoading": "Laster PDF-viser..."
+  },
   "Toolbar": {
     "annotations": "Annoteringer",
     "history": "Historikk",

--- a/packages/react-ui/translations/pl.json
+++ b/packages/react-ui/translations/pl.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parametry żądania:",
     "processing": "Bieżący: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Nie udało się załadować PDF",
+    "loading": "Ładowanie PDF...",
+    "next": "Następna",
+    "pageLoadFailed": "Nie udało się załadować strony",
+    "pageOf": "Strona {{page}} z {{total}}",
+    "pagination": "Nawigacja stron",
+    "previous": "Poprzednia",
+    "viewerLoading": "Ładowanie przeglądarki PDF..."
+  },
   "Toolbar": {
     "annotations": "Adnotacje",
     "history": "Historia",

--- a/packages/react-ui/translations/pt.json
+++ b/packages/react-ui/translations/pt.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parâmetros da solicitação:",
     "processing": "Atual: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Falha ao carregar o PDF",
+    "loading": "Carregando PDF...",
+    "next": "Próxima",
+    "pageLoadFailed": "Falha ao carregar a página",
+    "pageOf": "Página {{page}} de {{total}}",
+    "pagination": "Navegação de páginas",
+    "previous": "Anterior",
+    "viewerLoading": "Carregando visualizador de PDF..."
+  },
   "Toolbar": {
     "annotations": "Anotações",
     "history": "Histórico",

--- a/packages/react-ui/translations/ro.json
+++ b/packages/react-ui/translations/ro.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Parametrii cererii:",
     "processing": "Curent: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Încărcarea PDF-ului a eșuat",
+    "loading": "Se încarcă PDF-ul...",
+    "next": "Următoarea",
+    "pageLoadFailed": "Încărcarea paginii a eșuat",
+    "pageOf": "Pagina {{page}} din {{total}}",
+    "pagination": "Navigare pagini",
+    "previous": "Anterioară",
+    "viewerLoading": "Se încarcă vizualizatorul PDF..."
+  },
   "Toolbar": {
     "annotations": "Adnotări",
     "history": "Istoric",

--- a/packages/react-ui/translations/sv.json
+++ b/packages/react-ui/translations/sv.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Begäranparametrar:",
     "processing": "Aktuell: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Det gick inte att läsa in PDF:en",
+    "loading": "Läser in PDF...",
+    "next": "Nästa",
+    "pageLoadFailed": "Det gick inte att läsa in sidan",
+    "pageOf": "Sida {{page}} av {{total}}",
+    "pagination": "Sidnavigering",
+    "previous": "Föregående",
+    "viewerLoading": "Läser in PDF-visare..."
+  },
   "Toolbar": {
     "annotations": "Annoteringar",
     "history": "Historik",

--- a/packages/react-ui/translations/th.json
+++ b/packages/react-ui/translations/th.json
@@ -4,6 +4,16 @@
     "paramsTitle": "พารามิเตอร์คำขอ:",
     "processing": "ปัจจุบัน: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "โหลด PDF ไม่สำเร็จ",
+    "loading": "กำลังโหลด PDF...",
+    "next": "ถัดไป",
+    "pageLoadFailed": "โหลดหน้าไม่สำเร็จ",
+    "pageOf": "หน้า {{page}} จาก {{total}}",
+    "pagination": "การนำทางหน้า",
+    "previous": "ก่อนหน้า",
+    "viewerLoading": "กำลังโหลดโปรแกรมดู PDF..."
+  },
   "Toolbar": {
     "annotations": "คำอธิบายประกอบ",
     "history": "ประวัติ",

--- a/packages/react-ui/translations/tr.json
+++ b/packages/react-ui/translations/tr.json
@@ -4,6 +4,16 @@
     "paramsTitle": "İstek parametreleri:",
     "processing": "Mevcut: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF yüklenemedi",
+    "loading": "PDF yükleniyor...",
+    "next": "Sonraki",
+    "pageLoadFailed": "Sayfa yüklenemedi",
+    "pageOf": "Sayfa {{page}} / {{total}}",
+    "pagination": "Sayfa gezinmesi",
+    "previous": "Önceki",
+    "viewerLoading": "PDF görüntüleyici yükleniyor..."
+  },
   "Toolbar": {
     "annotations": "Açıklamalar",
     "history": "Geçmiş",

--- a/packages/react-ui/translations/uk.json
+++ b/packages/react-ui/translations/uk.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Параметри запиту:",
     "processing": "Поточний: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Не вдалося завантажити PDF",
+    "loading": "Завантаження PDF...",
+    "next": "Наступна",
+    "pageLoadFailed": "Не вдалося завантажити сторінку",
+    "pageOf": "Сторінка {{page}} з {{total}}",
+    "pagination": "Навігація сторінками",
+    "previous": "Попередня",
+    "viewerLoading": "Завантаження переглядача PDF..."
+  },
   "Toolbar": {
     "annotations": "Анотації",
     "history": "Історія",

--- a/packages/react-ui/translations/vi.json
+++ b/packages/react-ui/translations/vi.json
@@ -4,6 +4,16 @@
     "paramsTitle": "Tham số yêu cầu:",
     "processing": "Hiện tại: {{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "Không tải được PDF",
+    "loading": "Đang tải PDF...",
+    "next": "Tiếp",
+    "pageLoadFailed": "Không tải được trang",
+    "pageOf": "Trang {{page}} / {{total}}",
+    "pagination": "Điều hướng trang",
+    "previous": "Trước",
+    "viewerLoading": "Đang tải trình xem PDF..."
+  },
   "Toolbar": {
     "annotations": "Chú thích",
     "history": "Lịch sử",

--- a/packages/react-ui/translations/zh.json
+++ b/packages/react-ui/translations/zh.json
@@ -4,6 +4,16 @@
     "paramsTitle": "请求参数：",
     "processing": "当前：{{label}}"
   },
+  "PdfViewer": {
+    "loadFailed": "PDF 加载失败",
+    "loading": "正在加载 PDF...",
+    "next": "下一页",
+    "pageLoadFailed": "页面加载失败",
+    "pageOf": "第 {{page}} 页，共 {{total}} 页",
+    "pagination": "页面导航",
+    "previous": "上一页",
+    "viewerLoading": "正在加载 PDF 查看器..."
+  },
   "Toolbar": {
     "annotations": "注释",
     "history": "历史",

--- a/scripts/lint/check-css-variables-defined.js
+++ b/scripts/lint/check-css-variables-defined.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Every `var(--x)` must resolve to a `--x:` defined somewhere in the same
+ * package's stylesheet set.
+ *
+ * WHY THIS IS NOT A STYLELINT RULE. Stylelint lints one file at a time, and a
+ * `var()` in a component's CSS is *supposed* to be satisfied by a token file
+ * it never imports — so per-file analysis cannot tell "defined elsewhere" from
+ * "defined nowhere" without whole-project knowledge stylelint does not have.
+ * Its nearest built-in, `custom-property-no-missing-var-function`, catches the
+ * opposite mistake (`color: --x` with no `var()`). There is no core rule for
+ * undefined references, which is why 46 of them accumulated silently.
+ *
+ * WHY IT MATTERS THAT NOTHING ERRORS. An unresolved `var()` with no fallback
+ * makes the declaration invalid at computed-value time: the property silently
+ * takes its inherited or initial value. A border becomes `currentColor`, a
+ * background becomes transparent. The page looks nearly right and cannot be
+ * themed, with no console warning and no failing build.
+ *
+ * Inline fallbacks — `var(--x, #fff)` — are ALLOWED and not reported: those
+ * are deliberate optional theming hooks a host may override.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOTS = process.argv.slice(2).length
+  ? process.argv.slice(2)
+  : ['packages/react-ui/src', 'apps/frontend/src'];
+
+/** Every .css under a root. */
+function cssFiles(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) cssFiles(full, out);
+    else if (entry.name.endsWith('.css')) out.push(full);
+  }
+  return out;
+}
+
+const DEFINITION = /^\s*(--[a-zA-Z0-9_-]+)\s*:/gm;
+// Capture the delimiter so `var(--x, fallback)` can be told from `var(--x)`.
+const USAGE = /var\(\s*(--[a-zA-Z0-9_-]+)\s*([,)])/g;
+
+let failed = false;
+
+for (const root of ROOTS) {
+  const files = cssFiles(root);
+  if (files.length === 0) continue;
+
+  const defined = new Set();
+  const missing = new Map(); // name -> Set<"file:line">
+
+  for (const file of files) {
+    const text = fs.readFileSync(file, 'utf8');
+    for (const m of text.matchAll(DEFINITION)) defined.add(m[1]);
+  }
+
+  for (const file of files) {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      for (const m of line.matchAll(USAGE)) {
+        const [, name, delimiter] = m;
+        if (delimiter === ',') continue; // has an inline fallback — allowed
+        if (defined.has(name)) continue;
+        if (!missing.has(name)) missing.set(name, new Set());
+        missing.get(name).add(`${file}:${i + 1}`);
+      }
+    });
+  }
+
+  if (missing.size === 0) {
+    console.log(`✅ ${root}: every var() resolves (${defined.size} defined, ${files.length} files)`);
+    continue;
+  }
+
+  failed = true;
+  console.error(`\n❌ ${root}: ${missing.size} CSS variable(s) used but never defined\n`);
+  for (const [name, sites] of [...missing].sort()) {
+    console.error(`   ${name}`);
+    for (const site of [...sites].slice(0, 3)) console.error(`      ${site}`);
+    if (sites.size > 3) console.error(`      …and ${sites.size - 3} more`);
+  }
+  console.error(
+    '\n   Fix by defining the token (styles/variables.css, in every theme block)\n' +
+    '   or by re-pointing the usage at the token that already exists.\n' +
+    '   Do NOT silence this with an inline fallback at each usage site.\n',
+  );
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Replaces the PDF viewer's two-button pager with a virtualized scrolling column and a page rail. A 70-page scan used to be 69 clicks.

Nine commits, developed against a real 72-page scanned document with the author reading and reporting between rounds — several of the changes below exist because the first version was wrong in use.

## The viewer

**Continuous scroll, virtualized.** Every page gets a slot so the scrollbar tells the truth about the document's length, but only pages near the viewport are mounted. The per-page unit is a `PdfPageView` that owns its raster, its text map, its annotation overlay and its drag — so **unmounting is the memory release**: the raster is a data-URL string, and the last reference going away is all it takes. No eviction bookkeeping. No virtualization dependency added; the need is a fixed-direction, known-count list, and the file's existing guarded-`ResizeObserver` pattern was the template.

**Both modes scroll.** The first cut shipped browse-only, with annotate left on the pager. That was backwards: annotate is where the author — and most users — actually work, so the feature was invisible to its audience and the "verify it before continuing" gate was unreachable by their own workflow. The registries are the seam, so annotate adopting the column was one line once the drag lived per-page.

**A page rail** on the leading edge: one rectangle per page, proportional to the document's aspect, numbered, current page highlighted, click to jump, and it follows the reader as they scroll. Rectangles rather than thumbnails — it needs no rasterization at all, only the page count and an aspect ratio already measured, so a 400-page scan costs 400 empty divs and zero renders.

**Keys and focus.** PageUp/PageDown and Left/Right step pages; Up/Down are deliberately left to the scroller, matching Preview, Chrome's PDF viewer and Acrobat — a page can be taller than the viewport, and taking the arrows would leave no keyboard way to reach the bottom of one. Guards: never inside an input, textarea, select or contenteditable; never with a modifier held. The rail uses roving tabindex (one tab stop, not one per page) and focus follows the current page **only when the rail already owns focus**, so scrolling with the mouse never snatches focus from what you were doing.

## Two defects fixed along the way, both introduced by the first cut

**The scrollbar jumped.** Unmounted slots reserved `getViewport({ scale }).height` — the *raster* height — while the image renders under `max-width: 100%; height: auto`, so its real height is set by the column's width. The reservation was never right, and was dropped entirely on mount, so the column's total height changed on every mount and unmount. Now a pure `estimateSlotHeight(columnWidth, rasterWidth, aspect)` models the CSS exactly (`max-width` shrinks but never upscales), and the reservation is applied as `min-height` to **every** slot, mounted or not, so mounting cannot change geometry.

**Two scrollbars.** `max-height: 80vh` on the column put a viewport-relative scroller inside a pane that already scrolls (`flex: 1; min-height: 0; overflow: auto`) — two bars along one axis, the inner one duplicating the rail beside it. The column now declares only its axis and lets the pane scroll. The rail is `position: sticky` rather than a fixed-height box, so it stays with the reader without claiming a second scroll region.

## i18n, a11y, and a CSS defect class

The viewer chrome was the last hardcoded-English surface here: Previous, Next, the page indicator, both failure lines, and the lazy-load fallbacks. New `PdfViewer` namespace across **all 29 locales**; the pager is now a `nav` landmark with `aria-live` on the indicator, which matters more in a scrolling column than under a pager — the page number changes without any control being activated, so a screen-reader user who scrolls would otherwise get silence.

**Then a bigger finding.** Moving the viewer's off-token CSS variables onto `--semiont-*` tokens turned out to be a move from one undefined variable to another: **46 custom properties were used in react-ui and defined nowhere**, including `--semiont-border-primary` in 10 files across the shared panel/card layer. Nothing errored — an unresolved `var()` silently falls back to inherited or initial values, so borders rendered as `currentColor` and the UI looked *nearly* right while being unthemeable.

Fixed: 38 were naming drift, re-pointed at tokens that already existed (no aliases — `--semiont-color-error` **is** `#ef4444` = `red-500`, and `--semiont-color-warning` **is** `#f59e0b` = `amber-500`, so the missing `danger-*`/`warning-*` ramps were the raw ramps all along). 8 were genuinely missing and are now defined in **all three theme blocks** — a token defined in only one block is the same bug wearing a theme.

**Why linting missed it, and the gate.** Two failures. Stylelint lints one file at a time, and a `var()` is *supposed* to be satisfied by a token file it never imports, so per-file analysis cannot distinguish "defined elsewhere" from "defined nowhere"; there is no core rule for it. Worse, **CI ran no CSS lint at all** — `lint:css` and `lint:no-utility-classes` existed in `package.json` and were only ever run by hand. This PR adds `scripts/lint/check-css-variables-defined.js` (proven red-then-green before wiring; inline fallbacks deliberately allowed) and wires **all three** CSS gates into the Architecture Compliance workflow.

## Tests

TDD throughout; every red observed before its fix. Notable ones, because they pin decisions rather than implementations:

- `estimate-slot-height.test.ts` — five pins including the never-upscale rule and the specific defect stated as a pin ("does NOT use the raster height as a width-independent constant").
- The mount window: every page gets a slot, only the window mounts, a page releases when it scrolls out, and — carried over — the whole-resource map is still fetched **once per document** across many mounted pages.
- A rectangle drawn on a scrolled page carries *that* page's number.
- PageUp/PageDown step pages **and Up/Down explicitly do not**, so a later change cannot quietly reclaim the arrows.

One process note worth recording: the first version of the slot-reservation pin **passed against the broken code**, because it asserted a CSS property neither implementation set. A pin that cannot fail is not a pin; it was rewritten and then failed properly.

## Verification

- react-ui: `tsc --noEmit` clean, `lint:css` clean, `lint:css-variables` clean, suite **2564 passed / 38 pre-existing skips**
- CSS variables used-but-undefined: **46 → 0**

## Not in this PR

- **Horizontal scrolling.** The CSS expresses both axes and the column and rail read one `SCROLL_AXIS`, so they cannot disagree — but the preload margin and the slot reservation are still vertical-only, and the preference has no home yet. Options are drafted separately; no decision taken.
- **Raster scale / DPR.** Pages still render at a fixed 1.5 and ignore `devicePixelRatio` (soft on hi-DPI). The mount window multiplies live rasters, so the window size and the scale cap want setting together from a measurement on a real large scan rather than from arithmetic.
