### PR TITLE
Repair lexical resource search: ordering, engine-side filtering, ranking, multi-term matching

### DIFF
--- a/docs/protocol/flows/MATCHER.md
+++ b/docs/protocol/flows/MATCHER.md
@@ -59,7 +59,7 @@ console.log(`Best match: ${top?.name} (score ${top?.score}, reason: ${top?.match
 
 The Matcher retrieves candidates in parallel from three sources, then deduplicates by resource ID:
 
-1. **Name match** — `graph.searchResources(searchTerm)` — text search against resource names
+1. **Name match** — `graph.listResources({ search: searchTerm, limit: 20 })` — every term matched against the resource name, its `storageUri` and its entity types
 2. **Entity type filter** — `graph.listResources({ entityTypes })` — resources sharing entity types with the annotation
 3. **Graph neighborhood** — resources connected to the source resource, derived from the shared `context.graph` (`deriveViews(context.graph, mainResourceId).connections`, from `@semiont/core`)
 

--- a/packages/core/src/resource-types.ts
+++ b/packages/core/src/resource-types.ts
@@ -11,6 +11,7 @@ export interface UpdateResourceInput {
 export interface ResourceFilter {
   entityTypes?: string[];
   search?: string;
+  archived?: boolean;
   limit?: number;
   offset?: number;
 }

--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -166,7 +166,7 @@ await graph.getResource(id);
 await graph.updateResource(id, updates);
 await graph.deleteResource(id);
 await graph.listResources({ entityTypes: ['Person'] });
-await graph.searchResources('query');
+await graph.listResources({ search: 'query' });
 
 // Annotation operations
 await graph.createAnnotation(input);

--- a/packages/graph/docs/API.md
+++ b/packages/graph/docs/API.md
@@ -11,7 +11,7 @@ All implementations conform to the `GraphDatabase` interface defined in [src/int
 Method groups at a glance:
 
 - **Connection management** — `connect()`, `disconnect()`, `isConnected()`
-- **Resource operations** — `createResource()`, `getResource()`, `updateResource()`, `deleteResource()`, `listResources()`, `searchResources()`
+- **Resource operations** — `createResource()`, `getResource()`, `updateResource()`, `deleteResource()`, `listResources()`
 - **Annotation operations** — `createAnnotation()`, `getAnnotation()`, `updateAnnotation()`, `deleteAnnotation()`, `listAnnotations()`
 - **Highlights and references** — `getHighlights()`, `resolveReference()`, `getReferences()`, `getEntityReferences()`
 - **Relationship queries** — `getResourceAnnotations()`, `getResourceReferencedBy()`
@@ -155,8 +155,13 @@ const { resources, total } = await graph.listResources({
   offset: 0
 });
 
-// Full-text-ish name/content search
-const matches = await graph.searchResources('Ada Lovelace', 10);
+// Search. Every term must match the name, the storageUri or an entity type;
+// results rank exact name matches first, then prefix, then any-term-in-name,
+// then matches the path or a tag had to complete.
+const { resources: matches } = await graph.listResources({
+  search: 'Ada Lovelace',
+  limit: 10
+});
 ```
 
 ### Graph Traversal

--- a/packages/graph/docs/GraphInterface.md
+++ b/packages/graph/docs/GraphInterface.md
@@ -19,7 +19,6 @@ export interface GraphDatabase {
   updateResource(id: ResourceId, input: UpdateResourceInput): Promise<ResourceDescriptor>;
   deleteResource(id: ResourceId): Promise<void>;
   listResources(filter: ResourceFilter): Promise<{ resources: ResourceDescriptor[]; total: number }>;
-  searchResources(query: string, limit?: number): Promise<ResourceDescriptor[]>;
 
   // Annotation operations
   createAnnotation(input: CreateAnnotationInternal): Promise<Annotation>;

--- a/packages/graph/src/__tests__/helpers/test-data.ts
+++ b/packages/graph/src/__tests__/helpers/test-data.ts
@@ -25,7 +25,7 @@ export function createTestResource(overrides: Partial<ResourceDescriptor> = {}):
         content: { value: 'test content' },
       },
     ],
-    created: new Date().toISOString(),
+    dateCreated: new Date().toISOString(),
     ...overrides,
   } as ResourceDescriptor;
 }

--- a/packages/graph/src/__tests__/interface-contract.test.ts
+++ b/packages/graph/src/__tests__/interface-contract.test.ts
@@ -337,6 +337,58 @@ describe('GraphDatabase Interface Contract', () => {
       expect(resources.map(r => r.name)).toEqual(['Marathon', 'About Marathon']);
     });
 
