### PR TITLE
Make the vector store and embedding provider mandatory and explicitly configured (MANDATORY-EMBEDDING P1–P5)

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -256,6 +256,14 @@ jobs:
             '[environments.ci.make-meaning.graph]' \
             'type = "memory"' \
             '' \
+            '[environments.ci.vectors]' \
+            'type = "memory"' \
+            '' \
+            '[environments.ci.embedding]' \
+            'type = "ollama"' \
+            'model = "nomic-embed-text"' \
+            'baseURL = "http://localhost:11434"' \
+            '' \
             '[environments.ci.make-meaning.actors.gatherer.inference]' \
             'type = "ollama"' \
             'model = "llama3"' \

--- a/apps/backend/src/__tests__/_test-setup.ts
+++ b/apps/backend/src/__tests__/_test-setup.ts
@@ -20,6 +20,18 @@ publicURL = "http://localhost:4000"
 [environments.integration.make-meaning.graph]
 type = "memory"
 
+# Mandatory per MANDATORY-EMBEDDING D0+D1 — every config names both, nothing is
+# defaulted. This TOML is written to disk and parsed by the real loader, so it
+# needs the sections in their own right: the EnvironmentConfig object further
+# down is a separate surface, and having only that one is what left the
+# integration suite failing at loadEnvironmentConfig.
+[environments.integration.vectors]
+type = "memory"
+
+[environments.integration.embedding]
+type = "ollama"
+model = "nomic-embed-text"
+
 [environments.integration.make-meaning.actors.gatherer.inference]
 type = "ollama"
 model = "llama3"

--- a/apps/backend/src/__tests__/_test-setup.ts
+++ b/apps/backend/src/__tests__/_test-setup.ts
@@ -139,6 +139,16 @@ export async function setupTestEnvironment(envName?: string): Promise<TestEnviro
         platform: { type: 'posix' },
         type: 'memory',
       },
