### PR TITLE
generation wire: job:create carries the context, not the ids — dispatcher derives and rejects

### DIFF
--- a/apps/launcher/internal/launcher/yield.go
+++ b/apps/launcher/internal/launcher/yield.go
@@ -150,12 +150,12 @@ func Yield(args []string) int {
 			fmt.Print(delegateUsage)
 			return 1
 		}
-		if dopts.title == "" {
-			u.fail("--delegate needs --title (GenerationJobParams requires one; the backend rejects a job without it).")
-			return 1
-		}
 		if dopts.storageURI == "" {
 			u.fail("--delegate needs --storage-uri (the generated resource must be given a home).")
+			return 1
+		}
+		if dopts.title == "" {
+			u.fail("--delegate needs --title: GenerationJobParams requires it, so the backend rejects a job without one.")
 			return 1
 		}
 		t, ok := verbSession(u, "yield", repo, wantLocal)

--- a/apps/launcher/internal/launcher/yield.go
+++ b/apps/launcher/internal/launcher/yield.go
@@ -150,6 +150,10 @@ func Yield(args []string) int {
 			fmt.Print(delegateUsage)
 			return 1
 		}
+		if dopts.title == "" {
+			u.fail("--delegate needs --title (GenerationJobParams requires one; the backend rejects a job without it).")
+			return 1
+		}
 		if dopts.storageURI == "" {
 			u.fail("--delegate needs --storage-uri (the generated resource must be given a home).")
 			return 1
@@ -343,7 +347,7 @@ or anchored to one annotation.
 
 Options:
   --storage-uri <uri>  Where the generated resource is written (required)
-  --title <text>       Title for the generated resource
+  --title <text>       Title for the generated resource (required)
   --prompt <text>      Instruction guiding the generation
   --language <tag>     BCP-47 language for the generated content
   --task <t>           Framing: resource | answer | summary (or free text)
@@ -401,23 +405,28 @@ func runYieldDelegate(u *ui, t verbTarget, positional []string, opts delegateOpt
 	}
 	defer sub.Close()
 
-	params := map[string]any{"storageUri": opts.storageURI, "context": gathered}
+	// GenerationJobParams requires title, storageUri and context; the rest are
+	// optional and omitted when empty.
+	params := map[string]any{"title": opts.title, "storageUri": opts.storageURI, "context": gathered}
 	for k, v := range map[string]string{
-		"title": opts.title, "prompt": opts.prompt, "language": opts.language,
+		"prompt": opts.prompt, "language": opts.language,
 		"task": opts.task, "structure": opts.structure,
 	} {
 		if v != "" {
 			params[k] = v
 		}
 	}
-	if len(positional) == 2 {
-		params["referenceId"] = positional[1]
-	}
 
+	// The CONTEXT carries the ids now. For jobType generation the dispatcher
+	// derives resourceId from params.context.focus and rejects a caller-supplied
+	// one; referenceId left the params schema entirely and the worker derives it
+	// the same way. So the envelope's ResourceId stays nil here — sending what we
+	// know would be rejected, and the focus is authoritative anyway. The gather
+	// above is what puts the right focus in the context: annotation-focused with
+	// two positionals, resource-focused with one.
 	created, err := cli.Request(ctx, "job:create", semiont.JobCreateCommand{
-		JobType:    semiont.JobType("generation"),
-		ResourceId: resourceID,
-		Params:     params,
+		JobType: semiont.JobType("generation"),
+		Params:  params,
 	}, nil)
 	if err != nil {
 		return busFail(u, "yield --delegate", err)

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -6366,6 +6366,18 @@ func TestYieldDelegateJSONSucceedsOnAGeneration(t *testing.T) {
 	mustContain(t, "raw payload", stdout, `"resourceId":"res-new"`)
 }
 
+// title joined storageUri as required when GenerationJobParams gained it
+// (generation-wire-context P1). Refused HERE rather than letting the backend
+// reject the job: the caller has already paid for a gather by then.
+func TestYieldDelegateNeedsTitle(t *testing.T) {
+	s := busScenario(t)
+	_, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md")
+	if code == 0 {
+		t.Fatal("--delegate without --title must refuse")
+	}
+	mustContain(t, "refusal", stderr, "--title")
+}
+
 func TestYieldDelegateNeedsStorageUri(t *testing.T) {
 	s := busScenario(t)
 	_, stderr, code := s.run(t, "yield", "--delegate", "res-src")

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -6288,15 +6288,25 @@ func TestYieldDelegateFollowsJobToCompletion(t *testing.T) {
 	b := lastEmit(t, s)
 	// The job carries the gathered context and the generation params.
 	mustContain(t, "job:create emit", b,
-		`"channel":"job:create"`, `"jobType":"generation"`, `"resourceId":"res-src"`,
+		`"channel":"job:create"`, `"jobType":"generation"`,
 		`"storageUri":"file://generated/out.md"`, `"title":"Derived"`, `"task":"summary"`, `"context"`)
+	// For jobType generation the dispatcher derives resourceId from
+	// params.context.focus and REJECTS a caller-supplied one; referenceId left
+	// the params schema entirely. Sending either is now an error, so assert
+	// their ABSENCE — a payload that still carries them would be refused by a
+	// real backend while this fake accepted it.
+	for _, gone := range []string{`"resourceId"`, `"referenceId"`} {
+		if strings.Contains(b, gone) {
+			t.Errorf("job:create still carries %s; the context's focus is authoritative now:\n%s", gone, b)
+		}
+	}
 }
 
 func TestYieldDelegateReportsJobFailure(t *testing.T) {
 	s := busScenario(t,
 		`FAKERT_BUS_REPLY_gather_resource_requested={"metadata":{},"focus":{},"graph":{}}`,
 		"FAKERT_JOB_FAIL=model refused")
-	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md")
+	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--title", "Derived")
 	if code == 0 {
 		t.Fatalf("a failed job must fail the command\nstdout:\n%s", stdout)
 	}
@@ -6316,7 +6326,7 @@ func TestYieldDelegateReportsADecline(t *testing.T) {
 	s := busScenario(t,
 		`FAKERT_BUS_REPLY_gather_resource_requested={"metadata":{},"focus":{},"graph":{}}`,
 		`FAKERT_JOB_RESULT={"declined":true,"reason":"encrypted","message":"the PDF is password-protected"}`)
-	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md")
+	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--title", "Derived")
 	if code == 0 {
 		t.Fatalf("a declined job produced nothing; exit 0 tells a script to carry on\nstdout:\n%s", stdout)
 	}
@@ -6337,7 +6347,7 @@ func TestYieldDelegateDeclineFailsUnderJSON(t *testing.T) {
 	s := busScenario(t,
 		`FAKERT_BUS_REPLY_gather_resource_requested={"metadata":{},"focus":{},"graph":{}}`,
 		`FAKERT_JOB_RESULT={"declined":true,"reason":"no-text-layer","message":"scanned pages, no recognizable text"}`)
-	stdout, _, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--json")
+	stdout, _, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--title", "Derived", "--json")
 	if code == 0 {
 		t.Fatalf("--json must not turn a decline into a success\nstdout:\n%s", stdout)
 	}
@@ -6349,7 +6359,7 @@ func TestYieldDelegateDeclineFailsUnderJSON(t *testing.T) {
 // passes the decline test above and nothing else notices.
 func TestYieldDelegateJSONSucceedsOnAGeneration(t *testing.T) {
 	s := busScenario(t, `FAKERT_BUS_REPLY_gather_resource_requested={"metadata":{},"focus":{},"graph":{}}`)
-	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--json")
+	stdout, stderr, code := s.run(t, "yield", "--delegate", "res-src", "--storage-uri", "file://generated/out.md", "--title", "Derived", "--json")
 	if code != 0 {
 		t.Fatalf("a completed generation under --json must exit 0, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}

--- a/docs/protocol/flows/YIELD.md
+++ b/docs/protocol/flows/YIELD.md
@@ -135,8 +135,9 @@ client.yield.fromContext(context, {
 User clicks "Generate" on reference annotation ❓
     ↓
 Frontend → client.yield.fromContext(...) emits job:create via /bus/emit
-           (the job's resourceId — and referenceId, for annotation-focus
-           contexts — are DERIVED from the context's focus)
+           (no ids on the wire — the dispatcher DERIVES the job's resourceId,
+           and the reference to auto-bind, from params.context.focus, and
+           REJECTS a caller-supplied id via job:create-failed)
     ↓
 Backend job:create handler builds a PendingJob, persists to queue, returns job:created
     ↓
@@ -167,14 +168,45 @@ Generation has no dedicated REST endpoint — it runs as a bus job. The SDK's `y
 
 **Dispatch**: [packages/sdk/src/namespaces/yield.ts](../../../packages/sdk/src/namespaces/yield.ts) → `job:create`, handled by [job-commands.ts](../../../packages/make-meaning/src/handlers/job-commands.ts)
 
-**Generation params** — the SDK's `yield` namespace maps `GenerationOptions`
-([packages/sdk/src/namespaces/types.ts](../../../packages/sdk/src/namespaces/types.ts)) into the `job:create` event's
-`params`, alongside the top-level `jobType: 'generation'` and the source
-`resourceId`:
+**The envelope carries no ids.** For `jobType: 'generation'` the context *is*
+the wire contract — it already names its anchor, so the ids are not sent
+beside it:
+
 ```typescript
 {
-  referenceId: string;        // annotation-focus only — the annotation being resolved
-                              // (derived from context.focus.annotation.id)
+  correlationId: string;
+  jobType: 'generation';
+  params: GenerationJobParams;   // options + context — no resourceId, no referenceId
+}
+```
+
+The dispatcher ([job-commands.ts](../../../packages/make-meaning/src/handlers/job-commands.ts)) derives what it needs from
+`params.context.focus` and **rejects**, via `job:create-failed`, anything that
+would let a caller disagree with it:
+
+| focus | job scopes to | reference resolution |
+|---|---|---|
+| `resource` | `focus.resource['@id']` | none — the worker mints a source→derived provenance reference |
+| `annotation` | `focus.sourceResource['@id']` | the worker auto-binds to `focus.annotation.id` |
+
+Rejected at creation: a top-level `resourceId` or a `params.referenceId`
+(*"the context's focus is authoritative"*); params missing the required trio
+`title` / `storageUri` / `context`; and a context with no usable focus — whose
+message names `gather.resource(...)` / `gather.annotation(...)` as the
+sanctioned producers. Rejection rather than silent ignoring is deliberate: a
+raw emitter must not believe its ids mattered.
+
+This is **generation-only**. Every other jobType still carries a
+caller-supplied envelope `resourceId`, and still requires it — that check now
+runs at the dispatcher too, because the schema cannot express a per-jobType
+conditional.
+
+**Generation params** (`GenerationJobParams`) — the SDK's `yield` namespace
+spreads `GenerationOptions`
+([packages/sdk/src/namespaces/types.ts](../../../packages/sdk/src/namespaces/types.ts)) into the params bag alongside the
+gathered context:
+```typescript
+{
   title: string;              // Title of the synthesized resource; also the LLM topic
   storageUri: string;         // Where the generated content is written (file://…)
   context: GatheredContext;   // Correlated context from the Gather flow (grounds the prompt)
@@ -217,7 +249,8 @@ their own canonical sets if/when their generators exist. Length knobs
 imply structure.
 
 **Dispatch responsibilities** (SDK `yield` namespace + [job-commands.ts](../../../packages/make-meaning/src/handlers/job-commands.ts)):
-1. Validate params and authentication
+1. Authenticate, then validate params — including the focus derivation and the
+   rejections above
 2. Create a generation job and submit it to the queue (`job:create` → `job:created`)
 3. Surface progress to the client over SSE via the unified job channels
 
@@ -402,13 +435,18 @@ persists. A second event — the reference auto-bind — is then emitted by the
 In [packages/jobs/src/worker-process.ts](../../../packages/jobs/src/worker-process.ts) the worker calls (content over HTTP,
 not the bus; `sourceAnnotationId` is what later drives the auto-bind):
 ```typescript
+// One derivation, shared by every jobType: for generation, referenceIdOf()
+// reads focus.annotation.id (annotation focus) or returns undefined (resource
+// focus); other jobTypes pass their own params.referenceId through.
+const genReferenceId = referenceIdOf(job);
+
 const { resourceId: newResourceId } = await session.client.yield.resource({
   name: genResult.title,
   file: Buffer.from(genResult.content),
   format: genResult.format,          // requested output media type; defaults to text/markdown
   storageUri,
   sourceResourceId,
-  sourceAnnotationId: referenceId,   // annotation-focus only — omitted for resource focus
+  ...(genReferenceId ? { sourceAnnotationId: genReferenceId } : {}),
   generationPrompt, language, entityTypes, generator,
 });
 ```

--- a/docs/protocol/skills/semiont-worker/SKILL.md
+++ b/docs/protocol/skills/semiont-worker/SKILL.md
@@ -108,12 +108,36 @@ adapter.activeJob$.subscribe((job) => {
 adapter.start();
 ```
 
-Inside `handleJob`, emit lifecycle events on the same transport, do the work, then complete or fail:
+First, one derivation for the anchoring annotation. Your own job types define
+their own params, so define this for the types you claim — and note that
+Semiont's built-in `generation` jobs deliberately carry no `referenceId`: the
+gathered context's `focus` is authoritative, and the `job:create` dispatcher
+rejects a params bag that tries to say otherwise.
+
+```typescript
+function anchorOf(job: ActiveJob): string | undefined {
+  if (job.type === 'generation') {
+    const focus = (job.params.context as { focus?: {
+      kind?: string;
+      annotation?: { id?: string };
+    } } | undefined)?.focus;
+    return focus?.kind === 'annotation' ? focus.annotation?.id : undefined;
+  }
+  // Your own job types: read whatever field you defined.
+  return typeof job.params.referenceId === 'string' ? job.params.referenceId : undefined;
+}
+```
+
+Then, inside `handleJob`, emit lifecycle events on the same transport, do the work, then complete or fail:
 
 ```typescript
 async function handleJob(job: ActiveJob): Promise<void> {
   const { jobId, type, resourceId, userId } = job;
-  const annotationId = (job.params as { referenceId?: string }).referenceId;
+  // Annotation-scoped jobs carry the anchoring annotation through every
+  // lifecycle payload. WHERE that id lives is per-jobType, so derive it once
+  // rather than reaching into params at each emit. Semiont's own `generation`
+  // jobs carry NO referenceId — their anchor is the gathered context's focus.
+  const annotationId = anchorOf(job);
   const lifecycleBase = {
     resourceId, userId, jobId, jobType: type,
     ...(annotationId ? { annotationId } : {}),

--- a/packages/jobs/README.md
+++ b/packages/jobs/README.md
@@ -30,8 +30,8 @@ npm install @semiont/jobs
 ## Quick Start
 
 ```typescript
-import { FsJobQueue, type PendingJob, type GenerationParams } from '@semiont/jobs';
-import { EventBus, userId, resourceId, annotationId, jobId } from '@semiont/core';
+import { FsJobQueue, type PendingJob, type DetectionParams } from '@semiont/jobs';
+import { EventBus, userId, resourceId, jobId } from '@semiont/core';
 import { SemiontProject } from '@semiont/core/node';
 
 // Initialize — jobs are stored under project.jobsDir
@@ -41,32 +41,33 @@ const jobQueue = new FsJobQueue(project, logger, eventBus);
 await jobQueue.initialize();
 
 // Create a job
-const job: PendingJob<GenerationParams> = {
+const job: PendingJob<DetectionParams> = {
   status: 'pending',
   metadata: {
     id: jobId('job-abc123'),
-    type: 'generation',
+    type: 'reference-annotation',
     userId: userId('user@example.com'),
     userName: 'Jane Doe',
     userEmail: 'jane@example.com',
     userDomain: 'example.com',
     created: new Date().toISOString(),
     retryCount: 0,
-    maxRetries: 3,
+    maxRetries: 1,
   },
   params: {
-    referenceId: annotationId('ref-123'),
-    sourceResourceId: resourceId('doc-456'),
-    sourceResourceName: 'Source Document',
-    annotation: { /* full W3C Annotation */ },
-    title: 'Generated Article',
-    prompt: 'Write about AI',
-    language: 'en-US',
+    resourceId: resourceId('doc-456'),
+    entityTypes: ['Person', 'Organization'],
   },
 };
 
 await jobQueue.createJob(job);
 ```
+
+Generation jobs are enqueued the same way, but their params are a
+[`GenerationJobParams`](./docs/JobTypes.md#generation-generation) bag whose
+`context` carries the anchor — writing one straight to the queue bypasses the
+dispatcher that normally derives and stamps `resourceId` from
+`context.focus`, so prefer `client.yield.fromContext(...)`.
 
 ## Job Types
 

--- a/packages/jobs/docs/API.md
+++ b/packages/jobs/docs/API.md
@@ -35,35 +35,35 @@ Stops the maintenance intervals.
 Persists a job to `{project.jobsDir}/{status}/{id}.json`. If status is `pending`, the EventBus is provided, and job params include `resourceId`, emits `job:queued`.
 
 ```typescript
-import type { PendingJob, GenerationParams } from '@semiont/jobs';
-import { jobId, userId, resourceId, annotationId } from '@semiont/core';
+import type { PendingJob, DetectionParams } from '@semiont/jobs';
+import { jobId, userId, resourceId } from '@semiont/core';
 
-const job: PendingJob<GenerationParams> = {
+const job: PendingJob<DetectionParams> = {
   status: 'pending',
   metadata: {
     id: jobId('job-abc123'),
-    type: 'generation',
+    type: 'reference-annotation',
     userId: userId('user@example.com'),
     userName: 'Jane Doe',
     userEmail: 'jane@example.com',
     userDomain: 'example.com',
     created: new Date().toISOString(),
     retryCount: 0,
-    maxRetries: 3,
+    maxRetries: 1,
   },
   params: {
-    referenceId: annotationId('ref-456'),
-    sourceResourceId: resourceId('doc-789'),
-    sourceResourceName: 'Source Document',
-    annotation: { /* W3C Annotation */ },
-    title: 'Generated Article',
-    prompt: 'Write about AI',
-    language: 'en-US',
+    resourceId: resourceId('doc-789'),
+    entityTypes: ['Person', 'Organization'],
   },
 };
 
 await queue.createJob(job);
 ```
+
+Generation params carry no `resourceId` of their own — the `job:create`
+dispatcher derives it from `context.focus` and stamps it in, which is what
+satisfies the `job:queued` condition above. See
+[JobTypes.md](./JobTypes.md#generation-generation).
 
 ### `getJob(jobId: JobId): Promise<AnyJob | null>`
 
@@ -108,7 +108,7 @@ Cancels all pending jobs in a category — the granularity of the `job:cancel-re
 ```typescript
 // Progress update (same status)
 if (job.status === 'running') {
-  const updated: RunningJob<GenerationParams, YieldProgress> = {
+  const updated: RunningJob<GenerationJobParams, YieldProgress> = {
     ...job,
     progress: { stage: 'generating', percentage: 50, message: 'Generating...' },
   };
@@ -117,7 +117,7 @@ if (job.status === 'running') {
 
 // Status transition (atomic move)
 if (job.status === 'running') {
-  const complete: CompleteJob<GenerationParams, GenerationResult> = {
+  const complete: CompleteJob<GenerationJobParams, GenerationResult> = {
     status: 'complete',
     metadata: job.metadata,
     params: job.params,

--- a/packages/jobs/docs/JobQueue.md
+++ b/packages/jobs/docs/JobQueue.md
@@ -50,30 +50,25 @@ await queue.initialize();
 Creates a new job and persists it to the queue.
 
 ```typescript
-import type { PendingJob, GenerationParams } from '@semiont/jobs';
-import { jobId, userId, resourceId, annotationId } from '@semiont/core';
+import type { PendingJob, DetectionParams } from '@semiont/jobs';
+import { jobId, userId, resourceId } from '@semiont/core';
 
-const job: PendingJob<GenerationParams> = {
+const job: PendingJob<DetectionParams> = {
   status: 'pending',
   metadata: {
     id: jobId('job-abc123'),
-    type: 'generation',
+    type: 'reference-annotation',
     userId: userId('user@example.com'),
     userName: 'Jane Doe',
     userEmail: 'jane@example.com',
     userDomain: 'example.com',
     created: new Date().toISOString(),
     retryCount: 0,
-    maxRetries: 3,
+    maxRetries: 1,
   },
   params: {
-    referenceId: annotationId('ref-456'),
-    sourceResourceId: resourceId('doc-789'),
-    sourceResourceName: 'Source Document',
-    annotation: { /* W3C Annotation */ },
-    title: 'Generated Article',
-    prompt: 'Write about AI',
-    language: 'en-US',
+    resourceId: resourceId('doc-789'),
+    entityTypes: ['Person', 'Organization'],
   },
 };
 
@@ -129,7 +124,7 @@ if (!job) return;
 
 // Simple update (same status) — immutable pattern
 if (job.status === 'running') {
-  const updatedJob: RunningJob<GenerationParams, YieldProgress> = {
+  const updatedJob: RunningJob<GenerationJobParams, YieldProgress> = {
     ...job,
     progress: { stage: 'generating', percentage: 50, message: 'Generating...' },
   };
@@ -138,7 +133,7 @@ if (job.status === 'running') {
 
 // Status transition (atomic move)
 if (job.status === 'running') {
-  const completeJob: CompleteJob<GenerationParams, GenerationResult> = {
+  const completeJob: CompleteJob<GenerationJobParams, GenerationResult> = {
     status: 'complete',
     metadata: job.metadata,
     params: job.params,

--- a/packages/jobs/docs/JobTypes.md
+++ b/packages/jobs/docs/JobTypes.md
@@ -91,7 +91,7 @@ const job: PendingJob<DetectionParams> = {
     userDomain: 'example.com',
     created: new Date().toISOString(),
     retryCount: 0,
-    maxRetries: 3,
+    maxRetries: 1,   // detection re-scans the same content — one self-heal retry
   },
   params: {
     resourceId: resourceId('doc-456'),
@@ -105,25 +105,25 @@ const job: PendingJob<DetectionParams> = {
 
 AI content generation — creates new resources from source material and prompts.
 
-**Parameters:**
+**Parameters:** `GenerationJobParams`, generated from the OpenAPI spec into
+`@semiont/core` — one type shared by the SDK's `yield.fromContext(context,
+options)` surface and this worker, so the params bag is exactly *options + the
+gathered context*.
 
 ```typescript
-interface GenerationParams {
-  referenceId?: AnnotationId;       // Annotation-focus only (derived from the context's focus) — the
-                                    // unresolved reference; the worker auto-binds the new
-                                    // resource to it. Absent for resource-focus generation
-                                    // (resource-focus contexts): provenance is a minted
-                                    // source→derived reference instead
+interface GenerationJobParams {
+  title: string;                    // Required — title of the generated resource;
+                                    // also the LLM topic
+  storageUri: string;               // Required
+  context: GatheredContext;         // Required — grounds the prompt, and NAMES THE
+                                    // ANCHOR (see "Ids come from the focus" below)
   prompt?: string;                  // Freeform refinement — rendered as an authoritative
                                     // "Instruction:" line under the task framing
-  title?: string;
   entityTypes?: EntityType[];
   language?: string;                // Generated-content locale, e.g., 'en-US'
   sourceLanguage?: string;          // Source resource locale (BCP-47)
-  context?: GatheredContext;
   temperature?: number;
   maxTokens?: number;               // Length only — never implies structure
-  storageUri?: string;
   outputMediaType?: SupportedMediaType; // Default text/markdown; only text/markdown |
                                     // text/plain are produced — anything else fails the job
   task?: 'resource' | 'answer' | 'summary' | (string & {});
@@ -139,6 +139,22 @@ interface GenerationParams {
                                     // embedded context ids). Off ⇒ resolver never runs
 }
 ```
+
+**Ids come from the focus.** Generation params carry no `referenceId`, and the
+`job:create` envelope carries no `resourceId` — the context already names its
+anchor, so sending the ids beside it would encode the same fact twice and let
+the two disagree. The dispatcher derives the job's `resourceId` from
+`context.focus` (resource focus → `focus.resource`; annotation focus →
+`focus.sourceResource`) and rejects a caller-supplied id outright. In the
+worker, `referenceIdOf(job)` is the one derivation:
+
+| `context.focus.kind` | `referenceIdOf(job)` | what the worker does |
+|---|---|---|
+| `annotation` | `focus.annotation.id` | uploads with `sourceAnnotationId` — the Stower auto-binds the triggering reference |
+| `resource` | `undefined` | mints a source→derived provenance reference instead |
+
+The same helper serves every other jobType by passing their own
+`params.referenceId` through — detection echoes still carry one.
 
 **Progress:**
 
@@ -164,9 +180,10 @@ interface GenerationResult {
 **Example:**
 
 ```typescript
-import type { PendingJob, GenerationParams } from '@semiont/jobs';
+import type { PendingJob } from '@semiont/jobs';
+import type { GenerationJobParams } from '@semiont/core';
 
-const job: PendingJob<GenerationParams> = {
+const job: PendingJob<GenerationJobParams> = {
   status: 'pending',
   metadata: {
     id: jobId('job-789'),
@@ -177,14 +194,26 @@ const job: PendingJob<GenerationParams> = {
     userDomain: 'example.com',
     created: new Date().toISOString(),
     retryCount: 0,
-    maxRetries: 3,
+    // Generation is non-idempotent — a retry re-rolls the LLM and produces
+    // different content, not a replay — so the dispatcher sets 0 here.
+    // Detection jobs re-scan the same content and keep one self-heal retry.
+    maxRetries: 0,
   },
   params: {
-    referenceId: annotationId('ref-123'),
-    sourceResourceId: resourceId('doc-456'),
-    sourceResourceName: 'Source Document',
-    annotation: { /* W3C Annotation */ },
     title: 'Article about Quantum Computing',
+    storageUri: 'file://generated/quantum-computing.md',
+    // The context carries the anchor. This one is annotation-focus, so the
+    // worker auto-binds the new resource to focus.annotation — no referenceId
+    // field, and no resourceId on the envelope that created this job.
+    context: {
+      focus: {
+        kind: 'annotation',
+        annotation: { /* W3C Annotation — its `id` is the auto-bind target */ },
+        sourceResource: { '@id': 'doc-456' /* … */ },
+      },
+      graph: { /* … */ },
+      metadata: { /* … */ },
+    },
     prompt: 'Write a comprehensive overview',
     language: 'en-US',
   },
@@ -399,7 +428,7 @@ const job: PendingJob<TagDetectionParams> = {
 
 ```typescript
 type DetectionJob = Job<DetectionParams, DetectionProgress, DetectionResult>;
-type GenerationJob = Job<GenerationParams, YieldProgress, GenerationResult>;
+type GenerationJob = Job<GenerationJobParams, YieldProgress, GenerationResult>;
 type HighlightDetectionJob = Job<HighlightDetectionParams, HighlightDetectionProgress, HighlightDetectionResult>;
 type AssessmentDetectionJob = Job<AssessmentDetectionParams, AssessmentDetectionProgress, AssessmentDetectionResult>;
 type CommentDetectionJob = Job<CommentDetectionParams, CommentDetectionProgress, CommentDetectionResult>;
@@ -430,12 +459,12 @@ function processJob(job: AnyJob) {
 ```typescript
 function isRunningGenerationJob(
   job: AnyJob
-): job is RunningJob<GenerationParams, YieldProgress> {
+): job is RunningJob<GenerationJobParams, YieldProgress> {
   return job.status === 'running' && job.metadata.type === 'generation';
 }
 
 if (isRunningGenerationJob(job)) {
-  console.log(job.params.title);     // GenerationParams
+  console.log(job.params.title);     // GenerationJobParams
   console.log(job.progress.stage);   // YieldProgress
 }
 ```

--- a/packages/jobs/docs/TYPES.md
+++ b/packages/jobs/docs/TYPES.md
@@ -199,12 +199,12 @@ function handleJob(job: AnyJob) {
 ```typescript
 function isRunningGenerationJob(
   job: AnyJob
-): job is RunningJob<GenerationParams, YieldProgress> {
+): job is RunningJob<GenerationJobParams, YieldProgress> {
   return job.status === 'running' && job.metadata.type === 'generation';
 }
 
 if (isRunningGenerationJob(job)) {
-  console.log(job.params.title);      // GenerationParams
+  console.log(job.params.title);      // GenerationJobParams
   console.log(job.progress.stage);    // YieldProgress
 }
 ```

--- a/packages/jobs/docs/Workers.md
+++ b/packages/jobs/docs/Workers.md
@@ -75,10 +75,18 @@ Generation is the odd one out — it produces *content*, not annotations:
 ```typescript
 processGenerationJob(
   inferenceClient: InferenceClient,
-  params: GenerationParams,
+  params: GenerationJobParams,
   onProgress: OnProgress,
   logger: Logger,
-): Promise<{ content: string; title: string; format: string; result: GenerationResult }>
+): Promise<{
+  content: Uint8Array;              // bytes, not a string — the output media type decides
+  title: string;
+  format: SupportedMediaType;       // validated against the registry's `generatable` types;
+                                    // an unsupported request FAILS the job, never falls back
+  citations: GenerationCitation[];  // populated only under `cite`; minted as W3C linking
+                                    // annotations on the derived resource after upload
+  result: GenerationResult;
+}>
 ```
 
 ## Where Content Comes From

--- a/packages/jobs/src/__tests__/job-queue.test.ts
+++ b/packages/jobs/src/__tests__/job-queue.test.ts
@@ -11,7 +11,7 @@ import { FsJobQueue as JobQueue } from '../fs-job-queue';
 import type { JobStatus, PendingJob, RunningJob, CompleteJob, FailedJob, DetectionParams, DetectionProgress, DetectionResult } from '../types';
 import type { GenerationJobParams } from '@semiont/core';
 import { SemiontProject } from '@semiont/core/node';
-import { entityType, jobId, userId, resourceId, annotationId, EventBus } from '@semiont/core';
+import { entityType, jobId, userId, resourceId, EventBus } from '@semiont/core';
 
 const mockLogger = {
   debug: vi.fn(),
@@ -139,7 +139,6 @@ function createPendingGenerationJob(id: string): PendingJob<GenerationJobParams>
       maxRetries: 3,
     },
     params: {
-      referenceId: annotationId('ann-1'),
       prompt: 'Generate a summary',
       title: 'Summary',
       storageUri: 'file://generated/summary.md',

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GEN_REQUIRED } from './fixtures/generation-fixtures';
-import { resourceId, annotationId, entityType } from '@semiont/core';
+import { resourceId, entityType } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 import type { components, TagSchema, GatheredContext, Logger } from '@semiont/core';
 
@@ -368,7 +368,6 @@ describe('processGenerationJob', () => {
     const result = await processGenerationJob(
       makeInferenceClient(),
       { ...GEN_REQUIRED,
-        referenceId: annotationId('ann-1'),
         title: 'Initial',
         entityTypes: [],
       },
@@ -398,7 +397,6 @@ describe('processGenerationJob', () => {
     const result = await processGenerationJob(
       makeInferenceClient(),
       { ...GEN_REQUIRED,
-        referenceId: annotationId('ann-1'),
         title: 'Fallback Title',
         entityTypes: [],
       },
@@ -965,8 +963,7 @@ describe('locale threading', () => {
         client,
         {
           ...GEN_REQUIRED,
-          referenceId: annotationId('ann-1'),
-          title: 'Topic',
+            title: 'Topic',
           entityTypes: [],
           language: 'de',
           sourceLanguage: 'fr',

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -963,7 +963,7 @@ describe('locale threading', () => {
         client,
         {
           ...GEN_REQUIRED,
-            title: 'Topic',
+          title: 'Topic',
           entityTypes: [],
           language: 'de',
           sourceLanguage: 'fr',

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -30,7 +30,8 @@
  * file covers the iterate-and-emit orchestration layer.
  */
 
-import { GEN_REQUIRED } from './fixtures/generation-fixtures';
+import { GEN_REQUIRED, minimalContext } from './fixtures/generation-fixtures';
+import { referenceIdOf } from '../worker-process';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { extractPdfTextLayer } from '@semiont/content';
 import type { SemiontSession } from '@semiont/sdk';
@@ -281,7 +282,11 @@ describe('handleJob orchestration', () => {
       });
       const h = makeFakeSessionAndAdapter();
 
-      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { referenceId: 'ref-1', prompt: 'Write about X', language: 'en' }));
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', {
+        context: minimalContext('annotation'),   // the focus IS the reference now
+        prompt: 'Write about X',
+        language: 'en',
+      }));
 
       // Verify the upload went through session.client.yield.resource
       // (not a raw fetch to /resources) with the expected fields.
@@ -290,7 +295,7 @@ describe('handleJob orchestration', () => {
       expect(uploaded.name).toBe('New Resource');
       expect(uploaded.format).toBe('text/markdown');
       expect(uploaded.sourceResourceId).toBe(RID);
-      expect(uploaded.sourceAnnotationId).toBe('ref-1');
+      expect(uploaded.sourceAnnotationId).toBe('ann-1');   // derived from focus.annotation.id
       expect(uploaded.generationPrompt).toBe('Write about X');
       expect(uploaded.language).toBe('en');
       expect(uploaded.generator).toBeTruthy();
@@ -332,7 +337,7 @@ describe('handleJob orchestration', () => {
       vi.mocked(h.session.client.yield.resource).mockRejectedValueOnce(new Error('Upload failed: 500'));
 
       await expect(
-        handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { referenceId: 'ref-1' }))
+        handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { context: minimalContext('annotation') }))
       ).rejects.toThrow(/Upload failed: 500/);
     });
 
@@ -354,7 +359,6 @@ describe('handleJob orchestration', () => {
         h.adapter,
         makeConfig(h.session),
         makeJob('generation', {
-          referenceId: 'ref-1',
           entityTypes: ['Character', 'Hero'],
         }),
       );
@@ -377,7 +381,7 @@ describe('handleJob orchestration', () => {
       });
       const h = makeFakeSessionAndAdapter();
 
-      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { referenceId: 'ref-1' }));
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { context: minimalContext('annotation') }));
 
       expect(h.yieldResourceCalls).toHaveLength(1);
       expect(h.yieldResourceCalls[0]!.entityTypes).toBeUndefined();
@@ -427,7 +431,7 @@ describe('handleJob orchestration', () => {
       });
       const h = makeFakeSessionAndAdapter();
 
-      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { referenceId: 'ref-1', cite: true }));
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { context: minimalContext('annotation'), cite: true }));
 
       const markCreates = h.busEmits.filter(e => e.channel === 'mark:create');
       expect(markCreates, 'one mark:create per resolved citation').toHaveLength(1);
@@ -469,7 +473,7 @@ describe('handleJob orchestration', () => {
       await handleJob(
         h.adapter,
         makeConfig(h.session),
-        makeJob('generation', { referenceId: 'ref-1', cite: true, outputMediaType: 'application/pdf' }),
+        makeJob('generation', { context: minimalContext('annotation'), cite: true, outputMediaType: 'application/pdf' }),
       );
 
       const markCreates = h.busEmits.filter(e => e.channel === 'mark:create');
@@ -511,7 +515,7 @@ describe('handleJob orchestration', () => {
       await handleJob(
         h.adapter,
         makeConfig(h.session),
-        makeJob('generation', { referenceId: 'ref-1', cite: true, outputMediaType: 'application/pdf' }),
+        makeJob('generation', { context: minimalContext('annotation'), cite: true, outputMediaType: 'application/pdf' }),
       );
 
       const markCreates = h.busEmits.filter(e => e.channel === 'mark:create');
@@ -740,7 +744,7 @@ describe('handleJob orchestration', () => {
       });
       const h = makeFakeSessionAndAdapter();
 
-      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { referenceId: 'ref-1' }));
+      await handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { context: minimalContext('annotation') }));
 
       expect(h.session.client.browse.resource).not.toHaveBeenCalled();
       expect(h.busEmits.some(e => e.channel === 'job:complete')).toBe(true);
@@ -923,3 +927,19 @@ describe('startWorkerProcess', () => {
     vi.resetModules();
   });
 });
+
+// ─── GENERATION-WIRE-CONTEXT P1: one derivation for the reference id ───
+describe('referenceIdOf', () => {
+  it('derives from the focus for generation jobs (annotation focus → annotation.id)', () => {
+    expect(referenceIdOf(makeJob('generation', { context: minimalContext('annotation') }))).toBe('ann-1');
+  });
+
+  it('is undefined for resource-focus generation', () => {
+    expect(referenceIdOf(makeJob('generation', {}))).toBeUndefined();
+  });
+
+  it('passes through params.referenceId for NON-generation jobTypes (detection echoes)', () => {
+    expect(referenceIdOf(makeJob('reference-annotation', { referenceId: 'det-ref' }))).toBe('det-ref');
+  });
+});
+

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -29,6 +29,27 @@ import {
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
 import { isGenerationJobParams, getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, findClaimSpan, type EventMap } from '@semiont/core';
+
+/**
+ * The ONE derivation for a job's associated reference/annotation id
+ * (GENERATION-WIRE-CONTEXT D3). Generation params no longer carry
+ * `referenceId` on the wire — the context's focus is authoritative — so for
+ * generation jobs the id comes from `focus.annotation.id` (annotation focus)
+ * or is undefined (resource focus). Non-generation jobTypes (detection
+ * echoes) keep their own `params.referenceId` passthrough.
+ */
+export function referenceIdOf(job: { type: string; params: Record<string, unknown> }): string | undefined {
+  if (job.type === 'generation') {
+    const context = job.params.context as { focus?: { kind?: unknown; annotation?: { id?: unknown } } } | undefined;
+    const focus = context?.focus;
+    if (focus?.kind === 'annotation' && typeof focus.annotation?.id === 'string') {
+      return focus.annotation.id;
+    }
+    return undefined;
+  }
+  const ref = job.params.referenceId;
+  return typeof ref === 'string' ? ref : undefined;
+}
 import type { InferenceClient } from '@semiont/inference';
 import type { Logger, components } from '@semiont/core';
 import { deriveStorageUri, extractPdfTextLayer, type AnchoredTextStore } from '@semiont/content';
@@ -127,7 +148,7 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
     handleJob(adapter, config, job).catch((error) => {
       const message = error instanceof Error ? error.message : String(error);
       logger.error('Job failed', { jobId: job.jobId, error: message, stack: error instanceof Error ? error.stack : undefined });
-      const failAnnotationId = (job.params as { referenceId?: string }).referenceId;
+      const failAnnotationId = referenceIdOf(job);
       if (isJobType(job.type)) {
         emitEvent(session, 'job:fail', {
           resourceId: job.resourceId,
@@ -201,7 +222,7 @@ async function handleJobInner(
   // payload so the UI can attach visual feedback to that annotation.
   // Resource-scoped jobs (bulk reference/tag/highlight/comment/
   // assessment detection scanning a whole resource) leave it unset.
-  const annotationId = (job.params as { referenceId?: string }).referenceId;
+  const annotationId = referenceIdOf(job);
   // No `userId`: the job lifecycle commands declare only `_userId`, injected by
   // the gateway from the authenticated session. Spreading an extra field would
   // put out-of-contract data on a global channel — and would not be caught by
@@ -369,11 +390,13 @@ async function handleJobInner(
     // The backend writes content to disk and emits `yield:create`
     // internally; we only learn the new resourceId from the response.
     const genParams = job.params as {
-      referenceId?: string;
       prompt?: string;
       language?: string;
       entityTypes?: string[];
     };
+    // Annotation-focus generation auto-binds to the triggering reference; the
+    // id is derived from the context's focus (the wire no longer carries it).
+    const genReferenceId = referenceIdOf(job);
     const storageUri = deriveStorageUri(genResult.title, genResult.format);
 
     const { resourceId: newResourceId } = await session.client.yield.resource({
@@ -382,7 +405,7 @@ async function handleJobInner(
       format: genResult.format,
       storageUri,
       sourceResourceId: resourceId as unknown as string,
-      ...(genParams.referenceId ? { sourceAnnotationId: genParams.referenceId } : {}),
+      ...(genReferenceId ? { sourceAnnotationId: genReferenceId } : {}),
       ...(genParams.prompt ? { generationPrompt: genParams.prompt } : {}),
       ...(genParams.language ? { language: genParams.language } : {}),
       ...(genParams.entityTypes && genParams.entityTypes.length > 0 ? { entityTypes: genParams.entityTypes } : {}),
@@ -394,7 +417,7 @@ async function handleJobInner(
     // derivation is a first-class edge, targeting the whole source resource
     // (resource-level, no selector). Annotation-focus generation instead auto-binds
     // the triggering reference via `sourceAnnotationId` on the upload above.
-    if (!genParams.referenceId) {
+    if (!genReferenceId) {
       const { annotation: provenanceRef } = assembleAnnotation(
         {
           motivation: 'linking',

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -30,6 +30,23 @@ import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
 import { isGenerationJobParams, getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, findClaimSpan, type EventMap } from '@semiont/core';
 
+import type { InferenceClient } from '@semiont/inference';
+import type { Logger, components } from '@semiont/core';
+import { deriveStorageUri, extractPdfTextLayer, type AnchoredTextStore } from '@semiont/content';
+import { prepareDetection, type DetectionDecline } from './workers/detection/prepare-detection';
+import { SpanKind, recordJobOutcome, withSpan } from '@semiont/observability';
+import {
+  processHighlightJob,
+  processCommentJob,
+  processAssessmentJob,
+  processReferenceJob,
+  processTagJob,
+  processGenerationJob,
+  buildPdfAnnotation,
+  type OnProgress,
+  type BuildAnnotation,
+} from './processors';
+
 /**
  * The ONE derivation for a job's associated reference/annotation id
  * (GENERATION-WIRE-CONTEXT D3). Generation params no longer carry
@@ -50,22 +67,6 @@ export function referenceIdOf(job: { type: string; params: Record<string, unknow
   const ref = job.params.referenceId;
   return typeof ref === 'string' ? ref : undefined;
 }
-import type { InferenceClient } from '@semiont/inference';
-import type { Logger, components } from '@semiont/core';
-import { deriveStorageUri, extractPdfTextLayer, type AnchoredTextStore } from '@semiont/content';
-import { prepareDetection, type DetectionDecline } from './workers/detection/prepare-detection';
-import { SpanKind, recordJobOutcome, withSpan } from '@semiont/observability';
-import {
-  processHighlightJob,
-  processCommentJob,
-  processAssessmentJob,
-  processReferenceJob,
-  processTagJob,
-  processGenerationJob,
-  buildPdfAnnotation,
-  type OnProgress,
-  type BuildAnnotation,
-} from './processors';
 
 type Agent = components['schemas']['Agent'];
 

--- a/packages/make-meaning/docs/job-workers.md
+++ b/packages/make-meaning/docs/job-workers.md
@@ -47,10 +47,17 @@ async function processHighlightJob(
 ```typescript
 async function processGenerationJob(
   inferenceClient: InferenceClient,
-  params: GenerationParams,
+  params: GenerationJobParams,        // options + the gathered context; the context's
+                                      // focus is what anchors the job
   onProgress: OnProgress,
   logger: Logger,
-): Promise<{ content: string; title: string; format: string; result: GenerationResult }>
+): Promise<{
+  content: Uint8Array;                // bytes — the output media type decides the encoding
+  title: string;
+  format: SupportedMediaType;
+  citations: GenerationCitation[];    // only under `cite`
+  result: GenerationResult;
+}>
 ```
 
 The `generator` is a W3C `Agent` with `@type: "SoftwareAgent"` that identifies which inference provider and model produced the annotation. It is built once at worker-process startup and carried on the [`WorkerProcessConfig`](../../jobs/src/worker-process.ts) — processors never receive or read `InferenceConfig` directly.

--- a/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
@@ -226,8 +226,7 @@ describe('registerJobCommandHandlers — tag-annotation dispatcher', () => {
     eventBus.get('job:create').next({
       correlationId: 'cid-4',
       jobType: 'generation',
-      resourceId: 'rid-test',
-      params: { title: 'Test' },
+      params: { ...GEN_PARAMS, context: genContext('resource') },
       _userId: TEST_USER_DID,
     } as never);
 
@@ -243,8 +242,8 @@ describe('registerJobCommandHandlers — tag-annotation dispatcher', () => {
     const gen$ = (eventBus.get('job:created') as never as import('rxjs').Observable<JobCreatedEvent>)
       .pipe(filter((e) => e.correlationId === 'cid-retry-gen'), take(1));
     eventBus.get('job:create').next({
-      correlationId: 'cid-retry-gen', jobType: 'generation', resourceId: 'rid-test',
-      params: { title: 'T' }, _userId: TEST_USER_DID,
+      correlationId: 'cid-retry-gen', jobType: 'generation',
+      params: { ...GEN_PARAMS, context: genContext('resource') }, _userId: TEST_USER_DID,
     } as never);
     await firstValueFrom(race(gen$, timer(2_000)));
     const genJob = jobQueue.createJob.mock.calls.at(-1)![0] as { metadata: { maxRetries: number } };
@@ -359,8 +358,7 @@ describe('registerJobCommandHandlers — entity-type validation', () => {
     eventBus.get('job:create').next({
       correlationId: 'cid-gen-ok',
       jobType: 'generation',
-      resourceId: 'rid-test',
-      params: { title: 'X', entityTypes: ['Character', 'Hero'] },
+      params: { ...GEN_PARAMS, context: genContext('resource'), entityTypes: ['Character', 'Hero'] },
       _userId: TEST_USER_DID,
     } as never);
 
@@ -381,8 +379,7 @@ describe('registerJobCommandHandlers — entity-type validation', () => {
     eventBus.get('job:create').next({
       correlationId: 'cid-gen-bad',
       jobType: 'generation',
-      resourceId: 'rid-test',
-      params: { title: 'X', entityTypes: ['Character', 'UnknownThing'] },
+      params: { ...GEN_PARAMS, context: genContext('resource'), entityTypes: ['Character', 'UnknownThing'] },
       _userId: TEST_USER_DID,
     } as never);
 
@@ -636,3 +633,151 @@ describe('registerJobCommandHandlers — lifecycle integration (real FsJobQueue)
     expect(announced.map((e) => e.jobId)).toContain(jobId('job-int-fail'));
   });
 });
+
+// ─── GENERATION-WIRE-CONTEXT P1: context is the wire truth for generation ───
+//
+// The dispatcher DERIVES the job's resourceId from params.context.focus and
+// REJECTS (job:create-failed) caller-supplied ids or an unusable focus. The
+// envelope's resourceId stays required for every OTHER jobType — the check
+// moved from the schema's `required` array to here; it did not weaken.
+
+function genContext(kind: 'resource' | 'annotation'): Record<string, unknown> {
+  const sourceResource = {
+    '@context': 'https://semiont.dev/context/v1',
+    '@id': 'res-src',
+    name: 'Source',
+    representations: [],
+  };
+  return {
+    focus: kind === 'resource'
+      ? { kind, resource: sourceResource }
+      : {
+          kind,
+          annotation: {
+            '@context': 'http://www.w3.org/ns/anno.jsonld',
+            type: 'Annotation',
+            id: 'ann-src',
+            motivation: 'linking',
+            target: { source: 'res-src' },
+          },
+          sourceResource,
+        },
+    graph: { nodes: [], edges: [] },
+    metadata: {},
+  };
+}
+
+const GEN_PARAMS = {
+  title: 'Answer',
+  storageUri: 'file://generated/answer.md',
+};
+
+describe('registerJobCommandHandlers — generation dispatcher (context-derived ids)', () => {
+  let project: SemiontProject;
+  let teardown: () => Promise<void>;
+  let eventBus: EventBus;
+  let jobQueue: MockJobQueue;
+
+  beforeEach(async () => {
+    ({ project, teardown } = await createTestProject('job-commands-generation'));
+    eventBus = new EventBus();
+    jobQueue = makeJobQueue();
+    registerJobCommandHandlers(eventBus, jobQueue as never, project, silentLogger);
+  });
+
+  afterEach(async () => {
+    eventBus.destroy();
+    await teardown();
+  });
+
+  function sendCreate(cid: string, command: Record<string, unknown>) {
+    const created$ = (
+      eventBus.get('job:created') as never as import('rxjs').Observable<JobCreatedEvent>
+    ).pipe(filter((e) => e.correlationId === cid), take(1));
+    const failed$ = (
+      eventBus.get('job:create-failed') as never as import('rxjs').Observable<JobCreateFailedEvent>
+    ).pipe(filter((e) => e.correlationId === cid), take(1));
+    const outcome = firstValueFrom(race(created$, failed$));
+    eventBus.get('job:create').next({
+      correlationId: cid,
+      jobType: 'generation',
+      _userId: TEST_USER_DID,
+      ...command,
+    } as never);
+    return outcome;
+  }
+
+  it('derives the job resourceId from a resource-focus context', async () => {
+    const outcome = await sendCreate('g-1', {
+      params: { ...GEN_PARAMS, context: genContext('resource') },
+    });
+    expect(outcome).toHaveProperty('response.jobId');
+    const job = jobQueue.createJob.mock.calls[0]![0];
+    expect(job.params.resourceId).toBe('res-src');
+  });
+
+  it('derives from an annotation-focus context: resourceId = the SOURCE resource', async () => {
+    const outcome = await sendCreate('g-2', {
+      params: { ...GEN_PARAMS, context: genContext('annotation') },
+    });
+    expect(outcome).toHaveProperty('response.jobId');
+    const job = jobQueue.createJob.mock.calls[0]![0];
+    expect(job.params.resourceId).toBe('res-src');
+  });
+
+  it('rejects a generation create that carries a top-level resourceId', async () => {
+    const outcome = await sendCreate('g-3', {
+      resourceId: 'res-imposter',
+      params: { ...GEN_PARAMS, context: genContext('resource') },
+    });
+    expect(outcome).toHaveProperty('message');
+    expect((outcome as JobCreateFailedEvent).message).toMatch(/focus is authoritative|omit resourceId/i);
+    expect(jobQueue.createJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects a generation create that carries params.referenceId', async () => {
+    const outcome = await sendCreate('g-4', {
+      params: { ...GEN_PARAMS, referenceId: 'ann-imposter', context: genContext('annotation') },
+    });
+    expect(outcome).toHaveProperty('message');
+    expect((outcome as JobCreateFailedEvent).message).toMatch(/focus is authoritative|omit .*referenceId/i);
+    expect(jobQueue.createJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects a context with no usable focus, naming the sanctioned producers', async () => {
+    const outcome = await sendCreate('g-5', {
+      params: { ...GEN_PARAMS, context: { graph: {}, metadata: {} } },
+    });
+    expect(outcome).toHaveProperty('message');
+    expect((outcome as JobCreateFailedEvent).message).toMatch(/gather\.resource|gather\.annotation/);
+    expect(jobQueue.createJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects a trio-less params bag — wire requiredness is enforced at creation now', async () => {
+    const outcome = await sendCreate('g-6', {
+      params: { context: genContext('resource') },   // no title, no storageUri
+    });
+    expect(outcome).toHaveProperty('message');
+    expect((outcome as JobCreateFailedEvent).message).toMatch(/GenerationJobParams|title/);
+    expect(jobQueue.createJob).not.toHaveBeenCalled();
+  });
+
+  it('still REQUIRES the envelope resourceId for non-generation jobTypes', async () => {
+    const created$ = (
+      eventBus.get('job:created') as never as import('rxjs').Observable<JobCreatedEvent>
+    ).pipe(filter((e) => e.correlationId === 'g-7'), take(1));
+    const failed$ = (
+      eventBus.get('job:create-failed') as never as import('rxjs').Observable<JobCreateFailedEvent>
+    ).pipe(filter((e) => e.correlationId === 'g-7'), take(1));
+    const outcome = firstValueFrom(race(created$, failed$));
+    eventBus.get('job:create').next({
+      correlationId: 'g-7',
+      jobType: 'highlight-annotation',
+      _userId: TEST_USER_DID,
+      params: {},
+    } as never);
+    expect(await outcome).toHaveProperty('message');
+    expect(jobQueue.createJob).not.toHaveBeenCalled();
+  });
+});
+

--- a/packages/make-meaning/src/handlers/job-commands.ts
+++ b/packages/make-meaning/src/handlers/job-commands.ts
@@ -1,4 +1,4 @@
-import { generateUuid, jobId, userId, resourceId, entityType } from '@semiont/core';
+import { generateUuid, jobId, userId, resourceId, entityType, isGenerationJobParams } from '@semiont/core';
 import type { EventBus, Logger } from '@semiont/core';
 import type { SemiontProject } from '@semiont/core/node';
 import type { JobQueue } from '@semiont/jobs';
@@ -36,6 +36,51 @@ export function registerJobCommandHandlers(
 
       const user = parseDidUser(_userId);
 
+      // GENERATION-WIRE-CONTEXT D1/D2: for generation, the context is the wire
+      // truth — the job's resourceId is DERIVED from params.context.focus, and
+      // caller-supplied ids are REJECTED (never ignored: a raw emitter must not
+      // believe its ids mattered). Every OTHER jobType still requires the
+      // envelope resourceId — the schema can't express the conditionality, so
+      // both directions are enforced here.
+      let effectiveResourceId: string;
+      if (jobType === 'generation') {
+        if (resId !== undefined) {
+          throw new Error(
+            'generation job:create must omit resourceId — the context\'s focus is authoritative',
+          );
+        }
+        const bag = params as Record<string, unknown> | undefined;
+        if (bag && bag.referenceId !== undefined) {
+          throw new Error(
+            'generation job:create must omit params.referenceId — the context\'s focus is authoritative',
+          );
+        }
+        if (!isGenerationJobParams(params)) {
+          throw new Error(
+            'generation params do not satisfy GenerationJobParams (title, storageUri, and context are required)',
+          );
+        }
+        const focus = (params.context as { focus?: Record<string, unknown> }).focus;
+        const rid =
+          focus?.kind === 'resource'
+            ? (focus.resource as { '@id'?: unknown } | undefined)?.['@id']
+            : focus?.kind === 'annotation'
+              ? (focus.sourceResource as { '@id'?: unknown } | undefined)?.['@id']
+              : undefined;
+        if (typeof rid !== 'string' || rid.length === 0) {
+          throw new Error(
+            'generation context has no usable focus — pass a GatheredContext produced by '
+            + 'gather.resource(...) or gather.annotation(...)',
+          );
+        }
+        effectiveResourceId = rid;
+      } else {
+        if (typeof resId !== 'string' || resId.length === 0) {
+          throw new Error(`${jobType} job:create requires resourceId`);
+        }
+        effectiveResourceId = resId;
+      }
+
       const job = {
         status: 'pending' as const,
         metadata: {
@@ -54,7 +99,7 @@ export function registerJobCommandHandlers(
           maxRetries: jobType === 'generation' ? 0 : 1,
         },
         params: {
-          resourceId: resourceId(resId as string),
+          resourceId: resourceId(effectiveResourceId),
           ...(params as Record<string, unknown>),
         } as Record<string, unknown>,
       };

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -2176,7 +2176,7 @@ type GatheredContext_Focus struct {
 	union json.RawMessage
 }
 
-// GenerationJobParams Params bag for `job:create` with `jobType: 'generation'` — the ONE shape both ends of the wire share: the sdk composes it (yield.fromContext) and the generation worker narrows to it. Carried inside JobCreateCommand.params (which stays open because params vary by jobType); this schema is the generation shape's contract, including its requiredness.
+// GenerationJobParams Params bag for `job:create` with `jobType: 'generation'` — exactly the shape yield.fromContext(context, options) takes: options + the gathered context. The job's ids are DERIVED from context.focus at the dispatcher (resource focus → focus.resource; annotation focus → focus.sourceResource, with the worker auto-binding to focus.annotation); a caller-supplied referenceId is rejected. Carried inside JobCreateCommand.params; this schema is the generation shape's contract, including its requiredness.
 type GenerationJobParams struct {
 	// Cite Ask the model to cite: emit [[<id>]] transport tokens after each claim, using the ids the context embedding provides. The worker validates each id against the embedded context (unknown ids are dropped loudly), strips the tokens from the stored content, and mints W3C linking annotations on the derived resource.
 	Cite *bool `json:"cite,omitempty"`
@@ -2198,9 +2198,6 @@ type GenerationJobParams struct {
 
 	// Prompt Refining instruction, composed with `task` (task = what, prompt = how).
 	Prompt *string `json:"prompt,omitempty"`
-
-	// ReferenceId The unresolved reference an annotation-focus generation was triggered from. Absent for resource-focus generation. When present, the worker auto-binds the new resource to it; when absent, provenance is a minted source→derived reference annotation.
-	ReferenceId *string `json:"referenceId,omitempty"`
 
 	// SourceLanguage Source-resource locale — language of the resource being referenced, used in the prompt so the LLM understands embedded source-context snippets when source ≠ target language. BCP-47.
 	SourceLanguage *string `json:"sourceLanguage,omitempty"`
@@ -2399,9 +2396,11 @@ type JobCreateCommand struct {
 	CorrelationId    string  `json:"correlationId"`
 
 	// JobType Type of background job
-	JobType    JobType                `json:"jobType"`
-	Params     map[string]interface{} `json:"params"`
-	ResourceId string                 `json:"resourceId"`
+	JobType JobType                `json:"jobType"`
+	Params  map[string]interface{} `json:"params"`
+
+	// ResourceId Resource the job operates on. REQUIRED for every jobType EXCEPT 'generation', where it must be ABSENT: the dispatcher derives it from params.context.focus (the context is authoritative) and REJECTS a supplied value via job:create-failed. Both directions are enforced at the dispatcher — this schema cannot express the per-jobType conditionality.
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 // JobCreatedResult Result of a job:create command

--- a/packages/sdk/src/namespaces/__tests__/commands.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/commands.test.ts
@@ -585,14 +585,19 @@ describe('YieldNamespace', () => {
     expect(capturedSignal?.aborted).toBe(true);
   });
 
-  it('fromContext(annotation focus) derives resourceId AND referenceId from the focus', () => {
+  it('fromContext(annotation focus) sends NO ids — the context is the wire truth', () => {
     yld.fromContext(CTX_ANN, { title: 'T', storageUri: 'file://x' }).subscribe(() => {});
     return new Promise<void>((resolve) => setTimeout(() => {
-      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
-        jobType: 'generation',
-        resourceId: RID,                       // focus.sourceResource['@id']
-        params: expect.objectContaining({ referenceId: AID }),  // focus.annotation.id
-      }));
+      const call = emitSpy.mock.calls.find((c: unknown[]) => c[0] === 'job:create');
+      const payload = call![1] as Record<string, unknown>;
+      expect(payload.jobType).toBe('generation');
+      // The server derives both ids from params.context.focus (GENERATION-
+      // WIRE-CONTEXT D1); a caller-supplied id is REJECTED there, so the sdk
+      // must not send either.
+      expect('resourceId' in payload).toBe(false);
+      const params = payload.params as Record<string, unknown>;
+      expect('referenceId' in params).toBe(false);
+      expect(params.context).toBe(CTX_ANN);
       resolve();
     }, 20));
   });
@@ -604,14 +609,16 @@ describe('YieldNamespace', () => {
       .toThrow(/gather\.resource|gather\.annotation/);
   });
 
-  it('fromContext(resource focus) derives resourceId from the focus; no referenceId in params', () => {
+  it('fromContext(resource focus) sends NO ids; the context rides in params', () => {
     yld.fromContext(CTX_RES, { title: 'T', storageUri: 'file://x' }).subscribe(() => {});
     return new Promise<void>((resolve) => setTimeout(() => {
-      expect(emitSpy).toHaveBeenCalledWith('job:create', expect.objectContaining({
-        jobType: 'generation',
-        resourceId: RID,
-        params: expect.not.objectContaining({ referenceId: expect.anything() }),
-      }));
+      const call = emitSpy.mock.calls.find((c: unknown[]) => c[0] === 'job:create');
+      const payload = call![1] as Record<string, unknown>;
+      expect(payload.jobType).toBe('generation');
+      expect('resourceId' in payload).toBe(false);
+      const params = payload.params as Record<string, unknown>;
+      expect('referenceId' in params).toBe(false);
+      expect(params.context).toBe(CTX_RES);
       resolve();
     }, 20));
   });

--- a/packages/sdk/src/namespaces/yield.ts
+++ b/packages/sdk/src/namespaces/yield.ts
@@ -104,8 +104,8 @@ export class YieldNamespace implements IYieldNamespace {
    *   `focus.resource`; on completion the worker mints a navigable
    *   source→derived reference annotation (provenance).
    * - `annotation` focus (from `gather.annotation`) — the job scopes to
-   *   `focus.sourceResource` and carries `focus.annotation.id` as
-   *   `referenceId`; the worker auto-binds the new resource to it.
+   *   `focus.sourceResource`, and the worker auto-binds the new resource to
+   *   `focus.annotation` (derived server-side; nothing rides the wire twice).
    *
    * A context without a usable focus throws synchronously — the runtime half
    * of the schema's `required: focus` for values whose type history was
@@ -118,25 +118,26 @@ export class YieldNamespace implements IYieldNamespace {
     context: GatheredContext,
     options: GenerationOptions,
   ): StreamObservable<YieldGenerationEvent> {
+    // The wire carries NO ids for generation (GENERATION-WIRE-CONTEXT D1) —
+    // the dispatcher derives them from the context's focus and rejects a
+    // caller-supplied value. The rid derived here is CLIENT-side only, for the
+    // poll-fallback's synthesized complete event (D4: JobStatusResponse has no
+    // resourceId). The guard stays: fail fast locally with the same message
+    // the dispatcher would send.
     const focus = context?.focus;
-    if (focus?.kind === 'resource' && typeof focus.resource?.['@id'] === 'string') {
-      return this.runGeneration(toResourceId(focus.resource['@id']), { ...options, context });
+    const displayRid =
+      focus?.kind === 'resource' && typeof focus.resource?.['@id'] === 'string'
+        ? focus.resource['@id']
+        : focus?.kind === 'annotation' && typeof focus.sourceResource?.['@id'] === 'string'
+          ? focus.sourceResource['@id']
+          : undefined;
+    if (displayRid === undefined) {
+      throw new Error(
+        'yield.fromContext: context has no usable focus — pass a GatheredContext '
+        + 'produced by gather.resource(...) or gather.annotation(...).',
+      );
     }
-    if (
-      focus?.kind === 'annotation'
-      && typeof focus.sourceResource?.['@id'] === 'string'
-      && typeof focus.annotation?.id === 'string'
-    ) {
-      return this.runGeneration(toResourceId(focus.sourceResource['@id']), {
-        ...options,
-        context,
-        referenceId: focus.annotation.id,
-      });
-    }
-    throw new Error(
-      'yield.fromContext: context has no usable focus — pass a GatheredContext '
-      + 'produced by gather.resource(...) or gather.annotation(...).',
-    );
+    return this.runGeneration(toResourceId(displayRid), { ...options, context });
   }
 
   /**
@@ -148,6 +149,8 @@ export class YieldNamespace implements IYieldNamespace {
    * `job:status` fallback) as `YieldGenerationEvent`s, resolving on the
    * terminal `complete`.
    */
+  /** `resourceId` is CLIENT-side display only (the poll-synthesized complete
+   *  event, D4) — it is deliberately NOT sent on the wire. */
   private runGeneration(
     resourceId: ResourceId,
     params: GenerationJobParams,
@@ -245,7 +248,6 @@ export class YieldNamespace implements IYieldNamespace {
         'job:create',
         {
           jobType: 'generation',
-          resourceId,
           params,
         },
       ).then(({ jobId }) => {

--- a/specs/src/components/schemas/GenerationJobParams.json
+++ b/specs/src/components/schemas/GenerationJobParams.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "description": "Params bag for `job:create` with `jobType: 'generation'` — the ONE shape both ends of the wire share: the sdk composes it (yield.fromContext) and the generation worker narrows to it. Carried inside JobCreateCommand.params (which stays open because params vary by jobType); this schema is the generation shape's contract, including its requiredness.",
+  "description": "Params bag for `job:create` with `jobType: 'generation'` \u2014 exactly the shape yield.fromContext(context, options) takes: options + the gathered context. The job's ids are DERIVED from context.focus at the dispatcher (resource focus \u2192 focus.resource; annotation focus \u2192 focus.sourceResource, with the worker auto-binding to focus.annotation); a caller-supplied referenceId is rejected. Carried inside JobCreateCommand.params; this schema is the generation shape's contract, including its requiredness.",
   "properties": {
     "title": {
       "type": "string",
@@ -12,11 +12,7 @@
     },
     "context": {
       "$ref": "./GatheredContext.json",
-      "description": "The gathered context that grounds the generation. Its `focus` names the anchor (the sdk derives the job's resourceId — and referenceId, for annotation focus — from it); under `cite`, the ids its embedding carries are the only valid citation targets."
-    },
-    "referenceId": {
-      "type": "string",
-      "description": "The unresolved reference an annotation-focus generation was triggered from. Absent for resource-focus generation. When present, the worker auto-binds the new resource to it; when absent, provenance is a minted source→derived reference annotation."
+      "description": "The gathered context that grounds the generation. Its `focus` names the anchor (the sdk derives the job's resourceId \u2014 and referenceId, for annotation focus \u2014 from it); under `cite`, the ids its embedding carries are the only valid citation targets."
     },
     "prompt": {
       "type": "string",
@@ -24,16 +20,18 @@
     },
     "entityTypes": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Entity-type tags to stamp on the synthesized resource. Used both as a prompt bias for the generation worker and as the `entityTypes` set on the resulting resource."
     },
     "language": {
       "type": "string",
-      "description": "Annotation/resource body locale — language the generated resource is written in (typically the user's UI locale). BCP-47."
+      "description": "Annotation/resource body locale \u2014 language the generated resource is written in (typically the user's UI locale). BCP-47."
     },
     "sourceLanguage": {
       "type": "string",
-      "description": "Source-resource locale — language of the resource being referenced, used in the prompt so the LLM understands embedded source-context snippets when source ≠ target language. BCP-47."
+      "description": "Source-resource locale \u2014 language of the resource being referenced, used in the prompt so the LLM understands embedded source-context snippets when source \u2260 target language. BCP-47."
     },
     "temperature": {
       "type": "number",
@@ -45,20 +43,24 @@
     },
     "outputMediaType": {
       "$ref": "./SupportedMediaType.json",
-      "description": "Requested media type of the generated resource's content. Default `text/markdown` at the worker, which validates it against its supported output set and FAILS the job for anything it can't write — not a silent fallback."
+      "description": "Requested media type of the generated resource's content. Default `text/markdown` at the worker, which validates it against its supported output set and FAILS the job for anything it can't write \u2014 not a silent fallback."
     },
     "task": {
       "type": "string",
-      "description": "What the model is asked to produce — the prompt's framing verb. Canonical values ('resource', 'answer', 'summary') map to the worker's tested framings; any other string is used VERBATIM as the framing instruction (loud degrade: the worker warns, never silently falls back). Unset ⇒ 'resource' (article framing)."
+      "description": "What the model is asked to produce \u2014 the prompt's framing verb. Canonical values ('resource', 'answer', 'summary') map to the worker's tested framings; any other string is used VERBATIM as the framing instruction (loud degrade: the worker warns, never silently falls back). Unset \u21d2 'resource' (article framing)."
     },
     "structure": {
       "type": "string",
-      "description": "How the output is internally segmented — shape for text-bearing media, subordinate to `outputMediaType` (never its peer). Canonical values: 'prose' (flowing paragraphs), 'sections' (titled sections + title), 'chat' (speaker-labeled turns); any other string becomes a freeform \"organize as: …\" directive (loud degrade). Unset ⇒ NO structure directive at all — the task framing and the model determine shape."
+      "description": "How the output is internally segmented \u2014 shape for text-bearing media, subordinate to `outputMediaType` (never its peer). Canonical values: 'prose' (flowing paragraphs), 'sections' (titled sections + title), 'chat' (speaker-labeled turns); any other string becomes a freeform \"organize as: \u2026\" directive (loud degrade). Unset \u21d2 NO structure directive at all \u2014 the task framing and the model determine shape."
     },
     "cite": {
       "type": "boolean",
       "description": "Ask the model to cite: emit [[<id>]] transport tokens after each claim, using the ids the context embedding provides. The worker validates each id against the embedded context (unknown ids are dropped loudly), strips the tokens from the stored content, and mints W3C linking annotations on the derived resource."
     }
   },
-  "required": ["title", "storageUri", "context"]
+  "required": [
+    "title",
+    "storageUri",
+    "context"
+  ]
 }

--- a/specs/src/components/schemas/JobCreateCommand.json
+++ b/specs/src/components/schemas/JobCreateCommand.json
@@ -9,9 +9,12 @@
       "type": "string",
       "description": "Authenticated user's DID, injected by the /bus/emit gateway. Clients do not set this."
     },
-    "jobType": { "$ref": "./JobType.json" },
+    "jobType": {
+      "$ref": "./JobType.json"
+    },
     "resourceId": {
-      "type": "string"
+      "type": "string",
+      "description": "Resource the job operates on. REQUIRED for every jobType EXCEPT 'generation', where it must be ABSENT: the dispatcher derives it from params.context.focus (the context is authoritative) and REJECTS a supplied value via job:create-failed. Both directions are enforced at the dispatcher \u2014 this schema cannot express the per-jobType conditionality."
     },
     "params": {
       "type": "object",
@@ -21,7 +24,6 @@
   "required": [
     "correlationId",
     "jobType",
-    "resourceId",
     "params"
   ]
 }


### PR DESCRIPTION
## Summary

**Breaking wire change, scoped to `jobType: 'generation'` only:** `job:create` no longer carries the ids the context already contains. The wire is now

```
job:create { jobType: 'generation', params: { context, ...options } }
```

— the same shape `yield.fromContext(context, options)` takes. The dispatcher derives the job's ids from `params.context.focus` and **rejects** anything else:

| focus.kind | job record `resourceId` | reference for auto-bind |
|---|---|---|
| `resource` (from `gather.resource`) | `focus.resource['@id']` | — (worker mints source→derived provenance) |
| `annotation` (from `gather.annotation`) | `focus.sourceResource['@id']` | `focus.annotation.id`, derived by the worker |

Rejected loudly via `job:create-failed`, never ignored: a caller-supplied top-level `resourceId`, a `params.referenceId`, a params bag missing the required trio (`title`, `storageUri`, `context` — wire requiredness is now enforced at creation, not just in the worker), or a context with no usable focus (message names `gather.resource`/`gather.annotation`). **Every other jobType keeps its caller-supplied envelope `resourceId`** — detection jobs are untouched, and the dispatcher now enforces that presence too, since the schema no longer can.

## Why

The `fromContext` cutover (#1168) made a mismatched rid/aid pair unrepresentable for every caller who uses a door — but at the wire, the window was still open: a raw emitter could send an envelope `resourceId` disagreeing with `params.context.focus`, and the backend believed the envelope. The wire also carried the same facts twice (ids beside the context that contains them) — redundancy that existed only because the envelope predates the context. This PR removes the redundancy and gives the window the same guard as the door: for generation, the context IS the wire contract, with one source of truth and a named rejection for everything else.

## How it stays contained

The dispatcher already injected `resourceId` into the job record's params — derivation changes the **source** of that value, not the mechanism. So `job:queued` announcements, queue metadata, event scoping (`job:complete`/`job:fail` dual-emit), and the worker's generic paths are all untouched. The blast radius is exactly: two spec schemas, the dispatcher, the worker's generation branch, and the SDK's emit — **no react-ui, mcp-server, or frontend changes**, because the `fromContext(context, options)` surface didn't move. That containment is the dividend of landing #1168 first.

Specifics:

- **Specs**: `JobCreateCommand.required` drops `resourceId` (the property's description states the per-jobType conditionality — required everywhere except generation, rejected there — because JSON Schema can't express it; the dispatcher enforces both directions). `GenerationJobParams` drops `referenceId` and is now exactly *options + context*. TypeScript and Go bindings regenerated.
- **Dispatcher** (`job-commands.ts`): guard → derive → stamp → reject, beside the existing entityTypes/schemaId validation, using the same throw-to-`job:create-failed` plumbing.
- **Worker**: one `referenceIdOf(job)` derivation — focus-derived for generation, typed params passthrough for detection echoes — replacing three inline `as { referenceId?: string }` casts, including the two generic progress-echo peeks that run for every jobType (pinned so detection can't regress).
- **SDK**: `fromContext` posts `{ jobType, params }` and derives nothing for the wire. The focus guard stays (fail fast client-side with the same message the dispatcher sends everyone else). One locally-derived `resourceId` survives, deliberately: the poll-fallback's synthesized complete event needs a display value and `JobStatusResponse` doesn't carry one — commented as such at both sites.

## ⚠️ Deployment order is load-bearing

The failure modes are asymmetric: **old SDK → new backend** is rejected *loudly* (visible, diagnosable). **New SDK → old backend** fails *silently* — generation jobs get created without a record `resourceId`, and scoped job events quietly break. Therefore: **backend/make-meaning images deploy before or with any SDK publish carrying this change, fleet-wide.** Do not interleave.

Raw emitters (curl, hand-rolled clients) that send the old generation shape break by design — the rejection message tells them the fix.

## Tests

RED-first on all three sides: dispatcher (7 new pins: both derivations, three rejection classes, trio-less bags, and non-generation envelope-required), worker (`referenceIdOf` per jobType class; cite tests moved from an inert `referenceId` field to annotation-focus contexts, preserving their auto-bind intent), SDK (payload pins inverted: no envelope id, no `params.referenceId`, context rides once; poll-event display value pinned). Four legacy dispatcher tests that sent generation the old way were migrated — the requiredness ripple arriving where predicted.

Verified in-container: make-meaning 521 · jobs 383 · sdk 495 + build · core 571 · backend full 359 (bus schema validation green under the new envelope) · Go build + tests + launcher suite · doc-snippets gate green. Protocol docs (YIELD flow, JobTypes) updated to the new wire; MARK's detection examples deliberately untouched — they remain correct.