+    it('requires every query term to match, across name and path together', async () => {
+      await db.createResource(createTestResource({
+        '@id': resourceId('tok-split'), name: 'Greek victory',
+        storageUri: 'file://authors/Aeschylus/places/Marathon.md',
+      }));
+      // Has one term but not the other — AND, not OR.
+      await db.createResource(createTestResource({
+        '@id': resourceId('tok-partial'), name: 'Aeschylus alone',
+        storageUri: 'file://authors/Aeschylus/index.md',
+      }));
+
+      const results = await db.searchResources('Aeschylus Marathon');
+
+      expect(results.map(r => r.name)).toEqual(['Greek victory']);
+    });
+
+    it('matches query terms in any order', async () => {
+      await db.createResource(createTestResource({
+        '@id': resourceId('tok-order'), name: 'Battle of Marathon',
+      }));
+
+      const results = await db.searchResources('marathon battle');
+
+      expect(results.map(r => r.name)).toEqual(['Battle of Marathon']);
+    });
+
+    it('ranks a name-only match above one the path had to complete', async () => {
+      await db.createResource(createTestResource({
+        '@id': resourceId('tok-path'), name: 'Marathon notes',
+        storageUri: 'file://authors/Aeschylus/notes.md',
+        dateCreated: '2026-01-01T00:00:00.000Z',
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('tok-name'), name: 'Aeschylus on Marathon',
+        dateCreated: '2020-01-01T00:00:00.000Z',
+      }));
+
+      const results = await db.searchResources('Aeschylus Marathon');
+
+      expect(results.map(r => r.name)).toEqual(['Aeschylus on Marathon', 'Marathon notes']);
+    });
+
+    it('treats a whitespace-only query as no query at all', async () => {
+      // " " is truthy, and a bare CONTAINS would match every name with a space.
+      await db.createResource(createTestResource({ '@id': resourceId('ws-spaced'), name: 'Has a space' }));
+      await db.createResource(createTestResource({ '@id': resourceId('ws-plain'), name: 'Nospace' }));
+
+      const results = await db.searchResources('   ');
+
+      expect(results).toHaveLength(2);
+    });
+
     it('breaks dateCreated ties by id so paging cannot repeat or drop rows', async () => {
       const sameInstant = '2026-01-01T00:00:00.000Z';
       // Inserted out of id order — insertion order must not leak into results.

--- a/packages/graph/src/__tests__/interface-contract.test.ts
+++ b/packages/graph/src/__tests__/interface-contract.test.ts
@@ -188,16 +188,18 @@ describe('GraphDatabase Interface Contract', () => {
       // match set, since browse pages on it.
       for (let i = 0; i < 25; i++) {
         await db.createResource(createTestResource({
-          name: `Report ${i}`, entityTypes: ['Report'], archived: false,
+          name: `Quarterly Report ${i}`, entityTypes: ['Report'], archived: false,
         }));
       }
-      // One decoy per filter, each failing exactly one condition.
-      await db.createResource(createTestResource({ name: 'Report old', entityTypes: ['Report'], archived: true }));
-      await db.createResource(createTestResource({ name: 'Report memo', entityTypes: ['Memo'], archived: false }));
+      // One decoy per filter, each failing exactly one condition. The search
+      // term is one only names carry: since search also matches entity types,
+      // "tagged Report but not matching 'Report'" is not a constructible decoy.
+      await db.createResource(createTestResource({ name: 'Quarterly old', entityTypes: ['Report'], archived: true }));
+      await db.createResource(createTestResource({ name: 'Quarterly memo', entityTypes: ['Memo'], archived: false }));
       await db.createResource(createTestResource({ name: 'Unrelated', entityTypes: ['Report'], archived: false }));
 
       const page = await db.listResources({
-        search: 'Report', entityTypes: ['Report'], archived: false, limit: 10, offset: 0,
+        search: 'Quarterly', entityTypes: ['Report'], archived: false, limit: 10, offset: 0,
       });
 
       expect(page.total).toBe(25);
@@ -377,6 +379,50 @@ describe('GraphDatabase Interface Contract', () => {
       const { resources: results } = await db.listResources({ search: 'Aeschylus Marathon' });
 
       expect(results.map(r => r.name)).toEqual(['Aeschylus on Marathon', 'Marathon notes']);
+    });
+
+    it('finds resources by entity type name', async () => {
+      // Typing a type name into the search box is a natural thing to do, and
+      // `entityTypes` is otherwise reachable only as a separate filter.
+      await db.createResource(createTestResource({
+        '@id': resourceId('et-tagged'), name: 'Herodotus', entityTypes: ['Historian'],
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('et-other'), name: 'Marathon', entityTypes: ['Place'],
+      }));
+
+      const { resources } = await db.listResources({ search: 'Historian' });
+
+      expect(resources.map(r => r.name)).toEqual(['Herodotus']);
+    });
+
+    it('ranks an entity-type match below a name match', async () => {
+      await db.createResource(createTestResource({
+        '@id': resourceId('et-rank-tag'), name: 'Unrelated title', entityTypes: ['Historian'],
+        dateCreated: '2026-01-01T00:00:00.000Z',
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('et-rank-name'), name: 'Historian notes', entityTypes: ['Place'],
+        dateCreated: '2020-01-01T00:00:00.000Z',
+      }));
+
+      const { resources } = await db.listResources({ search: 'Historian' });
+
+      expect(resources.map(r => r.name)).toEqual(['Historian notes', 'Unrelated title']);
+    });
+
+    it('composes entity-type matching with multi-term queries', async () => {
+      await db.createResource(createTestResource({
+        '@id': resourceId('et-token'), name: 'Marathon', entityTypes: ['Place'],
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('et-token-miss'), name: 'Marathon', entityTypes: ['Person'],
+      }));
+
+      const { resources } = await db.listResources({ search: 'Place Marathon' });
+
+      expect(resources).toHaveLength(1);
+      expect(resources[0]?.entityTypes).toEqual(['Place']);
     });
 
     it('treats a whitespace-only query as no query at all', async () => {

--- a/packages/graph/src/__tests__/interface-contract.test.ts
+++ b/packages/graph/src/__tests__/interface-contract.test.ts
@@ -277,6 +277,66 @@ describe('GraphDatabase Interface Contract', () => {
       expect(results.map(r => r.name)).toEqual(['Report Newest', 'Report Middle', 'Report Oldest']);
     });
 
+    it('ranks exact name matches over prefix, over substring, over path-only', async () => {
+      // Dates run counter to the expected order, so recency cannot produce a
+      // passing result by accident — only the rank ladder can.
+      await db.createResource(createTestResource({
+        '@id': resourceId('rank-substring'), name: 'Notes about Marathon',
+        dateCreated: '2026-04-01T00:00:00.000Z',
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('rank-path'), name: 'Greek victory',
+        storageUri: 'file://places/Marathon.md', dateCreated: '2026-03-01T00:00:00.000Z',
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('rank-exact'), name: 'Marathon',
+        dateCreated: '2020-01-01T00:00:00.000Z',
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('rank-prefix'), name: 'Marathon Chronicle',
+        dateCreated: '2021-01-01T00:00:00.000Z',
+      }));
+
+      const results = await db.searchResources('Marathon');
+
+      expect(results.map(r => r.name)).toEqual([
+        'Marathon',
+        'Marathon Chronicle',
+        'Notes about Marathon',
+        'Greek victory',
+      ]);
+    });
+
+    it('falls back to recency within a rank tier', async () => {
+      await db.createResource(createTestResource({
+        '@id': resourceId('tier-older'), name: 'Marathon Notes',
+        dateCreated: '2020-01-01T00:00:00.000Z',
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('tier-newer'), name: 'Marathon Report',
+        dateCreated: '2026-01-01T00:00:00.000Z',
+      }));
+
+      const results = await db.searchResources('Marathon');
+
+      expect(results.map(r => r.name)).toEqual(['Marathon Report', 'Marathon Notes']);
+    });
+
+    it('applies the same ranking to listResources when search is set', async () => {
+      await db.createResource(createTestResource({
+        '@id': resourceId('list-substring'), name: 'About Marathon',
+        dateCreated: '2026-04-01T00:00:00.000Z',
+      }));
+      await db.createResource(createTestResource({
+        '@id': resourceId('list-exact'), name: 'Marathon',
+        dateCreated: '2020-01-01T00:00:00.000Z',
+      }));
+
+      const { resources } = await db.listResources({ search: 'Marathon' });
+
+      expect(resources.map(r => r.name)).toEqual(['Marathon', 'About Marathon']);
+    });
+
     it('breaks dateCreated ties by id so paging cannot repeat or drop rows', async () => {
       const sameInstant = '2026-01-01T00:00:00.000Z';
       // Inserted out of id order — insertion order must not leak into results.

--- a/packages/graph/src/__tests__/interface-contract.test.ts
+++ b/packages/graph/src/__tests__/interface-contract.test.ts
@@ -228,23 +228,23 @@ describe('GraphDatabase Interface Contract', () => {
       expect(result.total).toBe(3);
     });
 
-    it('searchResources() should find by text query', async () => {
+    it('search should find by text query', async () => {
       const resource = createTestResource({ name: 'Unique Searchable Name' });
       await db.createResource(resource);
       await db.createResource(createTestResource({ name: 'Other Document' }));
 
-      const results = await db.searchResources('Searchable');
+      const { resources: results } = await db.listResources({ search: 'Searchable' });
 
       expect(results).toHaveLength(1);
       expect(results[0]?.['@id']).toBe(resource['@id']);
     });
 
-    it('searchResources() should respect limit', async () => {
+    it('search should respect limit', async () => {
       for (let i = 0; i < 5; i++) {
         await db.createResource(createTestResource({ name: 'Test Document' }));
       }
 
-      const results = await db.searchResources('Test', 2);
+      const { resources: results } = await db.listResources({ search: 'Test', limit: 2 });
 
       expect(results).toHaveLength(2);
     });
@@ -267,12 +267,12 @@ describe('GraphDatabase Interface Contract', () => {
       expect(resources.map(r => r.name)).toEqual(['Newest', 'Middle', 'Oldest']);
     });
 
-    it('searchResources() returns newest first by dateCreated', async () => {
+    it('search returns newest first by dateCreated', async () => {
       await db.createResource(dated('Report Oldest', '2020-01-01T00:00:00.000Z', 'search-old'));
       await db.createResource(dated('Report Newest', '2026-01-01T00:00:00.000Z', 'search-new'));
       await db.createResource(dated('Report Middle', '2023-01-01T00:00:00.000Z', 'search-mid'));
 
-      const results = await db.searchResources('Report');
+      const { resources: results } = await db.listResources({ search: 'Report' });
 
       expect(results.map(r => r.name)).toEqual(['Report Newest', 'Report Middle', 'Report Oldest']);
     });
@@ -297,7 +297,7 @@ describe('GraphDatabase Interface Contract', () => {
         dateCreated: '2021-01-01T00:00:00.000Z',
       }));
 
-      const results = await db.searchResources('Marathon');
+      const { resources: results } = await db.listResources({ search: 'Marathon' });
 
       expect(results.map(r => r.name)).toEqual([
         'Marathon',
@@ -317,7 +317,7 @@ describe('GraphDatabase Interface Contract', () => {
         dateCreated: '2026-01-01T00:00:00.000Z',
       }));
 
-      const results = await db.searchResources('Marathon');
+      const { resources: results } = await db.listResources({ search: 'Marathon' });
 
       expect(results.map(r => r.name)).toEqual(['Marathon Report', 'Marathon Notes']);
     });
@@ -348,7 +348,7 @@ describe('GraphDatabase Interface Contract', () => {
         storageUri: 'file://authors/Aeschylus/index.md',
       }));
 
-      const results = await db.searchResources('Aeschylus Marathon');
+      const { resources: results } = await db.listResources({ search: 'Aeschylus Marathon' });
 
       expect(results.map(r => r.name)).toEqual(['Greek victory']);
     });
@@ -358,7 +358,7 @@ describe('GraphDatabase Interface Contract', () => {
         '@id': resourceId('tok-order'), name: 'Battle of Marathon',
       }));
 
-      const results = await db.searchResources('marathon battle');
+      const { resources: results } = await db.listResources({ search: 'marathon battle' });
 
       expect(results.map(r => r.name)).toEqual(['Battle of Marathon']);
     });
@@ -374,7 +374,7 @@ describe('GraphDatabase Interface Contract', () => {
         dateCreated: '2020-01-01T00:00:00.000Z',
       }));
 
-      const results = await db.searchResources('Aeschylus Marathon');
+      const { resources: results } = await db.listResources({ search: 'Aeschylus Marathon' });
 
       expect(results.map(r => r.name)).toEqual(['Aeschylus on Marathon', 'Marathon notes']);
     });
@@ -384,7 +384,7 @@ describe('GraphDatabase Interface Contract', () => {
       await db.createResource(createTestResource({ '@id': resourceId('ws-spaced'), name: 'Has a space' }));
       await db.createResource(createTestResource({ '@id': resourceId('ws-plain'), name: 'Nospace' }));
 
-      const results = await db.searchResources('   ');
+      const { resources: results } = await db.listResources({ search: '   ' });
 
       expect(results).toHaveLength(2);
     });

--- a/packages/graph/src/__tests__/interface-contract.test.ts
+++ b/packages/graph/src/__tests__/interface-contract.test.ts
@@ -218,6 +218,48 @@ describe('GraphDatabase Interface Contract', () => {
     });
   });
 
+  describe('Result Ordering', () => {
+    // Browse pages through these results, so the order must be total and stable:
+    // same query, same sequence, every call. Ordering on a property no backend
+    // writes leaves SKIP/LIMIT free to repeat or drop rows between pages.
+    const dated = (name: string, dateCreated: string, id: string) =>
+      createTestResource({ '@id': resourceId(id), name, dateCreated });
+
+    it('listResources() returns newest first by dateCreated', async () => {
+      await db.createResource(dated('Oldest', '2020-01-01T00:00:00.000Z', 'order-old'));
+      await db.createResource(dated('Newest', '2026-01-01T00:00:00.000Z', 'order-new'));
+      await db.createResource(dated('Middle', '2023-01-01T00:00:00.000Z', 'order-mid'));
+
+      const { resources } = await db.listResources({});
+
+      expect(resources.map(r => r.name)).toEqual(['Newest', 'Middle', 'Oldest']);
+    });
+
+    it('searchResources() returns newest first by dateCreated', async () => {
+      await db.createResource(dated('Report Oldest', '2020-01-01T00:00:00.000Z', 'search-old'));
+      await db.createResource(dated('Report Newest', '2026-01-01T00:00:00.000Z', 'search-new'));
+      await db.createResource(dated('Report Middle', '2023-01-01T00:00:00.000Z', 'search-mid'));
+
+      const results = await db.searchResources('Report');
+
+      expect(results.map(r => r.name)).toEqual(['Report Newest', 'Report Middle', 'Report Oldest']);
+    });
+
+    it('breaks dateCreated ties by id so paging cannot repeat or drop rows', async () => {
+      const sameInstant = '2026-01-01T00:00:00.000Z';
+      // Inserted out of id order — insertion order must not leak into results.
+      for (const id of ['tie-c', 'tie-a', 'tie-d', 'tie-b']) {
+        await db.createResource(dated(`Tied ${id}`, sameInstant, id));
+      }
+
+      const page1 = await db.listResources({ limit: 2, offset: 0 });
+      const page2 = await db.listResources({ limit: 2, offset: 2 });
+      const paged = [...page1.resources, ...page2.resources].map(r => String(r['@id']));
+
+      expect(paged).toEqual(['tie-a', 'tie-b', 'tie-c', 'tie-d']);
+    });
+  });
+
   describe('Annotation Operations', () => {
     it('createAnnotation() should create with highlighting motivation', async () => {
       const resource = createTestResource();

--- a/packages/graph/src/__tests__/interface-contract.test.ts
+++ b/packages/graph/src/__tests__/interface-contract.test.ts
@@ -172,6 +172,38 @@ describe('GraphDatabase Interface Contract', () => {
       expect(result.resources).toHaveLength(2);
     });
 
+    it('listResources() should filter by archived', async () => {
+      await db.createResource(createTestResource({ name: 'Live', archived: false }));
+      await db.createResource(createTestResource({ name: 'Archived', archived: true }));
+
+      const live = await db.listResources({ archived: false });
+      const archived = await db.listResources({ archived: true });
+
+      expect(live.resources.map(r => r.name)).toEqual(['Live']);
+      expect(archived.resources.map(r => r.name)).toEqual(['Archived']);
+    });
+
+    it('listResources() composes filters and totals every match, not just the page', async () => {
+      // More matches than fit in one page — `total` must describe the whole
+      // match set, since browse pages on it.
+      for (let i = 0; i < 25; i++) {
+        await db.createResource(createTestResource({
+          name: `Report ${i}`, entityTypes: ['Report'], archived: false,
+        }));
+      }
+      // One decoy per filter, each failing exactly one condition.
+      await db.createResource(createTestResource({ name: 'Report old', entityTypes: ['Report'], archived: true }));
+      await db.createResource(createTestResource({ name: 'Report memo', entityTypes: ['Memo'], archived: false }));
+      await db.createResource(createTestResource({ name: 'Unrelated', entityTypes: ['Report'], archived: false }));
+
+      const page = await db.listResources({
+        search: 'Report', entityTypes: ['Report'], archived: false, limit: 10, offset: 0,
+      });
+
+      expect(page.total).toBe(25);
+      expect(page.resources).toHaveLength(10);
+    });
+
     it('listResources() should paginate results', async () => {
       for (let i = 0; i < 5; i++) {
         await db.createResource(createTestResource({ name: `Resource ${i}` }));

--- a/packages/graph/src/__tests__/memorygraph.test.ts
+++ b/packages/graph/src/__tests__/memorygraph.test.ts
@@ -164,66 +164,66 @@ describe('MemoryGraphDatabase Implementation', () => {
       expect(result.resources).toEqual([]);
     });
 
-    it('searchResources() should be case-insensitive', async () => {
+    it('search should be case-insensitive', async () => {
       const resource = createTestResource({ name: 'Important Document' });
       await db.createResource(resource);
 
-      const results = await db.searchResources('IMPORTANT');
+      const { resources: results } = await db.listResources({ search: 'IMPORTANT' });
 
       expect(results).toHaveLength(1);
       expect(results[0]?.['@id']).toBe(resource['@id']);
     });
 
-    it('searchResources() should match substring', async () => {
+    it('search should match substring', async () => {
       await db.createResource(createTestResource({ name: 'Understanding TypeScript' }));
 
-      const results = await db.searchResources('script');
+      const { resources: results } = await db.listResources({ search: 'script' });
 
       expect(results).toHaveLength(1);
     });
 
-    it('searchResources() should return empty for no matches', async () => {
+    it('search should return empty for no matches', async () => {
       await db.createResource(createTestResource({ name: 'Test Document' }));
 
-      const results = await db.searchResources('xyz123');
+      const { resources: results } = await db.listResources({ search: 'xyz123' });
 
       expect(results).toEqual([]);
     });
 
-    it('searchResources() should match against storageUri', async () => {
+    it('search should match against storageUri', async () => {
       const resource = createTestResource({
         name: 'Greek Victory',
         storageUri: 'file://authors/Herodotus/places/Marathon.md',
       });
       await db.createResource(resource);
 
-      const results = await db.searchResources('marathon');
+      const { resources: results } = await db.listResources({ search: 'marathon' });
 
       expect(results).toHaveLength(1);
       expect(results[0]?.['@id']).toBe(resource['@id']);
     });
 
-    it('searchResources() against storageUri is case-insensitive', async () => {
+    it('search against storageUri is case-insensitive', async () => {
       const resource = createTestResource({
         name: 'Plays',
         storageUri: 'file://authors/Aeschylus/plays.md',
       });
       await db.createResource(resource);
 
-      const results = await db.searchResources('AESCHYLUS');
+      const { resources: results } = await db.listResources({ search: 'AESCHYLUS' });
 
       expect(results).toHaveLength(1);
       expect(results[0]?.['@id']).toBe(resource['@id']);
     });
 
-    it('searchResources() returns a single result when query matches both name and storageUri', async () => {
+    it('search returns a single result when query matches both name and storageUri', async () => {
       const resource = createTestResource({
         name: 'Marathon',
         storageUri: 'file://places/Marathon.md',
       });
       await db.createResource(resource);
 
-      const results = await db.searchResources('marathon');
+      const { resources: results } = await db.listResources({ search: 'marathon' });
 
       expect(results).toHaveLength(1);
     });

--- a/packages/graph/src/implementations/janusgraph.ts
+++ b/packages/graph/src/implementations/janusgraph.ts
@@ -2,7 +2,7 @@
 // This replaces the mock in-memory implementation
 
 import { GraphDatabase } from '../interface';
-import { assertMutableResourceUpdate } from '../interface';
+import { assertMutableResourceUpdate, compareByRecencyThenId } from '../interface';
 import type { Logger } from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId } from '@semiont/core';
 import { getBodySource, getPrimaryRepresentation, getResourceId, getExactText } from '@semiont/core';
@@ -349,7 +349,7 @@ export class JanusGraphDatabase implements GraphDatabase {
     const limit = filter.limit || 50;
 
     return {
-      resources: resources.slice(offset, offset + limit),
+      resources: resources.sort(compareByRecencyThenId).slice(offset, offset + limit),
       total
     };
   }

--- a/packages/graph/src/implementations/janusgraph.ts
+++ b/packages/graph/src/implementations/janusgraph.ts
@@ -2,7 +2,8 @@
 // This replaces the mock in-memory implementation
 
 import { GraphDatabase } from '../interface';
-import { assertMutableResourceUpdate, compareByRecencyThenId } from '../interface';
+import { assertMutableResourceUpdate } from '../interface';
+import { queryResources } from '../resource-query';
 import type { Logger } from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId } from '@semiont/core';
 import { getBodySource, getPrimaryRepresentation, getResourceId, getExactText } from '@semiont/core';
@@ -328,38 +329,11 @@ export class JanusGraphDatabase implements GraphDatabase {
     // anonymous-traversal API; for a backend that's not the production
     // target today, JS post-filtering is simpler and adequate at our scale.
     const docs = await this.g!.V().hasLabel('Resource').toList();
-    let resources = docs.map((v: any) => this.vertexToResource(v));
-
-    if (filter.search) {
-      const needle = filter.search.toLowerCase();
-      resources = resources.filter((doc: ResourceDescriptor) =>
-        (doc.name?.toLowerCase().includes(needle) ?? false) ||
-        (doc.storageUri?.toLowerCase().includes(needle) ?? false)
-      );
-    }
-
-    if (filter.entityTypes && filter.entityTypes.length > 0) {
-      resources = resources.filter((doc: ResourceDescriptor) =>
-        filter.entityTypes!.some((type: string) => doc.entityTypes?.includes(type))
-      );
-    }
-
-    if (filter.archived !== undefined) {
-      resources = resources.filter((doc: ResourceDescriptor) => (doc.archived ?? false) === filter.archived);
-    }
-
-    const total = resources.length;
-    const offset = filter.offset || 0;
-    const limit = filter.limit || 50;
-
-    return {
-      resources: resources.sort(compareByRecencyThenId).slice(offset, offset + limit),
-      total
-    };
+    return queryResources(docs.map((v: any) => this.vertexToResource(v)), filter);
   }
-  
+
   async searchResources(query: string, limit?: number): Promise<ResourceDescriptor[]> {
-    const result = await this.listResources({ search: query, limit: limit || 10 });
+    const result = await this.listResources({ search: query, limit: limit ?? 20 });
     return result.resources;
   }
   

--- a/packages/graph/src/implementations/janusgraph.ts
+++ b/packages/graph/src/implementations/janusgraph.ts
@@ -332,10 +332,6 @@ export class JanusGraphDatabase implements GraphDatabase {
     return queryResources(docs.map((v: any) => this.vertexToResource(v)), filter);
   }
 
-  async searchResources(query: string, limit?: number): Promise<ResourceDescriptor[]> {
-    const result = await this.listResources({ search: query, limit: limit ?? 20 });
-    return result.resources;
-  }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {
     // The caller's id is the system of record's — never mint a fresh one

--- a/packages/graph/src/implementations/janusgraph.ts
+++ b/packages/graph/src/implementations/janusgraph.ts
@@ -344,6 +344,10 @@ export class JanusGraphDatabase implements GraphDatabase {
       );
     }
 
+    if (filter.archived !== undefined) {
+      resources = resources.filter((doc: ResourceDescriptor) => (doc.archived ?? false) === filter.archived);
+    }
+
     const total = resources.length;
     const offset = filter.offset || 0;
     const limit = filter.limit || 50;

--- a/packages/graph/src/implementations/memorygraph.ts
+++ b/packages/graph/src/implementations/memorygraph.ts
@@ -118,6 +118,10 @@ export class MemoryGraphDatabase implements GraphDatabase {
       );
     }
 
+    if (filter.archived !== undefined) {
+      docs = docs.filter(doc => (doc.archived ?? false) === filter.archived);
+    }
+
     const total = docs.length;
     const offset = filter.offset || 0;
     const limit = filter.limit || 20;

--- a/packages/graph/src/implementations/memorygraph.ts
+++ b/packages/graph/src/implementations/memorygraph.ts
@@ -106,9 +106,6 @@ export class MemoryGraphDatabase implements GraphDatabase {
     return queryResources(Array.from(this.resources.values()), filter);
   }
 
-  async searchResources(query: string, limit: number = 20): Promise<ResourceDescriptor[]> {
-    return (await this.listResources({ search: query, limit })).resources;
-  }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {
     // The caller's id is the system of record's — never mint a fresh one

--- a/packages/graph/src/implementations/memorygraph.ts
+++ b/packages/graph/src/implementations/memorygraph.ts
@@ -2,7 +2,7 @@
 // Used for development and testing without requiring a real graph database
 
 import { GraphDatabase } from '../interface';
-import { assertMutableResourceUpdate } from '../interface';
+import { assertMutableResourceUpdate, compareByRecencyThenId } from '../interface';
 import type { Logger } from '@semiont/core';
 import type {
   AnnotationCategory,
@@ -121,7 +121,7 @@ export class MemoryGraphDatabase implements GraphDatabase {
     const total = docs.length;
     const offset = filter.offset || 0;
     const limit = filter.limit || 20;
-    docs = docs.slice(offset, offset + limit);
+    docs = docs.sort(compareByRecencyThenId).slice(offset, offset + limit);
 
     return { resources: docs, total };
   }
@@ -134,6 +134,7 @@ export class MemoryGraphDatabase implements GraphDatabase {
         doc.name.toLowerCase().includes(searchLower) ||
         (doc.storageUri?.toLowerCase().includes(searchLower) ?? false)
       )
+      .sort(compareByRecencyThenId)
       .slice(0, limit);
 
     return results;

--- a/packages/graph/src/implementations/memorygraph.ts
+++ b/packages/graph/src/implementations/memorygraph.ts
@@ -2,7 +2,8 @@
 // Used for development and testing without requiring a real graph database
 
 import { GraphDatabase } from '../interface';
-import { assertMutableResourceUpdate, compareByRecencyThenId } from '../interface';
+import { assertMutableResourceUpdate } from '../interface';
+import { queryResources } from '../resource-query';
 import type { Logger } from '@semiont/core';
 import type {
   AnnotationCategory,
@@ -102,46 +103,11 @@ export class MemoryGraphDatabase implements GraphDatabase {
   }
   
   async listResources(filter: ResourceFilter): Promise<{ resources: ResourceDescriptor[]; total: number }> {
-    let docs = Array.from(this.resources.values());
-
-    if (filter.entityTypes && filter.entityTypes.length > 0) {
-      docs = docs.filter(doc =>
-        doc.entityTypes && doc.entityTypes.some((type: string) => filter.entityTypes!.includes(type))
-      );
-    }
-
-    if (filter.search) {
-      const searchLower = filter.search.toLowerCase();
-      docs = docs.filter(doc =>
-        doc.name.toLowerCase().includes(searchLower) ||
-        (doc.storageUri?.toLowerCase().includes(searchLower) ?? false)
-      );
-    }
-
-    if (filter.archived !== undefined) {
-      docs = docs.filter(doc => (doc.archived ?? false) === filter.archived);
-    }
-
-    const total = docs.length;
-    const offset = filter.offset || 0;
-    const limit = filter.limit || 20;
-    docs = docs.sort(compareByRecencyThenId).slice(offset, offset + limit);
-
-    return { resources: docs, total };
+    return queryResources(Array.from(this.resources.values()), filter);
   }
 
   async searchResources(query: string, limit: number = 20): Promise<ResourceDescriptor[]> {
-    // Simple text search in memory across name and storageUri
-    const searchLower = query.toLowerCase();
-    const results = Array.from(this.resources.values())
-      .filter(doc =>
-        doc.name.toLowerCase().includes(searchLower) ||
-        (doc.storageUri?.toLowerCase().includes(searchLower) ?? false)
-      )
-      .sort(compareByRecencyThenId)
-      .slice(0, limit);
-
-    return results;
+    return (await this.listResources({ search: query, limit })).resources;
   }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -331,7 +331,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       const result = await session.run(
         `MATCH (d:Resource) ${whereClause}
          RETURN d
-         ORDER BY d.updatedAt DESC
+         ORDER BY d.created DESC, d.id
          SKIP $skip LIMIT $limit`,
         params
       );
@@ -352,7 +352,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
          WHERE toLower(d.name) CONTAINS toLower($query)
             OR toLower(coalesce(d.storageUri, "")) CONTAINS toLower($query)
          RETURN d
-         ORDER BY d.updatedAt DESC
+         ORDER BY d.created DESC, d.id
          LIMIT $limit`,
         { query, limit: this.neo4j.int(limit) }
       );

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -301,7 +301,16 @@ export class Neo4jGraphDatabase implements GraphDatabase {
     try {
       let whereClause = '';
       const params: any = {};
-      const conditions: string[] = [];
+      // Stub nodes are id-only placeholders that `MERGE` creates when a
+      // REFERENCES edge points at a resource whose `resource.created` event
+      // hasn't landed yet. They carry no name, so they are not listable — and
+      // `parseResourceNode` throws on the missing field rather than inventing one.
+      const conditions: string[] = ['coalesce(d.stub, false) = false'];
+
+      if (filter.archived !== undefined) {
+        conditions.push('d.archived = $archived');
+        params.archived = filter.archived;
+      }
 
       if (filter.entityTypes && filter.entityTypes.length > 0) {
         conditions.push('ANY(type IN $entityTypes WHERE type IN d.entityTypes)');

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -323,7 +323,9 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       const terms = filter.search ? searchTerms(filter.search) : [];
       if (terms.length > 0) {
         conditions.push(
-          'ALL(t IN $terms WHERE toLower(d.name) CONTAINS t OR toLower(coalesce(d.storageUri, "")) CONTAINS t)'
+          `ALL(t IN $terms WHERE toLower(d.name) CONTAINS t
+                             OR toLower(coalesce(d.storageUri, "")) CONTAINS t
+                             OR ANY(e IN coalesce(d.entityTypes, []) WHERE toLower(e) CONTAINS t))`
         );
         params.terms = terms;
         params.search = filter.search!.trim().toLowerCase();

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -4,6 +4,7 @@
 import type { Driver, Session } from 'neo4j-driver';
 import { GraphDatabase } from '../interface';
 import { assertMutableResourceUpdate } from '../interface';
+import { searchTerms } from '../resource-query';
 import type { Logger } from '@semiont/core';
 import { annotationId as makeAnnotationId } from '@semiont/core';
 import type {
@@ -317,9 +318,15 @@ export class Neo4jGraphDatabase implements GraphDatabase {
         params.entityTypes = filter.entityTypes;
       }
 
-      if (filter.search) {
-        conditions.push('(toLower(d.name) CONTAINS toLower($search) OR toLower(coalesce(d.storageUri, "")) CONTAINS toLower($search))');
-        params.search = filter.search;
+      // Every term must appear, each satisfiable by the name or the path. A
+      // whitespace-only query yields no terms and so is not a search at all.
+      const terms = filter.search ? searchTerms(filter.search) : [];
+      if (terms.length > 0) {
+        conditions.push(
+          'ALL(t IN $terms WHERE toLower(d.name) CONTAINS t OR toLower(coalesce(d.storageUri, "")) CONTAINS t)'
+        );
+        params.terms = terms;
+        params.search = filter.search!.trim().toLowerCase();
       }
 
       if (conditions.length > 0) {
@@ -340,16 +347,16 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       // Rank only means something against a query; an unsearched listing orders
       // on recency alone. Ranking must happen here rather than over the returned
       // page, or it would sort one page instead of the match set.
-      const rankClause = filter.search
+      const rankClause = terms.length > 0
         ? `WITH d, CASE
-             WHEN toLower(d.name) = toLower($search) THEN 0
-             WHEN toLower(d.name) STARTS WITH toLower($search) THEN 1
-             WHEN toLower(d.name) CONTAINS toLower($search) THEN 2
+             WHEN toLower(d.name) = $search THEN 0
+             WHEN toLower(d.name) STARTS WITH $search THEN 1
+             WHEN ALL(t IN $terms WHERE toLower(d.name) CONTAINS t) THEN 2
              ELSE 3
            END AS rank
          `
         : '';
-      const orderClause = filter.search
+      const orderClause = terms.length > 0
         ? 'ORDER BY rank, d.created DESC, d.id'
         : 'ORDER BY d.created DESC, d.id';
 

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -337,10 +337,26 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       params.skip = this.neo4j.int(filter.offset || 0);
       params.limit = this.neo4j.int(filter.limit || 20);
 
+      // Rank only means something against a query; an unsearched listing orders
+      // on recency alone. Ranking must happen here rather than over the returned
+      // page, or it would sort one page instead of the match set.
+      const rankClause = filter.search
+        ? `WITH d, CASE
+             WHEN toLower(d.name) = toLower($search) THEN 0
+             WHEN toLower(d.name) STARTS WITH toLower($search) THEN 1
+             WHEN toLower(d.name) CONTAINS toLower($search) THEN 2
+             ELSE 3
+           END AS rank
+         `
+        : '';
+      const orderClause = filter.search
+        ? 'ORDER BY rank, d.created DESC, d.id'
+        : 'ORDER BY d.created DESC, d.id';
+
       const result = await session.run(
         `MATCH (d:Resource) ${whereClause}
-         RETURN d
-         ORDER BY d.created DESC, d.id
+         ${rankClause}RETURN d
+         ${orderClause}
          SKIP $skip LIMIT $limit`,
         params
       );
@@ -354,22 +370,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
   }
 
   async searchResources(query: string, limit: number = 20): Promise<ResourceDescriptor[]> {
-    const session = this.getSession();
-    try {
-      const result = await session.run(
-        `MATCH (d:Resource)
-         WHERE toLower(d.name) CONTAINS toLower($query)
-            OR toLower(coalesce(d.storageUri, "")) CONTAINS toLower($query)
-         RETURN d
-         ORDER BY d.created DESC, d.id
-         LIMIT $limit`,
-        { query, limit: this.neo4j.int(limit) }
-      );
-
-      return result.records.map(record => this.parseResourceNode(record.get('d')));
-    } finally {
-      await session.close();
-    }
+    return (await this.listResources({ search: query, limit })).resources;
   }
 
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -376,9 +376,6 @@ export class Neo4jGraphDatabase implements GraphDatabase {
     }
   }
 
-  async searchResources(query: string, limit: number = 20): Promise<ResourceDescriptor[]> {
-    return (await this.listResources({ search: query, limit })).resources;
-  }
 
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {
     const session = this.getSession();

--- a/packages/graph/src/implementations/neptune.ts
+++ b/packages/graph/src/implementations/neptune.ts
@@ -452,11 +452,20 @@ export class NeptuneGraphDatabase implements GraphDatabase {
   /**
    * Filtering, ranking and pagination happen in JS rather than in Gremlin.
    *
-   * The ranking ladder (exact name over prefix over substring over path-only)
-   * has no natural Gremlin expression, and a rank applied after `range()` would
-   * order one page instead of the match set. JanusGraph post-filters for the
-   * same reason. Both share `queryResources` with the memory backend so search
-   * cannot mean three different things across three backends.
+   * The ranking ladder (exact name over prefix over substring over path- or
+   * tag-assisted) has no natural Gremlin expression, and a rank applied after
+   * `range()` would order one page instead of the match set. JanusGraph
+   * post-filters for the same reason. Both share `queryResources` with the
+   * memory backend so search cannot mean three different things across three
+   * backends.
+   *
+   * The cost is explicit and accepted: this materializes every `Resource`
+   * vertex per call, so it is O(N) in the size of the KB rather than in the
+   * size of the result. Neo4j is the production path and pushes the whole
+   * query — filter, rank, page — into Cypher; Neptune and JanusGraph are not
+   * deployment targets today. If either becomes one at scale, the fix is a
+   * Gremlin rank expression (`choose` over `toLower`, engine-version
+   * permitting), not a return to per-backend search semantics.
    */
   async listResources(filter: ResourceFilter): Promise<{ resources: ResourceDescriptor[]; total: number }> {
     try {

--- a/packages/graph/src/implementations/neptune.ts
+++ b/packages/graph/src/implementations/neptune.ts
@@ -468,9 +468,6 @@ export class NeptuneGraphDatabase implements GraphDatabase {
     }
   }
 
-  async searchResources(query: string, limit: number = 20): Promise<ResourceDescriptor[]> {
-    return (await this.listResources({ search: query, limit })).resources;
-  }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {
     // The caller's id is the system of record's — never mint a fresh one

--- a/packages/graph/src/implementations/neptune.ts
+++ b/packages/graph/src/implementations/neptune.ts
@@ -3,6 +3,7 @@
 
 import { GraphDatabase } from '../interface';
 import { assertMutableResourceUpdate } from '../interface';
+import { queryResources } from '../resource-query';
 import { getEntityTypes } from '@semiont/ontology';
 import type { Logger } from '@semiont/core';
 import { annotationId as makeAnnotationId } from '@semiont/core';
@@ -28,7 +29,6 @@ let DescribeDBClustersCommand: any;
 let gremlin: any;
 let process: any;
 let TextP: any;
-let order: any;
 let cardinality: any;
 let __: any;
 
@@ -43,7 +43,6 @@ async function loadDependencies() {
     gremlin = await import('gremlin');
     process = gremlin.process;
     TextP = process.TextP;
-    order = process.order;
     cardinality = process.cardinality;
     __ = process.statics;
   }
@@ -450,80 +449,27 @@ export class NeptuneGraphDatabase implements GraphDatabase {
     }
   }
   
+  /**
+   * Filtering, ranking and pagination happen in JS rather than in Gremlin.
+   *
+   * The ranking ladder (exact name over prefix over substring over path-only)
+   * has no natural Gremlin expression, and a rank applied after `range()` would
+   * order one page instead of the match set. JanusGraph post-filters for the
+   * same reason. Both share `queryResources` with the memory backend so search
+   * cannot mean three different things across three backends.
+   */
   async listResources(filter: ResourceFilter): Promise<{ resources: ResourceDescriptor[]; total: number }> {
     try {
-      let traversal = this.g.V().hasLabel('Resource');
-      
-      // Apply filters
-      if (filter.entityTypes && filter.entityTypes.length > 0) {
-        // Filter by entity types (stored as JSON string)
-        traversal = traversal.filter(
-          process.statics.or(
-            ...filter.entityTypes.map((type: string) =>
-              process.statics.has('entityTypes', TextP.containing(`"${type}"`))
-            )
-          )
-        );
-      }
-      
-      if (filter.search) {
-        // Search across name and storageUri (case-insensitive substring)
-        traversal = traversal.filter(
-          process.statics.or(
-            process.statics.has('name', TextP.containing(filter.search)),
-            process.statics.has('storageUri', TextP.containing(filter.search))
-          )
-        );
-      }
-
-      if (filter.archived !== undefined) {
-        traversal = traversal.has('archived', filter.archived);
-      }
-      
-      // Count total before pagination
-      const totalResult = await traversal.clone().count().next();
-      const total = totalResult.value || 0;
-      
-      // Apply pagination
-      const offset = filter.offset || 0;
-      const limit = filter.limit || 20;
-      
-      const results = await traversal
-        .order().by('created', order.desc).by('id', order.asc)
-        .range(offset, offset + limit)
-        .elementMap()
-        .toList();
-      
-      const resources = results.map(vertexToResource);
-      
-      return { resources, total };
+      const results = await this.g.V().hasLabel('Resource').elementMap().toList();
+      return queryResources(results.map(vertexToResource), filter);
     } catch (error) {
       this.logger?.error('Failed to list resources from Neptune', { error });
       throw error;
     }
   }
-  
-  async searchResources(query: string, limit: number = 20): Promise<ResourceDescriptor[]> {
-    try {
-      // Search across name and storageUri (case-insensitive substring)
-      const results = await this.g.V()
-        .hasLabel('Resource')
-        .filter(
-          process.statics.or(
-            process.statics.has('name', TextP.containing(query)),
-            process.statics.has('storageUri', TextP.containing(query))
-          )
-        )
-        .order().by('created', order.desc).by('id', order.asc)
-        .limit(limit)
-        .elementMap()
-        .toList();
 
-      return results.map(vertexToResource);
-    } catch (error) {
-      this.logger?.error('Failed to search resources in Neptune', { error });
-      throw error;
-    }
+  async searchResources(query: string, limit: number = 20): Promise<ResourceDescriptor[]> {
+    return (await this.listResources({ search: query, limit })).resources;
   }
   
   async createAnnotation(input: CreateAnnotationInternal): Promise<Annotation> {

--- a/packages/graph/src/implementations/neptune.ts
+++ b/packages/graph/src/implementations/neptune.ts
@@ -485,7 +485,7 @@ export class NeptuneGraphDatabase implements GraphDatabase {
       const limit = filter.limit || 20;
       
       const results = await traversal
-        .order().by('created', order.desc)
+        .order().by('created', order.desc).by('id', order.asc)
         .range(offset, offset + limit)
         .elementMap()
         .toList();
@@ -510,7 +510,7 @@ export class NeptuneGraphDatabase implements GraphDatabase {
             process.statics.has('storageUri', TextP.containing(query))
           )
         )
-        .order().by('created', order.desc)
+        .order().by('created', order.desc).by('id', order.asc)
         .limit(limit)
         .elementMap()
         .toList();

--- a/packages/graph/src/implementations/neptune.ts
+++ b/packages/graph/src/implementations/neptune.ts
@@ -475,6 +475,10 @@ export class NeptuneGraphDatabase implements GraphDatabase {
           )
         );
       }
+
+      if (filter.archived !== undefined) {
+        traversal = traversal.has('archived', filter.archived);
+      }
       
       // Count total before pagination
       const totalResult = await traversal.clone().count().next();

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -11,6 +11,7 @@
 
 // Graph Database interface
 export type { GraphDatabase } from './interface';
+export { compareByRecencyThenId } from './interface';
 
 // Factory pattern (singleton)
 export { getGraphDatabase, createGraphDatabase, closeGraphDatabase } from './factory';

--- a/packages/graph/src/interface.ts
+++ b/packages/graph/src/interface.ts
@@ -31,8 +31,8 @@ export function assertMutableResourceUpdate(input: UpdateResourceInput): void {
 }
 
 /**
- * Newest first, ties broken by id — the ordering every `listResources` and
- * `searchResources` result must carry.
+ * Newest first, ties broken by id — the ordering every `listResources` result
+ * must carry.
  *
  * The tiebreak is not cosmetic: browse pages these results with offset/limit,
  * and a partial order lets two pages repeat or drop rows. Ids compare by code
@@ -61,7 +61,6 @@ export interface GraphDatabase {
   updateResource(id: ResourceId, input: UpdateResourceInput): Promise<ResourceDescriptor>;
   deleteResource(id: ResourceId): Promise<void>;
   listResources(filter: ResourceFilter): Promise<{ resources: ResourceDescriptor[]; total: number }>;
-  searchResources(query: string, limit?: number): Promise<ResourceDescriptor[]>;
 
   // Annotation operations
   createAnnotation(input: CreateAnnotationInternal): Promise<Annotation>;

--- a/packages/graph/src/interface.ts
+++ b/packages/graph/src/interface.ts
@@ -30,6 +30,24 @@ export function assertMutableResourceUpdate(input: UpdateResourceInput): void {
   }
 }
 
+/**
+ * Newest first, ties broken by id — the ordering every `listResources` and
+ * `searchResources` result must carry.
+ *
+ * The tiebreak is not cosmetic: browse pages these results with offset/limit,
+ * and a partial order lets two pages repeat or drop rows. Ids compare by code
+ * point rather than locale so the JS backends agree with the engines, whose
+ * `ORDER BY` is codepoint-ordered.
+ */
+export function compareByRecencyThenId(a: ResourceDescriptor, b: ResourceDescriptor): number {
+  const aTime = a.dateCreated ? Date.parse(a.dateCreated) : 0;
+  const bTime = b.dateCreated ? Date.parse(b.dateCreated) : 0;
+  if (aTime !== bTime) return bTime - aTime;
+  const aId = String(a['@id']);
+  const bId = String(b['@id']);
+  return aId < bId ? -1 : aId > bId ? 1 : 0;
+}
+
 export interface GraphDatabase {
   // Connection management
   connect(): Promise<void>;

--- a/packages/graph/src/resource-query.ts
+++ b/packages/graph/src/resource-query.ts
@@ -1,0 +1,70 @@
+/**
+ * The resource query — filtering, ranking and pagination — expressed in JS.
+ *
+ * Shared by every backend whose engine does not express it directly (memory,
+ * JanusGraph, Neptune) so those three cannot drift apart. Neo4j expresses the
+ * same semantics in Cypher, and the interface contract tests pin both shapes to
+ * one behaviour.
+ */
+
+import { getResourceEntityTypes } from '@semiont/core';
+import type { ResourceDescriptor, ResourceFilter } from '@semiont/core';
+import { compareByRecencyThenId } from './interface';
+
+/**
+ * How directly a resource answers the query: 0 exact name, 1 name prefix,
+ * 2 name substring, 3 matched on `storageUri` alone.
+ *
+ * Path-only hits rank last deliberately. Someone searching "Marathon" wants the
+ * document *called* Marathon before every file that merely lives under a folder
+ * of that name.
+ */
+export function searchRank(resource: ResourceDescriptor, query: string): number {
+  const needle = query.toLowerCase();
+  const name = (resource.name ?? '').toLowerCase();
+  if (name === needle) return 0;
+  if (name.startsWith(needle)) return 1;
+  if (name.includes(needle)) return 2;
+  return 3;
+}
+
+function matchesSearch(resource: ResourceDescriptor, query: string): boolean {
+  const needle = query.toLowerCase();
+  return (resource.name ?? '').toLowerCase().includes(needle)
+    || (resource.storageUri?.toLowerCase().includes(needle) ?? false);
+}
+
+/**
+ * Filter, order and page a resource set. Filters always run before pagination,
+ * so `total` describes the match set rather than the page.
+ */
+export function queryResources(
+  all: ResourceDescriptor[],
+  filter: ResourceFilter,
+): { resources: ResourceDescriptor[]; total: number } {
+  let matches = all;
+
+  if (filter.entityTypes && filter.entityTypes.length > 0) {
+    matches = matches.filter((doc) =>
+      filter.entityTypes!.some((type) => getResourceEntityTypes(doc).includes(type)));
+  }
+
+  if (filter.search) {
+    matches = matches.filter((doc) => matchesSearch(doc, filter.search!));
+  }
+
+  if (filter.archived !== undefined) {
+    matches = matches.filter((doc) => (doc.archived ?? false) === filter.archived);
+  }
+
+  const { search } = filter;
+  const ordered = [...matches].sort(
+    search
+      ? (a, b) => (searchRank(a, search) - searchRank(b, search)) || compareByRecencyThenId(a, b)
+      : compareByRecencyThenId,
+  );
+
+  const offset = filter.offset ?? 0;
+  const limit = filter.limit ?? 20;
+  return { resources: ordered.slice(offset, offset + limit), total: ordered.length };
+}

--- a/packages/graph/src/resource-query.ts
+++ b/packages/graph/src/resource-query.ts
@@ -12,26 +12,39 @@ import type { ResourceDescriptor, ResourceFilter } from '@semiont/core';
 import { compareByRecencyThenId } from './interface';
 
 /**
+ * Split a query into the terms every match must satisfy. Blank input yields no
+ * terms, which callers read as "no query" — a bare substring match on `" "`
+ * would otherwise match every name containing a space.
+ */
+export function searchTerms(query: string): string[] {
+  return query.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/**
  * How directly a resource answers the query: 0 exact name, 1 name prefix,
- * 2 name substring, 3 matched on `storageUri` alone.
+ * 2 every term present in the name, 3 the path had to supply a term.
  *
- * Path-only hits rank last deliberately. Someone searching "Marathon" wants the
- * document *called* Marathon before every file that merely lives under a folder
- * of that name.
+ * Path-assisted hits rank last deliberately. Someone searching "Marathon" wants
+ * the document *called* Marathon before every file that merely lives under a
+ * folder of that name.
  */
 export function searchRank(resource: ResourceDescriptor, query: string): number {
-  const needle = query.toLowerCase();
+  const whole = query.trim().toLowerCase();
   const name = (resource.name ?? '').toLowerCase();
-  if (name === needle) return 0;
-  if (name.startsWith(needle)) return 1;
-  if (name.includes(needle)) return 2;
+  if (name === whole) return 0;
+  if (name.startsWith(whole)) return 1;
+  if (searchTerms(query).every((term) => name.includes(term))) return 2;
   return 3;
 }
 
-function matchesSearch(resource: ResourceDescriptor, query: string): boolean {
-  const needle = query.toLowerCase();
-  return (resource.name ?? '').toLowerCase().includes(needle)
-    || (resource.storageUri?.toLowerCase().includes(needle) ?? false);
+/**
+ * Every term must appear, though each may come from the name or the path — so
+ * "Aeschylus Marathon" finds a resource named for one and filed under the other.
+ */
+function matchesSearch(resource: ResourceDescriptor, terms: string[]): boolean {
+  const name = (resource.name ?? '').toLowerCase();
+  const uri = resource.storageUri?.toLowerCase() ?? '';
+  return terms.every((term) => name.includes(term) || uri.includes(term));
 }
 
 /**
@@ -49,15 +62,17 @@ export function queryResources(
       filter.entityTypes!.some((type) => getResourceEntityTypes(doc).includes(type)));
   }
 
-  if (filter.search) {
-    matches = matches.filter((doc) => matchesSearch(doc, filter.search!));
+  // A query of only whitespace has no terms, and so filters nothing.
+  const terms = filter.search ? searchTerms(filter.search) : [];
+  if (terms.length > 0) {
+    matches = matches.filter((doc) => matchesSearch(doc, terms));
   }
 
   if (filter.archived !== undefined) {
     matches = matches.filter((doc) => (doc.archived ?? false) === filter.archived);
   }
 
-  const { search } = filter;
+  const search = terms.length > 0 ? filter.search! : undefined;
   const ordered = [...matches].sort(
     search
       ? (a, b) => (searchRank(a, search) - searchRank(b, search)) || compareByRecencyThenId(a, b)

--- a/packages/graph/src/resource-query.ts
+++ b/packages/graph/src/resource-query.ts
@@ -22,11 +22,12 @@ export function searchTerms(query: string): string[] {
 
 /**
  * How directly a resource answers the query: 0 exact name, 1 name prefix,
- * 2 every term present in the name, 3 the path had to supply a term.
+ * 2 every term present in the name, 3 something other than the name — the path
+ * or an entity type — had to supply a term.
  *
- * Path-assisted hits rank last deliberately. Someone searching "Marathon" wants
- * the document *called* Marathon before every file that merely lives under a
- * folder of that name.
+ * Those assisted hits rank last deliberately. Someone searching "Marathon"
+ * wants the document *called* Marathon before every file that merely lives
+ * under a folder of that name or is tagged with it.
  */
 export function searchRank(resource: ResourceDescriptor, query: string): number {
   const whole = query.trim().toLowerCase();
@@ -38,13 +39,16 @@ export function searchRank(resource: ResourceDescriptor, query: string): number 
 }
 
 /**
- * Every term must appear, though each may come from the name or the path — so
- * "Aeschylus Marathon" finds a resource named for one and filed under the other.
+ * Every term must appear, though each may come from the name, the path or an
+ * entity type — so "Aeschylus Marathon" finds a resource named for one and
+ * filed under the other, and "Historian" finds what is tagged as one.
  */
 function matchesSearch(resource: ResourceDescriptor, terms: string[]): boolean {
   const name = (resource.name ?? '').toLowerCase();
   const uri = resource.storageUri?.toLowerCase() ?? '';
-  return terms.every((term) => name.includes(term) || uri.includes(term));
+  const types = getResourceEntityTypes(resource).map((t) => t.toLowerCase());
+  return terms.every((term) =>
+    name.includes(term) || uri.includes(term) || types.some((t) => t.includes(term)));
 }
 
 /**

--- a/packages/make-meaning/docs/SCRIPTING.md
+++ b/packages/make-meaning/docs/SCRIPTING.md
@@ -172,7 +172,7 @@ const resource = await ResourceContext.getResourceMetadata(resourceId, kb);
 const annotations = await AnnotationContext.getAllAnnotations(resourceId, kb);
 
 // Search resources via graph
-const results = await GraphContext.searchResources('query text', kb, 10);
+const { resources: results } = await kb.graph.listResources({ search: 'query text', limit: 10 });
 
 // Get graph stats
 const stats = await kb.graph.getStats();

--- a/packages/make-meaning/docs/api-reference.md
+++ b/packages/make-meaning/docs/api-reference.md
@@ -302,16 +302,6 @@ static async getBacklinks(
 ): Promise<Annotation[]>
 ```
 
-#### searchResources()
-
-```typescript
-static async searchResources(
-  query: string,
-  kb: KnowledgeBase,
-  limit?: number,
-): Promise<ResourceDescriptor[]>
-```
-
 #### findPath()
 
 ```typescript

--- a/packages/make-meaning/docs/architecture.md
+++ b/packages/make-meaning/docs/architecture.md
@@ -115,7 +115,7 @@ The read actor for the Knowledge Base. Handles deterministic, fact-based queries
 | Request Event | Handler | Result Event |
 |--------------|---------|-------------|
 | `browse:resource-requested` | `assembleResourceGraph()` — materializes the resource from the event store and filters its inbound entity references (shared with `LocalContentTransport.getResourceGraph`) | `browse:resource-result` / `browse:resource-failed` |
-| `browse:resources-requested` | `ResourceContext.listResources()` (delegates to `kb.graph.searchResources` when `search` is set) | `browse:resources-result` / `browse:resources-failed` |
+| `browse:resources-requested` | `ResourceContext.listResources()` (delegates to `kb.graph.listResources` when `search` is set, otherwise reads the materialized views) | `browse:resources-result` / `browse:resources-failed` |
 | `browse:annotations-requested` | `AnnotationContext.getAllAnnotations()` | `browse:annotations-result` / `browse:annotations-failed` |
 | `browse:annotation-requested` | `AnnotationContext.getAnnotation()` + `ResourceContext.getResourceMetadata()` | `browse:annotation-result` / `browse:annotation-failed` |
 | `browse:events-requested` | `EventQuery.queryEvents()` | `browse:events-result` / `browse:events-failed` |
@@ -130,11 +130,11 @@ The read actor for the Knowledge Base. Handles deterministic, fact-based queries
 
 Both actors can find resources by name; the question is what kind of question is being asked.
 
-- **Browse handles a query.** One signal, one ordering, deterministic. "Resources whose names contain X, sorted by date." `kb.graph.searchResources(query)` is a Browse primitive when used standalone — it answers the literal question and returns. The discover page's search box uses this path: a name match is exactly what the user asked for, nothing more.
+- **Browse handles a query.** Lexical signals only, one deterministic ordering. "Resources where every term appears in the name, the path or an entity type, ranked by how directly the name answers and then by recency." `kb.graph.listResources({ search })` is a Browse primitive when used standalone — it answers the literal question and returns. The discover page's search box uses this path: a lexical match is exactly what the user asked for, nothing more.
 
 - **Match handles a recommendation.** Multiple candidate sources, composite scoring against `GatheredContext`, optional LLM blending. "Given this annotation, this passage, and this graph neighborhood, what are the most relevant resources to bind?" That's not a query — it's a ranked judgment.
 
-The same primitive (`kb.graph.searchResources`) is used by both actors today. That's fine: the difference is what each actor *does with the result*. Browse returns it sorted by date. Match treats it as one of four candidate sources and runs it through structural + semantic scoring.
+The same primitive (`kb.graph.listResources({ search })`) is used by both actors today. That's fine: the difference is what each actor *does with the result*. Browse returns it ranked and paged. Match treats it as one of four candidate sources and runs it through structural + semantic scoring.
 
 The rule: **if the answer could be a single SQL/Cypher query against a single index, it's Browse. If it needs to fuse multiple sources or score against context, it's Match.** When discover-page search eventually wants fuzzy / semantic / context-boosted recall, that's the moment to route it through the Matcher instead of the Browser — and the http-transport surface would shift from `browse.resources({ search })` to `match.search(...)` accordingly.
 

--- a/packages/make-meaning/docs/examples.md
+++ b/packages/make-meaning/docs/examples.md
@@ -63,9 +63,12 @@ if (resource) {
 ```typescript
 import { ResourceContext } from '@semiont/make-meaning';
 
-const resources = await ResourceContext.listResources({
-  createdAfter: '2024-01-01',
-  mimeType: 'text/markdown',
+// `total` is the size of the whole match set, not of the returned page.
+const { resources, total } = await ResourceContext.listResources({
+  search: 'lovelace',
+  entityType: 'Person',
+  archived: false,
+  offset: 0,
   limit: 10,
 }, kb);
 
@@ -208,7 +211,10 @@ const backlinks = await GraphContext.getBacklinks(resourceId, kb);
 console.log(`Found ${backlinks.length} backlinks`);
 
 // Search resources
-const results = await GraphContext.searchResources('neural networks', kb, 10);
+const { resources: results } = await kb.graph.listResources({
+  search: 'neural networks',
+  limit: 10,
+});
 
 // Find paths between resources
 const paths = await GraphContext.findPath(fromId, toId, kb, 3);

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -26,7 +26,6 @@ function createMockGraphDb(): GraphDatabase {
     updateResource: vi.fn().mockResolvedValue({}),
     deleteResource: vi.fn().mockResolvedValue(undefined),
     listResources: vi.fn().mockResolvedValue({ resources: [], total: 0 }),
-    searchResources: vi.fn().mockResolvedValue([]),
     createAnnotation: vi.fn().mockResolvedValue({}),
     getAnnotation: vi.fn().mockResolvedValue(null),
     updateAnnotation: vi.fn().mockResolvedValue({}),

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -17,8 +17,7 @@ const mockGraphDb = {
   getResourceReferencedBy: vi.fn(),
   getResourceAnnotations: vi.fn(),
   findPath: vi.fn(),
-  getResourceConnections: vi.fn(),
-  searchResources: vi.fn()
+  getResourceConnections: vi.fn()
 };
 
 const mockViews = { get: vi.fn() };
@@ -116,30 +115,6 @@ describe('GraphContext', () => {
     expect(mockGraphDb.getResourceConnections).toHaveBeenCalledWith(resourceId('test'));
   });
 
-  it('should search resources by query', async () => {
-    mockGraphDb.searchResources.mockResolvedValue([
-      {
-        id: 'http://localhost:4000/resources/match1',
-        name: 'Matching Resource 1',
-        format: 'text/plain',
-        createdAt: '2024-01-01T00:00:00Z'
-      },
-      {
-        id: 'http://localhost:4000/resources/match2',
-        name: 'Matching Resource 2',
-        format: 'text/plain',
-        createdAt: '2024-01-02T00:00:00Z'
-      }
-    ]);
-
-    const result = await GraphContext.searchResources('test query', mockKb, 10);
-
-    expect(result).toHaveLength(2);
-    expect(result[0].name).toBe('Matching Resource 1');
-    expect(result[1].name).toBe('Matching Resource 2');
-    expect(mockGraphDb.searchResources).toHaveBeenCalledWith('test query', 10);
-  });
-
   it('should handle empty backlinks', async () => {
     mockGraphDb.getResourceReferencedBy.mockResolvedValue([]);
 
@@ -160,14 +135,6 @@ describe('GraphContext', () => {
     expect(result).toEqual([]);
   });
 
-  it('should handle search with no results', async () => {
-    mockGraphDb.searchResources.mockResolvedValue([]);
-
-    const result = await GraphContext.searchResources('nonexistent query', mockKb);
-
-    expect(result).toEqual([]);
-  });
-
   it('should call findPath without maxDepth when not provided', async () => {
     mockGraphDb.findPath.mockResolvedValue([]);
 
@@ -182,14 +149,6 @@ describe('GraphContext', () => {
       resourceId('to'),
       undefined
     );
-  });
-
-  it('should call searchResources without limit when not provided', async () => {
-    mockGraphDb.searchResources.mockResolvedValue([]);
-
-    await GraphContext.searchResources('query', mockKb);
-
-    expect(mockGraphDb.searchResources).toHaveBeenCalledWith('query', undefined);
   });
 
   describe('buildKnowledgeGraph (CONTEXT-UNIFICATION P2)', () => {

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -120,11 +120,23 @@ const noopInference = {
   generateTextWithMetadata: vi.fn().mockResolvedValue({ text: '', usage: {} }),
 } as unknown as InferenceClient;
 
+type MockResourceFilter = { search?: string; entityTypes?: string[]; limit?: number };
+
+type SearchMatches = (filter: MockResourceFilter) => Promise<unknown[]>;
+type EntityTypeMatches = (filter: MockResourceFilter) => Promise<{ resources: unknown[]; total: number }>;
+type SearchMatchesMock = ReturnType<typeof vi.fn<SearchMatches>>;
+type EntityTypeMatchesMock = ReturnType<typeof vi.fn<EntityTypeMatches>>;
+
+// The Matcher draws name matches and entity-type matches from the same
+// `listResources` method, told apart by the filter it passes. These two knobs
+// stand for those two retrieval sources; the mock below routes between them.
 interface MockGraphOverrides {
-  searchResources?: ReturnType<typeof vi.fn>;
+  /** Name-match source — `listResources({ search })`. Resolves an array. */
+  searchMatches?: SearchMatches;
+  /** Entity-type source — `listResources({ entityTypes })`. Resolves `{ resources, total }`. */
+  entityTypeMatches?: EntityTypeMatches;
   getResourceReferencedBy?: ReturnType<typeof vi.fn>;
   getResource?: ReturnType<typeof vi.fn>;
-  listResources?: ReturnType<typeof vi.fn>;
   viewsGet?: ReturnType<typeof vi.fn>;
 }
 
@@ -137,10 +149,20 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
     projectionsDir: '',
       weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
     graph: {
-      searchResources: overrides.searchResources ?? vi.fn().mockResolvedValue([]),
       getResourceReferencedBy: overrides.getResourceReferencedBy ?? vi.fn().mockResolvedValue([]),
       getResource: overrides.getResource ?? vi.fn().mockResolvedValue(null),
-      listResources: overrides.listResources ?? vi.fn().mockResolvedValue({ resources: [], total: 0 }),
+      listResources: vi.fn(async (filter: MockResourceFilter) => {
+        if (filter?.search) {
+          const resources = overrides.searchMatches ? await overrides.searchMatches(filter) : [];
+          return { resources, total: resources.length };
+        }
+        if (filter?.entityTypes?.length) {
+          return overrides.entityTypeMatches
+            ? await overrides.entityTypeMatches(filter)
+            : { resources: [], total: 0 };
+        }
+        return { resources: [], total: 0 };
+      }),
       createResource: vi.fn(),
       deleteResource: vi.fn(),
       getBacklinks: vi.fn(),
@@ -155,14 +177,14 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
 describe('Matcher', () => {
   let eventBus: EventBus;
   let matcher: Matcher;
-  let mockSearchFn: ReturnType<typeof vi.fn>;
+  let mockSearchFn: SearchMatchesMock;
   let kb: KnowledgeBase;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     eventBus = new EventBus();
-    mockSearchFn = vi.fn();
-    kb = createMockKb({ searchResources: mockSearchFn });
+    mockSearchFn = vi.fn<SearchMatches>();
+    kb = createMockKb({ searchMatches: mockSearchFn });
     matcher = new Matcher(kb, eventBus, mockLogger, noopInference);
     await matcher.initialize();
   });
@@ -203,7 +225,7 @@ describe('Matcher', () => {
         expect(r).toHaveProperty('score');
       }
 
-      expect(mockSearchFn).toHaveBeenCalledWith('test query');
+      expect(mockSearchFn).toHaveBeenCalledWith({ search: 'test query', limit: 20 });
     });
 
     it('should emit match:search-failed on error', async () => {
@@ -241,8 +263,8 @@ describe('Matcher', () => {
   });
 
   describe('context-driven search', () => {
-    let mockSearchFn2: ReturnType<typeof vi.fn>;
-    let mockListResources: ReturnType<typeof vi.fn>;
+    let mockSearchFn2: SearchMatchesMock;
+    let mockListResources: EntityTypeMatchesMock;
     let mockGetResource: ReturnType<typeof vi.fn>;
     let mockViewGet: ReturnType<typeof vi.fn>;
 
@@ -256,13 +278,13 @@ describe('Matcher', () => {
 
       vi.clearAllMocks();
       eventBus = new EventBus();
-      mockSearchFn2 = vi.fn().mockResolvedValue([]);
-      mockListResources = vi.fn().mockResolvedValue({ resources: [], total: 0 });
+      mockSearchFn2 = vi.fn<SearchMatches>().mockResolvedValue([]);
+      mockListResources = vi.fn<EntityTypeMatches>().mockResolvedValue({ resources: [], total: 0 });
       mockGetResource = vi.fn().mockResolvedValue(null);
       mockViewGet = vi.fn().mockResolvedValue(null);
       kb = createMockKb({
-        searchResources: mockSearchFn2,
-        listResources: mockListResources,
+        searchMatches: mockSearchFn2,
+        entityTypeMatches: mockListResources,
         getResource: mockGetResource,
         viewsGet: mockViewGet,
       });
@@ -597,12 +619,12 @@ describe('Matcher', () => {
 
       vi.clearAllMocks();
       eventBus = new EventBus();
-      mockSearchFn2 = vi.fn().mockResolvedValue([RES_A, RES_B]);
-      mockListResources = vi.fn().mockResolvedValue({ resources: [], total: 0 });
+      mockSearchFn2 = vi.fn<SearchMatches>().mockResolvedValue([RES_A, RES_B]);
+      mockListResources = vi.fn<EntityTypeMatches>().mockResolvedValue({ resources: [], total: 0 });
       mockGetResource = vi.fn().mockResolvedValue(null);
       kb = createMockKb({
-        searchResources: mockSearchFn2,
-        listResources: mockListResources,
+        searchMatches: mockSearchFn2,
+        entityTypeMatches: mockListResources,
         getResource: mockGetResource,
       });
 
@@ -644,12 +666,12 @@ describe('Matcher', () => {
 
       vi.clearAllMocks();
       eventBus = new EventBus();
-      mockSearchFn2 = vi.fn().mockResolvedValue([RES_A]);
-      mockListResources = vi.fn().mockResolvedValue({ resources: [], total: 0 });
+      mockSearchFn2 = vi.fn<SearchMatches>().mockResolvedValue([RES_A]);
+      mockListResources = vi.fn<EntityTypeMatches>().mockResolvedValue({ resources: [], total: 0 });
       mockGetResource = vi.fn().mockResolvedValue(null);
       kb = createMockKb({
-        searchResources: mockSearchFn2,
-        listResources: mockListResources,
+        searchMatches: mockSearchFn2,
+        entityTypeMatches: mockListResources,
         getResource: mockGetResource,
       });
 
@@ -727,12 +749,12 @@ describe('Matcher', () => {
 
         vi.clearAllMocks();
         eventBus = new EventBus();
-        mockSearchFn2 = vi.fn().mockResolvedValue([RES_A, RES_B, RES_C]);
-        mockListResources = vi.fn().mockResolvedValue({ resources: [], total: 0 });
+        mockSearchFn2 = vi.fn<SearchMatches>().mockResolvedValue([RES_A, RES_B, RES_C]);
+        mockListResources = vi.fn<EntityTypeMatches>().mockResolvedValue({ resources: [], total: 0 });
         mockGetResource = vi.fn().mockResolvedValue(null);
         kb = createMockKb({
-          searchResources: mockSearchFn2,
-          listResources: mockListResources,
+          searchMatches: mockSearchFn2,
+          entityTypeMatches: mockListResources,
           getResource: mockGetResource,
         });
 

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -40,7 +40,7 @@ describe('ResourceContext', () => {
     };
 
     mockGraph = {
-      searchResources: vi.fn().mockResolvedValue([]),
+      listResources: vi.fn().mockResolvedValue({ resources: [], total: 0 }),
     };
 
     mockKb = {
@@ -103,6 +103,18 @@ describe('ResourceContext', () => {
   });
 
   describe('listResources', () => {
+    const asView = (resource: ResourceDescriptor) => ({
+      resource,
+      annotations: {
+        highlights: [],
+        assessments: [],
+        comments: [],
+        tags: [],
+        links: [],
+        entityReferences: [],
+      },
+    });
+
     const mockResource1: ResourceDescriptor = {
       '@context': 'https://schema.org/',
       '@id': resourceId('res-1'),
@@ -134,192 +146,93 @@ describe('ResourceContext', () => {
     };
 
     test('should list all resources when no filters provided', async () => {
-      mockViewStorage.getAll.mockResolvedValue([
-        {
-          resource: mockResource1,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-        {
-          resource: mockResource2,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-      ]);
+      mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource2)]);
 
       const result = await ResourceContext.listResources(undefined, mockKb);
 
-      expect(result).toHaveLength(2);
-      expect(result).toContainEqual(mockResource1);
-      expect(result).toContainEqual(mockResource2);
+      expect(result.total).toBe(2);
+      expect(result.resources).toContainEqual(mockResource1);
+      expect(result.resources).toContainEqual(mockResource2);
     });
 
     test('should filter by archived status (false)', async () => {
-      mockViewStorage.getAll.mockResolvedValue([
-        {
-          resource: mockResource1,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-        {
-          resource: mockResource3,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-      ]);
+      mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource3)]);
 
       const result = await ResourceContext.listResources({ archived: false }, mockKb);
 
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(mockResource1);
-      expect(result.every(r => !r.archived)).toBe(true);
+      expect(result.resources).toEqual([mockResource1]);
+      expect(result.total).toBe(1);
     });
 
     test('should filter by archived status (true)', async () => {
-      mockViewStorage.getAll.mockResolvedValue([
-        {
-          resource: mockResource1,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-        {
-          resource: mockResource3,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-      ]);
+      mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource3)]);
 
       const result = await ResourceContext.listResources({ archived: true }, mockKb);
 
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(mockResource3);
-      expect(result.every(r => r.archived)).toBe(true);
+      expect(result.resources).toEqual([mockResource3]);
+      expect(result.total).toBe(1);
     });
 
-    test('should delegate to graph.searchResources when search is set', async () => {
-      const specialDoc = { ...mockResource2, name: 'Special Document' };
-      mockGraph.searchResources.mockResolvedValue([specialDoc]);
-
-      const result = await ResourceContext.listResources({ search: 'special' }, mockKb);
-
-      expect(mockGraph.searchResources).toHaveBeenCalledWith('special');
-      expect(mockViewStorage.getAll).not.toHaveBeenCalled();
-      expect(result).toHaveLength(1);
-      expect(result[0]?.name).toBe('Special Document');
-    });
-
-    test('should narrow graph search results by archived filter', async () => {
-      const searchableArchived: ResourceDescriptor = {
-        '@context': 'https://schema.org/',
-        '@id': resourceId('res-4'),
-        name: 'Archived Special',
-        archived: true,
-        entityTypes: ['Document'],
-        dateCreated: '2024-01-04T00:00:00Z',
-        representations: [],
-      };
-
-      mockGraph.searchResources.mockResolvedValue([
-        { ...mockResource1, name: 'Special Live' },
-        searchableArchived,
+    test('view path filters by entityType and paginates, totalling every match', async () => {
+      mockViewStorage.getAll.mockResolvedValue([
+        asView(mockResource1), asView(mockResource2), asView(mockResource3),
       ]);
 
       const result = await ResourceContext.listResources(
-        { archived: true, search: 'special' },
-        mockKb
+        { entityType: 'Document', limit: 1, offset: 0 },
+        mockKb,
       );
 
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(searchableArchived);
+      // Two Documents match; the page holds one. `total` describes the match
+      // set, because that is what the caller pages on.
+      expect(result.total).toBe(2);
+      expect(result.resources).toEqual([mockResource3]);
     });
 
-    test('should return empty array when graph search has no matches', async () => {
-      mockGraph.searchResources.mockResolvedValue([]);
+    test('search path pushes every filter into the graph query', async () => {
+      const specialDoc = { ...mockResource2, name: 'Special Document' };
+      mockGraph.listResources.mockResolvedValue({ resources: [specialDoc], total: 42 });
+
+      const result = await ResourceContext.listResources(
+        { search: 'special', archived: false, entityType: 'Document', offset: 20, limit: 10 },
+        mockKb,
+      );
+
+      // Every filter travels into the engine. Narrowing any of them in JS after
+      // the fact would apply it to one page instead of the whole match set.
+      expect(mockGraph.listResources).toHaveBeenCalledWith({
+        search: 'special',
+        archived: false,
+        entityTypes: ['Document'],
+        offset: 20,
+        limit: 10,
+      });
+      expect(mockViewStorage.getAll).not.toHaveBeenCalled();
+      expect(result.total).toBe(42);
+      expect(result.resources).toEqual([specialDoc]);
+    });
+
+    test('search path returns nothing when the graph has no matches', async () => {
+      mockGraph.listResources.mockResolvedValue({ resources: [], total: 0 });
 
       const result = await ResourceContext.listResources({ search: 'nonexistent' }, mockKb);
 
-      expect(result).toEqual([]);
+      expect(result.resources).toEqual([]);
+      expect(result.total).toBe(0);
     });
 
     test('should sort by creation date (newest first)', async () => {
       mockViewStorage.getAll.mockResolvedValue([
-        {
-          resource: mockResource1,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-        {
-          resource: mockResource2,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-        {
-          resource: mockResource3,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
+        asView(mockResource1), asView(mockResource2), asView(mockResource3),
       ]);
 
       const result = await ResourceContext.listResources(undefined, mockKb);
 
-      // Should be sorted newest first
-      expect(result[0]?.dateCreated).toBe('2024-01-03T00:00:00Z');
-      expect(result[1]?.dateCreated).toBe('2024-01-02T00:00:00Z');
-      expect(result[2]?.dateCreated).toBe('2024-01-01T00:00:00Z');
+      expect(result.resources.map(r => r.dateCreated)).toEqual([
+        '2024-01-03T00:00:00Z',
+        '2024-01-02T00:00:00Z',
+        '2024-01-01T00:00:00Z',
+      ]);
     });
 
     test('should handle resources without dateCreated', async () => {
@@ -332,36 +245,13 @@ describe('ResourceContext', () => {
         representations: [],
       };
 
-      mockViewStorage.getAll.mockResolvedValue([
-        {
-          resource: mockResource1,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-        {
-          resource: resourceNoDate,
-          annotations: {
-            highlights: [],
-            assessments: [],
-            comments: [],
-            tags: [],
-            links: [],
-            entityReferences: [],
-          },
-        },
-      ]);
+      mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(resourceNoDate)]);
 
       const result = await ResourceContext.listResources(undefined, mockKb);
 
-      expect(result).toHaveLength(2);
+      expect(result.total).toBe(2);
       // Resource with date should come first
-      expect(result[0]).toEqual(mockResource1);
+      expect(result.resources[0]).toEqual(mockResource1);
     });
   });
 

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -212,6 +212,18 @@ describe('ResourceContext', () => {
       expect(result.resources).toEqual([specialDoc]);
     });
 
+    test('a whitespace-only query is not a search', async () => {
+      mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource2)]);
+
+      const result = await ResourceContext.listResources({ search: '   ' }, mockKb);
+
+      // Blank input must not divert the listing onto the eventually-consistent
+      // graph path, and must not match every name containing a space.
+      expect(mockGraph.listResources).not.toHaveBeenCalled();
+      expect(mockViewStorage.getAll).toHaveBeenCalled();
+      expect(result.total).toBe(2);
+    });
+
     test('search path returns nothing when the graph has no matches', async () => {
       mockGraph.listResources.mockResolvedValue({ resources: [], total: 0 });
 

--- a/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
@@ -337,7 +337,8 @@ describe('Scripting Example: Query Graph Database', () => {
     await new Promise(resolve => setTimeout(resolve, 1000));
 
     // Search for resources using GraphDatabase interface
-    const searchResults = await makeMeaning.knowledgeSystem.kb.graph.searchResources('Custom', 10);
+    const { resources: searchResults } =
+      await makeMeaning.knowledgeSystem.kb.graph.listResources({ search: 'Custom', limit: 10 });
 
     console.log('Search results:');
     searchResults.forEach(resource => {

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -66,7 +66,6 @@ function createMockGraphDb(): GraphDatabase {
     updateResource: vi.fn().mockResolvedValue({}),
     deleteResource: vi.fn().mockResolvedValue(undefined),
     listResources: vi.fn().mockResolvedValue({ resources: [], total: 0 }),
-    searchResources: vi.fn().mockResolvedValue([]),
     createAnnotation: vi.fn().mockResolvedValue({}),
     getAnnotation: vi.fn().mockResolvedValue(null),
     updateAnnotation: vi.fn().mockResolvedValue({}),

--- a/packages/make-meaning/src/browser.ts
+++ b/packages/make-meaning/src/browser.ts
@@ -27,7 +27,7 @@ import type { SemiontProject } from '@semiont/core/node';
 import type { EventMap, Logger, components } from '@semiont/core';
 import { EventBus, resourceId, annotationId, errField } from '@semiont/core';
 import { withActorSpan } from '@semiont/observability';
-import { getExactText, getTargetSource, getTargetSelector, getResourceEntityTypes, getBodySource } from '@semiont/core';
+import { getExactText, getTargetSource, getTargetSelector, getBodySource } from '@semiont/core';
 import { EventQuery } from '@semiont/event-sourcing';
 import type { ViewStorage } from '@semiont/event-sourcing';
 import type { KnowledgeBase } from './knowledge-base';
@@ -163,31 +163,27 @@ export class Browser {
 
   private async handleBrowseResources(event: EventMap['browse:resources-requested']): Promise<void> {
     try {
-      let filteredDocs = await ResourceContext.listResources({
-        search: event.search,
-        archived: event.archived,
-      }, this.kb);
-
-      // Filter by entity type
-      if (event.entityType) {
-        filteredDocs = filteredDocs.filter((doc) => getResourceEntityTypes(doc).includes(event.entityType!));
-      }
-
-      // Paginate
       const offset = event.offset ?? 0;
       const limit = event.limit ?? 50;
-      const paginatedDocs = filteredDocs.slice(offset, offset + limit);
+
+      const { resources, total } = await ResourceContext.listResources({
+        search: event.search,
+        archived: event.archived,
+        entityType: event.entityType,
+        offset,
+        limit,
+      }, this.kb);
 
       // Add content previews for search results
       const formattedDocs = event.search
-        ? await ResourceContext.addContentPreviews(paginatedDocs, this.kb)
-        : paginatedDocs;
+        ? await ResourceContext.addContentPreviews(resources, this.kb)
+        : resources;
 
       this.eventBus.get('browse:resources-result').next({
         correlationId: event.correlationId,
         response: {
           resources: formattedDocs,
-          total: filteredDocs.length,
+          total,
           offset,
           limit,
         },

--- a/packages/make-meaning/src/graph-context.ts
+++ b/packages/make-meaning/src/graph-context.ts
@@ -19,7 +19,6 @@ import type { KnowledgeBase } from './knowledge-base';
 import { WeaveProgressTimeout } from './weave-progress';
 
 import type { Annotation } from '@semiont/core';
-import type { ResourceDescriptor } from '@semiont/core';
 
 // The unified knowledge-graph shape is the core/spec type (CONTEXT-UNIFICATION):
 // resources AND annotations are nodes; edges are typed and directional. The
@@ -80,14 +79,6 @@ export class GraphContext {
    */
   static async getResourceConnections(resourceId: ResourceId, kb: KnowledgeBase): Promise<GraphConnection[]> {
     return kb.graph.getResourceConnections(resourceId);
-  }
-
-  /**
-   * Search resources by name (cross-resource query)
-   * Requires full-text search - must use graph database
-   */
-  static async searchResources(query: string, kb: KnowledgeBase, limit?: number): Promise<ResourceDescriptor[]> {
-    return kb.graph.searchResources(query, limit);
   }
 
   /**

--- a/packages/make-meaning/src/index.ts
+++ b/packages/make-meaning/src/index.ts
@@ -77,7 +77,7 @@ export type { CreateAnnotationResult, UpdateAnnotationBodyResult } from './annot
 
 // Context assembly exports
 export { ResourceContext } from './resource-context';
-export type { ListResourcesFilters } from './resource-context';
+export type { ListResourcesFilters, ListResourcesResult } from './resource-context';
 export { AnnotationContext } from './annotation-context';
 export type { BuildContextOptions } from './annotation-context';
 export { GraphContext } from './graph-context';

--- a/packages/make-meaning/src/matcher.ts
+++ b/packages/make-meaning/src/matcher.ts
@@ -108,7 +108,7 @@ export class Matcher {
    * Context-driven search: multi-source retrieval + composite scoring
    *
    * Retrieval sources:
-   * 1. Name match — graph.searchResources(searchTerm)
+   * 1. Name match — graph.listResources({ search: searchTerm })
    * 2. Entity type match — graph.listResources({ entityTypes })
    * 3. Graph neighborhood — connections from GatheredContext
    *
@@ -138,7 +138,7 @@ export class Matcher {
     // this search", and multi-source retrieval absorbs a just-created
     // resource missing from one source for the Weaver's ~tens-of-ms lag.
     const [nameMatches, entityTypeMatches, semanticMatches] = await Promise.all([
-      this.kb.graph.searchResources(searchTerm),
+      this.kb.graph.listResources({ search: searchTerm, limit: 20 }).then(r => r.resources),
       annotationEntityTypes.length > 0
         ? this.kb.graph.listResources({ entityTypes: annotationEntityTypes, limit: 50 })
             .then(r => r.resources)

--- a/packages/make-meaning/src/resource-context.ts
+++ b/packages/make-meaning/src/resource-context.ts
@@ -54,18 +54,20 @@ export class ResourceContext {
    * where the graph is only eventually consistent.
    */
   static async listResources(filters: ListResourcesFilters | undefined, kb: KnowledgeBase): Promise<ListResourcesResult> {
-    const offset = filters?.offset ?? 0;
-    const limit = filters?.limit ?? 50;
+    const { search: rawSearch, archived, entityType, offset = 0, limit = 50 } = filters ?? {};
+    // Blank input is not a search: it must not divert the listing onto the
+    // eventually-consistent graph path, and it has nothing to match on.
+    const search = rawSearch?.trim() || undefined;
 
-    if (filters?.search) {
+    if (search) {
       // Set-shaped graph read — eventually consistent BY DESIGN
       // (graph-read-after-write-coverage.md, mechanism (d)): no key to
       // await, human-timescale browse; a just-created resource appears in
       // search after the Weaver's ~tens-of-ms apply.
       return kb.graph.listResources({
-        search: filters.search,
-        archived: filters.archived,
-        entityTypes: filters.entityType ? [filters.entityType] : undefined,
+        search,
+        archived,
+        entityTypes: entityType ? [entityType] : undefined,
         offset,
         limit,
       });
@@ -74,8 +76,8 @@ export class ResourceContext {
     const allViews = await kb.views.getAll();
     const matches = allViews
       .map((view) => view.resource)
-      .filter((doc) => filters?.archived === undefined || doc.archived === filters.archived)
-      .filter((doc) => !filters?.entityType || getResourceEntityTypes(doc).includes(filters.entityType))
+      .filter((doc) => archived === undefined || doc.archived === archived)
+      .filter((doc) => !entityType || getResourceEntityTypes(doc).includes(entityType))
       .sort(compareByRecencyThenId);
 
     return { resources: matches.slice(offset, offset + limit), total: matches.length };

--- a/packages/make-meaning/src/resource-context.ts
+++ b/packages/make-meaning/src/resource-context.ts
@@ -5,8 +5,9 @@
  * Does NOT touch the graph - graph queries go through GraphContext
  */
 
-import { getPrimaryRepresentation, decodeRepresentation } from '@semiont/core';
+import { getPrimaryRepresentation, decodeRepresentation, getResourceEntityTypes } from '@semiont/core';
 import type { ResourceId } from '@semiont/core';
+import { compareByRecencyThenId } from '@semiont/graph';
 import type { KnowledgeBase } from './knowledge-base';
 
 import type { ResourceDescriptor } from '@semiont/core';
@@ -14,6 +15,15 @@ import type { ResourceDescriptor } from '@semiont/core';
 export interface ListResourcesFilters {
   search?: string;
   archived?: boolean;
+  entityType?: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface ListResourcesResult {
+  resources: ResourceDescriptor[];
+  /** Size of the whole match set, not of the returned page. */
+  total: number;
 }
 
 export class ResourceContext {
@@ -30,48 +40,45 @@ export class ResourceContext {
   }
 
   /**
-   * List resources, optionally filtered.
+   * List resources, optionally filtered, as one page plus the size of the whole
+   * match set. Every filter is applied before pagination on both paths — a
+   * filter applied afterwards narrows the page rather than the match set, which
+   * is how a search scoped to an entity type can come back empty while hundreds
+   * of resources match.
    *
-   * When `search` is set, delegates to `kb.graph.searchResources`, which runs
-   * the name match in the graph engine instead of scanning every view in JS.
-   * The graph result is then narrowed by `archived` if requested.
+   * When `search` is set, the entire query — filtering, ordering and
+   * pagination — runs inside the graph engine.
    *
-   * When `search` is unset, falls back to scanning all materialized views.
-   * (TODO: also push the listing path through the graph for large KBs.)
+   * When `search` is unset, the materialized views answer instead. They are the
+   * barrier-stamped projection, so an unsearched listing is read-your-writes
+   * where the graph is only eventually consistent.
    */
-  static async listResources(filters: ListResourcesFilters | undefined, kb: KnowledgeBase): Promise<ResourceDescriptor[]> {
+  static async listResources(filters: ListResourcesFilters | undefined, kb: KnowledgeBase): Promise<ListResourcesResult> {
+    const offset = filters?.offset ?? 0;
+    const limit = filters?.limit ?? 50;
+
     if (filters?.search) {
       // Set-shaped graph read — eventually consistent BY DESIGN
       // (graph-read-after-write-coverage.md, mechanism (d)): no key to
       // await, human-timescale browse; a just-created resource appears in
       // search after the Weaver's ~tens-of-ms apply.
-      const matches = await kb.graph.searchResources(filters.search);
-      const filtered = filters.archived !== undefined
-        ? matches.filter((doc) => doc.archived === filters.archived)
-        : matches;
-      return ResourceContext.sortByDateDesc(filtered);
+      return kb.graph.listResources({
+        search: filters.search,
+        archived: filters.archived,
+        entityTypes: filters.entityType ? [filters.entityType] : undefined,
+        offset,
+        limit,
+      });
     }
 
     const allViews = await kb.views.getAll();
-    const resources: ResourceDescriptor[] = [];
+    const matches = allViews
+      .map((view) => view.resource)
+      .filter((doc) => filters?.archived === undefined || doc.archived === filters.archived)
+      .filter((doc) => !filters?.entityType || getResourceEntityTypes(doc).includes(filters.entityType))
+      .sort(compareByRecencyThenId);
 
-    for (const view of allViews) {
-      const doc = view.resource;
-      if (filters?.archived !== undefined && doc.archived !== filters.archived) {
-        continue;
-      }
-      resources.push(doc);
-    }
-
-    return ResourceContext.sortByDateDesc(resources);
-  }
-
-  private static sortByDateDesc(resources: ResourceDescriptor[]): ResourceDescriptor[] {
-    return [...resources].sort((a, b) => {
-      const aTime = a.dateCreated ? new Date(a.dateCreated).getTime() : 0;
-      const bTime = b.dateCreated ? new Date(b.dateCreated).getTime() : 0;
-      return bTime - aTime;
-    });
+    return { resources: matches.slice(offset, offset + limit), total: matches.length };
   }
 
   /**

--- a/packages/react-ui/src/components/annotation/annotations.css
+++ b/packages/react-ui/src/components/annotation/annotations.css
@@ -45,7 +45,7 @@
  * or a position-fallback. The hover tooltip (added by
  * `getAnnotationDecorationMeta`) names the strategy. */
 .annotation-low-confidence {
-  text-decoration: underline dotted var(--semiont-color-amber-500, #d97706);
+  text-decoration: underline dotted var(--semiont-color-amber-500);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.css
@@ -98,7 +98,12 @@
   flex: 0 0 auto;
   gap: 2px;
   padding: 0.5rem;
-  scrollbar-width: none;
+  scrollbar-width: none; /* standard; Firefox + recent Chromium */
+}
+
+/* WebKit/Safari, which has no `scrollbar-width` support to rely on. */
+.semiont-pdf-annotation-canvas__strip::-webkit-scrollbar {
+  display: none;
 }
 
 /*
@@ -233,11 +238,11 @@
 }
 
 .semiont-pdf-annotation-canvas__button:hover:not(:disabled) {
-  background-color: var(--semiont-bg-hover, rgba(0, 0, 0, 0.05));
+  background-color: var(--semiont-bg-hover);
 }
 
 .semiont-pdf-annotation-canvas__button:focus-visible {
-  outline: 2px solid var(--semiont-focus-ring, #0066cc);
+  outline: 2px solid var(--semiont-focus-ring);
   outline-offset: 2px;
 }
 

--- a/packages/react-ui/src/features/auth/auth.css
+++ b/packages/react-ui/src/features/auth/auth.css
@@ -316,12 +316,12 @@
 }
 
 .semiont-form__input-row:focus-visible {
-  outline: 2px solid var(--semiont-focus-ring, #3b82f6);
+  outline: 2px solid var(--semiont-focus-ring);
   outline-offset: 2px;
 }
 
 [data-theme="dark"] .semiont-form__input-row:focus-visible {
-  outline-color: var(--semiont-focus-ring, #60a5fa);
+  outline-color: var(--semiont-focus-ring);
 }
 
 .semiont-form__input-row .semiont-input {
@@ -329,12 +329,12 @@
 }
 
 .semiont-form__input-row .semiont-input:focus-visible {
-  outline: 2px solid var(--semiont-focus-ring, #3b82f6);
+  outline: 2px solid var(--semiont-focus-ring);
   outline-offset: 2px;
 }
 
 [data-theme="dark"] .semiont-form__input-row .semiont-input:focus-visible {
-  outline-color: var(--semiont-focus-ring, #60a5fa);
+  outline-color: var(--semiont-focus-ring);
 }
 
 .semiont-form__url-status {
@@ -345,27 +345,27 @@
 }
 
 .semiont-form__url-status--checking {
-  color: var(--semiont-text-tertiary, #888888);
+  color: var(--semiont-text-tertiary);
   animation: spin 1s linear infinite;
   display: inline-block;
 }
 
 [data-theme="dark"] .semiont-form__url-status--checking {
-  color: var(--semiont-text-tertiary, #888888);
+  color: var(--semiont-text-tertiary);
 }
 
 .semiont-form__url-status--ok {
-  color: var(--semiont-color-success, #22c55e);
+  color: var(--semiont-color-success);
 }
 
 [data-theme="dark"] .semiont-form__url-status--ok {
-  color: var(--semiont-color-success, #22c55e);
+  color: var(--semiont-color-success);
 }
 
 .semiont-form__url-status--error {
-  color: var(--semiont-color-error, #ef4444);
+  color: var(--semiont-color-error);
 }
 
 [data-theme="dark"] .semiont-form__url-status--error {
-  color: var(--semiont-color-error, #ef4444);
+  color: var(--semiont-color-error);
 }

--- a/packages/react-ui/src/styles/core/inputs.css
+++ b/packages/react-ui/src/styles/core/inputs.css
@@ -137,7 +137,7 @@
   align-items: center;
   padding: 0.5rem 0.5rem 0.5rem 0.75rem;
   font-size: var(--semiont-text-sm);
-  font-family: var(--semiont-font-mono, monospace);
+  font-family: var(--semiont-font-mono);
   color: var(--semiont-text-tertiary);
   background-color: var(--semiont-color-gray-50);
   border-right: 1px solid var(--semiont-color-gray-300);

--- a/packages/react-ui/src/styles/features/compose.css
+++ b/packages/react-ui/src/styles/features/compose.css
@@ -118,7 +118,7 @@
    highlight while a drag hovers. */
 .semiont-form__upload-dropzone[data-drag-over="true"] {
   border-color: var(--semiont-color-primary-500);
-  background: var(--semiont-color-primary-50, rgba(59, 130, 246, 0.06));
+  background: var(--semiont-color-primary-50);
 }
 
 /* Dark mode needs its own tint: primary-50 is a near-white wash that would

--- a/packages/react-ui/src/styles/features/resource-viewer.css
+++ b/packages/react-ui/src/styles/features/resource-viewer.css
@@ -324,7 +324,7 @@
 }
 
 [data-theme="dark"] .semiont-browse-view__content tr:nth-child(even) td {
-  background: var(--semiont-color-gray-800, var(--semiont-color-gray-800));
+  background: var(--semiont-color-gray-800);
 }
 
 /* GFM task list checkboxes */

--- a/packages/react-ui/src/styles/motivations/motivation-reference.css
+++ b/packages/react-ui/src/styles/motivations/motivation-reference.css
@@ -14,8 +14,8 @@
   /* Light theme colors */
   --semiont-motivation-reference-primary: var(--semiont-color-cyan-600);
   --semiont-motivation-reference-secondary: var(--semiont-color-blue-600);
-  --semiont-motivation-reference-bg: linear-gradient(to right, var(--semiont-color-cyan-200, #a5f3fc), var(--semiont-color-blue-200));
-  --semiont-motivation-reference-bg-hover: linear-gradient(to right, var(--semiont-color-cyan-300, #67e8f9), var(--semiont-color-blue-300));
+  --semiont-motivation-reference-bg: linear-gradient(to right, var(--semiont-color-cyan-200), var(--semiont-color-blue-200));
+  --semiont-motivation-reference-bg-hover: linear-gradient(to right, var(--semiont-color-cyan-300), var(--semiont-color-blue-300));
   --semiont-motivation-reference-border: rgba(6, 182, 212, 0.3);
   --semiont-motivation-reference-border-hover: rgba(6, 182, 212, 0.5);
   --semiont-motivation-reference-text: var(--semiont-color-gray-900);

--- a/packages/react-ui/src/styles/patterns/panels-base.css
+++ b/packages/react-ui/src/styles/patterns/panels-base.css
@@ -405,12 +405,12 @@
 
 /* Login form pulsing border for first-launch nudge */
 @keyframes semiont-pulse-border {
-  0%, 100% { border-color: var(--semiont-color-primary-300, #93c5fd); }
-  50% { border-color: var(--semiont-color-primary-600, #2563eb); }
+  0%, 100% { border-color: var(--semiont-color-primary-300); }
+  50% { border-color: var(--semiont-color-primary-600); }
 }
 
 .semiont-panel__login-form--pulsing {
-  border: 2px solid var(--semiont-color-primary-400, #60a5fa);
-  border-radius: var(--semiont-panel-border-radius, 0.5rem);
+  border: 2px solid var(--semiont-color-primary-400);
+  border-radius: var(--semiont-panel-border-radius);
   animation: semiont-pulse-border 2s ease-in-out infinite;
 }

--- a/packages/react-ui/src/styles/utilities/motion.css
+++ b/packages/react-ui/src/styles/utilities/motion.css
@@ -124,7 +124,7 @@
 .semiont-transition {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: var(--semiont-duration-base, 150ms);
+  transition-duration: var(--semiont-duration-base);
 }
 
 .semiont-transition-none {
@@ -134,58 +134,58 @@
 .semiont-transition-all {
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: var(--semiont-duration-base, 150ms);
+  transition-duration: var(--semiont-duration-base);
 }
 
 .semiont-transition-colors {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: var(--semiont-duration-base, 150ms);
+  transition-duration: var(--semiont-duration-base);
 }
 
 .semiont-transition-opacity {
   transition-property: opacity;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: var(--semiont-duration-base, 150ms);
+  transition-duration: var(--semiont-duration-base);
 }
 
 .semiont-transition-transform {
   transition-property: transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: var(--semiont-duration-base, 150ms);
+  transition-duration: var(--semiont-duration-base);
 }
 
 /* Animation classes */
 .semiont-animate-fade-in {
-  animation: fadeIn var(--semiont-duration-base, 150ms) ease-in-out;
+  animation: fadeIn var(--semiont-duration-base) ease-in-out;
 }
 
 .semiont-animate-fade-out {
-  animation: fadeOut var(--semiont-duration-base, 150ms) ease-in-out;
+  animation: fadeOut var(--semiont-duration-base) ease-in-out;
 }
 
 .semiont-animate-slide-in-up {
-  animation: slideInUp var(--semiont-duration-base, 300ms) ease-out;
+  animation: slideInUp var(--semiont-duration-base) ease-out;
 }
 
 .semiont-animate-slide-in-down {
-  animation: slideInDown var(--semiont-duration-base, 300ms) ease-out;
+  animation: slideInDown var(--semiont-duration-base) ease-out;
 }
 
 .semiont-animate-slide-in-left {
-  animation: slideInLeft var(--semiont-duration-base, 300ms) ease-out;
+  animation: slideInLeft var(--semiont-duration-base) ease-out;
 }
 
 .semiont-animate-slide-in-right {
-  animation: slideInRight var(--semiont-duration-base, 300ms) ease-out;
+  animation: slideInRight var(--semiont-duration-base) ease-out;
 }
 
 .semiont-animate-scale-in {
-  animation: scaleIn var(--semiont-duration-base, 150ms) ease-out;
+  animation: scaleIn var(--semiont-duration-base) ease-out;
 }
 
 .semiont-animate-scale-out {
-  animation: scaleOut var(--semiont-duration-base, 150ms) ease-in;
+  animation: scaleOut var(--semiont-duration-base) ease-in;
 }
 
 .semiont-animate-spin {
@@ -299,13 +299,13 @@
   .semiont-motion-safe-transition-all {
     transition-property: all;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: var(--semiont-duration-base, 150ms);
+    transition-duration: var(--semiont-duration-base);
   }
 
   .semiont-motion-safe-transition-transform {
     transition-property: transform;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: var(--semiont-duration-base, 150ms);
+    transition-duration: var(--semiont-duration-base);
   }
 }
 


### PR DESCRIPTION
## Summary

Search on the discover page had a set of defects that compounded: filters were applied *after* a hard 20-row cap, ordering was on a property no backend ever wrote, and matching was a single literal substring. A search scoped to an entity type could come back empty while hundreds of resources matched.

This repairs the lexical search path end to end, in the graph layer and below. It also carries a CSS fix that was already on the branch.

## What changed

**Ordering was sorting on nothing.** Both `searchResources` and `listResources` ordered by `d.updatedAt`, which is never written to a `:Resource` node — only annotations get that property. Every row sorted equal, so the effective order was whatever the scan produced, and `SKIP`/`LIMIT` paging could repeat or drop rows between pages. Now `d.created DESC, d.id`, with the id tiebreak making paging deterministic. The in-memory and JanusGraph backends had no ordering at all and now share one comparator with the engines.

**Filters ran after the cap.** `searchResources` returned at most 20 rows and *then* `archived` and `entityType` were filtered in JS. The graph already had a `listResources` that does search, entity types, a true count and `SKIP`/`LIMIT` server-side, so the search path now goes through it; `archived` was the only missing filter and is added across all four backends. `ResourceContext.listResources` returns `{ resources, total }` and the Browser handler is a pass-through. The SDK asks for `limit: 100` and now actually receives up to 100 with a truthful `total`.

**Results were in date order, not relevance order.** Added a rank ladder — exact name, name prefix, every term in the name, then matches the path or an entity type had to complete — applied in the engine so it ranks the match set rather than one page.

**Multi-word queries returned nothing.** Matching is now token-AND: every term must appear, but each may come from the name, the `storageUri` or an entity type. So "Aeschylus Marathon" finds a resource *named* "Greek victory" and *filed under* `authors/Aeschylus/places/Marathon.md`, where neither field alone holds both terms. Terms match in any order. A whitespace-only query is treated as no query, where previously `" "` was truthy and matched every name containing a space.

**Entity types were unsearchable.** Typing a type name into the search box returned nothing, because `entityType` existed only as a separate filter. Type names now participate in matching, ranked below name matches.

**`searchResources` is deleted.** It had become exactly `listResources({ search, limit }).resources` in all four implementations. The `GraphContext.searchResources` wrapper went with it — it had no production callers. The Matcher reads name matches from `listResources` directly, with its recall budget unchanged at 20.

Neptune moves to the same JS filter/rank/page path JanusGraph already used, since the rank ladder has no natural Gremlin expression and a rank applied after `range()` would sort a page rather than the match set. That's an O(N) vertex scan per call, deliberately accepted and now documented at the call site: Neo4j is the production path and pushes the entire query into Cypher.

## Correctness notes

- Neo4j `listResources` now excludes stub nodes — the id-only placeholders `MERGE` creates when a `REFERENCES` edge outruns its `resource.created` event. They have no `name`, and `parseResourceNode` throws on that. The old `WHERE` clause excluded them only incidentally, which stopped being true once `archived` could be the sole filter.
- Filtering, ranking and pagination for the three non-Cypher backends live in one shared `queryResources`, so search cannot mean three different things across three backends. Net across the change is more deletion than addition.

## Testing

Interface-contract tests drive every backend through the same assertions: ordering and tiebreak, filter composition with `total` describing the whole match set, the rank ladder, token-AND, entity-type matching, and blank-query handling. Ranking tests deliberately set dates that run *counter* to the expected order so recency cannot produce a passing result by accident.

120 graph tests and the affected make-meaning suites pass; both packages typecheck.

## Scope

No UI changes. Every change is at or below `ResourceContext`, and the wire shape is unchanged — `resources`, `total`, `offset` and `limit` were already there, they just started telling the truth. The frontend gets better recall, honest totals, working pagination and ranked results through the same SDK call it was already making.

Stale documentation referencing the removed method is updated across the graph and make-meaning docs.