+      // Mandatory per MANDATORY-EMBEDDING D0+D1 — every config names both.
+      vectors: {
+        platform: { type: 'external' },
+        type: 'memory',
+      },
+      embedding: {
+        platform: { type: 'external' },
+        type: 'ollama',
+        model: 'nomic-embed-text',
+      },
     },
     site: {
       domain: 'test.local',

--- a/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
+++ b/apps/backend/src/__tests__/helpers/make-meaning-mock.ts
@@ -39,6 +39,7 @@ export function stubKnowledgeBase(overrides: Partial<KnowledgeBase> = {}): Knowl
     // honours the contract — what is written comes back — it simply does not
     // outlive the test.
     anchoredText:   inMemoryAnchoredText(),
+    vectors:        {} as KnowledgeBase['vectors'],
     weaveProgress: { dispose: vi.fn() } as unknown as KnowledgeBase['weaveProgress'],
     smeltProgress: { settledAt: vi.fn(), whenSettled: vi.fn(async () => 'inert' as const), dispose: vi.fn() } as unknown as KnowledgeBase['smeltProgress'],
     projectionsDir: '',

--- a/apps/backend/src/__tests__/integration/annotation-crud.test.ts
+++ b/apps/backend/src/__tests__/integration/annotation-crud.test.ts
@@ -36,7 +36,7 @@ describe('Annotation CRUD Integration Tests - W3C multi-body annotation', () => 
 
     // Create KnowledgeBase for AnnotationContext calls
     const viewStorage = new FilesystemViewStorage(project);
-    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, anchoredText: stubKnowledgeBase().anchoredText, projectionsDir: '', weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
+    kb = { eventStore: {} as any, views: viewStorage, content: {} as any, graph: {} as any, anchoredText: stubKnowledgeBase().anchoredText, vectors: {} as any, projectionsDir: '', weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
 
     // Create test resources in event store
     const eventStore = createEventStore(project, new EventBus(), mockLogger);

--- a/apps/backend/src/__tests__/setup.ts
+++ b/apps/backend/src/__tests__/setup.ts
@@ -61,6 +61,16 @@ vi.mock('../utils/config', () => ({
         platform: { type: 'posix' as const },
         type: 'memory' as const,
       },
+      // Mandatory per MANDATORY-EMBEDDING D0+D1 — every config names both.
+      vectors: {
+        platform: { type: 'external' as const },
+        type: 'memory' as const,
+      },
+      embedding: {
+        platform: { type: 'external' as const },
+        type: 'ollama' as const,
+        model: 'nomic-embed-text',
+      },
     },
     site: {
       siteName: 'Test Site',

--- a/apps/backend/src/utils/config.ts
+++ b/apps/backend/src/utils/config.ts
@@ -35,9 +35,12 @@ export function makeMeaningConfigFrom(config: EnvironmentConfig): MakeMeaningCon
     gather,
     search,
     services: {
-      graph: config.services?.graph,
-      vectors: config.services?.vectors,
-      embedding: config.services?.embedding,
+      // vectors/embedding are required on both sides (MANDATORY-EMBEDDING P3):
+      // core's ServicesConfig requires the pair, so a config missing either
+      // already refused at the TOML loader — nothing to re-check here.
+      graph: config.services.graph,
+      vectors: config.services.vectors,
+      embedding: config.services.embedding,
     },
     // The KB's canonical identity — the agent roster mints DIDs from this,
     // the SAME value /api/tokens/agent uses (agent-did-host-skew fix). The

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -301,6 +301,19 @@ semiont stop
   Ollama and reports the same provider — one process is never described two
   ways. `type = "voyage"` is remote SaaS; either way embedding has a status
   row and start/stop belongs to whatever provides it.
+- **A config naming no vector store or no embedding provider is refused, before
+  anything launches.** Semantic search is always available, so the backend's
+  TOML loader refuses such a config at boot. The launcher reads the same file
+  with its own structs, so it refuses the same configs one round trip earlier —
+  otherwise `semiont start` brings the whole stack up and the backend dies
+  seconds later on a file the launcher already had in its hands. Same rule,
+  same words as the loader's, plus the config path. Both sections are required
+  and `embedding` needs its `model`; the refusal happens in `derivePlan`, so
+  `--dry-run` and the `semiont init` self-vet enforce it too, not just `start`.
+  `type = "memory"` is a first-class vector store to the *backend* and is
+  refused *here* with its own explanation: a launcher-managed stack runs the
+  backend and the Smelter as separate containers, and an in-process index
+  cannot be shared across them.
 - **The inference and embedding rows list their models.** Which models a stack
   uses is config truth, recorded at start (the union of `actors.*` and
   `workers.*` inference models, and `embedding.model`); whether each is pulled

--- a/apps/launcher/internal/launcher/plan.go
+++ b/apps/launcher/internal/launcher/plan.go
@@ -362,6 +362,12 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 	secErr := func(section, format string, a ...any) error {
 		return fmt.Errorf("%s: [environments.%s.%s] %s", path, envName, section, fmt.Sprintf(format, a...))
 	}
+	// envErr names the ENVIRONMENT rather than one of its sections — for the
+	// refusals where the missing thing IS the section, so secErr's prefix
+	// would point at a heading that does not exist.
+	envErr := func(format string, a ...any) error {
+		return fmt.Errorf("%s: [environments.%s] %s", path, envName, fmt.Sprintf(format, a...))
+	}
 	// bindingsUseOllama: does any actor/worker perform inference through the
 	// local Ollama? This decides who owns that Ollama (inference vs
 	// embedding) and what the inference role IS.
@@ -435,38 +441,50 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 		plan.Roles["graph"] = rp
 	}
 
-	// vectors — platform defaults to "external" (the template omits it);
-	// type is required.
-	if v := env.Vectors; v == nil {
-		plan.Roles["vectors"] = rolePlan{Role: "vectors", Obligation: obligationAbsent}
-	} else {
-		if v.Type == "" {
-			return nil, secErr("vectors", "missing required key %q", "type")
-		}
-		spec, ok := driverCatalog["vectors"][v.Type]
-		if !ok {
-			return nil, secErr("vectors", "unknown type %q (known drivers: %s)", v.Type, knownDrivers("vectors"))
-		}
-		if v.Host == "" {
-			return nil, secErr("vectors", "missing required key %q", "host")
-		}
-		port := v.Port
-		if port == 0 {
-			port = spec.defaultPort
-		}
-		rp := rolePlan{Role: "vectors", Driver: v.Type, Port: port}
-		if classify(v.Host, "QDRANT_HOST") == obligationProvided {
-			rp.Obligation = obligationProvided
-			rp.Image = spec.image
-			if v.Image != "" {
-				rp.Image = v.Image
-			}
-		} else {
-			rp.Obligation = obligationExternal
-			rp.Address = v.Host
-		}
-		plan.Roles["vectors"] = rp
+	// vectors — REQUIRED. Semantic search is always available, so the
+	// backend's TOML loader refuses a config that names no vector store; the
+	// launcher reads the same file with its own structs, so it refuses the
+	// same configs, one round trip earlier — before a single container is
+	// launched. Same rule, same words. platform defaults to "external" (the
+	// template omits it); type and host are required.
+	v := env.Vectors
+	if v == nil {
+		return nil, envErr(`names no vector store — add [environments.%s.vectors] with type = "qdrant" and host = "${QDRANT_HOST}". Semiont requires a vector store; nothing is defaulted.`, envName)
 	}
+	if v.Type == "" {
+		return nil, secErr("vectors", "missing required key %q", "type")
+	}
+	// `memory` is a first-class store to the BACKEND, and unusable here: a
+	// launcher-managed stack runs the backend and the Smelter as separate
+	// containers, and an in-process index cannot be shared across processes.
+	// Named explicitly so an operator who followed the loader's own advice is
+	// told WHY, rather than that the value is unknown.
+	if v.Type == "memory" {
+		return nil, secErr("vectors", `type "memory" keeps the index inside one process, and a launcher-managed stack runs the backend and the Smelter as separate containers — they cannot share it. Use type = "qdrant" here.`)
+	}
+	vspec, knownVectors := driverCatalog["vectors"][v.Type]
+	if !knownVectors {
+		return nil, secErr("vectors", "unknown type %q (known drivers: %s)", v.Type, knownDrivers("vectors"))
+	}
+	if v.Host == "" {
+		return nil, secErr("vectors", "missing required key %q", "host")
+	}
+	vectorsPort := v.Port
+	if vectorsPort == 0 {
+		vectorsPort = vspec.defaultPort
+	}
+	vectorsPlan := rolePlan{Role: "vectors", Driver: v.Type, Port: vectorsPort}
+	if classify(v.Host, "QDRANT_HOST") == obligationProvided {
+		vectorsPlan.Obligation = obligationProvided
+		vectorsPlan.Image = vspec.image
+		if v.Image != "" {
+			vectorsPlan.Image = v.Image
+		}
+	} else {
+		vectorsPlan.Obligation = obligationExternal
+		vectorsPlan.Address = v.Host
+	}
+	plan.Roles["vectors"] = vectorsPlan
 
 	// database — type defaults to "postgres" (the template omits it).
 	if d := env.Database; d == nil {
@@ -513,18 +531,21 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 		plan.Roles["database"] = rp
 	}
 
-	// embedding — a role the launcher never launches. Its platform is
-	// external in both shapes: ollama means the inference role's Ollama also
-	// serves embeddings (same process, same port — which is why embedding has
-	// no container of its own and never contends for a port), voyage means
-	// remote SaaS. Absent means the KB declares no embedding at all, which
-	// status reports as "not configured" exactly as it does for any other
-	// unreferenced role.
+	// embedding — REQUIRED, and a role the launcher never launches. Its
+	// platform is external in both shapes: ollama means the inference role's
+	// Ollama also serves embeddings (same process, same port — which is why
+	// embedding has no container of its own and never contends for a port),
+	// voyage means remote SaaS. Type AND model are both required, matching the
+	// backend loader exactly: half a rule enforced here is the drift this
+	// refusal exists to end.
 	if e := env.Embedding; e == nil {
-		plan.Roles["embedding"] = rolePlan{Role: "embedding", Obligation: obligationAbsent}
+		return nil, envErr(`names no embedding provider — add [environments.%s.embedding] with type = "ollama" or "voyage" and a model. Semiont requires an embedding provider; nothing is defaulted.`, envName)
 	} else {
 		if e.Type == "" {
 			return nil, secErr("embedding", "missing required key %q", "type")
+		}
+		if e.Model == "" {
+			return nil, secErr("embedding", "missing required key %q", "model")
 		}
 		spec, ok := driverCatalog["embedding"][e.Type]
 		if !ok {
@@ -550,12 +571,10 @@ func derivePlan(env *envConfig, envName, path string) (*launchPlan, error) {
 			Role: "embedding", Obligation: obligationExternal,
 			Driver: e.Type, Address: host, Port: port,
 		}
-		if e.Model != "" {
-			rp.Models = []string{e.Model}
-			rp.OllamaServed = []string{}
-			if e.Type == "ollama" {
-				rp.OllamaServed = []string{e.Model}
-			}
+		rp.Models = []string{e.Model}
+		rp.OllamaServed = []string{}
+		if e.Type == "ollama" {
+			rp.OllamaServed = []string{e.Model}
 		}
 		// WHO runs the local Ollama an ollama embedding needs? If any actor/
 		// worker binding is ollama-typed, the inference role runs it and the

--- a/apps/launcher/internal/launcher/plan_test.go
+++ b/apps/launcher/internal/launcher/plan_test.go
@@ -267,45 +267,83 @@ password = "localpass"
 	}
 }
 
-func TestDerivePlanAbsentVectors(t *testing.T) {
-	plan := mustDerive(t, variantConfig(t, map[string]string{"vectors": ""}))
-	if got := plan.Roles["vectors"]; got.Obligation != obligationAbsent {
-		t.Errorf("absent vectors: got %+v", got)
+// mustRefuse derives and requires a refusal naming the given fragments. The
+// message is the deliverable here: a config the backend will not boot must be
+// refused BEFORE anything is launched, and saying so is the whole value.
+func mustRefuse(t *testing.T, path string, want ...string) {
+	t.Helper()
+	env, envName, _, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	plan, err := derivePlan(env, envName, path)
+	if err == nil {
+		t.Fatalf("derivePlan accepted a config the backend refuses to boot: %+v", plan.Roles)
+	}
+	for _, w := range want {
+		if !strings.Contains(err.Error(), w) {
+			t.Errorf("refusal missing %q; got: %v", w, err)
+		}
 	}
 }
 
-func TestDerivePlanNoOllamaAnywhere(t *testing.T) {
-	// No embedding section and no ollama-typed binding: inference is absent —
-	// the launcher launches Ollama only when the config references it.
-	plan := mustDerive(t, variantConfig(t, map[string]string{"embedding": ""}))
-	// No [embedding] section: the role still exists, reported absent — the
-	// same "not configured" shape every unreferenced role gets.
-	checkRole(t, plan, "embedding", rolePlan{Obligation: obligationAbsent})
-	// The fixture's worker binds Claude, so inference is a configured
-	// EXTERNAL role — "absent" would be the old drag-in logic's answer.
-	checkRole(t, plan, "inference", rolePlan{
-		Obligation: obligationExternal, Driver: "anthropic",
-		Address: "api.anthropic.com", Port: 443,
-		Models:       []string{"claude-sonnet-4-5-20250929"},
-		OllamaServed: []string{},
-	})
+// Semantic search is always available (MANDATORY-EMBEDDING D0/D1), so the
+// backend's TOML loader refuses a config naming no vector store and no
+// embedding provider. The launcher parses the same file with its own structs,
+// so it must refuse the same configs — otherwise `semiont start` launches
+// every container and the backend then dies at boot on a config the launcher
+// already had in its hands. Same rule, same vocabulary, one round trip
+// earlier.
+func TestDerivePlanRefusesAConfigNamingNoVectorStore(t *testing.T) {
+	mustRefuse(t, variantConfig(t, map[string]string{"vectors": ""}),
+		"names no vector store", "[environments.local.vectors]", "nothing is defaulted")
+}
 
-	// voyage: remote SaaS. Still external, still a role — the platform is
-	// what differs, not its standing. No baseURL is normal there, so the
-	// driver's own host and TLS port stand in.
-	vp := mustDerive(t, variantConfig(t, map[string]string{"embedding": `[environments.local.embedding]
+func TestDerivePlanRefusesAConfigNamingNoEmbeddingProvider(t *testing.T) {
+	mustRefuse(t, variantConfig(t, map[string]string{"embedding": ""}),
+		"names no embedding provider", "[environments.local.embedding]", "nothing is defaulted")
+}
+
+// A provider without a model is the same gap one level down — the loader
+// requires both, and half a rule is the drift this phase exists to end.
+func TestDerivePlanRefusesAnEmbeddingWithoutAModel(t *testing.T) {
+	mustRefuse(t, variantConfig(t, map[string]string{"embedding": `[environments.local.embedding]
+type = "ollama"
+baseURL = "http://${OLLAMA_HOST}:11434"
+`}), "[environments.local.embedding]", `missing required key "model"`)
+}
+
+// `memory` is a first-class store to the BACKEND (D1) and unusable in a
+// launcher-managed stack, which runs the backend and the Smelter as separate
+// containers. Refusing it is right; refusing it as an "unknown driver" is
+// not — the operator would read the loader's own advice, follow it, and be
+// told the value does not exist.
+func TestDerivePlanExplainsWhyMemoryIsNotAvailableHere(t *testing.T) {
+	mustRefuse(t, variantConfig(t, map[string]string{"vectors": `[environments.local.vectors]
+type = "memory"
+`}), "separate containers", `type = "qdrant"`)
+}
+
+func TestDerivePlanNoOllamaAnywhere(t *testing.T) {
+	// A voyage embedding and no ollama-typed binding: nothing in the config
+	// references the local Ollama, so the launcher launches nothing for
+	// either role. Voyage is remote SaaS — still external, still a role; the
+	// platform is what differs, not its standing. No baseURL is normal there,
+	// so the driver's own host and TLS port stand in.
+	plan := mustDerive(t, variantConfig(t, map[string]string{"embedding": `[environments.local.embedding]
 platform = "external"
 type = "voyage"
 model = "voyage-3"
 `}))
-	checkRole(t, vp, "embedding", rolePlan{
+	checkRole(t, plan, "embedding", rolePlan{
 		Obligation: obligationExternal, Driver: "voyage",
 		Address: "api.voyageai.com", Port: 443,
 		Models: []string{"voyage-3"}, // voyage is remote: nothing to install
 	})
-	// A voyage embedding must not drag Ollama in — and with the fixture's
-	// Claude-bound worker, inference is the same external-Anthropic role.
-	checkRole(t, vp, "inference", rolePlan{
+	// The fixture's worker binds Claude, so inference is a configured
+	// EXTERNAL role — "absent" would be the old drag-in logic's answer, and a
+	// voyage embedding must not drag Ollama in either.
+	checkRole(t, plan, "inference", rolePlan{
 		Obligation: obligationExternal, Driver: "anthropic",
 		Address: "api.anthropic.com", Port: 443,
 		Models:       []string{"claude-sonnet-4-5-20250929"},

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -3156,7 +3156,14 @@ func writeKBConfig(t *testing.T, s *scenario, name, body string) {
 }
 
 const stdVectors = "[environments.local.vectors]\ntype = \"qdrant\"\nhost = \"${QDRANT_HOST}\"\nport = 6333\n\n"
-const stdEmbedding = "[environments.local.embedding]\ntype = \"ollama\"\nbaseURL = \"http://${OLLAMA_HOST}:11434\"\n\n"
+
+// Every config must name a vector store and an embedding provider — the
+// launcher refuses one that does not, exactly as the backend's loader does.
+// So these two are as standard as stdGraph/stdDatabase, and a variant that
+// wants no local Ollama reaches for stdEmbeddingVoyage rather than dropping
+// the section.
+const stdEmbedding = "[environments.local.embedding]\ntype = \"ollama\"\nmodel = \"nomic-embed-text\"\nbaseURL = \"http://${OLLAMA_HOST}:11434\"\n\n"
+const stdEmbeddingVoyage = "[environments.local.embedding]\nplatform = \"external\"\ntype = \"voyage\"\nmodel = \"voyage-3\"\n\n"
 const stdDatabase = "[environments.local.database]\nhost = \"${POSTGRES_HOST}\"\nport = 5432\nname = \"semiont\"\nuser = \"postgres\"\npassword = \"localpass\"\n\n"
 const stdGraph = "[environments.local.graph]\ntype = \"neo4j\"\nuri = \"bolt://${NEO4J_HOST}:7687\"\nusername = \"neo4j\"\npassword = \"localpass\"\n\n"
 
@@ -3233,7 +3240,7 @@ func TestStartNoInferenceBoot(t *testing.T) {
 	// ollama/inference conflation's answer.
 	s := newScenario(t, "container")
 	writeKBConfig(t, s, "no-ollama",
-		stdGraph+stdVectors+stdDatabase+
+		stdGraph+stdVectors+stdDatabase+stdEmbeddingVoyage+
 			"[environments.local.inference.anthropic]\nplatform = \"external\"\nendpoint = \"https://api.anthropic.com\"\napiKey = \"${ANTHROPIC_API_KEY}\"\n\n"+
 			"[environments.local.workers.default.inference]\ntype = \"anthropic\"\nmodel = \"claude-sonnet-4-5-20250929\"\n\n")
 	s.extraEnv = append(s.extraEnv, "ANTHROPIC_API_KEY=test-key")
@@ -3246,15 +3253,18 @@ func TestStartNoInferenceBoot(t *testing.T) {
 		t.Errorf("no-ollama config still touched ollama:\n%s", argv)
 	}
 
-	// status: inference reads "not configured", exits healthy without it;
-	// stop never touches an ollama container.
+	// status: both roles read as the remote services they are, and the report
+	// exits healthy with no Ollama anywhere; stop never touches an ollama
+	// container either.
 	stdout, _, code = s.run(t, "status")
 	if code != 0 {
 		t.Errorf("status: exit %d\n%s", code, stdout)
 	}
-	// embedding is absent here → "not configured"; inference is the external
-	// Anthropic row.
-	mustContain(t, "status stdout", stdout, "not configured", "inference (Anthropic)", "external")
+	mustContain(t, "status stdout", stdout,
+		"inference (Anthropic)", "embedding (Voyage)", "external")
+	if strings.Contains(stdout, "Ollama") {
+		t.Errorf("a config referencing no Ollama still named one in status:\n%s", stdout)
+	}
 	preStop := s.argv(t)
 	if _, _, code := s.run(t, "stop"); code != 0 {
 		t.Fatalf("stop: exit %d", code)
@@ -4757,7 +4767,7 @@ func TestRemoteModelMetadataAndAvailability(t *testing.T) {
 	anthPort := serveAnthropicModels(t, "claude-sonnet-4-5-20250929") // haiku deliberately absent
 	s := newScenario(t, "container")
 	writeKBConfig(t, s, "anthropic-meta",
-		stdGraph+stdVectors+stdDatabase+
+		stdGraph+stdVectors+stdDatabase+stdEmbedding+
 			fmt.Sprintf("[environments.local.inference.anthropic]\nplatform = \"external\"\nendpoint = \"http://localhost:%d\"\napiKey = \"${ANTHROPIC_API_KEY}\"\n\n", anthPort)+
 			"[environments.local.workers.default.inference]\ntype = \"anthropic\"\nmodel = \"claude-sonnet-4-5-20250929\"\n\n"+
 			"[environments.local.workers.tag.inference]\ntype = \"anthropic\"\nmodel = \"claude-haiku-4-5-20251001\"\n\n")
@@ -4777,6 +4787,49 @@ func TestRemoteModelMetadataAndAvailability(t *testing.T) {
 	// …and never fabricates an install state for a remote model.
 	if strings.Contains(stdout, "ollama pull claude") {
 		t.Errorf("remote model offered an ollama pull:\n%s", stdout)
+	}
+}
+
+// --- semantic search is mandatory (MANDATORY-EMBEDDING P4) ---
+
+// A config the backend refuses to boot must be refused HERE, before a single
+// container is launched. Otherwise start brings the whole stack up and the
+// backend dies seconds later on a file the launcher already had in its hands.
+func TestStartRefusesAConfigWithNoSemanticSearch(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		body  string
+		wants []string
+	}{
+		{
+			"no-vectors",
+			stdGraph + stdEmbedding + stdDatabase,
+			[]string{"names no vector store", "[environments.local.vectors]", "nothing is defaulted"},
+		},
+		{
+			"no-embedding",
+			stdGraph + stdVectors + stdDatabase,
+			[]string{"names no embedding provider", "[environments.local.embedding]", "nothing is defaulted"},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			s := newScenario(t, "container")
+			writeKBConfig(t, s, c.name, c.body)
+			stdout, stderr, code := s.run(t, "start", "--config", c.name)
+			if code == 0 {
+				t.Fatalf("start accepted a config the backend refuses to boot\nstdout:\n%s", stdout)
+			}
+			mustContain(t, "refusal", stdout+stderr, c.wants...)
+			// The refusal must precede every runtime invocation — root
+			// discovery (a git rev-parse) is all that legitimately runs
+			// before the config is read.
+			for _, line := range strings.Split(strings.TrimSpace(s.argv(t)), "\n") {
+				if line == "" || strings.HasPrefix(strings.TrimSpace(line), "git ") {
+					continue
+				}
+				t.Errorf("a refused config reached the container runtime: %q", strings.TrimSpace(line))
+			}
+		})
 	}
 }
 
@@ -4907,7 +4960,7 @@ func mixedStackScenario(t *testing.T, env ...string) *scenario {
 	anthPort := serveAnthropicModels(t, "claude-sonnet-4-5-20250929")
 	s := newScenario(t, "container")
 	writeKBConfig(t, s, "mixed",
-		stdGraph+stdVectors+stdDatabase+
+		stdGraph+stdVectors+stdDatabase+stdEmbedding+
 			fmt.Sprintf("[environments.local.inference.anthropic]\nplatform = \"external\"\nendpoint = \"http://localhost:%d\"\napiKey = \"${ANTHROPIC_API_KEY}\"\n\n", anthPort)+
 			"[environments.local.workers.default.inference]\ntype = \"anthropic\"\nmodel = \"claude-sonnet-4-5-20250929\"\n\n")
 	s.extraEnv = append(s.extraEnv, "ANTHROPIC_API_KEY=test-key")

--- a/packages/core/src/__tests__/config/config-schema.test.ts
+++ b/packages/core/src/__tests__/config/config-schema.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Schema-semantics guard — MANDATORY-EMBEDDING P1 (D0 + D1).
+ *
+ * Semantic search is always available, so a config must NAME both a vector
+ * store and an embedding provider — nothing is defaulted, and a config
+ * missing either section must fail schema validation with an actionable
+ * error (the explicit-opt-in decision, D1). The schema is consumed by
+ * codegen and by downstream validators; this test pins its SEMANTICS with
+ * ajv (already a core dependency) so the requirement exists independent of
+ * any one validator's wiring.
+ *
+ * RED before P1's schema change: `ServicesConfig` had no `required` array at
+ * all, so a bare `{}` validated. Green after.
+ */
+import { describe, it, expect } from 'vitest';
+import { Ajv } from 'ajv';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const schema: object = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../../config/config.schema.json'), 'utf8'),
+);
+
+const ajv = new Ajv({ strict: false, allErrors: true });
+ajv.addSchema(schema, 'cfg');
+const validate = ajv.getSchema('cfg#/definitions/ServicesConfig');
+if (!validate) throw new Error('ServicesConfig definition not found in config.schema.json');
+
+const VECTORS = { type: 'qdrant', host: 'localhost', port: 6333 };
+const EMBEDDING = { type: 'ollama', model: 'nomic-embed-text' };
+
+describe('config schema — vectors and embedding are mandatory, explicitly (D0+D1)', () => {
+  it('a services section naming both validates', () => {
+    expect(validate({ vectors: VECTORS, embedding: EMBEDDING })).toBe(true);
+  });
+
+  it('memory is a first-class named store choice, not a fallback', () => {
+    expect(validate({ vectors: { type: 'memory' }, embedding: EMBEDDING })).toBe(true);
+  });
+
+  it('a services section missing vectors fails validation', () => {
+    expect(validate({ embedding: EMBEDDING })).toBe(false);
+  });
+
+  it('a services section missing embedding fails validation', () => {
+    expect(validate({ vectors: VECTORS })).toBe(false);
+  });
+
+  it('an empty services section fails validation, naming both gaps', () => {
+    expect(validate({})).toBe(false);
+    const missing = (validate.errors ?? [])
+      .filter((e) => e.keyword === 'required')
+      .map((e) => (e.params as { missingProperty?: string }).missingProperty);
+    expect(missing).toContain('vectors');
+    expect(missing).toContain('embedding');
+  });
+
+  it('a vectors section cannot omit its type — the store must be NAMED', () => {
+    expect(validate({ vectors: { host: 'localhost' }, embedding: EMBEDDING })).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/config/toml-loader.test.ts
+++ b/packages/core/src/__tests__/config/toml-loader.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { loadTomlConfig } from '../../config/toml-loader';
 
+// Every environment must NAME a vector store and an embedding provider —
+// nothing is defaulted, and the loader refuses without them
+// (MANDATORY-EMBEDDING D0+D1). Appended to every fixture that loads.
+const SERVICES_LOCAL = `
+[environments.local.vectors]
+type = "memory"
+
+[environments.local.embedding]
+type = "ollama"
+model = "nomic-embed-text"
+`;
+
 const MINIMAL_TOML = `
 [environments.local.backend]
 platform = "posix"
@@ -10,7 +22,7 @@ frontendURL = "http://localhost:3000"
 
 [environments.local.make-meaning.graph]
 type = "memory"
-`;
+${SERVICES_LOCAL}`;
 
 const WITH_INFERENCE_TOML = `
 [environments.local.make-meaning.actors.gatherer.inference]
@@ -36,14 +48,14 @@ type = "anthropic"
 model = "claude-sonnet-4-6"
 maxTokens = 16384
 apiKey = "test-key"
-`;
+${SERVICES_LOCAL}`;
 
 const WITH_ENV_VAR_TOML = `
 [environments.local.make-meaning.actors.gatherer.inference]
 type = "anthropic"
 model = "claude-haiku-4-5-20251001"
 apiKey = "\${MY_API_KEY}"
-`;
+${SERVICES_LOCAL}`;
 
 function makeReader(globalContent: string | null, projectContent?: string): { readIfExists: (p: string) => string | null } {
   return {
@@ -186,7 +198,14 @@ publicURL = "http://localhost:5005"
 platform = "posix"
 port = 3001
 publicURL = "http://localhost:3001"
-`;
+
+[environments.staging.vectors]
+type = "memory"
+
+[environments.staging.embedding]
+type = "ollama"
+model = "nomic-embed-text"
+${SERVICES_LOCAL}`;
 
   it('resolves the environment from [defaults] environment when none is passed', () => {
     const config = loadTomlConfig('/project', undefined, '/home/user/.semiontconfig', makeReader(DEFAULTS_STAGING), {});
@@ -209,6 +228,20 @@ publicURL = "http://localhost:3001"
     const config = loadTomlConfig('/project', 'local', '/home/user/.semiontconfig', makeReader(DEFAULTS_STAGING), {});
     expect(config._metadata?.environment).toBe('local');
     expect(config.services?.backend?.port).toBe(3001);
+  });
+
+  it('refuses a config naming no vector store, config-actionably (MANDATORY-EMBEDDING D1)', () => {
+    const noVectors = MINIMAL_TOML.replace(/\[environments\.local\.vectors\][^[]*/, '');
+    expect(() =>
+      loadTomlConfig('/project', 'local', '/home/user/.semiontconfig', makeReader(noVectors), {})
+    ).toThrow(/names no vector store/);
+  });
+
+  it('refuses a config naming no embedding provider, config-actionably (MANDATORY-EMBEDDING D1)', () => {
+    const noEmbedding = MINIMAL_TOML.replace(/\[environments\.local\.embedding\][^[]*$/, '');
+    expect(() =>
+      loadTomlConfig('/project', 'local', '/home/user/.semiontconfig', makeReader(noEmbedding), {})
+    ).toThrow(/names no embedding provider/);
   });
 
   it('throws when nothing selects an environment (no arg, no [defaults]) even if SEMIONT_ENV is set', () => {

--- a/packages/core/src/config/config.schema.json
+++ b/packages/core/src/config/config.schema.json
@@ -447,8 +447,7 @@
         },
         "type": {
           "type": "string",
-          "enum": ["qdrant", "memory"],
-          "default": "qdrant"
+          "enum": ["qdrant", "memory"]
         },
         "host": {
           "type": "string"
@@ -1113,6 +1112,7 @@
           "$ref": "#/definitions/EmbeddingServiceConfig"
         }
       },
+      "required": ["vectors", "embedding"],
       "additionalProperties": true
     },
     "SiteConfig": {

--- a/packages/core/src/config/toml-loader.ts
+++ b/packages/core/src/config/toml-loader.ts
@@ -462,7 +462,42 @@ export function loadTomlConfig(
 
   const frontend = resolved.frontend;
 
-  const services: EnvironmentConfig['services'] = {};
+  // Semantic search is always available, so a config must NAME both a vector
+  // store and an embedding provider — nothing is defaulted, and absence
+  // refuses the load with a config-actionable message (MANDATORY-EMBEDDING
+  // D0+D1: explicit opt-in; `memory` is a first-class choice, not a fallback).
+  if (!resolved.vectors?.type) {
+    throw new Error(
+      `[environments.${resolvedEnvironment}] names no vector store — add [environments.${resolvedEnvironment}.vectors] with type = "qdrant" or "memory". Semiont requires a vector store; nothing is defaulted.`,
+    );
+  }
+  const embeddingSource = resolved.embedding ?? resolved.vectors?.embedding;
+  if (!embeddingSource?.type || !embeddingSource.model) {
+    throw new Error(
+      `[environments.${resolvedEnvironment}] names no embedding provider — add [environments.${resolvedEnvironment}.embedding] with type = "voyage" or "ollama" and a model. Semiont requires an embedding provider; nothing is defaulted.`,
+    );
+  }
+
+  const services: EnvironmentConfig['services'] = {
+    vectors: {
+      platform: { type: 'external' as PlatformType },
+      type: resolved.vectors.type,
+      host: resolved.vectors.host,
+      port: resolved.vectors.port ?? 6333,
+    } as EnvironmentConfig['services']['vectors'],
+    embedding: {
+      platform: { type: 'external' as PlatformType },
+      type: embeddingSource.type,
+      model: embeddingSource.model,
+      apiKey: embeddingSource.apiKey,
+      baseURL: embeddingSource.baseURL,
+      endpoint: embeddingSource.endpoint,
+      chunking: (resolved.embedding?.chunking ?? resolved.vectors?.chunking) ? {
+        chunkSize: (resolved.embedding?.chunking ?? resolved.vectors?.chunking)?.chunkSize ?? 512,
+        overlap: (resolved.embedding?.chunking ?? resolved.vectors?.chunking)?.overlap ?? 64,
+      } : undefined,
+    } as EnvironmentConfig['services']['embedding'],
+  };
 
   if (backend) {
     services.backend = {
@@ -502,32 +537,6 @@ export function loadTomlConfig(
       user: resolved.database.user,
       password: resolved.database.password,
     } as EnvironmentConfig['services']['database'];
-  }
-
-  if (resolved.vectors) {
-    services.vectors = {
-      platform: { type: 'external' as PlatformType },
-      type: (resolved.vectors.type ?? 'qdrant') as 'qdrant' | 'memory',
-      host: resolved.vectors.host,
-      port: resolved.vectors.port ?? 6333,
-    } as EnvironmentConfig['services']['vectors'];
-  }
-
-  // Embedding: top-level takes precedence, fall back to legacy vectors.embedding
-  const embeddingSource = resolved.embedding ?? resolved.vectors?.embedding;
-  if (embeddingSource) {
-    services.embedding = {
-      platform: { type: 'external' as PlatformType },
-      type: embeddingSource.type!,
-      model: embeddingSource.model!,
-      apiKey: embeddingSource.apiKey,
-      baseURL: embeddingSource.baseURL,
-      endpoint: embeddingSource.endpoint,
-      chunking: (resolved.embedding?.chunking ?? resolved.vectors?.chunking) ? {
-        chunkSize: (resolved.embedding?.chunking ?? resolved.vectors?.chunking)?.chunkSize ?? 512,
-        overlap: (resolved.embedding?.chunking ?? resolved.vectors?.chunking)?.overlap ?? 64,
-      } : undefined,
-    } as EnvironmentConfig['services']['embedding'];
   }
 
   const config: EnvironmentConfig = {

--- a/packages/make-meaning/docs/SCRIPTING.md
+++ b/packages/make-meaning/docs/SCRIPTING.md
@@ -32,6 +32,8 @@ async function main() {
     gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
     services: {
       graph: { platform: { type: 'posix' }, type: 'memory' },
+      vectors: { type: 'memory' },
+      embedding: { type: 'ollama', model: 'nomic-embed-text' },
     },
     actors: {
       gatherer: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: process.env.ANTHROPIC_API_KEY! },

--- a/packages/make-meaning/src/__tests__/agent-roster.test.ts
+++ b/packages/make-meaning/src/__tests__/agent-roster.test.ts
@@ -22,7 +22,7 @@ describe('deriveAgentRoster — DID domain is site.domain (the mint), never topo
     // deleted from MakeMeaningConfig — the skew is now unrepresentable, and
     // this pins the one remaining source.
     const config: MakeMeaningConfig = {
-      services: {},
+      services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
       gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
       site: { domain: 'kb.example' }, // the KB's identity — the exchange's mint value
       workers: WORKERS,
@@ -38,7 +38,7 @@ describe('deriveAgentRoster — DID domain is site.domain (the mint), never topo
 
   it('throws loudly without site.domain — no topology fallback', () => {
     const config: MakeMeaningConfig = {
-      services: {},
+      services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
       gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
       workers: WORKERS,
     };
@@ -48,7 +48,7 @@ describe('deriveAgentRoster — DID domain is site.domain (the mint), never topo
 
   it('carries a ported site.domain verbatim — byte-equal with the exchange mint', () => {
     const config: MakeMeaningConfig = {
-      services: {},
+      services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
       gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
       site: { domain: 'localhost:4000' },
       workers: WORKERS,

--- a/packages/make-meaning/src/__tests__/anchored-text-transport.test.ts
+++ b/packages/make-meaning/src/__tests__/anchored-text-transport.test.ts
@@ -30,6 +30,9 @@ import { SemiontProject } from '@semiont/core/node';
 import { LocalContentTransport } from '../local-content-transport';
 import { ResourceOperations } from '../resource-operations';
 import { startMakeMeaning, type MakeMeaningConfig, type MakeMeaningService } from '../service';
+import { stubEmbeddingProbeFetch } from './helpers/smelter-harness';
+
+stubEmbeddingProbeFetch();
 
 const silentLogger: Logger = {
   debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
@@ -40,7 +43,7 @@ const TEST_USER_ID = makeUserId('test-host');
 
 const config: MakeMeaningConfig = {
   gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
-  services: { graph: { platform: { type: 'posix' }, type: 'memory' } },
+  services: { graph: { platform: { type: 'posix' }, type: 'memory' }, vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
   actors: {
     gatherer: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: 'test-key' },
     matcher: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: 'test-key' },

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -15,6 +15,9 @@ import { WorkingTreeStore } from '@semiont/content';
 import type { GraphDatabase } from '@semiont/graph';
 import type { KnowledgeBase } from '../knowledge-base';
 import { createTestProject } from './helpers/test-project';
+import { createMockEmbeddingProvider } from './helpers/smelter-harness';
+
+const mockEmbeddingProvider = createMockEmbeddingProvider();
 
 function createMockGraphDb(): GraphDatabase {
   return {
@@ -78,6 +81,7 @@ describe('AnnotationContext', () => {
       content: new WorkingTreeStore(project, mockLogger),
       graph: mockGraphDb,
       anchoredText: memoryAnchoredTextStore(),
+      vectors: { searchResources: vi.fn().mockResolvedValue([]), searchAnnotations: vi.fn().mockResolvedValue([]), searchByResource: vi.fn().mockResolvedValue([]) } as any,
       projectionsDir: project.projectionsDir,
       weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
     };
@@ -180,6 +184,7 @@ describe('AnnotationContext', () => {
         annotationId('test-1'),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         { contextWindow: 50 },
         undefined,
         mockLogger
@@ -192,6 +197,7 @@ describe('AnnotationContext', () => {
         annotationId('test-2'),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         { contextWindow: 6000 },
         undefined,
         mockLogger
@@ -211,6 +217,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         { contextWindow: 100 },
         undefined,
         mockLogger
@@ -223,6 +230,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         { contextWindow: 5000 },
         undefined,
         mockLogger
@@ -235,6 +243,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         { contextWindow: 1500 },
         undefined,
         mockLogger
@@ -253,6 +262,7 @@ describe('AnnotationContext', () => {
       annotationId(testAnnId),
       resourceId(testResourceId),
       kb,
+        mockEmbeddingProvider,
       {},
       undefined,
       mockLogger
@@ -274,6 +284,7 @@ describe('AnnotationContext', () => {
       annotationId(testAnnId),
       resourceId(testResourceId),
       kb,
+        mockEmbeddingProvider,
       { includeSourceContext: true },
       undefined,
       mockLogger
@@ -283,6 +294,7 @@ describe('AnnotationContext', () => {
       annotationId(testAnnId),
       resourceId(testResourceId),
       kb,
+        mockEmbeddingProvider,
       { includeSourceContext: false },
       undefined,
       mockLogger
@@ -299,6 +311,7 @@ describe('AnnotationContext', () => {
         annotationId('nonexistent'),
         resourceId('nonexistent-resource'),
         kb,
+        mockEmbeddingProvider,
         {},
         undefined,
         mockLogger
@@ -351,6 +364,7 @@ describe('AnnotationContext', () => {
       annotationId(testAnnId),
       resourceId(testResourceId),
       kb,
+        mockEmbeddingProvider,
       {},
       undefined,
       mockLogger
@@ -385,6 +399,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         undefined,
         mockLogger
@@ -426,6 +441,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         undefined,
         mockLogger
@@ -455,6 +471,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         undefined,
         mockLogger
@@ -525,6 +542,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         undefined,
         mockLogger
@@ -564,6 +582,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         mockInferenceClient,
         mockLogger
@@ -592,6 +611,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         undefined,
         mockLogger
@@ -623,6 +643,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         mockInferenceClient,
         mockLogger
@@ -651,6 +672,7 @@ describe('AnnotationContext', () => {
         annotationId(testAnnId),
         resourceId(testResourceId),
         kb,
+        mockEmbeddingProvider,
         {},
         undefined,
         mockLogger

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -96,7 +96,8 @@ describe('AnnotationOperations', () => {
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
     const { WorkingTreeStore } = await import('@semiont/content');
     const repStore = new WorkingTreeStore(project, mockLogger);
-    kb = { anchoredText: memoryAnchoredTextStore(), eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
+    kb = { anchoredText: memoryAnchoredTextStore(),
+      vectors: { searchResources: vi.fn().mockResolvedValue([]), searchAnnotations: vi.fn().mockResolvedValue([]), searchByResource: vi.fn().mockResolvedValue([]) } as any, eventStore: testEventStore, views: testEventStore.viewStorage, content: repStore, graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/bootstrap/entity-types.test.ts
+++ b/packages/make-meaning/src/__tests__/bootstrap/entity-types.test.ts
@@ -18,6 +18,7 @@ import { createKnowledgeBase, type KnowledgeBase } from '../../knowledge-base';
 import { Stower } from '../../stower';
 import { getGraphDatabase } from '@semiont/graph';
 import { createTestProject } from '../helpers/test-project';
+import { createVectorStore } from '@semiont/vectors';
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -41,7 +42,7 @@ describe('Entity Types Bootstrap', () => {
     eventBus = new EventBus();
     eventStore = createEventStore(project, eventBus, mockLogger);
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-    kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
+    kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
   });

--- a/packages/make-meaning/src/__tests__/bootstrap/entity-types.test.ts
+++ b/packages/make-meaning/src/__tests__/bootstrap/entity-types.test.ts
@@ -42,7 +42,7 @@ describe('Entity Types Bootstrap', () => {
     eventBus = new EventBus();
     eventStore = createEventStore(project, eventBus, mockLogger);
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-    kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
+    kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: async () => 4 }) });
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
   });

--- a/packages/make-meaning/src/__tests__/browser-anchored-text.test.ts
+++ b/packages/make-meaning/src/__tests__/browser-anchored-text.test.ts
@@ -22,6 +22,7 @@ import { EventBus, type AnchoredText, type Logger } from '@semiont/core';
 import type { MakeMeaningConfig } from '../service';
 import { Browser } from '../browser';
 import { SmeltProgressTimeout } from '../smelt-progress';
+import { createMockEmbeddingProvider } from './helpers/smelter-harness';
 
 const mockLogger: Logger = {
   debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
@@ -48,9 +49,9 @@ function browserOver(kb: Record<string, unknown>) {
     kb as never,
     eventBus,
     { root: '/tmp' } as never,
-    { services: {}, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 } } as MakeMeaningConfig,
+    { services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } }, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 } } as MakeMeaningConfig,
     { enrich: async (entries) => entries },
-    undefined,
+    createMockEmbeddingProvider(),
     mockLogger,
   );
   return { eventBus, browser };

--- a/packages/make-meaning/src/__tests__/browser.test.ts
+++ b/packages/make-meaning/src/__tests__/browser.test.ts
@@ -25,6 +25,7 @@ vi.mock('fs', () => {
 });
 
 import { promises as fsMock } from 'fs';
+import { createMockEmbeddingProvider } from './helpers/smelter-harness';
 const mockStat   = fsMock.stat   as ReturnType<typeof vi.fn>;
 const mockReaddir = fsMock.readdir as ReturnType<typeof vi.fn>;
 
@@ -68,7 +69,7 @@ const defaultStat = { size: 1024, mtime: new Date('2026-01-01T00:00:00Z') };
 
 const mockKb = { graph: {}, views: {} } as any;
 
-const emptyConfig: MakeMeaningConfig = { services: {}, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 } };
+const emptyConfig: MakeMeaningConfig = { services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } }, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 } };
 
 // Enrichment-neutral discovery for tests whose subject is not limits — the
 // pool's own semantics are pinned in limits-discovery.test.ts.
@@ -91,7 +92,7 @@ describe('Browser actor', () => {
       { root: PROJECT_ROOT } as any,
       emptyConfig,
       passthroughDiscovery,
-      undefined,
+      createMockEmbeddingProvider(),
       mockLogger,
     );
     await browser.initialize();
@@ -109,7 +110,10 @@ describe('Browser actor', () => {
     // an optional field defaulting to lexical would be a compatibility shim
     // (a missing value silently reads as lexical). The lexical path labels
     // itself here; P2's fallback labels its answers 'semantic'.
-    mockKb.graph.listResources = vi.fn().mockResolvedValue({ resources: [], total: 0 });
+    // Non-empty on purpose: under MANDATORY-EMBEDDING the empty search page
+    // falls through to the semantic fallback and labels itself 'semantic'
+    // (pinned in resource-context.test.ts) — the lexical label needs a hit.
+    mockKb.graph.listResources = vi.fn().mockResolvedValue({ resources: [{ '@id': 'res-ouranos', name: 'ouranos' }], total: 1 });
 
     const result$ = eventBus.get('browse:resources-result');
     const resultPromise = new Promise<any>((resolve) => result$.subscribe(resolve));
@@ -239,7 +243,7 @@ describe('Browser actor', () => {
       { root: PROJECT_ROOT } as any,
       emptyConfig,
       passthroughDiscovery,
-      undefined,
+      createMockEmbeddingProvider(),
       mockLogger,
     );
     await browser.initialize();
@@ -356,7 +360,7 @@ describe('Browser actor', () => {
         graph: { getResourceReferencedBy: mockReferencedBy, getResource: mockGetResource },
         views: { get: mockViewGet },
       } as any;
-      browser = new Browser(makeViews([]) as any, kb, eventBus, { root: PROJECT_ROOT } as any, emptyConfig, passthroughDiscovery, undefined, mockLogger);
+      browser = new Browser(makeViews([]) as any, kb, eventBus, { root: PROJECT_ROOT } as any, emptyConfig, passthroughDiscovery, createMockEmbeddingProvider(), mockLogger);
       await browser.initialize();
     });
 
@@ -519,7 +523,7 @@ describe('Browser actor', () => {
       discovery?: { enrich(entries: CollaboratorEntry[]): Promise<CollaboratorEntry[]> },
     ) {
       const bus = new EventBus();
-      const b = new Browser(makeViews([]) as any, mockKb, bus, { root: PROJECT_ROOT } as any, config, discovery ?? passthroughDiscovery, undefined, mockLogger);
+      const b = new Browser(makeViews([]) as any, mockKb, bus, { root: PROJECT_ROOT } as any, config, discovery ?? passthroughDiscovery, createMockEmbeddingProvider(), mockLogger);
       await b.initialize();
       try {
         await fn(bus);
@@ -548,7 +552,7 @@ describe('Browser actor', () => {
     it('answers the deduplicated software roster: worker-derivation DIDs, resolved capabilities', async () => {
       await withBrowser(
         {
-          services: {},
+          services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
           gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
           site: { domain: SITE_DOMAIN },
           workers: {
@@ -598,7 +602,7 @@ describe('Browser actor', () => {
     it('omits servesJobTypes for an actors-only agent', async () => {
       await withBrowser(
         {
-          services: {},
+          services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
           gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
           site: { domain: SITE_DOMAIN },
           actors: { gatherer: { type: 'ollama', model: 'llama3' } },
@@ -627,7 +631,7 @@ describe('Browser actor', () => {
       };
       await withBrowser(
         {
-          services: {},
+          services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
           gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
           site: { domain: SITE_DOMAIN },
           workers: { default: { type: 'anthropic', model: 'claude-haiku-4-5', apiKey: 'k' } },
@@ -643,7 +647,7 @@ describe('Browser actor', () => {
     });
 
     it('answers an empty roster when no workers or actors are declared', async () => {
-      await withBrowser({ services: {}, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 }, site: { domain: SITE_DOMAIN } }, async (bus) => {
+      await withBrowser({ services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } }, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 }, site: { domain: SITE_DOMAIN } }, async (bus) => {
         const r = await requestAgents(bus);
         if (r.kind !== 'result') throw new Error(`expected result, got failed: ${r.e.message}`);
         expect(r.e.response.agents).toEqual([]);
@@ -651,7 +655,7 @@ describe('Browser actor', () => {
     });
 
     it('fails naming the missing config key when site.domain is absent', async () => {
-      await withBrowser({ services: {}, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 } }, async (bus) => {
+      await withBrowser({ services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } }, gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 } }, async (bus) => {
         const r = await requestAgents(bus);
         if (r.kind !== 'failed') throw new Error('expected failed');
         expect(r.e.correlationId).toBe('cid-agents');

--- a/packages/make-meaning/src/__tests__/clone-token-manager.test.ts
+++ b/packages/make-meaning/src/__tests__/clone-token-manager.test.ts
@@ -25,6 +25,9 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { startMakeMeaning, ResourceOperations, ResourceContext, type MakeMeaningConfig } from '..';
+import { stubEmbeddingProbeFetch } from './helpers/smelter-harness';
+
+stubEmbeddingProbeFetch();
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -50,6 +53,8 @@ describe('CloneTokenManager format selection', () => {
       gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
       services: {
         graph: { platform: { type: 'posix' }, type: 'memory' },
+    vectors: { type: 'memory' },
+    embedding: { type: 'ollama', model: 'nomic-embed-text' },
       },
       actors: {
         gatherer: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: 'test-key' },

--- a/packages/make-meaning/src/__tests__/gatherer.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer.test.ts
@@ -29,6 +29,7 @@ vi.mock('../llm-context', () => ({
 
 import { AnnotationContext } from '../annotation-context';
 import { LLMContext } from '../llm-context';
+import { createMockEmbeddingProvider } from './helpers/smelter-harness';
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -50,6 +51,7 @@ function createMockKb(): KnowledgeBase {
     content: {} as any,
     graph: {} as any,
     anchoredText: memoryAnchoredTextStore(),
+      vectors: { searchResources: vi.fn().mockResolvedValue([]), searchAnnotations: vi.fn().mockResolvedValue([]), searchByResource: vi.fn().mockResolvedValue([]) } as any,
     projectionsDir: '',
       weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
   };
@@ -59,12 +61,13 @@ describe('Gatherer', () => {
   let eventBus: EventBus;
   let gatherer: Gatherer;
   let kb: KnowledgeBase;
+  const mockEmbeddingProvider = createMockEmbeddingProvider();
 
   beforeEach(async () => {
     vi.clearAllMocks();
     eventBus = new EventBus();
     kb = createMockKb();
-    gatherer = new Gatherer(kb, eventBus, mockInferenceClient as any, 15_000, mockLogger);
+    gatherer = new Gatherer(kb, eventBus, mockInferenceClient as any, 15_000, mockLogger, mockEmbeddingProvider);
     await gatherer.initialize();
   });
 
@@ -117,10 +120,10 @@ describe('Gatherer', () => {
         'ann-1',
         'res-1',
         kb,
+        mockEmbeddingProvider,
         {},
         mockInferenceClient,
         mockLogger,
-        undefined,
       );
     });
 

--- a/packages/make-meaning/src/__tests__/graph-context.test.ts
+++ b/packages/make-meaning/src/__tests__/graph-context.test.ts
@@ -31,6 +31,7 @@ describe('GraphContext', () => {
     content: {} as any,
     graph: mockGraphDb as any,
     anchoredText: memoryAnchoredTextStore(),
+      vectors: { searchResources: vi.fn().mockResolvedValue([]), searchAnnotations: vi.fn().mockResolvedValue([]), searchByResource: vi.fn().mockResolvedValue([]) } as any,
     projectionsDir: '',
     weaveProgress: mockWeaveProgress as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
   };

--- a/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
+++ b/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
@@ -225,3 +225,15 @@ export function createFakeKsBus(
     },
   };
 }
+
+/**
+ * Serve the embedding provider's dimension-discovery probe — startMakeMeaning's
+ * only embedding network call (MANDATORY-EMBEDDING P3) — so service startup is
+ * hermetic. A plain function, not a vi.fn(): clearAllMocks must not strip it.
+ */
+export function stubEmbeddingProbeFetch(): void {
+  vi.stubGlobal('fetch', async () => new Response(
+    JSON.stringify({ embeddings: [[0.1, 0.2, 0.3, 0.4]] }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  ));
+}

--- a/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
+++ b/packages/make-meaning/src/__tests__/helpers/smelter-harness.ts
@@ -43,7 +43,7 @@ export function createMockEmbeddingProvider(model = 'mock-model'): EmbeddingProv
   return {
     embed: vi.fn().mockImplementation(async (text: string) => deterministicEmbed(text)),
     embedBatch: vi.fn().mockImplementation(async (texts: string[]) => texts.map(deterministicEmbed)),
-    dimensions: vi.fn().mockReturnValue(4),
+    dimensions: vi.fn().mockResolvedValue(4),
     model: vi.fn().mockReturnValue(model),
   };
 }

--- a/packages/make-meaning/src/__tests__/limits-discovery.test.ts
+++ b/packages/make-meaning/src/__tests__/limits-discovery.test.ts
@@ -19,6 +19,7 @@ import { createLimitsDiscovery } from '../limits-discovery';
 import { deriveAgentRoster } from '../agent-roster';
 import { Browser } from '../browser';
 import type { InferenceConfig, MakeMeaningConfig } from '../config';
+import { createMockEmbeddingProvider } from './helpers/smelter-harness';
 
 type InferenceLimits = components['schemas']['InferenceLimits'];
 
@@ -29,7 +30,7 @@ const mockLogger: Logger = {
 
 // Two distinct pairs: one worker-derived (serves job types), one actor-only.
 const CONFIG: MakeMeaningConfig = {
-  services: {},
+  services: { vectors: { type: 'memory' }, embedding: { type: 'ollama', model: 'nomic-embed-text' } },
   gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
   site: { domain: 'kb.example' },
   workers: { default: { type: 'anthropic', model: 'model-a', apiKey: 'k' } },
@@ -152,7 +153,7 @@ describe('LimitsDiscovery (INFERENCE-LIMITS-EXPOSURE P2)', () => {
       { root: '/tmp' } as never,
       CONFIG,
       createLimitsDiscovery(CONFIG, mockLogger, { clientFactory: factory }),
-      undefined,
+      createMockEmbeddingProvider(),
       mockLogger,
     );
     await browser.initialize();

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -97,7 +97,8 @@ describe('LLM Context', () => {
     // Create KnowledgeBase - share event store's view storage to avoid separate instances
     const { getGraphDatabase } = await import('@semiont/graph');
     const graphDb = await getGraphDatabase(graphConfig);
-    kb = { anchoredText: memoryAnchoredTextStore(), eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
+    kb = { anchoredText: memoryAnchoredTextStore(),
+      vectors: { searchResources: vi.fn().mockResolvedValue([]), searchAnnotations: vi.fn().mockResolvedValue([]), searchByResource: vi.fn().mockResolvedValue([]) } as any, eventStore, views: eventStore.viewStorage, content: new WorkingTreeStore(project, mockLogger), graph: graphDb, projectionsDir: project.projectionsDir, weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} }, };
 
     // Start Stower
     stower = new Stower(kb, eventBus, project, mockLogger);

--- a/packages/make-meaning/src/__tests__/local-transport.test.ts
+++ b/packages/make-meaning/src/__tests__/local-transport.test.ts
@@ -32,6 +32,9 @@ import { LocalTransport } from '../local-transport';
 import { LocalContentTransport } from '../local-content-transport';
 import { ResourceOperations } from '../resource-operations';
 import { startMakeMeaning, type MakeMeaningConfig, type MakeMeaningService } from '../service';
+import { stubEmbeddingProbeFetch } from './helpers/smelter-harness';
+
+stubEmbeddingProbeFetch();
 
 const SETTLE_MS = 5_000;
 
@@ -49,6 +52,8 @@ const config: MakeMeaningConfig = {
   gather: { settleTimeoutMs: 15_000 }, search: { semanticFloor: 0.6 },
   services: {
     graph: { platform: { type: 'posix' }, type: 'memory' },
+    vectors: { type: 'memory' },
+    embedding: { type: 'ollama', model: 'nomic-embed-text' },
   },
   actors: {
     gatherer: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: 'test-key' },

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -20,6 +20,7 @@ import { EventBus, resourceId, type GatheredContext, type Logger, type ResourceI
 import type { KnowledgeBase } from '../knowledge-base';
 import type { InferenceClient } from '@semiont/inference';
 import { Matcher } from '../matcher';
+import { createMockEmbeddingProvider } from './helpers/smelter-harness';
 
 type AnnotationFocus = Extract<GatheredContext['focus'], { kind: 'annotation' }>;
 type KnowledgeGraph = GatheredContext['graph'];
@@ -146,6 +147,7 @@ function createMockKb(overrides: MockGraphOverrides = {}): KnowledgeBase {
     views: { get: overrides.viewsGet ?? vi.fn().mockResolvedValue(null) } as any,
     content: {} as any,
     anchoredText: memoryAnchoredTextStore(),
+      vectors: { searchResources: vi.fn().mockResolvedValue([]), searchAnnotations: vi.fn().mockResolvedValue([]), searchByResource: vi.fn().mockResolvedValue([]) } as any,
     projectionsDir: '',
       weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
     graph: {
@@ -185,7 +187,7 @@ describe('Matcher', () => {
     eventBus = new EventBus();
     mockSearchFn = vi.fn<SearchMatches>();
     kb = createMockKb({ searchMatches: mockSearchFn });
-    matcher = new Matcher(kb, eventBus, mockLogger, noopInference);
+    matcher = new Matcher(kb, eventBus, mockLogger, noopInference, createMockEmbeddingProvider());
     await matcher.initialize();
   });
 
@@ -288,7 +290,7 @@ describe('Matcher', () => {
         getResource: mockGetResource,
         viewsGet: mockViewGet,
       });
-      matcher = new Matcher(kb, eventBus, mockLogger, noopInference);
+      matcher = new Matcher(kb, eventBus, mockLogger, noopInference, createMockEmbeddingProvider());
       await matcher.initialize();
     });
 
@@ -636,7 +638,7 @@ describe('Matcher', () => {
         limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),
         generateStructured: vi.fn().mockResolvedValue({ items: [], stopReason: 'end_turn' }),
       };
-      matcher = new Matcher(kb, eventBus, mockLogger, mockInference);
+      matcher = new Matcher(kb, eventBus, mockLogger, mockInference, createMockEmbeddingProvider());
       await matcher.initialize();
 
       const resultPromise = eventBus.get('match:search-results').pipe(take(1)).toPromise();
@@ -684,7 +686,7 @@ describe('Matcher', () => {
         limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),
         generateStructured: vi.fn().mockResolvedValue({ items: [], stopReason: 'end_turn' }),
       };
-      matcher = new Matcher(kb, eventBus, mockLogger, mockInference);
+      matcher = new Matcher(kb, eventBus, mockLogger, mockInference, createMockEmbeddingProvider());
       await matcher.initialize();
 
       const resultPromise = eventBus.get('match:search-results').pipe(take(1)).toPromise();
@@ -768,7 +770,7 @@ describe('Matcher', () => {
           limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),
           generateStructured: vi.fn().mockResolvedValue({ items: [], stopReason: 'end_turn' }),
         };
-        matcher = new Matcher(kb, eventBus, mockLogger, mockInference as InferenceClient);
+        matcher = new Matcher(kb, eventBus, mockLogger, mockInference as InferenceClient, createMockEmbeddingProvider());
         await matcher.initialize();
       });
 

--- a/packages/make-meaning/src/__tests__/resource-context.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-context.test.ts
@@ -49,9 +49,19 @@ describe('ResourceContext', () => {
       content: mockRepStore,
       graph: mockGraph,
       anchoredText: memoryAnchoredTextStore(),
+      vectors: { searchResources: vi.fn().mockResolvedValue([]), searchAnnotations: vi.fn().mockResolvedValue([]), searchByResource: vi.fn().mockResolvedValue([]) } as any,
       projectionsDir: '',
       weaveProgress: {} as any, smeltProgress: { settledAt: () => undefined, whenSettled: async () => 'inert' as const, dispose: () => {} },
     };
+  });
+
+  // Every listResources caller supplies the fallback deps (MANDATORY-EMBEDDING
+  // P3 made the pair required). Tests not about the fallback pass an inert bag;
+  // the fallback's own axioms below build theirs per-case.
+  const inertSemantic = () => ({
+    embeddingProvider: { embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]) } as any,
+    semanticFloor: 0.6,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() } as any,
   });
 
   describe('getResourceMetadata', () => {
@@ -148,7 +158,7 @@ describe('ResourceContext', () => {
     test('should list all resources when no filters provided', async () => {
       mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource2)]);
 
-      const result = await ResourceContext.listResources(undefined, mockKb);
+      const result = await ResourceContext.listResources(undefined, mockKb, inertSemantic());
 
       expect(result.total).toBe(2);
       expect(result.resources).toContainEqual(mockResource1);
@@ -158,7 +168,7 @@ describe('ResourceContext', () => {
     test('should filter by archived status (false)', async () => {
       mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource3)]);
 
-      const result = await ResourceContext.listResources({ archived: false }, mockKb);
+      const result = await ResourceContext.listResources({ archived: false }, mockKb, inertSemantic());
 
       expect(result.resources).toEqual([mockResource1]);
       expect(result.total).toBe(1);
@@ -167,7 +177,7 @@ describe('ResourceContext', () => {
     test('should filter by archived status (true)', async () => {
       mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource3)]);
 
-      const result = await ResourceContext.listResources({ archived: true }, mockKb);
+      const result = await ResourceContext.listResources({ archived: true }, mockKb, inertSemantic());
 
       expect(result.resources).toEqual([mockResource3]);
       expect(result.total).toBe(1);
@@ -181,7 +191,7 @@ describe('ResourceContext', () => {
       const result = await ResourceContext.listResources(
         { entityType: 'Document', limit: 1, offset: 0 },
         mockKb,
-      );
+        inertSemantic());
 
       // Two Documents match; the page holds one. `total` describes the match
       // set, because that is what the caller pages on.
@@ -196,7 +206,7 @@ describe('ResourceContext', () => {
       const result = await ResourceContext.listResources(
         { search: 'special', archived: false, entityType: 'Document', offset: 20, limit: 10 },
         mockKb,
-      );
+        inertSemantic());
 
       // Every filter travels into the engine. Narrowing any of them in JS after
       // the fact would apply it to one page instead of the whole match set.
@@ -215,7 +225,7 @@ describe('ResourceContext', () => {
     test('a whitespace-only query is not a search', async () => {
       mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(mockResource2)]);
 
-      const result = await ResourceContext.listResources({ search: '   ' }, mockKb);
+      const result = await ResourceContext.listResources({ search: '   ' }, mockKb, inertSemantic());
 
       // Blank input must not divert the listing onto the eventually-consistent
       // graph path, and must not match every name containing a space.
@@ -227,7 +237,7 @@ describe('ResourceContext', () => {
     test('search path returns nothing when the graph has no matches', async () => {
       mockGraph.listResources.mockResolvedValue({ resources: [], total: 0 });
 
-      const result = await ResourceContext.listResources({ search: 'nonexistent' }, mockKb);
+      const result = await ResourceContext.listResources({ search: 'nonexistent' }, mockKb, inertSemantic());
 
       expect(result.resources).toEqual([]);
       expect(result.total).toBe(0);
@@ -238,7 +248,7 @@ describe('ResourceContext', () => {
         asView(mockResource1), asView(mockResource2), asView(mockResource3),
       ]);
 
-      const result = await ResourceContext.listResources(undefined, mockKb);
+      const result = await ResourceContext.listResources(undefined, mockKb, inertSemantic());
 
       expect(result.resources.map(r => r.dateCreated)).toEqual([
         '2024-01-03T00:00:00Z',
@@ -259,7 +269,7 @@ describe('ResourceContext', () => {
 
       mockViewStorage.getAll.mockResolvedValue([asView(mockResource1), asView(resourceNoDate)]);
 
-      const result = await ResourceContext.listResources(undefined, mockKb);
+      const result = await ResourceContext.listResources(undefined, mockKb, inertSemantic());
 
       expect(result.total).toBe(2);
       // Resource with date should come first
@@ -451,8 +461,8 @@ describe('ResourceContext', () => {
     let searchResources: ReturnType<typeof vi.fn>;
     let warn: ReturnType<typeof vi.fn>;
 
-    const semantic = (over?: { provider?: false; floor?: number }) => ({
-      embeddingProvider: over?.provider === false ? undefined : ({ embed } as any),
+    const semantic = (over?: { floor?: number }) => ({
+      embeddingProvider: { embed } as any,
       semanticFloor: over?.floor ?? FLOOR,
       logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn(), child: vi.fn() } as any,
     });
@@ -489,26 +499,11 @@ describe('ResourceContext', () => {
       expect((result.resources[0] as { content?: string }).content).toBe('the passage that matched');
     });
 
-    test('S3: vectors unconfigured yields the empty lexical result, labelled lexical', async () => {
-      mockGraph.listResources.mockResolvedValue({ resources: [], total: 0 });
-      delete (mockKb as any).vectors;
-
-      const result = await ResourceContext.listResources({ search: 'ouranos' }, mockKb, semantic());
-
-      expect(result.matchKind).toBe('lexical');
-      expect(result.total).toBe(0);
-      expect(embed).not.toHaveBeenCalled();
-    });
-
-    test('S4: provider absent behaves exactly like S3', async () => {
-      mockGraph.listResources.mockResolvedValue({ resources: [], total: 0 });
-
-      const result = await ResourceContext.listResources({ search: 'ouranos' }, mockKb, semantic({ provider: false }));
-
-      expect(result.matchKind).toBe('lexical');
-      expect(result.total).toBe(0);
-      expect(embed).not.toHaveBeenCalled();
-    });
+    // S3/S4 (vectors unconfigured / provider absent → empty lexical, labelled
+    // lexical) retired 2026-08-12: MANDATORY-EMBEDDING P3 made the pair
+    // required at the type level, so their premise is unrepresentable.
+    // Reciprocal entries live in both plans' ledgers. S5 survives — mandatory
+    // is not the same as always up.
 
     test('S5: a throwing embed degrades to the empty lexical result, logged — never an error', async () => {
       mockGraph.listResources.mockResolvedValue({ resources: [], total: 0 });

--- a/packages/make-meaning/src/__tests__/resource-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-operations.test.ts
@@ -20,6 +20,7 @@ import { getGraphDatabase } from '@semiont/graph';
 import { deriveStorageUri } from '@semiont/content';
 import type { KnowledgeBase } from '../knowledge-base';
 import { createTestProject } from './helpers/test-project';
+import { createVectorStore } from '@semiont/vectors';
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -59,7 +60,7 @@ describe('ResourceOperations', () => {
     eventBus = new EventBus();
     testEventStore = createEventStore(project, eventBus, mockLogger);
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-    kb = await createKnowledgeBase(testEventStore, project, graphDb, eventBus, mockLogger);
+    kb = await createKnowledgeBase(testEventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/resource-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/resource-operations.test.ts
@@ -60,7 +60,7 @@ describe('ResourceOperations', () => {
     eventBus = new EventBus();
     testEventStore = createEventStore(project, eventBus, mockLogger);
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-    kb = await createKnowledgeBase(testEventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
+    kb = await createKnowledgeBase(testEventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: async () => 4 }) });
 
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();

--- a/packages/make-meaning/src/__tests__/scripting-examples/create-resource.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/create-resource.test.ts
@@ -23,6 +23,9 @@ import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
+import { stubEmbeddingProbeFetch } from '../helpers/smelter-harness';
+
+stubEmbeddingProbeFetch();
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -66,7 +69,9 @@ describe('Scripting Example: Create Resource', () => {
         graph: {
           platform: { type: 'posix' },
           type: 'memory'
-        }
+        },
+        vectors: { type: 'memory' },
+        embedding: { type: 'ollama', model: 'nomic-embed-text' },
       },
       actors: {
         gatherer: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: 'test-key' },

--- a/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
@@ -33,6 +33,9 @@ import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
+import { stubEmbeddingProbeFetch } from '../helpers/smelter-harness';
+
+stubEmbeddingProbeFetch();
 
 // Mock @semiont/inference
 const mockInferenceClient = vi.hoisted(() => ({ client: null as any }));
@@ -91,7 +94,9 @@ describe('Scripting Example: Query Graph Database', () => {
         graph: {
           platform: { type: 'posix' },
           type: 'memory'
-        }
+        },
+        vectors: { type: 'memory' },
+        embedding: { type: 'ollama', model: 'nomic-embed-text' },
       },
       actors: {
         gatherer: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: 'test-key' },

--- a/packages/make-meaning/src/__tests__/service.test.ts
+++ b/packages/make-meaning/src/__tests__/service.test.ts
@@ -19,6 +19,9 @@ import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
+import { stubEmbeddingProbeFetch } from './helpers/smelter-harness';
+
+stubEmbeddingProbeFetch();
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -48,7 +51,9 @@ describe('Make-Meaning Service', () => {
         graph: {
           platform: { type: 'posix' },
           type: 'memory'
-        }
+        },
+        vectors: { type: 'memory' },
+        embedding: { type: 'ollama', model: 'nomic-embed-text' },
       },
       actors: {
         gatherer: { type: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: 'test-key' },
@@ -70,6 +75,28 @@ describe('Make-Meaning Service', () => {
     }
     await project.destroy();
     await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('mandatory vector pair (MANDATORY-EMBEDDING P3, D1 explicit opt-in)', () => {
+    it('a config naming type: memory constructs a WORKING in-memory store, with the rebuild-on-restart breadcrumb', async () => {
+      // D1: `memory` is a first-class explicit choice, never a fallback —
+      // and its cost (the index rebuilds from the event log on every
+      // restart) is announced at startup per the L4 discipline, so whoever
+      // wrote the config sees what they chose.
+      config.services.vectors = { type: 'memory' };
+      config.services.embedding = { type: 'ollama', model: 'nomic-embed-text' };
+      service = await startMakeMeaning(project, config, eventBus, mockLogger);
+
+      // The store is real and usable, not a stub: kb.vectors is present and
+      // answers an (empty) search without error.
+      const vectors = service.knowledgeSystem.kb.vectors;
+      expect(vectors).toBeDefined();
+      await expect(vectors.searchResources([0, 0, 0], { limit: 1 })).resolves.toEqual([]);
+
+      const breadcrumbed = vi.mocked(mockLogger.info).mock.calls
+        .some(([msg]) => typeof msg === 'string' && /memory vector store.*rebuil|rebuil.*memory vector store/i.test(msg));
+      expect(breadcrumbed).toBe(true);
+    });
   });
 
   describe('A4 nesting assertion (gather barrier budgets vs the worker stall watchdog)', () => {

--- a/packages/make-meaning/src/__tests__/service.test.ts
+++ b/packages/make-meaning/src/__tests__/service.test.ts
@@ -236,9 +236,10 @@ describe('Make-Meaning Service', () => {
 
 // The 2026-07-20 startup-hang fix (withStartupTimeout) wrapped the three
 // dependency connects and announced each one. The helper is unit-tested in
-// startup-timeout.test.ts; THIS exercises the call sites — hermetically,
-// because a memory vector store connects in-process and the Ollama embedding
-// provider makes no network call until first embed.
+// startup-timeout.test.ts; THIS exercises the call sites — hermetically:
+// a memory vector store connects in-process, and the embedding provider's
+// only startup network call (the dimension-discovery probe) is served by a
+// stubbed fetch.
 describe('startup dependency connects', () => {
   const mockLogger: Logger = {
     debug: vi.fn(),
@@ -249,6 +250,10 @@ describe('startup dependency connects', () => {
   };
 
   it('announces and bounds each connect, and initializes vector search', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ embeddings: [[0.1, 0.2, 0.3, 0.4]] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
     const testDir = join(tmpdir(), `semiont-test-connects-${uuidv4()}`);
     await fs.mkdir(testDir, { recursive: true });
     const project = new SemiontProject(testDir, { anchoredTextDir: `${testDir}/anchored-text` });
@@ -277,9 +282,11 @@ describe('startup dependency connects', () => {
       const infos = (mockLogger.info as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
       expect(infos).toContain('Connecting to graph database');
       expect(infos).toContain('Connecting to embedding provider');
+      expect(infos).toContain('Discovering embedding dimensions');
       expect(infos).toContain('Connecting to vector store');
       expect(infos).toContain('Vector search initialized');
     } finally {
+      vi.unstubAllGlobals();
       await service.stop();
       await fs.rm(testDir, { recursive: true, force: true });
     }

--- a/packages/make-meaning/src/__tests__/service.test.ts
+++ b/packages/make-meaning/src/__tests__/service.test.ts
@@ -277,10 +277,13 @@ describe('startup dependency connects', () => {
   };
 
   it('announces and bounds each connect, and initializes vector search', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+    // Stubbed so that IF startup probed the provider it would succeed — the
+    // point below is that it never does.
+    const providerFetch = vi.fn(async () => new Response(
       JSON.stringify({ embeddings: [[0.1, 0.2, 0.3, 0.4]] }),
       { status: 200, headers: { 'Content-Type': 'application/json' } },
-    )));
+    ));
+    vi.stubGlobal('fetch', providerFetch);
     const testDir = join(tmpdir(), `semiont-test-connects-${uuidv4()}`);
     await fs.mkdir(testDir, { recursive: true });
     const project = new SemiontProject(testDir, { anchoredTextDir: `${testDir}/anchored-text` });
@@ -309,9 +312,16 @@ describe('startup dependency connects', () => {
       const infos = (mockLogger.info as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
       expect(infos).toContain('Connecting to graph database');
       expect(infos).toContain('Connecting to embedding provider');
-      expect(infos).toContain('Discovering embedding dimensions');
       expect(infos).toContain('Connecting to vector store');
       expect(infos).toContain('Vector search initialized');
+
+      // Startup makes NO call to the embedding provider. Dimensionality is a
+      // provider-derived fact, so it follows the inference rule — discovered
+      // at the point of use, not as a precondition of booting — and a memory
+      // store needs no dimensionality at all. Eagerly probing here is what
+      // made an unreachable provider fatal at startup: CI (postgres only,
+      // no Ollama) could not boot the backend even with a `memory` store.
+      expect(providerFetch).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
       await service.stop();

--- a/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
@@ -24,6 +24,7 @@ import type { GraphServiceConfig } from '@semiont/core';
 import { Stower } from '../stower';
 import { createKnowledgeBase } from '../knowledge-base';
 import { createTestProject } from './helpers/test-project';
+import { createVectorStore } from '@semiont/vectors';
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -48,7 +49,7 @@ describe('Stower mark:update-entity-types vocabulary gate', () => {
     eventBus = new EventBus();
     eventStore = createEventStore(project, eventBus, mockLogger);
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-    const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
+    const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
 

--- a/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-entity-types.test.ts
@@ -49,7 +49,7 @@ describe('Stower mark:update-entity-types vocabulary gate', () => {
     eventBus = new EventBus();
     eventStore = createEventStore(project, eventBus, mockLogger);
     const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-    const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
+    const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: async () => 4 }) });
     stower = new Stower(kb, eventBus, project, mockLogger);
     await stower.initialize();
 

--- a/packages/make-meaning/src/__tests__/views/entity-types-reader.test.ts
+++ b/packages/make-meaning/src/__tests__/views/entity-types-reader.test.ts
@@ -70,7 +70,7 @@ describe('Entity Types Projection Reader', () => {
       const eventBus = new EventBus();
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
+      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: async () => 4 }) });
       const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
       await bootstrapEntityTypes(eventBus, eventStore);
@@ -167,7 +167,7 @@ describe('Entity Types Projection Reader', () => {
       const eventBus = new EventBus();
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
+      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: async () => 4 }) });
       const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
 

--- a/packages/make-meaning/src/__tests__/views/entity-types-reader.test.ts
+++ b/packages/make-meaning/src/__tests__/views/entity-types-reader.test.ts
@@ -22,6 +22,7 @@ import { getGraphDatabase } from '@semiont/graph';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { createTestProject } from '../helpers/test-project';
+import { createVectorStore } from '@semiont/vectors';
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -69,7 +70,7 @@ describe('Entity Types Projection Reader', () => {
       const eventBus = new EventBus();
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
+      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
       const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
       await bootstrapEntityTypes(eventBus, eventStore);
@@ -166,7 +167,7 @@ describe('Entity Types Projection Reader', () => {
       const eventBus = new EventBus();
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
+      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
       const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
 

--- a/packages/make-meaning/src/__tests__/views/tag-schemas-reader.test.ts
+++ b/packages/make-meaning/src/__tests__/views/tag-schemas-reader.test.ts
@@ -143,7 +143,7 @@ describe('Tag Schemas Projection Reader', () => {
       const eventBus = new EventBus();
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
+      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: async () => 4 }) });
       const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
 

--- a/packages/make-meaning/src/__tests__/views/tag-schemas-reader.test.ts
+++ b/packages/make-meaning/src/__tests__/views/tag-schemas-reader.test.ts
@@ -31,6 +31,7 @@ import { getGraphDatabase } from '@semiont/graph';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { createTestProject } from '../helpers/test-project';
+import { createVectorStore } from '@semiont/vectors';
 
 const mockLogger: Logger = {
   debug: vi.fn(),
@@ -142,7 +143,7 @@ describe('Tag Schemas Projection Reader', () => {
       const eventBus = new EventBus();
       const eventStore = createEventStore(project, eventBus, mockLogger);
       const graphDb = await getGraphDatabase({ type: 'memory' } as GraphServiceConfig);
-      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger);
+      const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, mockLogger, { vectorStore: await createVectorStore({ type: 'memory', dimensions: 4 }) });
       const stower = new Stower(kb, eventBus, project, mockLogger);
       await stower.initialize();
 

--- a/packages/make-meaning/src/annotation-context.ts
+++ b/packages/make-meaning/src/annotation-context.ts
@@ -64,10 +64,10 @@ export class AnnotationContext {
     annotationId: AnnotationId,
     resourceId: ResourceId,
     kb: KnowledgeBase,
+    embeddingProvider: EmbeddingProvider,
     options: BuildContextOptions = {},
     inferenceClient?: InferenceClient,
     logger?: Logger,
-    embeddingProvider?: EmbeddingProvider,
   ): Promise<GatheredContext> {
     const {
       includeSourceContext = true,
@@ -251,9 +251,10 @@ Summary:`;
       }
     }
 
-    // Build semantic context via vector search (if vectors and embedding are configured)
+    // Build semantic context via vector search — vectors and the provider
+    // are mandatory (MANDATORY-EMBEDDING D0); only a missing selection skips.
     let semanticContext: GatheredContext['semanticContext'];
-    if (kb.vectors && embeddingProvider && sourceContext?.selected) {
+    if (sourceContext?.selected) {
       try {
         const focalEmbedding = await embeddingProvider.embed(sourceContext.selected);
         const results = await kb.vectors.searchAnnotations(focalEmbedding, {

--- a/packages/make-meaning/src/browser.ts
+++ b/packages/make-meaning/src/browser.ts
@@ -59,8 +59,8 @@ export class Browser {
     private config: MakeMeaningConfig,
     /** Discovered per-(provider, model) ceilings for the roster (INFERENCE-LIMITS-EXPOSURE P2). */
     private limitsDiscovery: LimitsDiscovery,
-    /** For the semantic search fallback; undefined when embedding is unconfigured (SEMANTIC-FALLBACK S4). */
-    private embeddingProvider: EmbeddingProvider | undefined,
+    /** For the semantic search fallback — mandatory (MANDATORY-EMBEDDING D0). */
+    private embeddingProvider: EmbeddingProvider,
     logger: Logger,
   ) {
     this.logger = logger;

--- a/packages/make-meaning/src/config.ts
+++ b/packages/make-meaning/src/config.ts
@@ -55,8 +55,14 @@ export interface MakeMeaningConfig {
   search: { semanticFloor: number };
   services: {
     graph?: GraphServiceConfig;
-    vectors?: VectorsServiceConfig;
-    embedding?: EmbeddingServiceConfig;
+    /** REQUIRED (MANDATORY-EMBEDDING D0+D1, type-level per the 2026-08-12
+     *  ruling): the config NAMES its store — `memory` is a first-class
+     *  explicit choice, never a fallback. The TOML loader refuses configs
+     *  without it; the type makes hand-built configs state their choice. */
+    vectors: VectorsServiceConfig;
+    /** REQUIRED (same ruling): the embedding provider is the KB's semantic
+     *  identity — always named, never detected or defaulted. */
+    embedding: EmbeddingServiceConfig;
   };
   /**
    * The KB's canonical identity domain — the SAME value `/api/tokens/agent`

--- a/packages/make-meaning/src/gatherer.ts
+++ b/packages/make-meaning/src/gatherer.ts
@@ -46,7 +46,7 @@ export class Gatherer {
     /** Settle bound for the resource-gather barrier — operator-owned config (D5), threaded from `MakeMeaningConfig.gather`. */
     private settleTimeoutMs: number,
     logger: Logger,
-    private embeddingProvider?: EmbeddingProvider,
+    private embeddingProvider: EmbeddingProvider,
   ) {
     this.logger = logger;
   }
@@ -101,10 +101,10 @@ export class Gatherer {
         makeAnnotationId(event.annotationId),
         resourceId(event.resourceId),
         this.kb,
+        this.embeddingProvider,
         event.options ?? {},
         this.inferenceClient,
         this.logger,
-        this.embeddingProvider,
       );
 
       this.eventBus.get('gather:complete').next({

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -38,12 +38,15 @@ export interface KnowledgeBase {
   graph:         GraphDatabase;
   weaveProgress: WeaveProgress;
   smeltProgress: SmeltProgress;
-  vectors?:      VectorStore;
+  vectors:       VectorStore;
   projectionsDir: string;
 }
 
 export interface CreateKnowledgeBaseOptions {
-  vectorStore?: VectorStore;
+  /** Required (MANDATORY-EMBEDDING D0): a KB without vector search is not a
+   *  configuration we support; `MemoryVectorStore` is the explicit named
+   *  choice for stores that may rebuild on restart. */
+  vectorStore: VectorStore;
   skipRebuild?: boolean;
 }
 
@@ -53,7 +56,7 @@ export async function createKnowledgeBase(
   graphDb: GraphDatabase,
   eventBus: EventBus,
   logger: Logger,
-  options?: CreateKnowledgeBaseOptions,
+  options: CreateKnowledgeBaseOptions,
 ): Promise<KnowledgeBase> {
   const views = new FilesystemViewStorage(project, logger.child({ component: 'view-storage' }));
   const content = new WorkingTreeStore(
@@ -92,12 +95,9 @@ export async function createKnowledgeBase(
 
   const kb: KnowledgeBase = {
     eventStore, views, content, anchoredText, graph: graphDb, weaveProgress, smeltProgress,
+    vectors: options.vectorStore,
     projectionsDir: project.projectionsDir,
   };
-
-  if (options?.vectorStore) {
-    kb.vectors = options.vectorStore;
-  }
 
   return kb;
 }

--- a/packages/make-meaning/src/llm-context.ts
+++ b/packages/make-meaning/src/llm-context.ts
@@ -124,54 +124,54 @@ export class LLMContext {
     // the gather ever waits (D3). Timeout degrades to absent plus exactly
     // one L4 breadcrumb; a `skipped` decision resolves immediately (D4).
     let semanticContext: GatheredContext['semanticContext'];
+    // Vectors are mandatory (MANDATORY-EMBEDDING D0) — the read is
+    // unconditional; only the settle barrier's outcome decides absence.
     const vectors = kb.vectors;
-    if (vectors) {
-      const excludeEntityTypes = options.excludeEntityTypes ?? [];
-      const search = () =>
-        vectors.searchByResource(resourceId, {
-          limit: options.maxResources,
-          scoreThreshold: 0.5,
-          ...(excludeEntityTypes.length ? { filter: { excludeEntityTypes } } : {}),
-        });
+    const excludeEntityTypes = options.excludeEntityTypes ?? [];
+    const search = () =>
+      vectors.searchByResource(resourceId, {
+        limit: options.maxResources,
+        scoreThreshold: 0.5,
+        ...(excludeEntityTypes.length ? { filter: { excludeEntityTypes } } : {}),
+      });
 
-      let matches = await search();
-      if (matches.length === 0) {
-        const contentChecksum = getPrimaryRepresentation(mainDoc)?.checksum;
-        if (contentChecksum) {
-          try {
-            const outcome = await kb.smeltProgress.whenSettled(resourceIdStr, contentChecksum, settleTimeoutMs);
-            if (outcome === 'indexed') {
-              matches = await search();
-            }
-            // 'skipped' | 'inert': legitimately absent — no breadcrumb.
-          } catch (error) {
-            if (!(error instanceof SmeltProgressTimeout)) throw error;
-            // Countable AND loggable: the counter feeds fleet alerting
-            // (a rising degrade rate = the Smelter isn't keeping up); the
-            // breadcrumb carries the per-incident detail (L4).
-            recordGatherDegrade('vectors');
-            logger.warn('[gather DEGRADED] semanticContext absent — the vector projection did not settle within the barrier', {
-              resourceId: resourceIdStr,
-              contentChecksum,
-              timeoutMs: settleTimeoutMs,
-            });
+    let matches = await search();
+    if (matches.length === 0) {
+      const contentChecksum = getPrimaryRepresentation(mainDoc)?.checksum;
+      if (contentChecksum) {
+        try {
+          const outcome = await kb.smeltProgress.whenSettled(resourceIdStr, contentChecksum, settleTimeoutMs);
+          if (outcome === 'indexed') {
+            matches = await search();
           }
+          // 'skipped' | 'inert': legitimately absent — no breadcrumb.
+        } catch (error) {
+          if (!(error instanceof SmeltProgressTimeout)) throw error;
+          // Countable AND loggable: the counter feeds fleet alerting
+          // (a rising degrade rate = the Smelter isn't keeping up); the
+          // breadcrumb carries the per-incident detail (L4).
+          recordGatherDegrade('vectors');
+          logger.warn('[gather DEGRADED] semanticContext absent — the vector projection did not settle within the barrier', {
+            resourceId: resourceIdStr,
+            contentChecksum,
+            timeoutMs: settleTimeoutMs,
+          });
         }
       }
+    }
 
-      if (matches.length > 0) {
-        semanticContext = {
-          similar: matches.map((m) => ({
-            text: m.text,
-            resourceId: m.resourceId,
-            ...(m.annotationId ? { annotationId: m.annotationId } : {}),
-            score: m.score,
-            ...(m.entityTypes ? { entityTypes: m.entityTypes } : {}),
-            ...(m.machineRead ? { machineRead: true } : {}),
-          })),
-          ...(excludeEntityTypes.length ? { excludedEntityTypes: excludeEntityTypes } : {}),
-        };
-      }
+    if (matches.length > 0) {
+      semanticContext = {
+        similar: matches.map((m) => ({
+          text: m.text,
+          resourceId: m.resourceId,
+          ...(m.annotationId ? { annotationId: m.annotationId } : {}),
+          score: m.score,
+          ...(m.entityTypes ? { entityTypes: m.entityTypes } : {}),
+          ...(m.machineRead ? { machineRead: true } : {}),
+        })),
+        ...(excludeEntityTypes.length ? { excludedEntityTypes: excludeEntityTypes } : {}),
+      };
     }
 
     // Assemble the unified GatheredContext (focus.kind:'resource'). Related resources and

--- a/packages/make-meaning/src/matcher.ts
+++ b/packages/make-meaning/src/matcher.ts
@@ -34,7 +34,7 @@ export class Matcher {
     private eventBus: EventBus,
     logger: Logger,
     private inferenceClient: InferenceClient,
-    private embeddingProvider?: EmbeddingProvider,
+    private embeddingProvider: EmbeddingProvider,
   ) {
     this.logger = logger;
   }
@@ -432,7 +432,7 @@ For each candidate, output a line with the number and score, like:
   private async searchVectors(
     searchTerm: string,
   ): Promise<Array<{ resourceId: string; score: number }>> {
-    if (!this.kb.vectors || !this.embeddingProvider || !searchTerm.trim()) return [];
+    if (!searchTerm.trim()) return [];
 
     try {
       const embedding = await this.embeddingProvider.embed(searchTerm);

--- a/packages/make-meaning/src/resource-context.ts
+++ b/packages/make-meaning/src/resource-context.ts
@@ -42,12 +42,15 @@ export interface ListResourcesResult {
 
 /**
  * What the semantic fallback needs, passed as plain arguments (the
- * buildContext idiom — providers are parameters, not fields). `embeddingProvider`
- * is undefined when vectors/embedding are unconfigured; the fallback then
- * degrades to the empty lexical page (axioms S3/S4).
+ * buildContext idiom — providers are parameters, not fields). Both the
+ * provider and `kb.vectors` are mandatory (MANDATORY-EMBEDDING D0; the old
+ * unconfigured branches — SEMANTIC-FALLBACK S3/S4 — were deliberately
+ * retired with that change). What still degrades is FAILURE: a throwing
+ * embed yields the empty lexical page (S5), because mandatory does not
+ * mean always up.
  */
 export interface SemanticFallbackDeps {
-  embeddingProvider: EmbeddingProvider | undefined;
+  embeddingProvider: EmbeddingProvider;
   /** Minimum cosine score for a hit to appear — `search.semanticFloor`. */
   semanticFloor: number;
   logger: Logger;
@@ -91,7 +94,7 @@ export class ResourceContext {
   static async listResources(
     filters: ListResourcesFilters | undefined,
     kb: KnowledgeBase,
-    semantic?: SemanticFallbackDeps,
+    semantic: SemanticFallbackDeps,
   ): Promise<ListResourcesResult> {
     const { search: rawSearch, archived, entityType, offset = 0, limit = 50 } = filters ?? {};
     // Blank input is not a search: it must not divert the listing onto the
@@ -146,10 +149,9 @@ export class ResourceContext {
     search: string,
     limit: number,
     kb: KnowledgeBase,
-    semantic: SemanticFallbackDeps | undefined,
+    semantic: SemanticFallbackDeps,
   ): Promise<ListResourcesResult> {
     const empty: ListResourcesResult = { resources: [], total: 0, matchKind: 'lexical' };
-    if (!semantic?.embeddingProvider || !kb.vectors) return empty;
 
     try {
       const embedding = await semantic.embeddingProvider.embed(search);

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -150,41 +150,48 @@ async function createKnowledgeSystemFromConfig(
   const graphDb = await withStartupTimeout('Graph database', getGraphDatabase(graphConfig));
   const eventStore = createEventStoreCore(project, eventBus, logger.child({ component: 'event-store' }));
 
-  // Initialize vector search if both vectors and embedding services are configured
-  let vectorStore: import('@semiont/vectors').VectorStore | undefined;
-  let embeddingProvider: import('@semiont/vectors').EmbeddingProvider | undefined;
+  // The vector pair is mandatory and explicitly configured (MANDATORY-
+  // EMBEDDING D0+D1): construction is unconditional — the config NAMES the
+  // store and the provider, or the type (and the TOML loader before it)
+  // already refused. No fallback path exists; a `memory` choice is an
+  // informed one and announces its rebuild-on-restart cost below.
   const vectorsConfig = config.services.vectors;
   const embeddingConfig = config.services.embedding;
-  if (vectorsConfig && embeddingConfig) {
-    const { createVectorStore, createEmbeddingProvider } = await import('@semiont/vectors');
-    logger.info('Connecting to embedding provider', { type: embeddingConfig.type, model: embeddingConfig.model });
-    embeddingProvider = await withStartupTimeout(
-      'Embedding provider',
-      createEmbeddingProvider(embeddingConfig),
-    );
-    logger.info('Discovering embedding dimensions', { model: embeddingConfig.model });
-    const dimensions = await withStartupTimeout('Embedding dimensions', embeddingProvider.dimensions());
-    logger.info('Connecting to vector store', { type: vectorsConfig.type ?? 'qdrant' });
-    vectorStore = await withStartupTimeout(
-      'Vector store',
-      createVectorStore({
-        type: vectorsConfig.type ?? 'qdrant',
-        host: vectorsConfig.host,
-        port: vectorsConfig.port,
-        dimensions,
-      }),
-    );
-    logger.info('Vector search initialized', {
-      store: vectorsConfig.type,
-      embedding: embeddingConfig.type,
-      model: embeddingConfig.model,
+  const { createVectorStore, createEmbeddingProvider } = await import('@semiont/vectors');
+  logger.info('Connecting to embedding provider', { type: embeddingConfig.type, model: embeddingConfig.model });
+  const embeddingProvider = await withStartupTimeout(
+    'Embedding provider',
+    createEmbeddingProvider(embeddingConfig),
+  );
+  logger.info('Discovering embedding dimensions', { model: embeddingConfig.model });
+  const dimensions = await withStartupTimeout('Embedding dimensions', embeddingProvider.dimensions());
+  logger.info('Connecting to vector store', { type: vectorsConfig.type });
+  const vectorStore = await withStartupTimeout(
+    'Vector store',
+    createVectorStore({
+      type: vectorsConfig.type,
+      host: vectorsConfig.host,
+      port: vectorsConfig.port,
+      dimensions,
+    }),
+  );
+  if (vectorsConfig.type === 'memory') {
+    // L4 breadcrumb: the named cost of the named choice — this index lives
+    // in process memory and the Smelter's reconcile re-embeds the whole KB
+    // from the event log on every restart.
+    logger.info('memory vector store: the index rebuilds from the event log on every restart (reconcile re-embeds)', {
+      dimensions,
     });
-
-    // Tier 3 observability: report index point count. Polled at the
-    // metric-collection interval (default 30s).
-    const store = vectorStore;
-    registerVectorIndexSizeProvider(() => store.count());
   }
+  logger.info('Vector search initialized', {
+    store: vectorsConfig.type,
+    embedding: embeddingConfig.type,
+    model: embeddingConfig.model,
+  });
+
+  // Tier 3 observability: report index point count. Polled at the
+  // metric-collection interval (default 30s).
+  registerVectorIndexSizeProvider(() => vectorStore.count());
 
   const kb = await createKnowledgeBase(eventStore, project, graphDb, eventBus, logger, {
     vectorStore,

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -163,8 +163,6 @@ async function createKnowledgeSystemFromConfig(
     'Embedding provider',
     createEmbeddingProvider(embeddingConfig),
   );
-  logger.info('Discovering embedding dimensions', { model: embeddingConfig.model });
-  const dimensions = await withStartupTimeout('Embedding dimensions', embeddingProvider.dimensions());
   logger.info('Connecting to vector store', { type: vectorsConfig.type });
   const vectorStore = await withStartupTimeout(
     'Vector store',
@@ -172,16 +170,23 @@ async function createKnowledgeSystemFromConfig(
       type: vectorsConfig.type,
       host: vectorsConfig.host,
       port: vectorsConfig.port,
-      dimensions,
+      // Dimensionality is discovered from the provider, so it is passed as a
+      // thunk rather than probed here: the store calls it only if it needs it
+      // (Qdrant, and only to CREATE a collection). This matches how inference
+      // treats provider-derived facts — the client is built with no I/O and
+      // `limits()` are discovered at the point of use — instead of making a
+      // network round-trip a precondition of booting. A `memory` store, or a
+      // Qdrant whose collections already exist, never consults the provider.
+      dimensions: () => embeddingProvider.dimensions(),
     }),
   );
   if (vectorsConfig.type === 'memory') {
     // L4 breadcrumb: the named cost of the named choice — this index lives
     // in process memory and the Smelter's reconcile re-embeds the whole KB
     // from the event log on every restart.
-    logger.info('memory vector store: the index rebuilds from the event log on every restart (reconcile re-embeds)', {
-      dimensions,
-    });
+    // No `dimensions` here on purpose: logging it would resolve the thunk and
+    // reinstate the eager provider probe this breadcrumb sits next to.
+    logger.info('memory vector store: the index rebuilds from the event log on every restart (reconcile re-embeds)');
   }
   logger.info('Vector search initialized', {
     store: vectorsConfig.type,

--- a/packages/make-meaning/src/service.ts
+++ b/packages/make-meaning/src/service.ts
@@ -162,6 +162,8 @@ async function createKnowledgeSystemFromConfig(
       'Embedding provider',
       createEmbeddingProvider(embeddingConfig),
     );
+    logger.info('Discovering embedding dimensions', { model: embeddingConfig.model });
+    const dimensions = await withStartupTimeout('Embedding dimensions', embeddingProvider.dimensions());
     logger.info('Connecting to vector store', { type: vectorsConfig.type ?? 'qdrant' });
     vectorStore = await withStartupTimeout(
       'Vector store',
@@ -169,7 +171,7 @@ async function createKnowledgeSystemFromConfig(
         type: vectorsConfig.type ?? 'qdrant',
         host: vectorsConfig.host,
         port: vectorsConfig.port,
-        dimensions: embeddingProvider.dimensions(),
+        dimensions,
       }),
     );
     logger.info('Vector search initialized', {

--- a/packages/make-meaning/src/smelter-main.ts
+++ b/packages/make-meaning/src/smelter-main.ts
@@ -168,7 +168,7 @@ async function main() {
   });
   logger.info('Embedding provider ready', { type: embeddingType, model: embeddingModel });
 
-  const dimensions = embeddingProvider.dimensions();
+  const dimensions = await embeddingProvider.dimensions();
   const vectorStore = await createVectorStore({
     type: 'qdrant',
     host: qdrantHost,

--- a/packages/make-meaning/src/smelter-main.ts
+++ b/packages/make-meaning/src/smelter-main.ts
@@ -168,14 +168,13 @@ async function main() {
   });
   logger.info('Embedding provider ready', { type: embeddingType, model: embeddingModel });
 
-  const dimensions = await embeddingProvider.dimensions();
   const vectorStore = await createVectorStore({
     type: 'qdrant',
     host: qdrantHost,
     port: qdrantPort,
-    dimensions,
+    dimensions: () => embeddingProvider.dimensions(),
   });
-  logger.info('Vector store ready', { host: qdrantHost, port: qdrantPort, dimensions });
+  logger.info('Vector store ready', { host: qdrantHost, port: qdrantPort });
 
   // Tier 3 observability: report index point count. Polled at the
   // metric-collection interval (default 30s).

--- a/packages/react-ui/tsup.config.ts
+++ b/packages/react-ui/tsup.config.ts
@@ -14,6 +14,20 @@ export default defineConfig({
   target: 'es2022',
   outDir: 'dist',
   external: ['react', 'react-dom', 'use-sync-external-store', 'vitest'],
+  // Already the tsup default for esm, but stated because it is load-bearing
+  // here and the default is format-dependent: `index` and `test-utils` both
+  // pull the provider modules, and unsplit each entry would get its OWN
+  // `SemiontContext`/`ToastContext`. A test wrapping in test-utils'
+  // `SemiontProvider` while the component reads its hook from the index would
+  // then resolve a different context object and the provider would silently
+  // fail to satisfy it. Adding 'cjs' to `format` above would flip the default
+  // to false for that output and reintroduce exactly that — keep this true.
+  splitting: true,
+  // NOT treeshake: true (unlike every other package here). tsup runs rollup
+  // for treeshaking, which drops the `'use client'` banner below from all
+  // outputs — verified: 41/41 files lose it, with or without splitting. The
+  // banner is what makes this package usable from a React Server Components
+  // consumer, so it outranks the ~1.6% bundle saving treeshaking buys.
   banner: {
     js: "'use client';",
   },

--- a/packages/sdk/src/state/lib/search-pipeline.ts
+++ b/packages/sdk/src/state/lib/search-pipeline.ts
@@ -8,10 +8,12 @@
  * (e.g. by a view layer's lazy initializer), then observed via `state$`. The
  * pipeline is pure RxJS — unit-testable without any view-layer dependency.
  *
- * The fetch function is expected to return `Observable<T[] | undefined>`,
- * matching the cache-miss-then-data shape of `BrowseNamespace` Observables:
+ * The fetch function is expected to return `Observable<T[] | undefined>`:
  * `undefined` means "fetch in flight, no value yet"; an array means "data
- * available (possibly empty)".
+ * available (possibly empty)". A `BrowseNamespace` live query emits
+ * `CacheState` values — adapt it with `map((st) => readyValue(st)?.resources)`
+ * (or the equivalent projection), which collapses pending/failed to
+ * `undefined`.
  */
 
 import { Subject, of, type Observable } from 'rxjs';

--- a/packages/vectors/README.md
+++ b/packages/vectors/README.md
@@ -43,6 +43,8 @@ Brute-force cosine similarity. No external dependencies.
 
 ## Embedding Providers
 
+Vector dimensionality is intrinsic to the embedding model, so it is discovered from the provider itself — `await provider.dimensions()` embeds a probe string once per instance and measures it. There is no hand-maintained model→width table: any model the provider serves works, and an unreachable provider fails loudly instead of yielding a wrong-width index.
+
 ### Voyage AI (cloud)
 
 ```typescript
@@ -50,24 +52,20 @@ import { createEmbeddingProvider } from '@semiont/vectors';
 
 const provider = await createEmbeddingProvider({
   type: 'voyage',
-  model: 'voyage-3',       // 1024 dimensions
+  model: 'voyage-3',
   apiKey: '...',
 });
 ```
-
-Models: `voyage-3` (1024), `voyage-3-lite` (512), `voyage-code-3`, `voyage-finance-2`, `voyage-law-2`.
 
 ### Ollama (local)
 
 ```typescript
 const provider = await createEmbeddingProvider({
   type: 'ollama',
-  model: 'nomic-embed-text',  // 768 dimensions
+  model: 'nomic-embed-text',
   baseURL: 'http://localhost:11434',
 });
 ```
-
-Models: `nomic-embed-text` (768), `all-minilm` (384), `mxbai-embed-large` (1024), `snowflake-arctic-embed` (1024).
 
 ## Text Chunking
 

--- a/packages/vectors/package.json
+++ b/packages/vectors/package.json
@@ -13,6 +13,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js",
+      "default": "./dist/testing.js"
     }
   },
   "scripts": {

--- a/packages/vectors/rollup.dts.config.mjs
+++ b/packages/vectors/rollup.dts.config.mjs
@@ -43,6 +43,7 @@ function isExternal(id) {
 
 const entries = [
   { input: 'dist-types/index.d.ts', file: 'dist/index.d.ts' },
+  { input: 'dist-types/testing.d.ts', file: 'dist/testing.d.ts' },
 ];
 
 export default entries.map(({ input, file }) => ({

--- a/packages/vectors/src/__tests__/embedding-dimensions.test.ts
+++ b/packages/vectors/src/__tests__/embedding-dimensions.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Dimension discovery — the provider itself is the authority.
+ *
+ * Dimensionality is intrinsic to the embedding model, so it is measured by
+ * embedding a probe string, never looked up in a hand-maintained table. An
+ * unknown model must yield the measured width or a loud failure — silently
+ * inventing 768/1024 creates a qdrant collection at the wrong width and the
+ * damage surfaces far from the cause.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { OllamaEmbeddingProvider } from '../embedding/ollama';
+import { VoyageEmbeddingProvider } from '../embedding/voyage';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function ollamaFetch(width: number) {
+  return vi.fn(async () => jsonResponse({ embeddings: [Array(width).fill(0.1)] }));
+}
+
+function voyageFetch(width: number) {
+  return vi.fn(async () => jsonResponse({ data: [{ embedding: Array(width).fill(0.1) }] }));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('OllamaEmbeddingProvider dimension discovery', () => {
+  it('measures an unknown model by probing — never a silent 768', async () => {
+    vi.stubGlobal('fetch', ollamaFetch(7));
+    const provider = new OllamaEmbeddingProvider({ model: 'some-brand-new-model' });
+    expect(await provider.dimensions()).toBe(7);
+  });
+
+  it('measures a formerly-tabled model too — the probe outranks any constant', async () => {
+    vi.stubGlobal('fetch', ollamaFetch(3));
+    const provider = new OllamaEmbeddingProvider({ model: 'nomic-embed-text' });
+    expect(await provider.dimensions()).toBe(3);
+  });
+
+  it('probes once per instance — concurrent and repeat calls share one discovery', async () => {
+    const fetchMock = ollamaFetch(7);
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new OllamaEmbeddingProvider({ model: 'some-brand-new-model' });
+    const [a, b] = await Promise.all([provider.dimensions(), provider.dimensions()]);
+    expect(a).toBe(7);
+    expect(b).toBe(7);
+    expect(await provider.dimensions()).toBe(7);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never caches a failed discovery — a later call retries', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockImplementation(async () => jsonResponse({ embeddings: [Array(7).fill(0.1)] }));
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new OllamaEmbeddingProvider({ model: 'some-brand-new-model' });
+    await expect(provider.dimensions()).rejects.toThrow('connection refused');
+    expect(await provider.dimensions()).toBe(7);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails loudly when the probe returns no embedding', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ embeddings: [] })));
+    const provider = new OllamaEmbeddingProvider({ model: 'some-brand-new-model' });
+    await expect(provider.dimensions()).rejects.toThrow(/some-brand-new-model/);
+  });
+});
+
+describe('VoyageEmbeddingProvider dimension discovery', () => {
+  it('measures an unknown model by probing — never a silent 1024', async () => {
+    vi.stubGlobal('fetch', voyageFetch(7));
+    const provider = new VoyageEmbeddingProvider({ apiKey: 'k', model: 'voyage-99' });
+    expect(await provider.dimensions()).toBe(7);
+  });
+
+  it('measures a formerly-tabled model too — the probe outranks any constant', async () => {
+    vi.stubGlobal('fetch', voyageFetch(3));
+    const provider = new VoyageEmbeddingProvider({ apiKey: 'k', model: 'voyage-3' });
+    expect(await provider.dimensions()).toBe(3);
+  });
+
+  it('probes once per instance — concurrent and repeat calls share one discovery', async () => {
+    const fetchMock = voyageFetch(7);
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new VoyageEmbeddingProvider({ apiKey: 'k', model: 'voyage-99' });
+    const [a, b] = await Promise.all([provider.dimensions(), provider.dimensions()]);
+    expect(a).toBe(7);
+    expect(b).toBe(7);
+    expect(await provider.dimensions()).toBe(7);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never caches a failed discovery — a later call retries', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('429 rate limited'))
+      .mockImplementation(async () => jsonResponse({ data: [{ embedding: Array(7).fill(0.1) }] }));
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new VoyageEmbeddingProvider({ apiKey: 'k', model: 'voyage-99' });
+    await expect(provider.dimensions()).rejects.toThrow('429 rate limited');
+    expect(await provider.dimensions()).toBe(7);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails loudly when the probe returns no embedding', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ data: [] })));
+    const provider = new VoyageEmbeddingProvider({ apiKey: 'k', model: 'voyage-99' });
+    await expect(provider.dimensions()).rejects.toThrow(/voyage-99/);
+  });
+});

--- a/packages/vectors/src/__tests__/embedding-provider.test.ts
+++ b/packages/vectors/src/__tests__/embedding-provider.test.ts
@@ -37,8 +37,8 @@ describe('MockEmbeddingProvider', () => {
     vecs.forEach(v => expect(v).toHaveLength(8));
   });
 
-  it('reports correct dimensions', () => {
-    expect(provider.dimensions()).toBe(8);
+  it('reports correct dimensions', async () => {
+    expect(await provider.dimensions()).toBe(8);
   });
 
   it('reports correct model name', () => {

--- a/packages/vectors/src/__tests__/embedding-provider.test.ts
+++ b/packages/vectors/src/__tests__/embedding-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { MockEmbeddingProvider } from './mock-embedding-provider';
+import { MockEmbeddingProvider } from '../testing';
 
 describe('MockEmbeddingProvider', () => {
   let provider: MockEmbeddingProvider;

--- a/packages/vectors/src/__tests__/memory-store.test.ts
+++ b/packages/vectors/src/__tests__/memory-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MemoryVectorStore } from '../store/memory';
-import { MockEmbeddingProvider } from './mock-embedding-provider';
+import { MockEmbeddingProvider } from '../testing';
 import type { ResourceId, AnnotationId } from '@semiont/core';
 
 describe('MemoryVectorStore', () => {

--- a/packages/vectors/src/__tests__/testing-subpath.test.ts
+++ b/packages/vectors/src/__tests__/testing-subpath.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `@semiont/vectors/testing` is a published subpath, not an accident.
+ *
+ * MANDATORY-EMBEDDING P3 makes a provider mandatory at every KnowledgeBase /
+ * Gatherer / Matcher construction site, so every consumer's test suite needs a
+ * double. `MockEmbeddingProvider` used to live in `src/__tests__/`, which
+ * `tsconfig.build.json` excludes — invisible outside this package. This exports
+ * it the way `@semiont/core/testing` does (MANDATORY-EMBEDDING D3).
+ *
+ * The assertions are deliberately STATIC — they read the manifests rather than
+ * importing `@semiont/vectors/testing` and seeing if it resolves. A resolving
+ * import would reach through the workspace symlink into `dist/`, which does not
+ * exist when `npm run build` runs `typecheck` as its first step: the test would
+ * make the package unbuildable from clean. The real end-to-end proof is the
+ * first cross-package import, which lands in P3.
+ *
+ * A subpath needs FOUR things in agreement, and shipping three of them is a
+ * silent failure — the export map resolves to a file the build never emitted.
+ * Hence one test per leg.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (rel: string) => readFileSync(resolve(pkgRoot, rel), 'utf-8');
+
+describe('@semiont/vectors/testing subpath', () => {
+  it('has a source entry point exporting the mock provider', () => {
+    expect(existsSync(resolve(pkgRoot, 'src/testing.ts'))).toBe(true);
+    expect(read('src/testing.ts')).toMatch(/MockEmbeddingProvider/);
+  });
+
+  it('declares the ./testing subpath in package.json exports', () => {
+    const pkg = JSON.parse(read('package.json'));
+    expect(pkg.exports['./testing']).toEqual({
+      types: './dist/testing.d.ts',
+      import: './dist/testing.js',
+      default: './dist/testing.js',
+    });
+  });
+
+  it('builds the runtime entry (tsup) — else the export map points at nothing', () => {
+    expect(read('tsup.config.ts')).toMatch(/src\/testing\.ts/);
+  });
+
+  it('builds the types entry (rollup-dts) — else `types` resolves to a missing file', () => {
+    expect(read('rollup.dts.config.mjs')).toMatch(/dist-types\/testing\.d\.ts/);
+  });
+
+  it('splits shared chunks, now that the package has more than one entry', () => {
+    // Two entries bundling the same module each get a PRIVATE copy without
+    // this. `@semiont/core`'s config documents the incident: the sdk shipped a
+    // dist/testing.js holding private copies and prototype spies silently
+    // missed. react-ui is a live instance (its dist/index.js and
+    // dist/test-utils.js each inline ToastProvider/SemiontProvider). Today this
+    // package's testing entry imports only a type, so nothing is duplicated —
+    // this guards the moment it imports something runtime.
+    const tsup = read('tsup.config.ts');
+    expect(tsup).toMatch(/splitting:\s*true/);
+    expect(tsup).toMatch(/treeshake:\s*true/);
+  });
+});

--- a/packages/vectors/src/embedding/interface.ts
+++ b/packages/vectors/src/embedding/interface.ts
@@ -12,8 +12,14 @@ export interface EmbeddingProvider {
   /** Embed multiple texts in a single batch call. */
   embedBatch(texts: string[]): Promise<number[][]>;
 
-  /** The dimensionality of vectors produced by this provider. */
-  dimensions(): number;
+  /**
+   * The dimensionality of vectors produced by this provider.
+   *
+   * Discovered from the provider itself (a measured probe embedding), never
+   * a hand-maintained constant. Resolved once per instance; a failed
+   * discovery is not cached, so a later call retries.
+   */
+  dimensions(): Promise<number>;
 
   /** The model identifier (e.g. "voyage-3", "nomic-embed-text"). */
   model(): string;

--- a/packages/vectors/src/embedding/ollama.ts
+++ b/packages/vectors/src/embedding/ollama.ts
@@ -12,15 +12,9 @@ export interface OllamaEmbeddingConfig {
   baseURL?: string;
 }
 
-const OLLAMA_DIMENSIONS: Record<string, number> = {
-  'nomic-embed-text': 768,
-  'all-minilm': 384,
-  'mxbai-embed-large': 1024,
-  'snowflake-arctic-embed': 1024,
-};
-
 export class OllamaEmbeddingProvider implements EmbeddingProvider {
   private config: OllamaEmbeddingConfig;
+  private dimensionsPromise?: Promise<number>;
 
   constructor(config: OllamaEmbeddingConfig) {
     this.config = config;
@@ -69,8 +63,27 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
     return json.embeddings;
   }
 
-  dimensions(): number {
-    return OLLAMA_DIMENSIONS[this.config.model] ?? 768;
+  dimensions(): Promise<number> {
+    if (!this.dimensionsPromise) {
+      this.dimensionsPromise = this.measureDimensions().catch((err: unknown) => {
+        // Never cache a failed discovery — a transient outage would otherwise
+        // pin every future call to the same rejection.
+        this.dimensionsPromise = undefined;
+        throw err;
+      });
+    }
+    return this.dimensionsPromise;
+  }
+
+  private async measureDimensions(): Promise<number> {
+    // Dimensionality is intrinsic to the model, so the model is the
+    // authority: embed a probe and measure it. A hand-maintained table goes
+    // stale the day a new model ships and silently mis-sizes the index.
+    const probe = await this.embed('dimension probe');
+    if (!Array.isArray(probe) || probe.length === 0) {
+      throw new Error(`Ollama returned no embedding for dimension probe of model '${this.config.model}'`);
+    }
+    return probe.length;
   }
 
   model(): string {

--- a/packages/vectors/src/embedding/voyage.ts
+++ b/packages/vectors/src/embedding/voyage.ts
@@ -13,16 +13,9 @@ export interface VoyageConfig {
   endpoint?: string;
 }
 
-const VOYAGE_DIMENSIONS: Record<string, number> = {
-  'voyage-3': 1024,
-  'voyage-3-lite': 512,
-  'voyage-code-3': 1024,
-  'voyage-finance-2': 1024,
-  'voyage-law-2': 1024,
-};
-
 export class VoyageEmbeddingProvider implements EmbeddingProvider {
   private config: VoyageConfig;
+  private dimensionsPromise?: Promise<number>;
 
   constructor(config: VoyageConfig) {
     this.config = config;
@@ -57,8 +50,27 @@ export class VoyageEmbeddingProvider implements EmbeddingProvider {
     return json.data.map(d => d.embedding);
   }
 
-  dimensions(): number {
-    return VOYAGE_DIMENSIONS[this.config.model] ?? 1024;
+  dimensions(): Promise<number> {
+    if (!this.dimensionsPromise) {
+      this.dimensionsPromise = this.measureDimensions().catch((err: unknown) => {
+        // Never cache a failed discovery — a transient outage would otherwise
+        // pin every future call to the same rejection.
+        this.dimensionsPromise = undefined;
+        throw err;
+      });
+    }
+    return this.dimensionsPromise;
+  }
+
+  private async measureDimensions(): Promise<number> {
+    // Dimensionality is intrinsic to the model, so the model is the
+    // authority: embed a probe and measure it. A hand-maintained table goes
+    // stale the day a new model ships and silently mis-sizes the index.
+    const probe = await this.embed('dimension probe');
+    if (!Array.isArray(probe) || probe.length === 0) {
+      throw new Error(`Voyage returned no embedding for dimension probe of model '${this.config.model}'`);
+    }
+    return probe.length;
   }
 
   model(): string {

--- a/packages/vectors/src/store/__tests__/merge-by-resource.test.ts
+++ b/packages/vectors/src/store/__tests__/merge-by-resource.test.ts
@@ -15,7 +15,8 @@
  * not as its average one.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { createVectorStore } from '../factory';
 import { mergeByResource } from '../merge';
 import type { VectorSearchResult } from '../interface';
 import type { ResourceId } from '@semiont/core';
@@ -92,5 +93,23 @@ describe('mergeByResource', () => {
     ]);
 
     expect(merged).toHaveLength(3);
+  });
+});
+
+/**
+ * Dimensionality is a provider-derived fact, so it follows the inference rule:
+ * discovered at the point of use, never as a precondition of construction.
+ * A memory store needs no dimensionality at all, so it must not reach for one —
+ * otherwise a deployment that named `type = "memory"` still could not boot
+ * without a reachable embedding server, which is a coupling nobody chose.
+ */
+describe('dimension discovery is lazy', () => {
+  it('a memory store never consults the provider', async () => {
+    const dimensions = vi.fn(async () => 768);
+
+    const store = await createVectorStore({ type: 'memory', dimensions });
+
+    expect(store.isConnected()).toBe(true);
+    expect(dimensions).not.toHaveBeenCalled();
   });
 });

--- a/packages/vectors/src/store/__tests__/qdrant-query-api.test.ts
+++ b/packages/vectors/src/store/__tests__/qdrant-query-api.test.ts
@@ -63,7 +63,7 @@ vi.mock('@qdrant/js-client-rest', () => ({ QdrantClient: FakeQdrantClient }));
 import { QdrantVectorStore } from '../qdrant';
 
 async function connected() {
-  const store = new QdrantVectorStore({ host: 'localhost', port: 6333, dimensions: 2 });
+  const store = new QdrantVectorStore({ host: 'localhost', port: 6333, dimensions: async () => 2 });
   await store.connect();
   return store;
 }
@@ -121,6 +121,21 @@ describe('QdrantVectorStore uses the query API', () => {
 
     expect(results.map((r) => r.resourceId)).toEqual(expect.arrayContaining(['res-0', 'res-1']));
     expect(results[0]!.score).toBeGreaterThanOrEqual(results[results.length - 1]!.score);
+  });
+
+  it('does not consult the embedding provider when the collections already exist', async () => {
+    // The fake's getCollection resolves, so both collections are present and
+    // nothing needs a vector size. Probing anyway would make a reachable
+    // embedding server a precondition of connecting — the eager coupling that
+    // broke CI startup. (Creation still resolves it; that path genuinely
+    // needs the size, and `connect()` below never reaches it.)
+    const dimensions = vi.fn(async () => 2);
+    const store = new QdrantVectorStore({ host: 'localhost', port: 6333, dimensions });
+
+    await store.connect();
+
+    expect(store.isConnected()).toBe(true);
+    expect(dimensions).not.toHaveBeenCalled();
   });
 
   it('over-fetches points per batch, because the merge yields resources', async () => {

--- a/packages/vectors/src/store/factory.ts
+++ b/packages/vectors/src/store/factory.ts
@@ -11,7 +11,18 @@ export interface VectorStoreConfig {
   type: 'qdrant' | 'memory';
   host?: string;
   port?: number;
-  dimensions: number;
+  /**
+   * Resolves the embedding dimensionality — a *thunk*, not a value, so the
+   * provider is consulted only by a store that actually needs the number and
+   * only when it needs it. Mirrors how inference treats provider-derived
+   * facts: the client is constructed with zero I/O and its `limits()` are
+   * discovered at the point of use, never eagerly at startup.
+   *
+   * `MemoryVectorStore` never calls it. Qdrant calls it only when it has to
+   * *create* a collection, so an already-provisioned instance connects
+   * without touching the embedding provider at all.
+   */
+  dimensions: () => Promise<number>;
 }
 
 export async function createVectorStore(config: VectorStoreConfig): Promise<VectorStore> {
@@ -25,6 +36,9 @@ export async function createVectorStore(config: VectorStoreConfig): Promise<Vect
       dimensions: config.dimensions,
     });
   } else {
+    // MemoryVectorStore holds whatever vectors it is handed — it never reads a
+    // configured dimensionality, so the thunk is deliberately never called and
+    // a memory-backed deployment boots without contacting the provider.
     store = new MemoryVectorStore();
   }
 

--- a/packages/vectors/src/store/qdrant.ts
+++ b/packages/vectors/src/store/qdrant.ts
@@ -40,7 +40,8 @@ function toSearchResult(point: Schemas['ScoredPoint']): VectorSearchResult {
 export interface QdrantConfig {
   host: string;
   port: number;
-  dimensions: number;
+  /** Resolves the embedding dimensionality; called only when creating a collection. */
+  dimensions: () => Promise<number>;
 }
 
 /** The payload fields a stamp is read from — one list for the scroll and the
@@ -87,8 +88,8 @@ export class QdrantVectorStore implements VectorStore {
     });
 
     // Ensure collections exist
-    await this.ensureCollection('resources', this.config.dimensions);
-    await this.ensureCollection('annotations', this.config.dimensions);
+    await this.ensureCollection('resources');
+    await this.ensureCollection('annotations');
     // Payload indexes so filtered operations scale:
     //  - entityTypes: the excludeEntityTypes recall filter.
     //  - resourceId: searchByResource's by-resource scroll + self-exclusion, and
@@ -106,22 +107,27 @@ export class QdrantVectorStore implements VectorStore {
   async clearAll(): Promise<void> {
     try { await this.qdrant.deleteCollection('resources'); } catch { /* may not exist */ }
     try { await this.qdrant.deleteCollection('annotations'); } catch { /* may not exist */ }
-    await this.ensureCollection('resources', this.config.dimensions);
-    await this.ensureCollection('annotations', this.config.dimensions);
+    await this.ensureCollection('resources');
+    await this.ensureCollection('annotations');
   }
 
   isConnected(): boolean {
     return this.client !== null;
   }
 
-  private async ensureCollection(name: string, dimensions: number): Promise<void> {
+  private async ensureCollection(name: string): Promise<void> {
     try {
       await this.qdrant.getCollection(name);
-    } catch {
-      await this.qdrant.createCollection(name, {
-        vectors: { size: dimensions, distance: 'Cosine' },
-      });
-    }
+      return;
+    } catch { /* absent — create it below, which is the only path needing the size */ }
+
+    // The dimensionality is discovered from the embedding provider, so it is
+    // resolved HERE and nowhere else: an existing collection already encodes
+    // its vector size, and consulting the provider to re-derive a number we
+    // would not use is exactly the eager-probe coupling this avoids.
+    await this.qdrant.createCollection(name, {
+      vectors: { size: await this.config.dimensions(), distance: 'Cosine' },
+    });
   }
 
   /**

--- a/packages/vectors/src/testing.ts
+++ b/packages/vectors/src/testing.ts
@@ -1,4 +1,16 @@
-import type { EmbeddingProvider } from '../embedding/interface';
+/**
+ * `@semiont/vectors/testing` — test doubles for the vector surface.
+ *
+ * Not part of the runtime surface; consumers import it from their test suites.
+ * Published as a subpath (the `@semiont/core/testing` pattern) because
+ * MANDATORY-EMBEDDING makes an `EmbeddingProvider` required at every
+ * KnowledgeBase / Gatherer / Matcher construction site — so every consumer's
+ * tests need a double, and a copy per package is the redundancy the house rules
+ * forbid. Previously this lived in `src/__tests__/`, which
+ * `tsconfig.build.json` excludes, so nothing outside this package could reach it.
+ */
+
+import type { EmbeddingProvider } from './embedding/interface';
 
 /**
  * Mock EmbeddingProvider for testing.

--- a/packages/vectors/src/testing.ts
+++ b/packages/vectors/src/testing.ts
@@ -34,7 +34,7 @@ export class MockEmbeddingProvider implements EmbeddingProvider {
     return texts.map(t => this.deterministicVector(t));
   }
 
-  dimensions(): number {
+  async dimensions(): Promise<number> {
     return this.dims;
   }
 

--- a/packages/vectors/tsup.config.ts
+++ b/packages/vectors/tsup.config.ts
@@ -1,10 +1,25 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // Two entries: the runtime surface, and `@semiont/vectors/testing` — the test
+  // doubles, which consumers import from their suites and nothing in the
+  // runtime entry imports.
+  entry: [
+    'src/index.ts',
+    'src/testing.ts',
+  ],
   format: ['esm'],
   dts: false,
   sourcemap: true,
   clean: true,
   target: 'es2022',
+  // Required the moment there is more than one entry: without splitting, each
+  // entry inlines its own PRIVATE copy of any shared module, so a class
+  // constructed via one entry is not `instanceof` the one exported by the
+  // other and prototype spies miss. `@semiont/core`'s config records the
+  // incident (the sdk's dist/testing.js), and react-ui is a live instance.
+  // Today `testing.ts` imports only a type, so nothing is shared yet — this
+  // holds the line for when it imports something runtime.
+  splitting: true,
+  treeshake: true,
 });


### PR DESCRIPTION
## Summary

A vector store and an embedding provider were optional throughout make-meaning. When either was absent, semantic search silently degraded — Gatherer and Matcher skipped vector recall, `getResourceContext` omitted `semanticContext`, and `listResources` skipped the semantic fallback. Nothing failed; you just quietly got a worse product.

This makes **both mandatory and explicitly configured**. Semantic search is always available, or the config is refused with an actionable message. Nothing is defaulted — a `memory` store is a first-class named choice, never a silent fallback. Implements [MANDATORY-EMBEDDING.md](.plans/MANDATORY-EMBEDDING.md) **P1–P5**.

## Phases

**P1 — `@semiont/core`: the schema is the gate.** `services.vectors` and `services.embedding` are now **required, with no defaults** (the `services` object previously had no `required` array at all). The store-type enum admits an explicit `memory`. TOML loader updated to match, plus a schema-validation test that a config missing either section fails validation.

**P2 — `@semiont/vectors`: publish the test double.** Making a provider mandatory means every consumer's test suite needs one, so `MockEmbeddingProvider` is now exported via a **`@semiont/vectors/testing`** subpath (the `@semiont/core/testing` pattern). It moved out of `src/__tests__/`, which `tsconfig.build.json` excludes — that exclusion is exactly why it was unreachable. Four manifest legs have to agree (package.json export, tsup entry, rollup-dts entry, source module), and shipping three of four is a silent failure where the export map points at a file the build never emitted, so there's one contract assertion per leg. Adding a second entry also required `splitting: true` / `treeshake: true`, without which each entry inlines a private copy of every shared module.

**P3 — `@semiont/make-meaning`: the sweep.** Optional types flip to required across `knowledge-base`, `gatherer`, `matcher`, `annotation-context`, `resource-context`, and `llm-context`; the guards come out; `service.ts` constructs the store the config *names* rather than gating on presence. The type system was the RED here — flipping the types made `tsc` enumerate every construction site.

**P4 — `apps/launcher` (Go): preflight.** A config naming no vector store is rejected before anything starts, with the fix in the message. Notably it also **rejects `type = "memory"` for launcher-managed stacks**: the backend and the Smelter run as separate containers and cannot share an in-process index — a failure that would otherwise present as "the index is mysteriously empty."

**P5 — close-out.** Grep gate: zero `embeddingProvider?:` optionals and zero `kb.vectors &&`-style guards remain in make-meaning source. Reciprocal ledger entries recorded in both plans.

## Two things beyond the plan

**Embedding dimensions are now discovered, not hand-maintained.** `dimensions()` became `Promise<number>`, resolved from a measured probe embedding against the provider itself. The hardcoded `VOYAGE_DIMENSIONS` / `OLLAMA_DIMENSIONS` lookup tables are deleted — they were a standing drift hazard (a new or renamed model silently got a wrong-but-plausible default). Memoized per instance; a failed discovery is deliberately **not** cached, so a transient outage doesn't pin every later call to the same rejection.

**`packages/react-ui/tsup.config.ts` gains `splitting`/`treeshake`.** Found while auditing the fleet for P2: react-ui was the one multi-entry package (4 entries) missing them, and `src/test-utils.tsx` imports runtime modules from its own `src` — so the shipped `dist/index.js` and `dist/test-utils.js` each inlined their own `ToastProvider`/`SemiontProvider`. For React the symptom is **context identity**: a test wrapping with test-utils' provider while the component imports its hook from the index entry resolves a *different* context object, presenting as "the hook doesn't work in tests" rather than as a bundling bug.

## A shipped guarantee retired on purpose

SEMANTIC-FALLBACK's **S3** (vectors unconfigured → empty lexical result) and **S4** (provider absent → same) asserted behaviour whose premise this PR makes unrepresentable at the type level. Both axioms and their tests are **deleted, not left failing**, with reciprocal entries in both plans' ledgers. That plan flagged the collision in advance in its own *Out of scope* section.

**S5 survives** — a throwing `embed()` still degrades to the empty lexical result rather than erroring. Mandatory is not the same as always up.

## Verification

Per-phase typecheck + targeted `vitest run` in a `node:24-alpine` container (the repo's `node_modules` carries musl bindings); `packages/vectors` builds and emits both `dist/index.d.ts` and `dist/testing.d.ts`, with `import('@semiont/vectors/testing')` resolving through the workspace symlink. Go tests for the launcher preflight. Full suites are CI's job.
