### PR TITLE
A transport seam for sdk-go (suite 389s → 176s), the fourth tour move, and honest cold starts

### DIFF
--- a/.github/workflows/architecture-compliance.yml
+++ b/.github/workflows/architecture-compliance.yml
@@ -26,21 +26,37 @@ jobs:
         run: npm ci --include=optional
 
       - name: Build packages (doc-snippets gate checks docs against dist)
+        id: build
         run: npm run build:packages
 
+      # Every gate below is INDEPENDENT: each checks a different invariant, and a
+      # failure in one says nothing about the others. They defaulted to
+      # `if: success()`, so the first failure skipped the rest — which meant one
+      # push per problem, and (because two of the skipped steps WRITE the
+      # compliance reports) a `cat` further down failing on a file nobody was
+      # going to produce.
+      #
+      # They all depend on the build, though: auditing docs against a `dist` that
+      # was never emitted would report nonsense. So each runs when the BUILD
+      # succeeded, regardless of its sibling gates. `!cancelled()` rather than
+      # `always()` so a cancelled run stops promptly.
+
       - name: Run Doc Snippets Audit
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           echo "::group::Doc Snippets Audit (sdk docs' code fences compile against dist through the exports map)"
           ./scripts/compliance/audit-doc-snippets.sh
           echo "::endgroup::"
 
       - name: Run Raw Bus Access Audit
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           echo "::group::Raw Bus Access Audit (forbid client.emit/.on/.stream outside the SDK)"
           ./scripts/compliance/audit-raw-bus.sh
           echo "::endgroup::"
 
       - name: Run CSS Gates
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           echo "::group::CSS Gates (stylelint + every var() resolves + no utility frameworks)"
           fail=0
@@ -53,6 +69,7 @@ jobs:
           exit $fail
 
       - name: Run StateUnit Compliance Audit
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           echo "::group::StateUnit Compliance Audit (A1-static no-class / X3-static no-module-state / X5 fire-and-forget)"
           fail=0
@@ -64,6 +81,7 @@ jobs:
 
       - name: Run React-UI Compliance Audit
         id: react-ui-audit
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           echo "::group::React-UI Compliance Audit"
           cd packages/react-ui
@@ -86,6 +104,7 @@ jobs:
 
       - name: Run Frontend Compliance Audit
         id: frontend-audit
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           echo "::group::Frontend Compliance Audit"
           cd apps/frontend

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -452,15 +452,33 @@ PARTICIPANT's screen instead of printing it here — the same act as a plain
 `browse`, with a different audience, which is why it is a flag and not a
 second verb. It emits `browse:resource-open`, a domain signal the viewer
 resolves into its own route; the launcher never learns a URL. `--browser`
-needs a resourceId and refuses to combine with `--json`, `--annotations` or
-`--entity-types`, since each of those names a local rendering and the pair
-would state two destinations at once.
+refuses to combine with `--json`, `--annotations` or `--entity-types`, since
+each of those names a local rendering and the pair would state two
+destinations at once.
+
+`semiont browse --annotation <id> --browser` opens **one annotation** the same
+way (`browse:click`): the viewer selects that entry in its annotations panel
+and scrolls to it. Where a `beckon` only *points*, this *opens* — the two are
+distinct moves, not synonyms.
+
+That form takes **no resourceId**, and rejects one rather than ignoring it. An
+annotation id names exactly one annotation on exactly one resource, so the id
+is the whole address; the wire carries nothing else. Accepting a resourceId
+the launcher never sends would hand the caller a second id to keep consistent
+for no benefit — and since verifying the pair would need a read this signal
+deliberately does not perform, a mismatched pair could only be echoed back as
+a lie.
+
+`--annotation` (open one, remotely) sits beside `--annotations` (list them
+here). They are one keystroke apart and mean opposite things, so they refuse
+each other with a message that says so.
 
 Every emit now reports how many subscribers the backend's target subject had
 **at dispatch**, and the verbs say so plainly:
 
 ```
 ✓ Opened res-42 in the Browser (2 subscribers — broadcast, so still no confirmation anyone looked)
+✓ Opened annotation ann-9 in the Browser (2 subscribers — broadcast, so still no confirmation anyone looked)
 ✓ Beckoned toward res-42 (ann-9) — nothing is subscribed to beckon:focus, so no one received it
 ```
 
@@ -471,11 +489,11 @@ the backend publishes unconditionally, so before this an emit into an empty
 room returned a clean ✓.
 
 `beckon` exits 0 into an empty room — a beckon is genuinely fire-and-forget,
-and an empty room is a fact, not a failure. **`browse --browser` does not.** It
-asked for a specific outcome, a resource on a participant's screen, and zero
-subscribers means that did not happen; a tour script running under `set -e`
-should stop rather than narrate on. So it probes the Browser and says which of
-three things is true:
+and an empty room is a fact, not a failure. **`browse --browser` does not,** in
+either form. It asked for a specific outcome, something on a participant's
+screen, and zero subscribers means that did not happen; a tour script running
+under `set -e` should stop rather than narrate on. So it probes the Browser and
+says which of three things is true:
 
 ```
 ✗ Nobody saw res-42 — nothing is subscribed to browse:resource-open.
@@ -494,6 +512,11 @@ The two failures are independent — the Browser is the frontend *container*,
 and what has to be watching it is a human's *web browser* — so the messages
 keep those words distinct. A container that exists but is not answering gets
 its own third sentence rather than being flattened into either.
+
+The annotation form reports the same three ways, naming what it sent and the
+command that retries *it*: `Nobody saw annotation ann-9 — nothing is subscribed
+to browse:click`, with `semiont browse --annotation ann-9 --browser --launch`.
+A retry line that named the wrong form would be worse than none.
 
 `--launch` starts the Browser when none is running, through the same
 `start --service frontend` that pulls, publishes the port and waits for health.

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -468,8 +468,44 @@ That number is deliberately not called delivery: a subscriber is a connection,
 not a pair of eyes, and these channels have no reply. But zero subscribers is a
 fact worth saying out loud — `/bus/subscribe` enforces no channel allowlist and
 the backend publishes unconditionally, so before this an emit into an empty
-room returned a clean ✓. Exit stays 0 either way; an empty room is a fact, not
-a failure.
+room returned a clean ✓.
+
+`beckon` exits 0 into an empty room — a beckon is genuinely fire-and-forget,
+and an empty room is a fact, not a failure. **`browse --browser` does not.** It
+asked for a specific outcome, a resource on a participant's screen, and zero
+subscribers means that did not happen; a tour script running under `set -e`
+should stop rather than narrate on. So it probes the Browser and says which of
+three things is true:
+
+```
+✗ Nobody saw res-42 — nothing is subscribed to browse:resource-open.
+  The Browser is running, but no web browser is watching it.
+  Open http://localhost:3000, log in, then run this again.
+```
+
+```
+✗ Nobody saw res-42 — nothing is subscribed to browse:resource-open.
+  No Browser is running on this machine.
+  Start it:  semiont browse res-42 --browser --launch
+  or:        semiont start --service frontend
+```
+
+The two failures are independent — the Browser is the frontend *container*,
+and what has to be watching it is a human's *web browser* — so the messages
+keep those words distinct. A container that exists but is not answering gets
+its own third sentence rather than being flattened into either.
+
+`--launch` starts the Browser when none is running, through the same
+`start --service frontend` that pulls, publishes the port and waits for health.
+It starts a *container*: it cannot open a window or log anyone in, so it still
+reports that nobody is watching. Starting one is never implicit — a read verb's
+flag does not get to bring a container up as a side effect.
+
+The launcher names an **origin** and never a path. `http://localhost:3000` is
+its own fact — it publishes that port and records the endpoint — while
+`/know/resource/<id>` belongs to the frontend, and mirroring a route here would
+break silently the day the route moves. `--browser-url` overrides the recorded
+origin (precedence: flag → record → `http://localhost:3000`).
 
 ### Watching a KB
 

--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -691,16 +692,44 @@ func runtimeCmd(base string, args []string) {
 			fmt.Fprintln(os.Stderr, "Error: no such volume")
 			os.Exit(1)
 		}
-	case "list":
-		// Apple container format: name in column 1.
-		if os.Getenv("FAKERT_STACK_RUNTIME") == base {
-			fmt.Println("ID              IMAGE                       STATE")
-			fmt.Println("semiont-backend ghcr.io/x/semiont-backend  running")
+	case "list", "ps":
+		// Two callers, two questions:
+		//
+		//   list / ps            "which runtime is the stack on?" — answered by
+		//                        FAKERT_STACK_RUNTIME, as before.
+		//   list -a / ps -a      "which semiont containers EXIST here?" — the
+		//                        teardown's question. Answered from
+		//                        FAKERT_STATE_<svc>, the same source `inspect`
+		//                        uses, so the fake cannot tell the launcher a
+		//                        container exists and then deny it on inspect.
+		all := false
+		for _, a := range args {
+			if a == "-a" || a == "--all" {
+				all = true
+			}
 		}
-	case "ps":
-		// docker/podman `ps --format {{.Names}}`: bare names.
+		header := base == "container" // Apple container prints a header row
+		if all {
+			names := existingContainers()
+			if header && len(names) > 0 {
+				fmt.Println("ID              IMAGE                       STATE")
+			}
+			for _, n := range names {
+				if header {
+					fmt.Printf("%s ghcr.io/x/%s  running\n", n, strings.TrimPrefix(n, "semiont-"))
+				} else {
+					fmt.Println(n)
+				}
+			}
+			return
+		}
 		if os.Getenv("FAKERT_STACK_RUNTIME") == base {
-			fmt.Println("semiont-backend")
+			if header {
+				fmt.Println("ID              IMAGE                       STATE")
+				fmt.Println("semiont-backend ghcr.io/x/semiont-backend  running")
+			} else {
+				fmt.Println("semiont-backend")
+			}
 		}
 	case "logs":
 		name := strings.TrimPrefix(handleName(args[len(args)-1]), "semiont-")
@@ -1143,6 +1172,47 @@ var busScripted = map[string]bool{
 	"bind:update-body":              true,
 	"match:search-requested":        true,
 	"job:create":                    true,
+}
+
+// existingContainers is every semiont-* container that exists here, from BOTH
+// sources — and it must be both, or the fake lies to a teardown:
+//
+//	FAKERT_STATE_<svc>   containers the TEST scripted as pre-existing
+//	serve-<name>.pid     containers THIS RUN started (`run -d --name`), which
+//	                     no env var knows about
+//
+// The second source is the one a restart depends on: a launcher that starts a
+// stack and then starts it again must find its own containers to tear them
+// down. Before the teardown asked (it fired stop/rm blindly), so the gap was
+// invisible; now that it asks, an incomplete answer becomes a name collision.
+//
+// Sorted, so the argv goldens are stable.
+func existingContainers() []string {
+	seen := map[string]bool{}
+	for _, kv := range os.Environ() {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || v == "" || !strings.HasPrefix(k, "FAKERT_STATE_") {
+			continue
+		}
+		seen["semiont-"+strings.TrimPrefix(k, "FAKERT_STATE_")] = true
+	}
+	if dir := os.Getenv("FAKERT_DIR"); dir != "" {
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			n := e.Name()
+			if strings.HasPrefix(n, "serve-") && strings.HasSuffix(n, ".pid") {
+				seen[strings.TrimSuffix(strings.TrimPrefix(n, "serve-"), ".pid")] = true
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		if strings.HasPrefix(n, "semiont-") {
+			out = append(out, n)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 func killServe(name string) bool {

--- a/apps/launcher/internal/launcher/beckon.go
+++ b/apps/launcher/internal/launcher/beckon.go
@@ -126,7 +126,7 @@ func Beckon(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 
 	// Two signals, one act (GUIDED-TOUR P6). Focus SCROLLS, so beckoning three
 	// references in a row scroll-fights and only the last survives; sparkle is

--- a/apps/launcher/internal/launcher/bind.go
+++ b/apps/launcher/internal/launcher/bind.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	semiont "github.com/The-AI-Alliance/semiont/packages/sdk-go"
-	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
 )
 
 const bindUsage = `Usage: semiont bind <resourceId> <annotationId> <targetResourceId>
@@ -93,7 +92,7 @@ func Bind(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 
 	var item semiont.AnnotationBody
 	purpose := semiont.BodyPurpose("linking")

--- a/apps/launcher/internal/launcher/browse.go
+++ b/apps/launcher/internal/launcher/browse.go
@@ -144,7 +144,7 @@ func Browse(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 
 	// --browser is the one path in this file that SIGNALS instead of reading:
 	// a fire-and-forget emit, no correlation id, no reply, nothing rendered

--- a/apps/launcher/internal/launcher/browse.go
+++ b/apps/launcher/internal/launcher/browse.go
@@ -23,19 +23,28 @@ const browseUsage = `Usage: semiont browse [<resourceId>] [options]
 Read the knowledge base. With no resourceId, lists resources; with one,
 shows that resource (add --annotations for its annotations).
 
-With --browser, the resource opens on the PARTICIPANT's screen instead of
-printing here — the same act, a different audience. That needs a web browser
-watching the Browser; when none is, the command says so and exits non-zero,
-so a tour script can stop rather than narrate to an empty room.
+With --browser, the act lands on the PARTICIPANT's screen instead of printing
+here — the same act, a different audience. Two things can be opened:
+
+  semiont browse <resourceId> --browser              a resource
+  semiont browse --annotation <id> --browser         one annotation, opened
+
+The annotation form takes no resourceId: an annotation id names exactly one
+annotation on exactly one resource, so the id is the whole address.
+
+Either form needs a web browser watching the Browser; when none is, the
+command says so and exits non-zero, so a tour script can stop rather than
+narrate to an empty room.
 
 Options:
-  --browser             Open <resourceId> in the Browser instead of printing it
+  --browser             Open it in the Browser instead of printing here
+  --annotation <id>     With --browser: open ONE annotation (not --annotations)
   --launch              With --browser: start the Browser if none is running
   --browser-url <url>   Browser origin to report (default: the recorded one)
   --search <text>       Filter the list by text
   --entity-type <name>  Filter the list by entity type
   --limit <n>           Maximum results (default 20)
-  --annotations         With a resourceId: show its annotations instead
+  --annotations         With a resourceId: show its annotations here
   --entity-types        List the KB's entity-type vocabulary
   --json                Raw JSON reply instead of a table
   --repo <owner/name>   Target a codespace stack (default: the local stack)
@@ -47,7 +56,7 @@ Requires a session:  semiont login --email <address>
 
 func Browse(args []string) int {
 	u := newUI(false)
-	var resourceID, search, entityType, repo, browserURL string
+	var resourceID, search, entityType, repo, browserURL, annotation string
 	limit := 20
 	annotations, entityTypes, asJSON, wantLocal := false, false, false, false
 	toBrowser, launch := false, false
@@ -105,6 +114,12 @@ func Browse(args []string) int {
 			asJSON = true
 		case "--browser":
 			toBrowser = true
+		case "--annotation":
+			v, ok := val()
+			if !ok {
+				return 1
+			}
+			annotation = v
 		case "--launch":
 			launch = true
 		case "--browser-url":
@@ -128,6 +143,14 @@ func Browse(args []string) int {
 			resourceID = a
 		}
 	}
+	// --annotation and --annotations are one keystroke apart and mean opposite
+	// things: one DRIVES a remote viewer to a single annotation, the other
+	// RENDERS a list here. Name the trap — "conflicting flags" is exactly the
+	// message a typo needs and does not get.
+	if annotation != "" && annotations {
+		u.fail("--annotation <id> opens ONE annotation on the participant's screen; --annotations (plural) lists them here. Pick one.")
+		return 1
+	}
 	if annotations && resourceID == "" {
 		u.fail("--annotations needs a resourceId: semiont browse <resourceId> --annotations")
 		return 1
@@ -141,11 +164,23 @@ func Browse(args []string) int {
 			flag string
 		}{{asJSON, "--json"}, {annotations, "--annotations"}, {entityTypes, "--entity-types"}} {
 			if conflict.set {
-				u.fail("--browser opens the resource in the Browser; %s renders it here. Pick one.", conflict.flag)
+				u.fail("--browser opens it in the Browser; %s renders it here. Pick one.", conflict.flag)
 				return 1
 			}
 		}
-		if resourceID == "" {
+		// An annotation id names exactly one annotation on exactly one
+		// resource, so this form carries no resourceId — on the wire OR here.
+		// Accepting one the launcher never sends would put the driver back in
+		// charge of keeping two ids consistent, which is the redundancy
+		// BrowseClickEvent was trimmed of; and since verifying the pair would
+		// take a read this verb must not do, an unmatched pair could only be
+		// echoed back as a lie.
+		if annotation != "" {
+			if resourceID != "" {
+				u.fail("--annotation %s already names one annotation on one resource; drop the resourceId %q.", annotation, resourceID)
+				return 1
+			}
+		} else if resourceID == "" {
 			u.fail("--browser needs a resourceId: semiont browse <resourceId> --browser")
 			fmt.Fprintln(os.Stderr, "  (Opening the resource LIST in the Browser is a different route and is not supported yet.)")
 			return 1
@@ -157,7 +192,7 @@ func Browse(args []string) int {
 	for _, dep := range []struct {
 		set  bool
 		flag string
-	}{{launch, "--launch"}, {browserURL != "", "--browser-url"}} {
+	}{{launch, "--launch"}, {browserURL != "", "--browser-url"}, {annotation != "", "--annotation"}} {
 		if dep.set && !toBrowser {
 			u.fail("%s only applies with --browser.", dep.flag)
 			return 1
@@ -175,8 +210,21 @@ func Browse(args []string) int {
 	// locally. It returns here rather than threading a "did we render" flag
 	// through the request/reply path below, which stays a pure read.
 	if toBrowser {
-		subscribers, err := cli.Emit(context.Background(), bus.BrowseResourceOpen,
-			semiont.BrowseResourceOpenEvent{ResourceId: resourceID}, "")
+		d := drive{
+			subject: resourceID,
+			channel: bus.BrowseResourceOpen,
+			payload: semiont.BrowseResourceOpenEvent{ResourceId: resourceID},
+			retry:   fmt.Sprintf("semiont browse %s --browser", resourceID),
+		}
+		if annotation != "" {
+			d = drive{
+				subject: "annotation " + annotation,
+				channel: bus.BrowseClick,
+				payload: semiont.BrowseClickEvent{AnnotationId: annotation},
+				retry:   fmt.Sprintf("semiont browse --annotation %s --browser", annotation),
+			}
+		}
+		subscribers, err := cli.Emit(context.Background(), d.channel, d.payload, "")
 		if err != nil {
 			return busFail(u, "browse", err)
 		}
@@ -185,9 +233,9 @@ func Browse(args []string) int {
 		// happy path must not pay for an HTTP round trip it never reads, and
 		// -1 ("count unknown") is not evidence of an empty room.
 		if subscribers == 0 {
-			return nobodySaw(u, resourceID, browserURL, launch)
+			return nobodySaw(u, d, browserURL, launch)
 		}
-		u.ok("Opened %s in the Browser %s", resourceID, audienceNote(u, subscribers, string(bus.BrowseResourceOpen)))
+		u.ok("Opened %s in the Browser %s", d.subject, audienceNote(u, subscribers, string(d.channel)))
 		return 0
 	}
 
@@ -230,6 +278,17 @@ func Browse(args []string) int {
 	return renderBrowse(u, op, reply)
 }
 
+// drive is one `--browser` act: what was sent, on which channel, and the
+// command that would retry it. It exists so the empty-room report below is
+// written once — a resource and an annotation fail for identical reasons, and
+// a second copy of that three-message branch would drift from this one.
+type drive struct {
+	subject string // how to name it to a human: "res-42", "annotation ann-9"
+	channel bus.Channel
+	payload any
+	retry   string // the exact command, minus --launch
+}
+
 // nobodySaw explains a `--browser` emit that reached zero subscribers, and
 // fails the command. Three situations reach here and they want three
 // different things said — collapsing them into one "not available" is the
@@ -244,7 +303,7 @@ func Browse(args []string) int {
 // asked for a specific outcome — a resource on a participant's screen — and
 // it did not happen. A tour that narrates on to step 2 is worse than one that
 // stops.
-func nobodySaw(u *ui, resourceID, override string, launch bool) int {
+func nobodySaw(u *ui, d drive, override string, launch bool) int {
 	p := browserTarget(loadStackSet(), override)
 	if !p.Running && launch {
 		next, ok := launchBrowser(u, override)
@@ -254,7 +313,7 @@ func nobodySaw(u *ui, resourceID, override string, launch bool) int {
 		p = next
 	}
 
-	u.fail("Nobody saw %s — nothing is subscribed to %s.", resourceID, bus.BrowseResourceOpen)
+	u.fail("Nobody saw %s — nothing is subscribed to %s.", d.subject, d.channel)
 	if p.Running {
 		// The Browser CONTAINER is up; what is missing is a human's web
 		// browser pointed at it. Those two fail independently — this branch
@@ -268,7 +327,7 @@ func nobodySaw(u *ui, resourceID, override string, launch bool) int {
 	} else {
 		fmt.Fprintf(os.Stderr, "  The Browser container is %s and is not answering on %s.\n", p.State, p.Endpoint)
 	}
-	fmt.Fprintf(os.Stderr, "  Start it:  semiont browse %s --browser --launch\n", resourceID)
+	fmt.Fprintf(os.Stderr, "  Start it:  %s --launch\n", d.retry)
 	fmt.Fprintln(os.Stderr, "  or:        semiont start --service frontend")
 	return 1
 }

--- a/apps/launcher/internal/launcher/browse.go
+++ b/apps/launcher/internal/launcher/browse.go
@@ -24,10 +24,14 @@ Read the knowledge base. With no resourceId, lists resources; with one,
 shows that resource (add --annotations for its annotations).
 
 With --browser, the resource opens on the PARTICIPANT's screen instead of
-printing here — the same act, a different audience.
+printing here — the same act, a different audience. That needs a web browser
+watching the Browser; when none is, the command says so and exits non-zero,
+so a tour script can stop rather than narrate to an empty room.
 
 Options:
   --browser             Open <resourceId> in the Browser instead of printing it
+  --launch              With --browser: start the Browser if none is running
+  --browser-url <url>   Browser origin to report (default: the recorded one)
   --search <text>       Filter the list by text
   --entity-type <name>  Filter the list by entity type
   --limit <n>           Maximum results (default 20)
@@ -43,10 +47,10 @@ Requires a session:  semiont login --email <address>
 
 func Browse(args []string) int {
 	u := newUI(false)
-	var resourceID, search, entityType, repo string
+	var resourceID, search, entityType, repo, browserURL string
 	limit := 20
 	annotations, entityTypes, asJSON, wantLocal := false, false, false, false
-	toBrowser := false
+	toBrowser, launch := false, false
 
 	for i := 0; i < len(args); i++ {
 		a := args[i]
@@ -101,6 +105,14 @@ func Browse(args []string) int {
 			asJSON = true
 		case "--browser":
 			toBrowser = true
+		case "--launch":
+			launch = true
+		case "--browser-url":
+			v, ok := val()
+			if !ok {
+				return 1
+			}
+			browserURL = v
 		case "--help", "-h":
 			fmt.Print(browseUsage)
 			return 0
@@ -139,6 +151,18 @@ func Browse(args []string) int {
 			return 1
 		}
 	}
+	// Starting a container is a large action for a READ verb to take, so it
+	// stays explicit twice over: --launch opts in, and it is refused outside
+	// the one destination it could possibly mean (BROWSER-HANDOFF D4).
+	for _, dep := range []struct {
+		set  bool
+		flag string
+	}{{launch, "--launch"}, {browserURL != "", "--browser-url"}} {
+		if dep.set && !toBrowser {
+			u.fail("%s only applies with --browser.", dep.flag)
+			return 1
+		}
+	}
 
 	t, ok := verbSession(u, "browse", repo, wantLocal)
 	if !ok {
@@ -155,6 +179,13 @@ func Browse(args []string) int {
 			semiont.BrowseResourceOpenEvent{ResourceId: resourceID}, "")
 		if err != nil {
 			return busFail(u, "browse", err)
+		}
+		// A count of exactly zero is the one case the launcher can act on: the
+		// signal was published and nobody was there. Probe only then — the
+		// happy path must not pay for an HTTP round trip it never reads, and
+		// -1 ("count unknown") is not evidence of an empty room.
+		if subscribers == 0 {
+			return nobodySaw(u, resourceID, browserURL, launch)
 		}
 		u.ok("Opened %s in the Browser %s", resourceID, audienceNote(u, subscribers, string(bus.BrowseResourceOpen)))
 		return 0
@@ -197,6 +228,74 @@ func Browse(args []string) int {
 		return 0
 	}
 	return renderBrowse(u, op, reply)
+}
+
+// nobodySaw explains a `--browser` emit that reached zero subscribers, and
+// fails the command. Three situations reach here and they want three
+// different things said — collapsing them into one "not available" is the
+// failure mode this exists to avoid (BROWSER-HANDOFF P2):
+//
+//	Browser up, nobody watching → the ORIGIN, and "open it and log in"
+//	Browser absent              → --launch, or start --service frontend
+//	Browser there but not answering → say so; the same two fix-its apply
+//
+// The exit code is the point for a tour script: `beckon` exits 0 with no
+// audience because a beckon is genuinely fire-and-forget, but here the caller
+// asked for a specific outcome — a resource on a participant's screen — and
+// it did not happen. A tour that narrates on to step 2 is worse than one that
+// stops.
+func nobodySaw(u *ui, resourceID, override string, launch bool) int {
+	p := browserTarget(loadStackSet(), override)
+	if !p.Running && launch {
+		next, ok := launchBrowser(u, override)
+		if !ok {
+			return 1
+		}
+		p = next
+	}
+
+	u.fail("Nobody saw %s — nothing is subscribed to %s.", resourceID, bus.BrowseResourceOpen)
+	if p.Running {
+		// The Browser CONTAINER is up; what is missing is a human's web
+		// browser pointed at it. Those two fail independently — this branch
+		// is the proof — so the words stay distinct in every message here.
+		fmt.Fprintln(os.Stderr, "  The Browser is running, but no web browser is watching it.")
+		fmt.Fprintf(os.Stderr, "  Open %s, log in, then run this again.\n", p.Endpoint)
+		return 1
+	}
+	if p.State == "" {
+		fmt.Fprintln(os.Stderr, "  No Browser is running on this machine.")
+	} else {
+		fmt.Fprintf(os.Stderr, "  The Browser container is %s and is not answering on %s.\n", p.State, p.Endpoint)
+	}
+	fmt.Fprintf(os.Stderr, "  Start it:  semiont browse %s --browser --launch\n", resourceID)
+	fmt.Fprintln(os.Stderr, "  or:        semiont start --service frontend")
+	return 1
+}
+
+// launchBrowser is `--launch`: it starts the Browser through the existing
+// `semiont start --service frontend` rather than re-deriving the run. That
+// path already pulls the image, publishes the port, records the endpoint and
+// WAITS for health (flowBrowser) — on a cold pull the container exists long
+// before it answers, and a message printed too early sends the user to an
+// origin that refuses the connection.
+//
+// It starts a CONTAINER. It cannot open a window or log anyone in, so its
+// caller still prints the "nobody is watching" message afterwards.
+func launchBrowser(u *ui, override string) (browserProbe, bool) {
+	// The runtime is named explicitly. A bare start on a machine whose only
+	// recorded stacks are codespaces dispatches to the cloud (start.go), and
+	// waking a paid VM is not what --launch asked for. The Browser is
+	// machine-level — it serves every KB here — so it is always local.
+	rt, ok := selectRuntime(u, "")
+	if !ok {
+		return browserProbe{}, false
+	}
+	if code := Start([]string{"--service", "frontend", "--runtime", rt}); code != 0 {
+		u.fail("--launch could not start the Browser.")
+		return browserProbe{}, false
+	}
+	return browserTarget(loadStackSet(), override), true
 }
 
 // busFail turns a bus error into the launcher's voice: a rejection carries

--- a/apps/launcher/internal/launcher/browser_target_test.go
+++ b/apps/launcher/internal/launcher/browser_target_test.go
@@ -1,0 +1,245 @@
+package launcher
+
+// BROWSER-HANDOFF P1–P3, in process.
+//
+// The subject is the COLD case: `browse --browser` published a signal and
+// nobody was there to receive it. What the launcher says next is the whole
+// user-facing feature (D6/O1 — it never opens a window), so these tests assert
+// the message and the exit code, not just the branch taken.
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// liveOrigin is a Browser that answers — enough for probeHealth, which asks
+// only whether the origin responds.
+func liveOrigin(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// deadOrigin is an address nothing listens on: bind a port, learn its number,
+// release it. Picking a number by hand is how a test starts passing for the
+// wrong reason on a machine that happens to run something there.
+func deadOrigin(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	l.Close()
+	return "http://" + addr
+}
+
+// noRuntimes empties PATH so installedRuntimes() finds nothing — the "no
+// Browser container anywhere" half of the absent case, without depending on
+// what the developer's machine has installed.
+func noRuntimes(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+// recordBrowserFixture writes a Browser record into the fixture's stack.json,
+// which is what browserTarget reads when no --browser-url overrides it.
+func recordBrowserFixture(t *testing.T, b *serviceState) {
+	t.Helper()
+	path := filepath.Join(stateDir(), "stack.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ss stackSet
+	if err := json.Unmarshal(raw, &ss); err != nil {
+		t.Fatal(err)
+	}
+	ss.Browser = b
+	out, _ := json.MarshalIndent(&ss, "", "  ")
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ── P1: the probe ───────────────────────────────────────────────────────
+
+// The case the stable-name fallback exists for: the record carries a container
+// ID that no longer resolves, while the endpoint is plainly live. Before the
+// fallback, status printed "absent" beside a ✓.
+func TestBrowserTargetFallsBackToTheStableNameForAStaleID(t *testing.T) {
+	shim := t.TempDir()
+	// A docker that knows only `semiont-frontend`, so a lookup by the stale
+	// recorded ID fails exactly as the real one would.
+	script := "#!/bin/sh\nfor a in \"$@\"; do [ \"$a\" = semiont-frontend ] && { echo running; exit 0; }; done\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(shim, "docker"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shim)
+
+	ss := &stackSet{Browser: &serviceState{
+		ID: "0000deadbeef", Runtime: "docker", Endpoint: liveOrigin(t),
+	}}
+	p := browserTarget(ss, "")
+	if !p.Running {
+		t.Errorf("Running = false for an endpoint that answers")
+	}
+	if p.State != "running" {
+		t.Errorf("State = %q, want %q from the semiont-frontend fallback", p.State, "running")
+	}
+}
+
+// Precedence is flag → record → default, and the flag has to win or
+// --browser-url could not name a Browser the record has never heard of.
+func TestBrowserTargetPrefersTheOverrideOverTheRecord(t *testing.T) {
+	noRuntimes(t)
+	live := liveOrigin(t)
+	ss := &stackSet{Browser: &serviceState{Endpoint: deadOrigin(t)}}
+
+	if p := browserTarget(ss, live); !p.Running || p.Endpoint != live {
+		t.Errorf("override ignored: endpoint %q running %v, want %q true", p.Endpoint, p.Running, live)
+	}
+	if p := browserTarget(&stackSet{}, ""); p.Endpoint != "http://localhost:3000" {
+		t.Errorf("no record, no flag: endpoint %q, want the default", p.Endpoint)
+	}
+}
+
+// ── P2: what it says when nobody was there ──────────────────────────────
+
+func TestBrowseBrowserRefusesWhenNoOneIsWatching(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		origin  func(*testing.T) string
+		want    []string
+		notWant []string
+	}{
+		{
+			// Row 2: the container is up, so the origin is the useful thing to
+			// print — someone has to point a web browser at it and log in.
+			name:    "Browser running, nobody watching",
+			origin:  liveOrigin,
+			want:    []string{"Nobody saw res-42", "no web browser is watching", "log in"},
+			notWant: []string{"--launch"},
+		},
+		{
+			// Row 3: there is nothing to open, so naming the origin would send
+			// the user to a refused connection. Name the commands instead.
+			name:    "no Browser at all",
+			origin:  deadOrigin,
+			want:    []string{"Nobody saw res-42", "No Browser is running", "--launch", "semiont start --service frontend"},
+			notWant: []string{"log in"},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake, restore := withFake(t)
+			defer restore()
+			noRuntimes(t)
+			fake.Subscribers = 0
+
+			out, errOut := captureOutput(t, func() {
+				if code := Browse([]string{"res-42", "--browser", "--browser-url", c.origin(t)}); code != 1 {
+					t.Errorf("exit %d, want 1 — a tour script must be able to stop here", code)
+				}
+			})
+			all := out + errOut
+			mustContainAll(t, "refusal", all, c.want...)
+			for _, n := range c.notWant {
+				if strings.Contains(all, n) {
+					t.Errorf("refusal should not mention %q; full text:\n%s", n, all)
+				}
+			}
+			// The signal still went out. Publishing to an empty room is not an
+			// error, and suppressing the emit would make the count unknowable.
+			if len(fake.Emits) != 1 {
+				t.Errorf("want the emit to have happened anyway, got %v", fake.Emits)
+			}
+		})
+	}
+}
+
+// A container that exists but does not answer is neither row: saying "no
+// Browser is running" would be false, and offering its origin would be
+// useless. It gets its own sentence and the same two fix-its.
+func TestBrowseBrowserNamesAContainerThatIsNotAnswering(t *testing.T) {
+	shim := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shim, "docker"), []byte("#!/bin/sh\necho exited\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fake, restore := withFake(t)
+	defer restore()
+	t.Setenv("PATH", shim)
+	fake.Subscribers = 0
+	recordBrowserFixture(t, &serviceState{Runtime: "docker", Endpoint: deadOrigin(t)})
+
+	out, errOut := captureOutput(t, func() {
+		if code := Browse([]string{"res-42", "--browser"}); code != 1 {
+			t.Errorf("exit %d, want 1", code)
+		}
+	})
+	mustContainAll(t, "stale container", out+errOut,
+		"container is exited", "semiont start --service frontend")
+}
+
+// A count of -1 means the server did not tell us. That is not an empty room,
+// and treating it as one would fail every tour step against a backend too old
+// to report the count.
+func TestBrowseBrowserDoesNotRefuseOnAnUnknownCount(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Subscribers = -1
+
+	out := captureStdout(t, func() {
+		if code := Browse([]string{"res-42", "--browser"}); code != 0 {
+			t.Fatalf("an unknown count must not fail the command: exit %d", code)
+		}
+	})
+	mustContainAll(t, "unknown count", out, "no delivery confirmation")
+}
+
+// ── P3: --launch is opt-in, and only means one thing ────────────────────
+
+func TestBrowseLaunchAndBrowserURLRequireBrowser(t *testing.T) {
+	for _, args := range [][]string{
+		{"res-42", "--launch"},
+		{"res-42", "--browser-url", "http://localhost:3000"},
+	} {
+		fake, restore := withFake(t)
+		out, errOut := captureOutput(t, func() {
+			if code := Browse(args); code == 0 {
+				t.Errorf("%v must refuse", args)
+			}
+		})
+		mustContainAll(t, "refusal", out+errOut, "only applies with --browser")
+		if len(fake.Emits) != 0 || len(fake.Requests) != 0 {
+			t.Errorf("%v still reached the wire: %v %v", args, fake.Emits, fake.Ops())
+		}
+		restore()
+	}
+}
+
+// Without --launch the launcher must not start anything — D4: a read verb's
+// flag does not get to bring a container up as a side effect. An empty PATH
+// makes any attempt fail loudly rather than silently succeeding on a machine
+// that has a runtime installed.
+func TestBrowseBrowserDoesNotStartTheBrowserUnasked(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	noRuntimes(t)
+	fake.Subscribers = 0
+
+	_, errOut := captureOutput(t, func() {
+		if code := Browse([]string{"res-42", "--browser", "--browser-url", deadOrigin(t)}); code != 1 {
+			t.Errorf("exit %d, want 1", code)
+		}
+	})
+	if strings.Contains(errOut, "No container runtime found") {
+		t.Error("browse --browser tried to start the Browser without --launch")
+	}
+}

--- a/apps/launcher/internal/launcher/codespace.go
+++ b/apps/launcher/internal/launcher/codespace.go
@@ -1619,6 +1619,8 @@ const forwardBindTries = 30
 
 // forwardSettle is how long a tunnel must outlive its first connection before
 // it counts as working — the death it may die arrives just after the dial.
+// LOAD-BEARING: see the select in tryForward for why the caller's death watch
+// cannot replace it.
 const forwardSettle = time.Second
 
 // tryForward makes one attempt and reports how it went, with gh's own last
@@ -1638,6 +1640,23 @@ func tryForward(u *ui, name string, kbPort int) (int, <-chan struct{}, forwardOu
 			// channel through and exits — so "the dial worked" is not "the
 			// tunnel works" (live 2026-07-28: the bind check passed and the
 			// forward died a second later). It has to survive being used.
+			//
+			// The settle is NOT redundant with the caller's death watch, and
+			// removing it (attempted 2026-08-14) fails
+			// TestCodespaceWaitsOutATransientSshOutage in 0.04 s. The two
+			// watchers classify the SAME event differently:
+			//
+			//   here    a death just after the dial means the remote port is
+			//           empty — forwardRemoteEmpty, which establishForward
+			//           RETRIES while the codespace is still coming up.
+			//   caller  a death during the health gate is a forward FAULT —
+			//           it fails the start and tells you to respawn.
+			//
+			// Return early and a not-yet-ready stack is reported as a broken
+			// forward instead of being waited out, which is precisely the bug
+			// the 2026-07-28 incident left behind. The second buys the
+			// distinction between "not up yet" and "broken", and nothing else
+			// in the flow can make it.
 			select {
 			case <-dead:
 				ghErr := lastForwardError(pid)

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -22,7 +22,7 @@ type executor interface {
 	// --- effects ---
 	stopRm(name string) bool        // teardown; reports whether anything existed
 	sweepStray(names []string) bool // stop+rm the names under every OTHER installed runtime; reports whether anything existed
-	pause()                         // the settle sleep after teardown
+	settle(ports ...int)            // wait for torn-down ports to be released
 	sweepStaging()                  // /tmp/semiont-config.* removal (+ state forget)
 	portChecks(ports []portNeed) bool
 	portCheck(p portNeed) bool    // singular wording in plan mode
@@ -77,20 +77,70 @@ const (
 // --- live ---
 
 type liveExec struct {
-	u       *ui
-	rt      string
-	st      *stackState
-	version string // SEMIONT_VERSION, for records created lazily (--service mode)
-	root    string // KB root, ditto ("" for root-free services)
+	u  *ui
+	rt string
+	st *stackState
+	// existing: semiont-* container names per runtime, listed once and cached
+	// for the life of the command (see present).
+	existing map[string]map[string]bool
+	version  string // SEMIONT_VERSION, for records created lazily (--service mode)
+	root     string // KB root, ditto ("" for root-free services)
 	// plan lets record() stamp each role's configured models without every
 	// flow having to pass them; models are config truth, so they belong to
 	// the record the same way the driver does.
 	plan *launchPlan
 }
 
+// present lists the semiont-* containers that EXIST under a runtime — running
+// or stopped, because a stopped container still holds its name and the next
+// `run --name` fails on it.
+//
+// ONE list per runtime, cached for the life of the command. The teardown used
+// to ask by firing `stop` then `rm` at all nine names blindly, on every
+// installed runtime: 54 fork/execs to discover, usually, that nothing was
+// there. It also inferred "did anything exist?" from the exit codes of commands
+// it EXPECTED to fail, which is why the settle below then slept a second on a
+// maybe. Asking once is both faster and a straight answer.
+func (x *liveExec) present(rt string) map[string]bool {
+	if x.existing == nil {
+		x.existing = map[string]map[string]bool{}
+	}
+	if got, ok := x.existing[rt]; ok {
+		return got
+	}
+	names := map[string]bool{}
+	// The listing idiom the launcher already trusts (see logs.go stackRuntime),
+	// with -a so STOPPED containers are included — the ones a teardown most
+	// needs to find.
+	var out string
+	var err error
+	if rt == "container" {
+		out, err = capture(rt, "list", "-a")
+	} else {
+		out, err = capture(rt, "ps", "-a", "--format", "{{.Names}}")
+	}
+	if err == nil {
+		for _, line := range strings.Split(out, "\n") {
+			if f := strings.Fields(line); len(f) > 0 && strings.HasPrefix(f[0], "semiont-") {
+				names[f[0]] = true
+			}
+		}
+	}
+	// A runtime that cannot be listed yields an empty set, and every later
+	// stop/rm is skipped. That is the honest failure: unknown is not "present",
+	// and firing teardown at a runtime that would not answer a list is how the
+	// old code spent 18 spawns learning nothing.
+	x.existing[rt] = names
+	return names
+}
+
 func (x *liveExec) stopRm(name string) bool {
+	if !x.present(x.rt)[name] {
+		return false // not there; nothing to stop, nothing to remove
+	}
 	stopped := runSilent(x.rt, "stop", name) == nil
 	rmed := runSilent(x.rt, "rm", name) == nil
+	delete(x.existing[x.rt], name)
 	return stopped || rmed
 }
 
@@ -103,8 +153,12 @@ func (x *liveExec) sweepStray(names []string) bool {
 		if rt == x.rt {
 			continue
 		}
+		here := x.present(rt)
 		removed := 0
 		for _, c := range names {
+			if !here[c] {
+				continue
+			}
 			stopped := runSilent(rt, "stop", c) == nil
 			rmed := runSilent(rt, "rm", c) == nil
 			if stopped || rmed {
@@ -119,7 +173,9 @@ func (x *liveExec) sweepStray(names []string) bool {
 	return swept
 }
 
-func (x *liveExec) pause() { time.Sleep(time.Second) }
+// settle waits for the named ports to be released after a teardown. See
+// settlePorts: a condition, not a duration.
+func (x *liveExec) settle(ports ...int) { settlePorts(ports...) }
 
 func (x *liveExec) portCheck(p portNeed) bool {
 	return requirePortFree(x.u, p.port, p.label)
@@ -624,7 +680,7 @@ type planExec struct {
 func (x *planExec) p(args ...string)          { fmt.Println(renderCmd(x.rt, args...)) }
 func (x *planExec) c(format string, a ...any) { fmt.Printf("# "+format+"\n", a...) }
 func (x *planExec) stopRm(name string) bool   { x.p("stop", name); x.p("rm", name); return false }
-func (x *planExec) pause()                    {}
+func (x *planExec) settle(...int)             {} // plan mode tears nothing down
 func (x *planExec) sweepStaging()             { x.c("remove staged config copies: /tmp/semiont-config.*") }
 
 func (x *planExec) sweepStray(names []string) bool {

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -54,7 +54,9 @@ func flowFullStart(x executor, fc flowCtx) int {
 	// nothing removed there is nothing to settle, and every first start paid
 	// a second for it.
 	if removed > 0 || swept {
-		x.pause()
+		// Every port this start is about to claim, since the sweep may have
+		// released any of them.
+		x.settle(claimedPorts(fc)...)
 	}
 	if removed == 0 {
 		x.say(sayOK, "No prior containers")
@@ -179,7 +181,7 @@ func flowBrowser(x executor, version string, port int, forceRestart bool) int {
 			// with "already exists" on every runtime (Copilot review, PR
 			// #1064; the same reason stop.go always rm's).
 			x.stopRm("semiont-frontend")
-			x.pause()
+			x.settle(port)
 			if !x.portCheck(portNeed{port, "Frontend"}) {
 				return 1
 			}
@@ -397,7 +399,7 @@ func flowOllama(x executor, fc flowCtx, role string, rp rolePlan, addr string) i
 			// hold the name (latent since the --rm removal; surfaced by the
 			// same review).
 			x.stopRm("semiont-ollama")
-			x.pause()
+			x.settle(rp.Port)
 			if !x.portCheck(portNeed{rp.Port, "Ollama"}) {
 				return 1
 			}
@@ -508,11 +510,11 @@ func flowOneService(x executor, fc flowCtx) int {
 	// verifies stack-port release while the Browser deliberately keeps
 	// running on its port.
 	if svc != "inference" && svc != "frontend" {
+		ports := servicePortNeeds(svc, fc.plan, fc.opts)
 		if x.stopRm(roles[svc].container) {
 			x.say(sayLog, "Removed prior %s container", svc)
-			x.pause()
+			x.settle(portNumbers(ports)...)
 		}
-		ports := servicePortNeeds(svc, fc.plan, fc.opts)
 		if !x.portChecks(ports) {
 			return 1
 		}
@@ -652,4 +654,32 @@ func servicePortNeeds(svc string, plan *launchPlan, opts startOptions) []portNee
 		}
 	}
 	return ports
+}
+
+// portNumbers strips a port-need list to bare numbers, for settle.
+func portNumbers(needs []portNeed) []int {
+	out := make([]int, 0, len(needs))
+	for _, n := range needs {
+		out = append(out, n.port)
+	}
+	return out
+}
+
+// claimedPorts is every port this start intends to bind — what a preflight
+// sweep may have just released, and therefore what is worth waiting on.
+func claimedPorts(fc flowCtx) []int {
+	if fc.plan == nil {
+		return nil
+	}
+	seen := map[int]bool{}
+	out := []int{}
+	for _, rp := range fc.plan.Roles {
+		for _, p := range append([]int{rp.Port}, 0) {
+			if p != 0 && !seen[p] {
+				seen[p] = true
+				out = append(out, p)
+			}
+		}
+	}
+	return out
 }

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -53,10 +53,16 @@ func flowFullStart(x executor, fc flowCtx) int {
 	// The settle is for the runtime to release what we just tore down. With
 	// nothing removed there is nothing to settle, and every first start paid
 	// a second for it.
+	// The ports this start is about to claim — computed once and used twice:
+	// waited on here because the sweep may have just released any of them,
+	// then verified free below. Deriving the wait from a second, hand-rolled
+	// list is how the two drift: the earlier one missed the backend, the three
+	// sidecars and Neo4j's aux port (exactly what a torn-down stack still
+	// holds) while including ports for roles bound to a REMOTE service, which
+	// this start never binds.
+	checks := planPortChecks(fc.plan, fc.opts.observe)
 	if removed > 0 || swept {
-		// Every port this start is about to claim, since the sweep may have
-		// released any of them.
-		x.settle(claimedPorts(fc)...)
+		x.settle(portNumbers(checks)...)
 	}
 	if removed == 0 {
 		x.say(sayOK, "No prior containers")
@@ -64,7 +70,6 @@ func flowFullStart(x executor, fc flowCtx) int {
 		x.say(sayOK, "Removed %d prior container(s)", removed)
 	}
 
-	checks := planPortChecks(fc.plan, fc.opts.observe)
 	if !x.portChecks(checks) {
 		return 1
 	}
@@ -661,25 +666,6 @@ func portNumbers(needs []portNeed) []int {
 	out := make([]int, 0, len(needs))
 	for _, n := range needs {
 		out = append(out, n.port)
-	}
-	return out
-}
-
-// claimedPorts is every port this start intends to bind — what a preflight
-// sweep may have just released, and therefore what is worth waiting on.
-func claimedPorts(fc flowCtx) []int {
-	if fc.plan == nil {
-		return nil
-	}
-	seen := map[int]bool{}
-	out := []int{}
-	for _, rp := range fc.plan.Roles {
-		for _, p := range append([]int{rp.Port}, 0) {
-			if p != 0 && !seen[p] {
-				seen[p] = true
-				out = append(out, p)
-			}
-		}
 	}
 	return out
 }

--- a/apps/launcher/internal/launcher/frame.go
+++ b/apps/launcher/internal/launcher/frame.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	semiont "github.com/The-AI-Alliance/semiont/packages/sdk-go"
-	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
 )
 
 const frameUsage = `Usage: semiont frame --entity-type <name> [--entity-type <name> ...]
@@ -100,7 +99,7 @@ func Frame(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 
 	// One command per type: the protocol has no batch add (the SDK's
 	// addEntityTypes is the same loop). A rejection STOPS the run rather

--- a/apps/launcher/internal/launcher/frame_test.go
+++ b/apps/launcher/internal/launcher/frame_test.go
@@ -41,7 +41,7 @@ func TestFrameAddsEachEntityTypeSeparatelyInProcess(t *testing.T) {
 			t.Fatalf("frame: exit %d", code)
 		}
 	})
-	mustContain(t, "stdout", out, "Person", "Organization")
+	mustContainAll(t, "stdout", out, "Person", "Organization")
 
 	// TWO commands, in order — one per entity type. A verb that batched them
 	// into a single request, or dropped the second, passes any assertion that
@@ -50,8 +50,14 @@ func TestFrameAddsEachEntityTypeSeparatelyInProcess(t *testing.T) {
 		t.Fatalf("want 2 requests, got %d: %v", len(fake.Requests), fake.Requests)
 	}
 	for i, want := range []bus.Channel{"frame:add-entity-type", "frame:add-entity-type"} {
-		if fake.Requests[i] != want {
-			t.Errorf("request %d = %q, want %q", i, fake.Requests[i], want)
+		if fake.Requests[i].Channel != want {
+			t.Errorf("request %d = %q, want %q", i, fake.Requests[i].Channel, want)
+		}
+	}
+	// One tag per command, in the order given.
+	for i, tag := range []string{"Person", "Organization"} {
+		if got := bustest.JSON(fake.Requests[i].Payload); !strings.Contains(got, tag) {
+			t.Errorf("request %d payload %s missing %q", i, got, tag)
 		}
 	}
 }
@@ -64,12 +70,12 @@ func TestFrameStopsAtTheFirstRejectionInProcess(t *testing.T) {
 	// backend's own words. A plain error would take a different branch.
 	fake.RequestErr = &bus.RequestError{Channel: "frame:add-entity-type-failed", Message: "vocabulary is frozen"}
 
-	out := captureStdout(t, func() {
+	out, errOut := captureOutput(t, func() {
 		if code := Frame([]string{"--entity-type", "Person", "--entity-type", "Organization"}); code == 0 {
 			t.Fatal("a rejected add must fail the command")
 		}
 	})
-	_ = out // the message goes to stderr via u.fail; the count is the assertion
+	mustContainAll(t, "rejection", out+errOut, "vocabulary is frozen")
 
 	if len(fake.Requests) != 1 {
 		t.Errorf("frame kept going after a rejection: %d requests: %v", len(fake.Requests), fake.Requests)
@@ -77,7 +83,7 @@ func TestFrameStopsAtTheFirstRejectionInProcess(t *testing.T) {
 }
 
 // Argument refusals never reach a transport — they land before verbSession, so
-// they need neither a session nor a stack.
+// nothing should be sent, whichever stream the message goes to.
 func TestFrameArgumentRefusals(t *testing.T) {
 	for _, c := range []struct {
 		name string
@@ -90,25 +96,15 @@ func TestFrameArgumentRefusals(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			fake, restore := withFake(t)
 			defer restore()
-			out := captureStdout(t, func() {
+			out, errOut := captureOutput(t, func() {
 				if code := Frame(c.args); code == 0 {
 					t.Fatal("must refuse")
 				}
 			})
-			if !strings.Contains(out, c.want) && !strings.Contains(captureStderrHint, c.want) {
-				// usage goes to stdout; the positional refusal to stderr — assert
-				// the one we can see and pin the request count either way.
-				if c.want == "Usage: semiont frame" {
-					t.Errorf("stdout %q missing %q", out, c.want)
-				}
-			}
+			mustContainAll(t, "refusal", out+errOut, c.want)
 			if len(fake.Requests) != 0 || len(fake.Emits) != 0 {
 				t.Errorf("a refused argument still reached the wire: %v %v", fake.Requests, fake.Emits)
 			}
 		})
 	}
 }
-
-// captureStderrHint is a placeholder for the stderr path; the refusal test
-// asserts on the request count, which is the behaviour that matters.
-const captureStderrHint = ""

--- a/apps/launcher/internal/launcher/frame_test.go
+++ b/apps/launcher/internal/launcher/frame_test.go
@@ -1,0 +1,114 @@
+package launcher
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
+	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bustest"
+)
+
+// `semiont frame`, in process (SDK-GO-TRANSPORT P2). These were black-box
+// tests: build the binary, `start` a fake stack, `login`, then run the verb
+// against fakert's HTTP server — ~3 s each to observe two requests. The verb's
+// behaviour is entirely about WHAT it sends and WHEN it stops, which the
+// transport seam exposes directly.
+//
+// What is deliberately NOT covered here, and stays end-to-end: that the built
+// binary speaks HTTP the backend understands. One wire test per verb family
+// keeps that honest — see TestFrameOverTheWire.
+
+// withFake wires a fake transport plus the on-disk session state a verb needs,
+// and returns the fake and a restore func.
+func withFake(t *testing.T) (*bustest.Fake, func()) {
+	t.Helper()
+	verbFixture(t)
+	fake := bustest.NewFake()
+	restore := useTransport(func(base, token string) bus.Transport {
+		fake.Base, fake.Token = base, token
+		return fake
+	})
+	return fake, restore
+}
+
+func TestFrameAddsEachEntityTypeSeparatelyInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Replies["frame:add-entity-type"] = []byte(`{"correlationId":"c","response":{}}`)
+
+	out := captureStdout(t, func() {
+		if code := Frame([]string{"--entity-type", "Person", "--entity-type", "Organization"}); code != 0 {
+			t.Fatalf("frame: exit %d", code)
+		}
+	})
+	mustContain(t, "stdout", out, "Person", "Organization")
+
+	// TWO commands, in order — one per entity type. A verb that batched them
+	// into a single request, or dropped the second, passes any assertion that
+	// only looks at the last call.
+	if len(fake.Requests) != 2 {
+		t.Fatalf("want 2 requests, got %d: %v", len(fake.Requests), fake.Requests)
+	}
+	for i, want := range []bus.Channel{"frame:add-entity-type", "frame:add-entity-type"} {
+		if fake.Requests[i] != want {
+			t.Errorf("request %d = %q, want %q", i, fake.Requests[i], want)
+		}
+	}
+}
+
+func TestFrameStopsAtTheFirstRejectionInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	// A rejection arrives on the operation's failure channel, which the client
+	// surfaces as *bus.RequestError — the type busFail unwraps to print the
+	// backend's own words. A plain error would take a different branch.
+	fake.RequestErr = &bus.RequestError{Channel: "frame:add-entity-type-failed", Message: "vocabulary is frozen"}
+
+	out := captureStdout(t, func() {
+		if code := Frame([]string{"--entity-type", "Person", "--entity-type", "Organization"}); code == 0 {
+			t.Fatal("a rejected add must fail the command")
+		}
+	})
+	_ = out // the message goes to stderr via u.fail; the count is the assertion
+
+	if len(fake.Requests) != 1 {
+		t.Errorf("frame kept going after a rejection: %d requests: %v", len(fake.Requests), fake.Requests)
+	}
+}
+
+// Argument refusals never reach a transport — they land before verbSession, so
+// they need neither a session nor a stack.
+func TestFrameArgumentRefusals(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"nothing to add", nil, "Usage: semiont frame"},
+		{"bare positional", []string{"Person"}, "--entity-type"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake, restore := withFake(t)
+			defer restore()
+			out := captureStdout(t, func() {
+				if code := Frame(c.args); code == 0 {
+					t.Fatal("must refuse")
+				}
+			})
+			if !strings.Contains(out, c.want) && !strings.Contains(captureStderrHint, c.want) {
+				// usage goes to stdout; the positional refusal to stderr — assert
+				// the one we can see and pin the request count either way.
+				if c.want == "Usage: semiont frame" {
+					t.Errorf("stdout %q missing %q", out, c.want)
+				}
+			}
+			if len(fake.Requests) != 0 || len(fake.Emits) != 0 {
+				t.Errorf("a refused argument still reached the wire: %v %v", fake.Requests, fake.Emits)
+			}
+		})
+	}
+}
+
+// captureStderrHint is a placeholder for the stderr path; the refusal test
+// asserts on the request count, which is the behaviour that matters.
+const captureStderrHint = ""

--- a/apps/launcher/internal/launcher/gather.go
+++ b/apps/launcher/internal/launcher/gather.go
@@ -117,7 +117,7 @@ func Gather(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 
 	// The two gathers take DIFFERENT option sets — the resource variant
 	// traverses a graph, the annotation variant windows text around a mark.

--- a/apps/launcher/internal/launcher/limits.go
+++ b/apps/launcher/internal/launcher/limits.go
@@ -59,7 +59,7 @@ func fetchModelCeilings(st *stackState) modelCeilings {
 	if !ok || e.Token == "" {
 		return nil
 	}
-	reply, err := bus.NewClient(base, e.Token).Request(
+	reply, err := newTransport(base, e.Token).Request(
 		context.Background(),
 		bus.BrowseAgentsRequested,
 		semiont.BrowseAgentsRequest{},

--- a/apps/launcher/internal/launcher/listen.go
+++ b/apps/launcher/internal/launcher/listen.go
@@ -114,7 +114,7 @@ func Listen(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 
 	// Resource names, fetched ONCE before the stream opens. Not per event: a
 	// lookup is a correlated Request, which opens its own SSE connection, and
@@ -176,7 +176,7 @@ func Listen(args []string) int {
 // uses. Best effort by design: a KB that cannot answer, or answers partially,
 // costs the console nothing — every id still renders as an id. Failing the
 // whole `listen` because a cosmetic lookup failed would be the wrong trade.
-func prefetchResourceNames(cli *bus.Client) map[string]string {
+func prefetchResourceNames(cli bus.Transport) map[string]string {
 	names := map[string]string{}
 	ctx, cancel := context.WithTimeout(context.Background(), prefetchTimeout)
 	defer cancel()

--- a/apps/launcher/internal/launcher/mark.go
+++ b/apps/launcher/internal/launcher/mark.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	semiont "github.com/The-AI-Alliance/semiont/packages/sdk-go"
-	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
 )
 
 const markUsage = `Usage: semiont mark <resourceId> [selector] [body] [options]
@@ -148,7 +147,7 @@ func Mark(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 
 	if deleteID != "" {
 		_, err := cli.Request(context.Background(), "mark:delete",

--- a/apps/launcher/internal/launcher/match.go
+++ b/apps/launcher/internal/launcher/match.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	semiont "github.com/The-AI-Alliance/semiont/packages/sdk-go"
-	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
 )
 
 const matchUsage = `Usage: semiont match <resourceId> <annotationId> [options]
@@ -97,7 +96,7 @@ func Match(args []string) int {
 	if !ok {
 		return 1
 	}
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 	ctx := context.Background()
 
 	// Step 1: the annotation's context (streaming operation).

--- a/apps/launcher/internal/launcher/start.go
+++ b/apps/launcher/internal/launcher/start.go
@@ -921,6 +921,47 @@ func removeStagedConfigs() {
 // incident. lsof -ti prints one PID per line when several processes hold a
 // port (parent+child servers, SO_REUSEPORT), so everything here iterates
 // over all of them.
+// portHeld reports whether anything holds the port, without judging it. The
+// judging (and the message) is requirePortFree's job.
+func portHeld(port int) bool {
+	out, err := capture("lsof", "-ti", fmt.Sprintf(":%d", port))
+	return err == nil && out != ""
+}
+
+// portSettleBudget bounds settlePorts. Generous, because it is only ever spent
+// when a runtime is genuinely slow to release — the common path returns on the
+// first check having waited nothing at all.
+const portSettleBudget = 3 * time.Second
+
+// settlePorts waits for ports we JUST tore something off to actually come free.
+//
+// It replaces a flat `time.Sleep(time.Second)` that ran after every teardown.
+// That sleep was both too long (a runtime that released instantly still paid a
+// second — and it was ~65% of the launcher test suite's runtime) and too short
+// (a loaded machine could need longer, and the port check that followed would
+// fail with a conflict message naming our own dying container).
+//
+// It deliberately does NOT decide anything. The caller's requirePortFree still
+// delivers the verdict and the "held by <pid> (<comm>)" message, so a port held
+// by a FOREIGN process is still refused promptly instead of being waited out.
+func settlePorts(ports ...int) {
+	deadline := time.Now().Add(portSettleBudget)
+	t0 := time.Now()
+	for {
+		held := false
+		for _, p := range ports {
+			if p != 0 && portHeld(p) {
+				held = true
+				break
+			}
+		}
+		if !held || !time.Now().Before(deadline) {
+			return
+		}
+		time.Sleep(pollDelay(time.Since(t0)))
+	}
+}
+
 func requirePortFree(u *ui, port int, service string) bool {
 	out, err := capture("lsof", "-ti", fmt.Sprintf(":%d", port))
 	if err != nil || out == "" {

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -241,6 +241,58 @@ func Status(args []string) int {
 	return 0
 }
 
+// browserProbe answers the two questions anything that wants to reach the
+// Browser has to ask: WHERE is it, and is it up?
+//
+// Endpoint is an ORIGIN and never a path. That line is the whole of
+// BROWSER-HANDOFF D6/O1: the launcher publishes the container's host port and
+// records the endpoint, so `http://localhost:3000` is its own fact —
+// `/know/resource/<id>` is the frontend's, and mirroring it here would drift
+// silently the day the route moves. If you find yourself adding a route to a
+// Go file, that decision was reopened without saying so.
+type browserProbe struct {
+	Endpoint string // origin: flag override → record → http://localhost:3000
+	Running  bool   // the endpoint answers — the only test of "can a human open this"
+	State    string // container state; "" when no container carries either handle
+}
+
+// browserTarget probes the Browser. Extracted from printBrowser, which is
+// still its first caller: `browse --browser` needs the same three facts to
+// explain an emit that reached nobody, and a second implementation would be
+// a second set of bugs (notably the stale-ID fallback below).
+//
+// override is `--browser-url`, taking precedence over the record.
+func browserTarget(ss *stackSet, override string) browserProbe {
+	b := ss.Browser
+	p := browserProbe{Endpoint: "http://localhost:3000"}
+	handle := "semiont-frontend"
+	if b != nil {
+		if b.Endpoint != "" {
+			p.Endpoint = b.Endpoint
+		}
+		if b.ID != "" {
+			handle = b.ID
+		}
+	}
+	if override != "" {
+		p.Endpoint = override
+	}
+	p.Running = probeHealth(p.Endpoint)
+	// Query only the runtime the record names — a record must narrow the
+	// sweep, same rule the stack table keeps. No record: all installed.
+	rts := installedRuntimes()
+	if b != nil && b.Runtime != "" && onPath(b.Runtime) {
+		rts = []string{b.Runtime}
+	}
+	p.State, _ = containerState(rts, handle)
+	if p.State == "" && handle != "semiont-frontend" {
+		// A stale recorded ID must not contradict a live endpoint ("absent"
+		// beside ✓): the stable name is the fallback truth (Copilot review).
+		p.State, _ = containerState(rts, "semiont-frontend")
+	}
+	return p
+}
+
 // printBrowser renders the BROWSER section — FIRST, because the viewer sits
 // architecturally above every stack it views (and is the least interesting
 // line, fine to scroll away). Shows the image tag so browser-vs-stack skew
@@ -248,30 +300,9 @@ func Status(args []string) int {
 func printBrowser(u *ui, ss *stackSet) (healthy bool) {
 	u.section("BROWSER")
 	b := ss.Browser
-	endpoint := "http://localhost:3000"
-	handle := "semiont-frontend"
-	if b != nil {
-		if b.Endpoint != "" {
-			endpoint = b.Endpoint
-		}
-		if b.ID != "" {
-			handle = b.ID
-		}
-	}
-	healthy = probeHealth(endpoint)
-	// Query only the runtime the record names — a record must narrow the
-	// sweep, same rule the stack table keeps. No record: all installed.
-	rts := installedRuntimes()
-	if b != nil && b.Runtime != "" && onPath(b.Runtime) {
-		rts = []string{b.Runtime}
-	}
-	state, _ := containerState(rts, handle)
-	if state == "" && handle != "semiont-frontend" {
-		// A stale recorded ID must not contradict a live endpoint ("absent"
-		// beside ✓): the stable name is the fallback truth (Copilot review).
-		state, _ = containerState(rts, "semiont-frontend")
-	}
-	word := state
+	p := browserTarget(ss, "")
+	healthy = p.Running
+	word := p.State
 	if word == "" {
 		word = "absent"
 	}
@@ -289,11 +320,11 @@ func printBrowser(u *ui, ss *stackSet) (healthy bool) {
 			}
 		}
 	}
-	if !healthy && state == "" {
+	if !healthy && p.State == "" {
 		fmt.Printf("  %s %-12s %s\n", mark, word, u.dim("any semiont start brings it up (or: semiont start --service frontend)"))
 		return healthy
 	}
-	fmt.Printf("  %s %-12s %s  %s\n", mark, word, endpoint, u.dim("("+detail+")"))
+	fmt.Printf("  %s %-12s %s  %s\n", mark, word, p.Endpoint, u.dim("("+detail+")"))
 	return healthy
 }
 

--- a/apps/launcher/internal/launcher/transport.go
+++ b/apps/launcher/internal/launcher/transport.go
@@ -1,0 +1,27 @@
+package launcher
+
+// transport.go — where verbs get their bus transport.
+//
+// Every knowledge verb used to construct its own `bus.Client`,
+// which meant the only way to observe one was to run the real binary against a
+// real HTTP server. One construction point, behind a swappable function, makes
+// a verb testable in process (SDK-GO-TRANSPORT P1).
+//
+// This is the seam, not a factory: production has exactly one implementation
+// and the indirection exists for substitutability, which is why it is a plain
+// package-level func rather than a registry.
+
+import "github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
+
+// newTransport builds the transport a verb talks to. Tests replace it via
+// useTransport.
+var newTransport = func(base, token string) bus.Transport { return bus.NewClient(base, token) }
+
+// useTransport swaps the constructor and returns a restore func. Test-only by
+// intent; it lives in the non-test file because the variable it closes over
+// does, and Go has no narrower visibility that keeps them together.
+func useTransport(f func(base, token string) bus.Transport) (restore func()) {
+	prev := newTransport
+	newTransport = f
+	return func() { newTransport = prev }
+}

--- a/apps/launcher/internal/launcher/transport_seam_test.go
+++ b/apps/launcher/internal/launcher/transport_seam_test.go
@@ -1,7 +1,6 @@
 package launcher
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -116,16 +115,22 @@ func TestBeckonReportsTheTransportsSubscriberCount(t *testing.T) {
 	}
 }
 
-func captureStdout(t *testing.T, fn func()) string {
+// captureOutput runs fn with both standard streams redirected and returns what
+// each received. Verbs print results to stdout and refusals to stderr, so a
+// helper that saw only one would silently miss half the behaviour under test.
+func captureOutput(t *testing.T, fn func()) (stdout, stderr string) {
 	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
+	oldOut, oldErr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = w
-	done := make(chan string, 1)
-	go func() {
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout, os.Stderr = wOut, wErr
+	drain := func(r *os.File, out chan<- string) {
 		var sb strings.Builder
 		buf := make([]byte, 4096)
 		for {
@@ -135,12 +140,32 @@ func captureStdout(t *testing.T, fn func()) string {
 				break
 			}
 		}
-		done <- sb.String()
-	}()
+		out <- sb.String()
+	}
+	outCh, errCh := make(chan string, 1), make(chan string, 1)
+	go drain(rOut, outCh)
+	go drain(rErr, errCh)
 	fn()
-	w.Close()
-	os.Stdout = old
-	return <-done
+	wOut.Close()
+	wErr.Close()
+	os.Stdout, os.Stderr = oldOut, oldErr
+	return <-outCh, <-errCh
 }
 
-var _ = context.Background
+// captureStdout is the stdout-only convenience the earlier tests read better with.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	out, _ := captureOutput(t, fn)
+	return out
+}
+
+// mustContainAll is the in-process twin of the black-box suite's mustContain
+// (that one lives in package launcher_test and is not importable here).
+func mustContainAll(t *testing.T, label, haystack string, needles ...string) {
+	t.Helper()
+	for _, n := range needles {
+		if !strings.Contains(haystack, n) {
+			t.Errorf("%s missing %q; full text:\n%s", label, n, haystack)
+		}
+	}
+}

--- a/apps/launcher/internal/launcher/transport_seam_test.go
+++ b/apps/launcher/internal/launcher/transport_seam_test.go
@@ -1,0 +1,146 @@
+package launcher
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
+	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bustest"
+)
+
+// SDK-GO-TRANSPORT P1: a verb's wire behaviour, tested IN PROCESS.
+//
+// Every other bus-verb test in this repo builds the launcher binary, spawns it,
+// and points it at `fakert`'s HTTP server — because `bus.Client` is concrete and
+// there is nothing to substitute. This test injects a transport instead. No
+// binary, no socket, no ports: it asserts the channel, the payload, and that the
+// verb reports the subscriber count the transport returned.
+//
+// The suite it replaces takes minutes; this takes microseconds.
+
+// verbFixture puts the on-disk state `verbSession` reads — a recorded local
+// stack and a stored token — under a temp HOME, so a verb can run without a
+// started stack.
+func verbFixture(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, "state"))
+	dir := stateDir()
+	if dir == "" {
+		t.Fatal("stateDir() is empty under the fixture HOME")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ss := &stackSet{Stacks: map[string]*stackState{
+		"local": {Runtime: "container", Services: map[string]serviceState{
+			"backend": {Endpoint: "http://localhost:4000/api/health"},
+		}},
+	}}
+	b, _ := json.MarshalIndent(ss, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "stack.json"), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	toks, _ := json.Marshal(map[string]tokenEntry{"local": {Token: "test-token", Email: "t@example.com"}})
+	if err := os.WriteFile(filepath.Join(dir, "tokens.json"), toks, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBeckonDrivesTheInjectedTransport(t *testing.T) {
+	verbFixture(t)
+	fake := bustest.NewFake()
+	fake.Subscribers = 2
+	restore := useTransport(func(base, token string) bus.Transport {
+		fake.Base, fake.Token = base, token
+		return fake
+	})
+	defer restore()
+
+	if code := Beckon([]string{"--resource", "res-1", "--annotation", "ann-2"}); code != 0 {
+		t.Fatalf("beckon: exit %d", code)
+	}
+
+	if len(fake.Emits) != 1 {
+		t.Fatalf("want exactly one emit, got %d", len(fake.Emits))
+	}
+	got := fake.Emits[0]
+	if got.Channel != bus.BeckonFocus {
+		t.Errorf("channel = %q, want %q", got.Channel, bus.BeckonFocus)
+	}
+	payload, _ := json.Marshal(got.Payload)
+	for _, want := range []string{`"resourceId":"res-1"`, `"annotationId":"ann-2"`} {
+		if !strings.Contains(string(payload), want) {
+			t.Errorf("payload %s missing %s", payload, want)
+		}
+	}
+	// The transport is also how the token and base reach the wire — a seam that
+	// dropped either would still emit, and still be wrong.
+	if fake.Token != "test-token" {
+		t.Errorf("transport built with token %q, want the stored one", fake.Token)
+	}
+}
+
+// The count the transport reports must reach the user's line, or the seam has
+// widened the gap GUIDED-TOUR P1 closed.
+func TestBeckonReportsTheTransportsSubscriberCount(t *testing.T) {
+	for _, c := range []struct {
+		subscribers int
+		want        string
+	}{
+		{0, "nothing is subscribed"},
+		{3, "3 subscribers"},
+		{-1, "no delivery confirmation"},
+	} {
+		verbFixture(t)
+		fake := bustest.NewFake()
+		fake.Subscribers = c.subscribers
+		restore := useTransport(func(base, token string) bus.Transport {
+			fake.Base, fake.Token = base, token
+			return fake
+		})
+		out := captureStdout(t, func() {
+			if code := Beckon([]string{"--resource", "res-1", "--annotation", "ann-2"}); code != 0 {
+				t.Fatalf("beckon: exit %d", code)
+			}
+		})
+		restore()
+		if !strings.Contains(out, c.want) {
+			t.Errorf("subscribers=%d: output %q missing %q", c.subscribers, out, c.want)
+		}
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			sb.Write(buf[:n])
+			if err != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+	fn()
+	w.Close()
+	os.Stdout = old
+	return <-done
+}
+
+var _ = context.Background

--- a/apps/launcher/internal/launcher/verbs_test.go
+++ b/apps/launcher/internal/launcher/verbs_test.go
@@ -110,6 +110,96 @@ func TestBrowseBrowserRefusalsInProcess(t *testing.T) {
 	}
 }
 
+// ── browse --annotation --browser: the fourth tour move (TOUR-CLICK P4) ──
+
+// The click drive: an annotation id is the WHOLE address, so the emit carries
+// it and nothing else, and the verb signals without also reading.
+func TestBrowseAnnotationDrivesAClick(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Subscribers = 1
+
+	out := captureStdout(t, func() {
+		if code := Browse([]string{"--annotation", "ann-9", "--browser"}); code != 0 {
+			t.Fatalf("browse --annotation --browser: exit %d", code)
+		}
+	})
+	if len(fake.Emits) != 1 || fake.Emits[0].Channel != bus.BrowseClick {
+		t.Fatalf("want one browse:click emit, got %v", fake.Emits)
+	}
+	payload := bustest.JSON(fake.Emits[0].Payload)
+	mustContainAll(t, "emit payload", payload, `"annotationId":"ann-9"`)
+	// D2/D3: the id determines the resource, so neither field rides along. A
+	// motivation here would be the denormalization the schema was trimmed of.
+	for _, gone := range []string{"resourceId", "motivation"} {
+		if strings.Contains(payload, gone) {
+			t.Errorf("payload carries %q, which the wire dropped: %s", gone, payload)
+		}
+	}
+	if len(fake.Requests) != 0 {
+		t.Errorf("--annotation --browser also performed a read: %v", fake.Ops())
+	}
+	mustContainAll(t, "report", out, "ann-9", "1 subscriber")
+}
+
+// An empty room fails the click for the same reason it fails the resource
+// move: the caller asked for a specific outcome and did not get it. The retry
+// line has to name the CLICK form, or it sends a tour author to the wrong one.
+func TestBrowseAnnotationRefusesWhenNoOneIsWatching(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	noRuntimes(t)
+	fake.Subscribers = 0
+
+	out, errOut := captureOutput(t, func() {
+		if code := Browse([]string{"--annotation", "ann-9", "--browser", "--browser-url", deadOrigin(t)}); code != 1 {
+			t.Errorf("exit %d, want 1", code)
+		}
+	})
+	mustContainAll(t, "refusal", out+errOut,
+		"Nobody saw annotation ann-9", "browse:click",
+		"semiont browse --annotation ann-9 --browser --launch")
+	if len(fake.Emits) != 1 {
+		t.Errorf("the emit should still have gone out, got %v", fake.Emits)
+	}
+}
+
+func TestBrowseAnnotationRefusals(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		args []string
+		want []string
+	}{
+		// The singular/plural trap is one keystroke, so the message names it
+		// rather than reporting a generic conflict.
+		{"with --annotations", []string{"res-42", "--annotation", "ann-9", "--browser", "--annotations"},
+			[]string{"--annotation", "--annotations", "plural"}},
+		// Option (c): the click form takes no resourceId, and silently
+		// ignoring one would leave the driver keeping two ids consistent.
+		{"with a resourceId", []string{"res-42", "--annotation", "ann-9", "--browser"},
+			[]string{"--annotation", "drop the resourceId"}},
+		// It names a remote act; there is no local rendering it could mean.
+		{"without --browser", []string{"--annotation", "ann-9"},
+			[]string{"--annotation", "only applies with --browser"}},
+		{"with --json", []string{"--annotation", "ann-9", "--browser", "--json"},
+			[]string{"--browser", "--json"}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake, restore := withFake(t)
+			defer restore()
+			out, errOut := captureOutput(t, func() {
+				if code := Browse(c.args); code == 0 {
+					t.Fatal("must refuse")
+				}
+			})
+			mustContainAll(t, "refusal", out+errOut, c.want...)
+			if len(fake.Emits) != 0 || len(fake.Requests) != 0 {
+				t.Errorf("a refused argument still reached the wire: %v %v", fake.Emits, fake.Ops())
+			}
+		})
+	}
+}
+
 func TestBrowseReportsARejection(t *testing.T) {
 	fake, restore := withFake(t)
 	defer restore()

--- a/apps/launcher/internal/launcher/verbs_test.go
+++ b/apps/launcher/internal/launcher/verbs_test.go
@@ -61,8 +61,10 @@ func TestBrowseBrowserSignalsWithoutReadingInProcess(t *testing.T) {
 	fake, restore := withFake(t)
 	defer restore()
 	// Stated, not defaulted: the fake's -1 means "count unknown", which prints
-	// a different line. An empty room is 0, and that is what this asserts.
-	fake.Subscribers = 0
+	// a different line. One subscriber is a room with someone in it — the
+	// EMPTY room is now a refusal with its own probe, and belongs to the
+	// BROWSER-HANDOFF tests rather than here.
+	fake.Subscribers = 1
 
 	out := captureStdout(t, func() {
 		if code := Browse([]string{"res-42", "--browser"}); code != 0 {
@@ -78,7 +80,7 @@ func TestBrowseBrowserSignalsWithoutReadingInProcess(t *testing.T) {
 	if len(fake.Requests) != 0 {
 		t.Errorf("--browser also performed a read: %v", fake.Ops())
 	}
-	mustContainAll(t, "audience", out, "nothing is subscribed to browse:resource-open")
+	mustContainAll(t, "audience", out, "1 subscriber")
 }
 
 func TestBrowseBrowserRefusalsInProcess(t *testing.T) {

--- a/apps/launcher/internal/launcher/verbs_test.go
+++ b/apps/launcher/internal/launcher/verbs_test.go
@@ -1,0 +1,252 @@
+package launcher
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
+	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bustest"
+)
+
+// The knowledge verbs, in process (SDK-GO-TRANSPORT P2).
+//
+// Each of these was a black-box test: build the binary, `start` a fake stack,
+// `login`, run the verb against fakert's HTTP server — ~3 s to observe one
+// request. What they actually assert is what the verb SENDS and what it PRINTS,
+// both of which the transport seam exposes directly.
+//
+// One test per verb family stays end-to-end in launcher_test.go, marked WIRE
+// SMOKE TEST. Those prove the built binary speaks HTTP a real server
+// understands; a family tested only against a double can agree with a bug in
+// our own client.
+
+// reply wraps a scripted response the way the backend does — the verbs decode
+// `{correlationId, response}`, so a bare body would fail to parse and the test
+// would be measuring the wrong thing.
+func reply(body string) []byte {
+	return []byte(`{"correlationId":"c","response":` + body + `}`)
+}
+
+// ── browse ──────────────────────────────────────────────────────────────
+
+func TestBrowseJSONPassesThroughInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Replies["browse:resources-requested"] = reply(`{"resources":[],"total":0}`)
+
+	out := captureStdout(t, func() {
+		if code := Browse([]string{"--json"}); code != 0 {
+			t.Fatalf("browse --json: exit %d", code)
+		}
+	})
+	if !strings.Contains(out, `"response"`) {
+		t.Errorf("--json must print the RAW reply, got:\n%s", out)
+	}
+}
+
+func TestBrowseSendsItsFilters(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Replies["browse:resources-requested"] = reply(`{"resources":[],"total":0}`)
+
+	captureStdout(t, func() { Browse([]string{"--limit", "5", "--search", "clause"}) })
+	if len(fake.Requests) != 1 {
+		t.Fatalf("want 1 request, got %v", fake.Ops())
+	}
+	got := bustest.JSON(fake.Requests[0].Payload)
+	mustContainAll(t, "request payload", got, `"limit":5`, `"search":"clause"`)
+}
+
+func TestBrowseBrowserSignalsWithoutReadingInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	// Stated, not defaulted: the fake's -1 means "count unknown", which prints
+	// a different line. An empty room is 0, and that is what this asserts.
+	fake.Subscribers = 0
+
+	out := captureStdout(t, func() {
+		if code := Browse([]string{"res-42", "--browser"}); code != 0 {
+			t.Fatalf("browse --browser: exit %d", code)
+		}
+	})
+	if len(fake.Emits) != 1 || fake.Emits[0].Channel != bus.BrowseResourceOpen {
+		t.Fatalf("want one browse:resource-open emit, got %v", fake.Emits)
+	}
+	mustContainAll(t, "emit payload", bustest.JSON(fake.Emits[0].Payload), `"resourceId":"res-42"`)
+	// A SIGNAL, not a read. A --browser that also fetched would double the work
+	// and print a table nobody asked for.
+	if len(fake.Requests) != 0 {
+		t.Errorf("--browser also performed a read: %v", fake.Ops())
+	}
+	mustContainAll(t, "audience", out, "nothing is subscribed to browse:resource-open")
+}
+
+func TestBrowseBrowserRefusalsInProcess(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"no resourceId", []string{"--browser"}, []string{"--browser", "resourceId"}},
+		{"with --json", []string{"res-42", "--browser", "--json"}, []string{"--browser", "--json"}},
+		{"with --annotations", []string{"res-42", "--browser", "--annotations"}, []string{"--browser", "--annotations"}},
+		{"with --entity-types", []string{"res-42", "--browser", "--entity-types"}, []string{"--browser", "--entity-types"}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake, restore := withFake(t)
+			defer restore()
+			out, errOut := captureOutput(t, func() {
+				if code := Browse(c.args); code == 0 {
+					t.Fatal("must refuse")
+				}
+			})
+			mustContainAll(t, "refusal", out+errOut, c.want...)
+			if len(fake.Emits) != 0 || len(fake.Requests) != 0 {
+				t.Errorf("a refused argument still reached the wire: %v %v", fake.Emits, fake.Ops())
+			}
+		})
+	}
+}
+
+func TestBrowseReportsARejection(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.RequestErr = &bus.RequestError{Channel: "browse:resource-failed", Message: "resource vanished"}
+
+	out, errOut := captureOutput(t, func() {
+		if code := Browse([]string{"res-9"}); code == 0 {
+			t.Fatal("a failure reply must fail the command")
+		}
+	})
+	mustContainAll(t, "rejection", out+errOut, "rejected", "resource vanished")
+}
+
+// ── beckon ──────────────────────────────────────────────────────────────
+
+func TestBeckonSparkleEmitsSparkleNotFocusInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Subscribers = 0 // an empty room, stated — see the browse test above
+
+	out := captureStdout(t, func() {
+		if code := Beckon([]string{"--resource", "res-42", "--annotation", "ref-a", "--sparkle"}); code != 0 {
+			t.Fatalf("beckon --sparkle: exit %d", code)
+		}
+	})
+	if len(fake.Emits) != 1 {
+		t.Fatalf("want exactly one emit, got %v", fake.Emits)
+	}
+	if fake.Emits[0].Channel != bus.BeckonSparkle {
+		t.Errorf("channel = %q, want %q", fake.Emits[0].Channel, bus.BeckonSparkle)
+	}
+	// Emitting BOTH would scroll-fight exactly as before, which is the thing
+	// this flag exists to avoid.
+	for _, e := range fake.Emits {
+		if e.Channel == bus.BeckonFocus {
+			t.Errorf("--sparkle also emitted focus, the scroll-fight it exists to avoid")
+		}
+	}
+	mustContainAll(t, "audience", out, "nothing is subscribed to beckon:sparkle")
+}
+
+func TestBeckonWithoutSparkleFocusesInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	captureStdout(t, func() {
+		if code := Beckon([]string{"--resource", "res-42", "--annotation", "ref-a"}); code != 0 {
+			t.Fatalf("beckon: exit %d", code)
+		}
+	})
+	if len(fake.Emits) != 1 || fake.Emits[0].Channel != bus.BeckonFocus {
+		t.Fatalf("want one beckon:focus emit, got %v", fake.Emits)
+	}
+}
+
+func TestBeckonRefusalsInProcess(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"no resource", nil, []string{"Usage: semiont beckon"}},
+		{"sparkle without annotation", []string{"--resource", "res-42", "--sparkle"}, []string{"--sparkle", "--annotation"}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake, restore := withFake(t)
+			defer restore()
+			out, errOut := captureOutput(t, func() {
+				if code := Beckon(c.args); code == 0 {
+					t.Fatal("must refuse")
+				}
+			})
+			mustContainAll(t, "refusal", out+errOut, c.want...)
+			if len(fake.Emits) != 0 {
+				t.Errorf("a refused argument still reached the wire: %v", fake.Emits)
+			}
+		})
+	}
+}
+
+// ── mark ────────────────────────────────────────────────────────────────
+
+func TestMarkLinkInfersLinkingMotivationInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Replies["mark:create-request"] = reply(`{"annotationId":"ann-9"}`)
+
+	captureStdout(t, func() {
+		if code := Mark([]string{"res-1", "--link", "res-2"}); code != 0 {
+			t.Fatalf("mark --link: exit %d", code)
+		}
+	})
+	if len(fake.Requests) != 1 {
+		t.Fatalf("want 1 request, got %v", fake.Ops())
+	}
+	mustContainAll(t, "request payload", bustest.JSON(fake.Requests[0].Payload),
+		`"motivation":"linking"`, `"SpecificResource"`, `"source":"res-2"`)
+}
+
+func TestMarkRefusalsInProcess(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"selector flags are exclusive", []string{"res-1", "--quote", "x", "--start", "1", "--end", "2"}, "pick one"},
+		{"half a position range", []string{"res-1", "--start", "1"}, "go together"},
+		{"delete needs a resource", []string{"--delete", "ann-1"}, "--resource"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake, restore := withFake(t)
+			defer restore()
+			out, errOut := captureOutput(t, func() {
+				if code := Mark(c.args); code == 0 {
+					t.Fatal("must refuse")
+				}
+			})
+			mustContainAll(t, "refusal", out+errOut, c.want)
+			if len(fake.Requests) != 0 {
+				t.Errorf("a refused argument still reached the wire: %v", fake.Ops())
+			}
+		})
+	}
+}
+
+// ── gather ──────────────────────────────────────────────────────────────
+
+func TestGatherAnnotationUsesTheStreamingOperationInProcess(t *testing.T) {
+	fake, restore := withFake(t)
+	defer restore()
+	fake.Replies["gather:requested"] = reply(`{"content":"ctx","resources":[]}`)
+
+	captureStdout(t, func() {
+		if code := Gather([]string{"res-1", "ann-7"}); code != 0 {
+			t.Fatalf("gather annotation: exit %d", code)
+		}
+	})
+	if ops := fake.Ops(); len(ops) != 1 || ops[0] != "gather:requested" {
+		t.Fatalf("want gather:requested, got %v", ops)
+	}
+	mustContainAll(t, "request payload", bustest.JSON(fake.Requests[0].Payload),
+		`"annotationId":"ann-7"`, `"resourceId":"res-1"`)
+}

--- a/apps/launcher/internal/launcher/yield.go
+++ b/apps/launcher/internal/launcher/yield.go
@@ -360,7 +360,7 @@ Requires a session:  semiont login --email <address>
 `
 
 func runYieldDelegate(u *ui, t verbTarget, positional []string, opts delegateOptions) int {
-	cli := bus.NewClient(t.base, t.token)
+	cli := newTransport(t.base, t.token)
 	ctx := context.Background()
 	resourceID := positional[0]
 

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -4285,6 +4285,12 @@ func TestStartServiceWorker(t *testing.T) {
 	s := newScenario(t, "container")
 	s.extraEnv = append(s.extraEnv,
 		"FAKERT_STATE_backend=running",
+		// The worker is ALREADY RUNNING — this is a restart, and a restart is
+		// only a restart if there is something to replace. The teardown now
+		// lists before it acts, so a scenario that wants stop+rm asserted has
+		// to say the container exists rather than relying on stop/rm being
+		// fired blindly at a name that was never there.
+		"FAKERT_STATE_worker=running",
 		"FAKERT_SECRET=recovered-secret-123",
 	)
 	serveHealth(t, 16686)
@@ -4336,6 +4342,10 @@ func TestStartServiceGraph(t *testing.T) {
 	// Infra service: no config, no secret, no host-addr probe, no pull
 	// (pinned image) — just its own stop+rm, run, and health gate.
 	s := newScenario(t, "container")
+	// Already running, so "Restarting graph" has something to replace. The
+	// teardown lists before it acts; a scenario asserting stop+rm must say the
+	// container is there rather than relying on a blind fire at its name.
+	s.extraEnv = append(s.extraEnv, "FAKERT_STATE_neo4j=running")
 	stdout, stderr, code := s.run(t, "start", "--service", "graph")
 	if code != 0 {
 		t.Fatalf("want exit 0, got %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
@@ -6214,6 +6224,11 @@ func busScenario(t *testing.T, env ...string) *scenario {
 	return s
 }
 
+// WIRE SMOKE TEST (browse) — SDK-GO-TRANSPORT P2. This family's logic now runs
+// in process against a fake transport (internal/launcher/verbs_test.go). This
+// one stays end-to-end deliberately: it is the only thing proving the BUILT
+// BINARY speaks HTTP a real server understands. A family tested only against a
+// double can agree with a bug in our own client.
 func TestBrowseListsResources(t *testing.T) {
 	s := busScenario(t, `FAKERT_BUS_REPLY_browse_resources_requested={"resources":[`+
 		`{"@id":"res-1","name":"Letter","entityTypes":["Letter"]},`+
@@ -6228,126 +6243,9 @@ func TestBrowseListsResources(t *testing.T) {
 	mustContain(t, "emit", b, `"channel":"browse:resources-requested"`, `"limit":5`, `"correlationId"`)
 }
 
-func TestBrowseJSONPassesThrough(t *testing.T) {
-	s := busScenario(t, `FAKERT_BUS_REPLY_browse_resources_requested={"resources":[],"total":0}`)
-	stdout, _, code := s.run(t, "browse", "--json")
-	if code != 0 {
-		t.Fatalf("exit %d", code)
-	}
-	if !strings.Contains(stdout, `"response"`) {
-		t.Errorf("--json must print the raw reply, got:\n%s", stdout)
-	}
-}
-
 // --- browse --browser: the same act, a different audience (GUIDED-TOUR P3) ---
 
-// `browse <id>` renders a resource HERE; `browse <id> --browser` renders it on
-// the participant's screen. One verb, two destinations — not a second verb,
-// because the act is identical and only the audience differs (D2b).
-func TestBrowseBrowserPutsTheResourceOnTheParticipantsScreen(t *testing.T) {
-	s := busScenario(t)
-	stdout, stderr, code := s.run(t, "browse", "res-42", "--browser")
-	if code != 0 {
-		t.Fatalf("browse --browser: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
-	}
-	b := lastEmit(t, s)
-	mustContain(t, "emit", b, `"channel":"browse:resource-open"`, `"resourceId":"res-42"`)
-
-	// It is a SIGNAL, not a read: nothing is fetched and nothing is rendered
-	// locally. A --browser that also performed the read would double the work
-	// and print a table nobody asked for.
-	for _, e := range emits(t, s) {
-		if strings.Contains(e, "browse:resource-requested") {
-			t.Errorf("--browser performed a local read as well as signalling:\n%s", e)
-		}
-	}
-
-	// P1's subscriber count carries through: nothing is watching in this
-	// scenario, and saying so is the whole point of that phase.
-	mustContain(t, "audience", stdout, "nothing is subscribed to browse:resource-open")
-}
-
-func TestBrowseBrowserNeedsAResourceId(t *testing.T) {
-	// "Show them the index" is a legitimate tour step and a different route;
-	// until that exists, a bare --browser must refuse rather than guess.
-	s := busScenario(t)
-	stdout, stderr, code := s.run(t, "browse", "--browser")
-	if code == 0 {
-		t.Fatalf("--browser without a resourceId must refuse\nstdout:\n%s", stdout)
-	}
-	mustContain(t, "refusal", stdout+stderr, "--browser", "resourceId")
-}
-
-// --browser names a DESTINATION; --json/--annotations/--entity-types each name
-// a local rendering. Combining them states two destinations at once, so the
-// verb refuses instead of silently honouring one (D2b).
-func TestBrowseBrowserRefusesLocalRenderings(t *testing.T) {
-	for _, flag := range []string{"--json", "--annotations", "--entity-types"} {
-		t.Run(flag, func(t *testing.T) {
-			s := busScenario(t)
-			stdout, stderr, code := s.run(t, "browse", "res-42", "--browser", flag)
-			if code == 0 {
-				t.Fatalf("--browser %s must refuse\nstdout:\n%s", flag, stdout)
-			}
-			mustContain(t, "refusal", stdout+stderr, "--browser", flag)
-		})
-	}
-}
-
 // --- beckon --sparkle: the branch menu (GUIDED-TOUR P6) ---
-
-// focus SCROLLS, so beckoning three references in a row scroll-fights and only
-// the last one wins. Sparkle is inert-but-visible: it marks an annotation
-// without moving anything, so a guide can light up three and say "any of
-// these". Same verb, same target, different signal — not a second command.
-func TestBeckonSparkleEmitsSparkleNotFocus(t *testing.T) {
-	s := busScenario(t)
-	stdout, stderr, code := s.run(t, "beckon", "--resource", "res-42", "--annotation", "ref-a", "--sparkle")
-	if code != 0 {
-		t.Fatalf("beckon --sparkle: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
-	}
-	mustContain(t, "emit", lastEmit(t, s), `"channel":"beckon:sparkle"`, `"annotationId":"ref-a"`)
-
-	// An implementation that emitted BOTH would scroll-fight exactly as before,
-	// which is the thing this flag exists to avoid.
-	for _, e := range emits(t, s) {
-		if strings.Contains(e, `"channel":"beckon:focus"`) {
-			t.Errorf("--sparkle also emitted focus, the scroll-fight it exists to avoid:\n%s", e)
-		}
-	}
-
-	// P1's subscriber count carries through, in beckon's existing vocabulary.
-	mustContain(t, "audience", stdout, "nothing is subscribed to beckon:sparkle")
-}
-
-// BeckonSparkleEvent requires annotationId — there is no resource-wide sparkle.
-// Refuse rather than guess at one.
-func TestBeckonSparkleNeedsAnAnnotation(t *testing.T) {
-	s := busScenario(t)
-	stdout, stderr, code := s.run(t, "beckon", "--resource", "res-42", "--sparkle")
-	if code == 0 {
-		t.Fatalf("--sparkle without an annotation must refuse\nstdout:\n%s", stdout)
-	}
-	mustContain(t, "refusal", stdout+stderr, "--sparkle", "--annotation")
-}
-
-// Without the flag, beckon is unchanged: focus, which scrolls.
-func TestBeckonWithoutSparkleStillFocuses(t *testing.T) {
-	s := busScenario(t)
-	if _, stderr, code := s.run(t, "beckon", "--resource", "res-42", "--annotation", "ref-a"); code != 0 {
-		t.Fatalf("beckon: exit %d\nstderr:\n%s", code, stderr)
-	}
-	mustContain(t, "emit", lastEmit(t, s), `"channel":"beckon:focus"`)
-}
-
-func TestBrowseFailureChannelIsReported(t *testing.T) {
-	s := busScenario(t, "FAKERT_BUS_FAIL=resource vanished")
-	stdout, stderr, code := s.run(t, "browse", "res-9")
-	if code == 0 {
-		t.Fatalf("a failure reply must fail the command\nstdout:\n%s", stdout)
-	}
-	mustContain(t, "rejection", stdout+stderr, "rejected", "resource vanished")
-}
 
 func TestBrowseWithoutSessionAdvisesLogin(t *testing.T) {
 	s := newScenario(t, "container")
@@ -6361,6 +6259,11 @@ func TestBrowseWithoutSessionAdvisesLogin(t *testing.T) {
 	mustContain(t, "fix-it", stdout+stderr, "semiont login")
 }
 
+// WIRE SMOKE TEST (gather) — SDK-GO-TRANSPORT P2. This family's logic now runs
+// in process against a fake transport (internal/launcher/verbs_test.go). This
+// one stays end-to-end deliberately: it is the only thing proving the BUILT
+// BINARY speaks HTTP a real server understands. A family tested only against a
+// double can agree with a bug in our own client.
 func TestGatherResourceSummarizes(t *testing.T) {
 	// The REAL GatheredContext shape (schema-defined): metadata +
 	// inferredRelationshipSummary, not the content/summary/resources fields
@@ -6382,17 +6285,11 @@ func TestGatherResourceSummarizes(t *testing.T) {
 	mustContain(t, "emit", b, `"channel":"gather:resource-requested"`, `"resourceId":"res-1"`, `"includeContent":true`)
 }
 
-func TestGatherAnnotationUsesStreamingOperation(t *testing.T) {
-	s := busScenario(t, `FAKERT_BUS_REPLY_gather_requested={"content":"ctx","resources":[]}`)
-	stdout, stderr, code := s.run(t, "gather", "res-1", "ann-7")
-	if code != 0 {
-		t.Fatalf("gather annotation: exit %d\nstderr:\n%s", code, stderr)
-	}
-	_ = stdout
-	b := lastEmit(t, s)
-	mustContain(t, "emit", b, `"channel":"gather:requested"`, `"annotationId":"ann-7"`, `"resourceId":"res-1"`)
-}
-
+// WIRE SMOKE TEST (mark) — SDK-GO-TRANSPORT P2. This family's logic now runs
+// in process against a fake transport (internal/launcher/verbs_test.go). This
+// one stays end-to-end deliberately: it is the only thing proving the BUILT
+// BINARY speaks HTTP a real server understands. A family tested only against a
+// double can agree with a bug in our own client.
 func TestMarkCreatesWithSelectorAndBody(t *testing.T) {
 	s := busScenario(t, `FAKERT_BUS_REPLY_mark_create_request={"annotationId":"ann-42"}`)
 	stdout, stderr, code := s.run(t, "mark", "res-1",
@@ -6409,39 +6306,11 @@ func TestMarkCreatesWithSelectorAndBody(t *testing.T) {
 		`"motivation":"commenting"`) // inferred from the body
 }
 
-func TestMarkLinkInfersLinkingMotivation(t *testing.T) {
-	s := busScenario(t, `FAKERT_BUS_REPLY_mark_create_request={"annotationId":"ann-9"}`)
-	if _, stderr, code := s.run(t, "mark", "res-1", "--link", "res-2"); code != 0 {
-		t.Fatalf("mark --link: exit %d\nstderr:\n%s", code, stderr)
-	}
-	b := lastEmit(t, s)
-	mustContain(t, "emit", b, `"motivation":"linking"`, `"SpecificResource"`, `"source":"res-2"`)
-}
-
-func TestMarkSelectorFlagsAreExclusive(t *testing.T) {
-	s := busScenario(t)
-	_, stderr, code := s.run(t, "mark", "res-1", "--quote", "x", "--start", "1", "--end", "2")
-	if code == 0 {
-		t.Fatal("--quote with --start/--end must refuse")
-	}
-	mustContain(t, "refusal", stderr, "pick one")
-	// And a half-given position range is a refusal, not a silent whole-resource mark.
-	if _, stderr, code := s.run(t, "mark", "res-1", "--start", "1"); code == 0 {
-		t.Error("--start without --end must refuse")
-	} else {
-		mustContain(t, "refusal", stderr, "go together")
-	}
-}
-
-func TestMarkDeleteNeedsResource(t *testing.T) {
-	s := busScenario(t)
-	_, stderr, code := s.run(t, "mark", "--delete", "ann-1")
-	if code == 0 {
-		t.Fatal("--delete without --resource must refuse")
-	}
-	mustContain(t, "refusal", stderr, "--resource")
-}
-
+// WIRE SMOKE TEST (bind) — SDK-GO-TRANSPORT P2. This family's logic now runs
+// in process against a fake transport (internal/launcher/verbs_test.go). This
+// one stays end-to-end deliberately: it is the only thing proving the BUILT
+// BINARY speaks HTTP a real server understands. A family tested only against a
+// double can agree with a bug in our own client.
 func TestBindAddsAndRemovesTarget(t *testing.T) {
 	s := busScenario(t, `FAKERT_BUS_REPLY_bind_update_body={}`)
 	if _, stderr, code := s.run(t, "bind", "res-1", "ann-1", "res-2"); code != 0 {
@@ -6458,6 +6327,11 @@ func TestBindAddsAndRemovesTarget(t *testing.T) {
 	mustContain(t, "emit", b, `"op":"remove"`)
 }
 
+// WIRE SMOKE TEST (match) — SDK-GO-TRANSPORT P2. This family's logic now runs
+// in process against a fake transport (internal/launcher/verbs_test.go). This
+// one stays end-to-end deliberately: it is the only thing proving the BUILT
+// BINARY speaks HTTP a real server understands. A family tested only against a
+// double can agree with a bug in our own client.
 func TestMatchGathersThenSearches(t *testing.T) {
 	// match is TWO exchanges: the search requires a context payload, so a
 	// gather must precede it — not an optimization, a precondition.
@@ -6493,6 +6367,11 @@ func TestMatchGathersThenSearches(t *testing.T) {
 // subscribed to beckon:focus in this scenario, and the backend now says so, so
 // the honest line names that — the old "no delivery confirmation" wording is
 // reserved for the case where the count is genuinely unknown.
+// WIRE SMOKE TEST (beckon) — SDK-GO-TRANSPORT P2. This family's logic now runs
+// in process against a fake transport (internal/launcher/verbs_test.go). This
+// one stays end-to-end deliberately: it is the only thing proving the BUILT
+// BINARY speaks HTTP a real server understands. A family tested only against a
+// double can agree with a bug in our own client.
 func TestBeckonSaysWhenNobodyIsSubscribed(t *testing.T) {
 	s := busScenario(t)
 	stdout, stderr, code := s.run(t, "beckon", "--resource", "res-1", "--annotation", "ann-2")
@@ -6509,21 +6388,19 @@ func TestBeckonSaysWhenNobodyIsSubscribed(t *testing.T) {
 	}
 }
 
-func TestBeckonNeedsAResource(t *testing.T) {
-	s := busScenario(t)
-	stdout, _, code := s.run(t, "beckon")
-	if code == 0 {
-		t.Fatal("beckon without a resource must refuse")
-	}
-	mustContain(t, "usage", stdout, "Usage: semiont beckon")
-}
-
 // --- frame: the schema-layer flow ---
 
 // Frame is a FAN-OUT verb: the protocol has no batch add, so N entity types
 // are N `frame:add-entity-type` commands. This asserts against every emit,
 // not the last one — a verb that dropped all but the final tag would pass a
 // last-emit check while losing the caller's work.
+// WIRE SMOKE TEST (SDK-GO-TRANSPORT P2). The verb's logic — one command per
+// entity type, stop at the first rejection, refuse bad arguments — moved to
+// internal/launcher/frame_test.go, where it runs in process against a fake
+// transport in ~0 s. This one stays end-to-end on purpose: it is the only thing
+// proving the BUILT BINARY speaks HTTP a server actually understands. Retiring
+// it would leave the whole verb family tested against a double that could agree
+// with a bug.
 func TestFrameAddsEachEntityTypeSeparately(t *testing.T) {
 	s := busScenario(t)
 	stdout, stderr, code := s.run(t, "frame", "--entity-type", "Person", "--entity-type", "Organization")
@@ -6544,43 +6421,6 @@ func TestFrameAddsEachEntityTypeSeparately(t *testing.T) {
 	if strings.Contains(all[0], `"_userId"`) {
 		t.Errorf("client set a field the gateway owns:\n%s", all[0])
 	}
-}
-
-// A rejected add STOPS the run. Continuing would report a success total the
-// backend never agreed to, and the remaining tags are cheap to re-issue —
-// the vocabulary is grow-only, so a rerun costs nothing.
-func TestFrameStopsAtTheFirstRejection(t *testing.T) {
-	s := busScenario(t, "FAKERT_BUS_FAIL=vocabulary is frozen")
-	stdout, stderr, code := s.run(t, "frame", "--entity-type", "Person", "--entity-type", "Organization")
-	if code == 0 {
-		t.Fatalf("a rejected add must fail the command\nstdout:\n%s", stdout)
-	}
-	mustContain(t, "rejection", stdout+stderr, "vocabulary is frozen")
-	if all := emits(t, s); len(all) != 1 {
-		t.Errorf("frame kept going after a rejection: %d commands sent:\n%s", len(all), strings.Join(all, "\n"))
-	}
-}
-
-func TestFrameNeedsAnEntityType(t *testing.T) {
-	s := busScenario(t)
-	stdout, _, code := s.run(t, "frame")
-	if code == 0 {
-		t.Fatal("frame with nothing to add must refuse")
-	}
-	mustContain(t, "usage", stdout, "Usage: semiont frame")
-}
-
-// Bare operands are refused rather than guessed at. Frame owns two schema
-// primitives in the protocol (entity types and tag schemas); a positional
-// would have to mean one of them, and picking silently is how the second
-// one becomes impossible to add later without breaking the first.
-func TestFrameRefusesBarePositionals(t *testing.T) {
-	s := busScenario(t)
-	_, stderr, code := s.run(t, "frame", "Person")
-	if code == 0 {
-		t.Fatal("a bare positional must refuse")
-	}
-	mustContain(t, "refusal", stderr, "--entity-type")
 }
 
 func TestListenRefusesWithoutSession(t *testing.T) {

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -6243,10 +6243,6 @@ func TestBrowseListsResources(t *testing.T) {
 	mustContain(t, "emit", b, `"channel":"browse:resources-requested"`, `"limit":5`, `"correlationId"`)
 }
 
-// --- browse --browser: the same act, a different audience (GUIDED-TOUR P3) ---
-
-// --- beckon --sparkle: the branch menu (GUIDED-TOUR P6) ---
-
 func TestBrowseWithoutSessionAdvisesLogin(t *testing.T) {
 	s := newScenario(t, "container")
 	if _, stderr, code := s.run(t, "start"); code != 0 {

--- a/apps/launcher/testdata/golden/start-default-boot.argv
+++ b/apps/launcher/testdata/golden/start-default-boot.argv
@@ -1,53 +1,8 @@
 git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
-container stop semiont-jaeger
-container rm semiont-jaeger
-container stop semiont-neo4j
-container rm semiont-neo4j
-container stop semiont-qdrant
-container rm semiont-qdrant
-container stop semiont-postgres
-container rm semiont-postgres
-container stop semiont-backend
-container rm semiont-backend
-container stop semiont-worker
-container rm semiont-worker
-container stop semiont-smelter
-container rm semiont-smelter
-container stop semiont-weaver
-container rm semiont-weaver
-docker stop semiont-jaeger
-docker rm semiont-jaeger
-docker stop semiont-neo4j
-docker rm semiont-neo4j
-docker stop semiont-qdrant
-docker rm semiont-qdrant
-docker stop semiont-postgres
-docker rm semiont-postgres
-docker stop semiont-backend
-docker rm semiont-backend
-docker stop semiont-worker
-docker rm semiont-worker
-docker stop semiont-smelter
-docker rm semiont-smelter
-docker stop semiont-weaver
-docker rm semiont-weaver
-podman stop semiont-jaeger
-podman rm semiont-jaeger
-podman stop semiont-neo4j
-podman rm semiont-neo4j
-podman stop semiont-qdrant
-podman rm semiont-qdrant
-podman stop semiont-postgres
-podman rm semiont-postgres
-podman stop semiont-backend
-podman rm semiont-backend
-podman stop semiont-worker
-podman rm semiont-worker
-podman stop semiont-smelter
-podman rm semiont-smelter
-podman stop semiont-weaver
-podman rm semiont-weaver
+container list -a
+docker ps -a --format {{.Names}}
+podman ps -a --format {{.Names}}
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -65,8 +20,7 @@ container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
-container stop semiont-ollama
-container rm semiont-ollama
+lsof -ti :11434
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -77,8 +31,7 @@ container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume 
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 container inspect semiont-frontend
-container stop semiont-frontend
-container rm semiont-frontend
+lsof -ti :3000
 lsof -ti :3000
 container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-docker-boot.argv
+++ b/apps/launcher/testdata/golden/start-docker-boot.argv
@@ -1,53 +1,8 @@
 git -C <kb-root> rev-parse --show-toplevel
 docker run --rm busybox:1.38.0 nslookup host.docker.internal
-docker stop semiont-jaeger
-docker rm semiont-jaeger
-docker stop semiont-neo4j
-docker rm semiont-neo4j
-docker stop semiont-qdrant
-docker rm semiont-qdrant
-docker stop semiont-postgres
-docker rm semiont-postgres
-docker stop semiont-backend
-docker rm semiont-backend
-docker stop semiont-worker
-docker rm semiont-worker
-docker stop semiont-smelter
-docker rm semiont-smelter
-docker stop semiont-weaver
-docker rm semiont-weaver
-container stop semiont-jaeger
-container rm semiont-jaeger
-container stop semiont-neo4j
-container rm semiont-neo4j
-container stop semiont-qdrant
-container rm semiont-qdrant
-container stop semiont-postgres
-container rm semiont-postgres
-container stop semiont-backend
-container rm semiont-backend
-container stop semiont-worker
-container rm semiont-worker
-container stop semiont-smelter
-container rm semiont-smelter
-container stop semiont-weaver
-container rm semiont-weaver
-podman stop semiont-jaeger
-podman rm semiont-jaeger
-podman stop semiont-neo4j
-podman rm semiont-neo4j
-podman stop semiont-qdrant
-podman rm semiont-qdrant
-podman stop semiont-postgres
-podman rm semiont-postgres
-podman stop semiont-backend
-podman rm semiont-backend
-podman stop semiont-worker
-podman rm semiont-worker
-podman stop semiont-smelter
-podman rm semiont-smelter
-podman stop semiont-weaver
-podman rm semiont-weaver
+docker ps -a --format {{.Names}}
+container list -a
+podman ps -a --format {{.Names}}
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -65,8 +20,7 @@ docker pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 docker run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 docker run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 docker run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
-docker stop semiont-ollama
-docker rm semiont-ollama
+lsof -ti :11434
 lsof -ti :11434
 docker run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 docker run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -77,8 +31,7 @@ docker run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume <co
 docker run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4318 --env BACKEND_HOST=host.docker.internal --env OLLAMA_HOST=host.docker.internal --env NEO4J_HOST=host.docker.internal --env QDRANT_HOST=host.docker.internal --env POSTGRES_HOST=host.docker.internal --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 docker run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4318 --env BACKEND_HOST=host.docker.internal --env OLLAMA_HOST=host.docker.internal --env NEO4J_HOST=host.docker.internal --env QDRANT_HOST=host.docker.internal --env POSTGRES_HOST=host.docker.internal --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 docker inspect semiont-frontend
-docker stop semiont-frontend
-docker rm semiont-frontend
+lsof -ti :3000
 lsof -ti :3000
 docker pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 docker run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-host-ollama-boot.argv
+++ b/apps/launcher/testdata/golden/start-host-ollama-boot.argv
@@ -1,21 +1,6 @@
 git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
-container stop semiont-jaeger
-container rm semiont-jaeger
-container stop semiont-neo4j
-container rm semiont-neo4j
-container stop semiont-qdrant
-container rm semiont-qdrant
-container stop semiont-postgres
-container rm semiont-postgres
-container stop semiont-backend
-container rm semiont-backend
-container stop semiont-worker
-container rm semiont-worker
-container stop semiont-smelter
-container rm semiont-smelter
-container stop semiont-weaver
-container rm semiont-weaver
+container list -a
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -42,8 +27,7 @@ container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume 
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 container inspect semiont-frontend
-container stop semiont-frontend
-container rm semiont-frontend
+lsof -ti :3000
 lsof -ti :3000
 container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-local-version-boot.argv
+++ b/apps/launcher/testdata/golden/start-local-version-boot.argv
@@ -1,21 +1,6 @@
 git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
-container stop semiont-jaeger
-container rm semiont-jaeger
-container stop semiont-neo4j
-container rm semiont-neo4j
-container stop semiont-qdrant
-container rm semiont-qdrant
-container stop semiont-postgres
-container rm semiont-postgres
-container stop semiont-backend
-container rm semiont-backend
-container stop semiont-worker
-container rm semiont-worker
-container stop semiont-smelter
-container rm semiont-smelter
-container stop semiont-weaver
-container rm semiont-weaver
+container list -a
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -29,8 +14,7 @@ lsof -ti :4318
 container run -d --name semiont-jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.76.0
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
-container stop semiont-ollama
-container rm semiont-ollama
+lsof -ti :11434
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -41,7 +25,6 @@ container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume 
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:local
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env OTEL_EXPORTER_OTLP_ENDPOINT=http://192.168.64.1:4318 --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:local
 container inspect semiont-frontend
-container stop semiont-frontend
-container rm semiont-frontend
+lsof -ti :3000
 lsof -ti :3000
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:local

--- a/apps/launcher/testdata/golden/start-no-observe-boot.argv
+++ b/apps/launcher/testdata/golden/start-no-observe-boot.argv
@@ -1,21 +1,6 @@
 git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
-container stop semiont-jaeger
-container rm semiont-jaeger
-container stop semiont-neo4j
-container rm semiont-neo4j
-container stop semiont-qdrant
-container rm semiont-qdrant
-container stop semiont-postgres
-container rm semiont-postgres
-container stop semiont-backend
-container rm semiont-backend
-container stop semiont-worker
-container rm semiont-worker
-container stop semiont-smelter
-container rm semiont-smelter
-container stop semiont-weaver
-container rm semiont-weaver
+container list -a
 lsof -ti :7474
 lsof -ti :7687
 lsof -ti :6333
@@ -30,8 +15,7 @@ container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest
 container image pull ghcr.io/the-ai-alliance/semiont-weaver:latest
 container run -d --name semiont-neo4j -p 7474:7474 -p 7687:7687 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/data:/data -v <home>/.local/share/semiont/roots/example.github.io-test-kb/neo4j/logs:/logs -e NEO4J_AUTH=neo4j/localpass -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:5.26.28-community
 container run -d --name semiont-qdrant -p 6333:6333 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/qdrant:/qdrant/storage qdrant/qdrant:v1.18.3
-container stop semiont-ollama
-container rm semiont-ollama
+lsof -ti :11434
 lsof -ti :11434
 container run -d --name semiont-ollama -p 11434:11434 -m 24G -v semiont-ollama-models:/root/.ollama ollama/ollama
 container run -d --name semiont-postgres -p 5432:5432 -v <home>/.local/share/semiont/roots/example.github.io-test-kb/postgres:/var/lib/postgresql/data -e PGDATA=/var/lib/postgresql/data/pgdata -e POSTGRES_PASSWORD=localpass -e POSTGRES_DB=semiont postgres:15.18-alpine
@@ -42,8 +26,7 @@ container run -d --name semiont-worker --memory 2G --publish 9090:9090 --volume 
 container run -d --name semiont-smelter --memory 2G --publish 9091:9091 --volume <config-stage>/smelter.toml:/home/semiont/.semiontconfig:ro --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-smelter:latest
 container run -d --name semiont-weaver --memory 3G --publish 9092:9092 --volume <config-stage>/weaver.toml:/home/semiont/.semiontconfig:ro --env BACKEND_HOST=192.168.64.1 --env OLLAMA_HOST=192.168.64.1 --env NEO4J_HOST=192.168.64.1 --env QDRANT_HOST=192.168.64.1 --env POSTGRES_HOST=192.168.64.1 --env SEMIONT_WORKER_SECRET=test-worker-secret ghcr.io/the-ai-alliance/semiont-weaver:latest
 container inspect semiont-frontend
-container stop semiont-frontend
-container rm semiont-frontend
+lsof -ti :3000
 lsof -ti :3000
 container image pull ghcr.io/the-ai-alliance/semiont-frontend:latest
 container run -d --name semiont-frontend --memory 1G --publish 3000:3000 -v <home>/.local/state/semiont/discovery:/discovery:ro ghcr.io/the-ai-alliance/semiont-frontend:latest

--- a/apps/launcher/testdata/golden/start-port-conflict.argv
+++ b/apps/launcher/testdata/golden/start-port-conflict.argv
@@ -1,20 +1,5 @@
 git -C <kb-root> rev-parse --show-toplevel
 container run --rm busybox:1.38.0 sh -c ip route | awk '/default/{print $3}'
-container stop semiont-jaeger
-container rm semiont-jaeger
-container stop semiont-neo4j
-container rm semiont-neo4j
-container stop semiont-qdrant
-container rm semiont-qdrant
-container stop semiont-postgres
-container rm semiont-postgres
-container stop semiont-backend
-container rm semiont-backend
-container stop semiont-worker
-container rm semiont-worker
-container stop semiont-smelter
-container rm semiont-smelter
-container stop semiont-weaver
-container rm semiont-weaver
+container list -a
 lsof -ti :7474
 ps -p 12345 -o comm=

--- a/docs/protocol/flows/BECKON.md
+++ b/docs/protocol/flows/BECKON.md
@@ -33,8 +33,10 @@ const annotations = await firstValueFrom(
 );
 
 // Programmatically direct attention — broadcasts across participants
-// via the bus gateway.
-client.beckon.attention(annotations[0].id, resourceId);
+// via the bus gateway. Each wire drive resolves with the subscriber
+// count at dispatch (-1 = unknown).
+await client.beckon.attention(resourceId, annotations[0].id);  // point at it
+await client.beckon.click(annotations[0].id);                  // OPEN it
 
 // Or, for local-only scroll (no broadcast), emit directly on the
 // workspace EventBus:
@@ -46,7 +48,7 @@ eventBus.get('beckon:focus').next({ annotationId: annotations[0].id });
 | Event | Payload | Description |
 |-------|---------|-------------|
 | `beckon:hover` | `{ annotationId: string \| null }` | Mouse entered/left an annotation element |
-| `browse:click` | `{ annotationId: string; motivation: Motivation; anchorRect? }` | User clicked an annotation |
+| `browse:click` | `{ annotationId: string }` (+ local-only `anchorRect?`) | An annotation was clicked — **open** it (see Browse flow) |
 | `beckon:focus` | `{ annotationId?: string \| null; resourceId? }` | Scroll-to-annotation signal (relayed from click) |
 | `beckon:sparkle` | `{ annotationId: string }` | Trigger sparkle animation on an annotation |
 
@@ -57,6 +59,18 @@ viewer is [`browse:resource-open`](./BROWSE.md#cross-participant-navigation)'s
 job. The field is optional, and **absence still scrolls** — the in-app emitters
 (history panel, annotation list) omit it because they are already scoped to the
 open resource, so treating absent as "not mine" would silence all of them.
+
+**Focus points; a click opens.** `beckon:focus` scrolls the viewer to an
+annotation and stops. `browse:click` opens it — the annotations panel comes up
+with that entry selected, and this flow's relay then produces the scroll. Both
+are drivable from outside the page, so a guide chooses between "notice this"
+and "read this"; see
+[Cross-participant navigation](./BROWSE.md#cross-participant-navigation).
+
+Note the asymmetry with the guard above: a click carries no `resourceId`
+because its `annotationId` is **required** and already names one annotation on
+one resource. Focus's `annotationId` is optional — it can name a resource
+alone — which is what leaves `resourceId` something to guard.
 
 Panel state is not an event flow — see
 [Panel and sidebar state](./BROWSE.md#panel-and-sidebar-state) in the Browse
@@ -83,7 +97,7 @@ Two forms are provided for emitting hover events:
 Click events relay through `beckon:focus` to scroll the document view:
 
 1. User clicks an annotation entry in the panel
-2. `browse:click` fires with `annotationId` and `motivation`
+2. `browse:click` fires with `annotationId` (the motivation is derived from the annotation it names, not carried)
 3. `createBeckonStateUnit` relays as `beckon:focus`
 4. BrowseView subscribes to `beckon:focus` and scrolls the document to the annotation's position
 
@@ -94,7 +108,7 @@ Click events relay through `beckon:focus` to scroll the document view:
 same `beckon:focus` signal to everyone watching the workspace, through
 the unified bus gateway:
 
-1. Originator calls `client.beckon.attention(annotationId, resourceId)`, which
+1. Originator calls `client.beckon.attention(resourceId, annotationId)`, which
    invokes `actor.emit('beckon:focus', ...)` → `POST /bus/emit`.
 2. Backend emits the event on the in-process EventBus.
 3. Every connected `SemiontClient` has `beckon:focus` and

--- a/docs/protocol/flows/BROWSE.md
+++ b/docs/protocol/flows/BROWSE.md
@@ -17,8 +17,8 @@ The Browse flow provides structured navigation through the knowledge base. The a
 Four categories, distinguished by *who can hear them*:
 
 1. **Read operations** — thirteen `browse:*-requested` request/reply pairs that fetch resources, annotations, history, and directory listings. Correlated; the replies are bridged by construction.
-2. **Cross-participant navigation** — `browse:resource-open` (drive) and `browse:resource-viewed` (report). Bridged broadcasts: an agent or the launcher can move a participant's Browser, and the viewer announces where it landed.
-3. **Local UI signals** — `browse:click`, `browse:entity-type-clicked`. Local-bus fan-out inside one browser session; never on the wire.
+2. **Cross-participant navigation** — `browse:resource-open` and `browse:click` (drives) and `browse:resource-viewed` (report). Bridged broadcasts: an agent or the launcher can move a participant's Browser or open an annotation on it, and the viewer announces where it landed.
+3. **Local UI signals** — `browse:entity-type-clicked`. Local-bus fan-out inside one browser session; never on the wire.
 4. **Host routing** — the `nav:*` channels. Framework-shaped, host-local, and deliberately never bridged.
 
 Browse is therefore **not** purely a frontend concern. Categories 1 and 2 cross the backend; only 3 and 4 stay in the page.
@@ -61,36 +61,45 @@ These are what `client.browse.*` calls in the SDK, and what `semiont browse` use
 
 ## Cross-participant navigation
 
-Within one browser session, clicking a resolved reference is a local affair. But `browse:resource-open` and `browse:resource-viewed` are **bridged broadcasts**, which makes the same acts available to anything holding a session — the launcher, an agent, a script running a guided tour. Signals are delivered to whoever is subscribed and silently dropped if nobody is, the same stateless semantics as Beckon.
+Within one browser session, clicking a resolved reference is a local affair. But `browse:resource-open`, `browse:click` and `browse:resource-viewed` are **bridged broadcasts**, which makes the same acts available to anything holding a session — the launcher, an agent, a script running a guided tour. Signals are delivered to whoever is subscribed and silently dropped if nobody is, the same stateless semantics as Beckon.
 
 | Event | Payload | Direction |
 |---|---|---|
 | `browse:resource-open` | `{ resourceId }` | **Drive** — put this resource on the participant's screen |
+| `browse:click` | `{ annotationId }` | **Drive** — open this annotation: select its panel entry, and scroll to it |
 | `browse:resource-viewed` | `{ resourceId }` | **Report** — the viewer arrived at this resource |
 
-**These two must never be collapsed into one bidirectional channel.** A driver signal and a user report sharing a channel is a feedback loop: a launcher listening for arrivals would hear its own commands, and one viewer's click would drive another viewer's page.
+**Drive and report must never be collapsed into one channel.** A driver signal and a user report sharing a channel is a feedback loop: a launcher listening for arrivals would hear its own commands, and one viewer's click would drive another viewer's page.
+
+**Bridging does not leak local clicks.** `BRIDGED_CHANNELS` is the *fan-in* set — channels a transport receives and pushes onto the client's bus. It says nothing about what the client emits. So `browse.click()` and `browse.openResource()`, which emit on the local bus only, stay inside the page even though their channels are bridged; the wire versions are separate methods (below).
 
 **`browse:resource-open`** is emitted by `browse.openResource(resourceId)` — from `ResourceInfoPanel`, from the CodeMirror reference-widget handlers, and from `semiont browse <resourceId> --browser`. `ResourceViewerPage` subscribes and translates to `nav:push`, so a remote caller never learns a URL.
+
+**`browse:click`** is the richer of the two drives: where `beckon:focus` only scrolls to an annotation, a click *opens* it — the annotations panel comes up with that entry selected, and the relay through `createBeckonStateUnit` does the scroll. Locally it comes from `browse.click(annotationId)` at every clickable annotation surface; over the wire from `beckon.click(annotationId)` and `semiont browse --annotation <id> --browser`.
+
+The payload is **the annotation id and nothing else**. An annotation id names exactly one annotation on exactly one resource, so the id is the whole address — no `resourceId` is carried, and none is needed to scope the event. The **motivation is derived viewer-side** from the annotation the id names rather than sent beside it, which keeps one fact in one place. A viewer that has not loaded that annotation resolves nothing and does nothing, so an unscoped drive is a natural no-op rather than a mis-fire. `anchorRect` is viewport geometry and stays a **local-only** extra on the same channel: a bridged-in remote click simply arrives without one.
 
 **`browse:resource-viewed`** is emitted on the viewer's load-complete transition (`useResourceViewedReport`), gated on the same condition as the accessibility load announcement — so "viewed" means content actually reached the screen. It fires however the participant arrived: followed cue, in-app link, back button, or typed URL. That last part is why it exists rather than the driver simply assuming its own cue landed.
 
 Because these are broadcasts on a KB-wide channel, the model is **one participant, one session**: a launcher authenticated as a given user reaches that user's open Browser. There is no addressing. Every emit through the bus gateway reports the subscriber count at dispatch, so a caller that expected one viewer can see that there were two — but the count is *not* delivery confirmation, since a subscriber is a connection rather than a pair of eyes, and these channels carry no reply.
 
+### Who handles a click
+
+Local or remote, a `browse:click` reaches the same subscribers:
+
+- **createBeckonStateUnit** — relays as `beckon:focus` to scroll the document view to the annotation
+- **ResourceViewer** — resolves the annotation by id, derives its motivation, and opens the annotations panel with scroll-to coordination
+- **Panel components** (HighlightPanel, CommentsPanel, AssessmentPanel, TaggingPanel, ReferencesPanel) — update focused/selected state to highlight the clicked entry
+
+Local emitters are every clickable annotation surface: CodeMirror document view, BrowseView, PDF canvas, image overlay, and the panel entries (HighlightEntry, CommentEntry, AssessmentEntry, TagEntry, ReferenceEntry).
+
 ## Local UI signals
 
-Local-bus fan-out within a single page. Not bridged, and `browse:click`'s payload has no wire schema at all.
+Local-bus fan-out within a single page — never on the wire.
 
 | Event | Payload | Description |
 |-------|---------|-------------|
-| `browse:click` | `{ annotationId, motivation, anchorRect? }` | User clicked an annotation element |
 | `browse:entity-type-clicked` | `{ entityType }` | Filter resources by an entity type |
-
-**`browse:click`** is emitted through `browse.click(...)` from every clickable annotation surface: CodeMirror document view, BrowseView, PDF canvas, image overlay, and the panel entries (HighlightEntry, CommentEntry, AssessmentEntry, TagEntry, ReferenceEntry). The optional `anchorRect` carries the clicked element's bounding rect for positioning.
-
-Subscribers:
-- **createBeckonStateUnit** — relays as `beckon:focus` to scroll the document view to the annotation
-- **ResourceViewer** — opens the annotations panel with scroll-to-annotation coordination
-- **Panel components** (HighlightPanel, CommentsPanel, AssessmentPanel, TaggingPanel, ReferencesPanel) — update focused/selected state to highlight the clicked entry
 
 **`browse:entity-type-clicked`** is consumed by `ResourceViewerPage`, which applies the filter by emitting `nav:push`. The channel is wired on the subscribe side only — no in-repo emitter currently sends it.
 

--- a/docs/protocol/skills/semiont-tour/SKILL.md
+++ b/docs/protocol/skills/semiont-tour/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: semiont-tour
-description: Drive a participant's Browser from outside — a timed, branching "guided tour" of a knowledge base using browse --browser, beckon, and listen
+description: Drive a participant's Browser from outside — a timed, branching "guided tour" of a knowledge base: browse --browser moves them to a resource or opens an annotation, beckon offers choices, listen reports where they went
 disable-model-invocation: false
 user-invocable: true
 allowed-tools: Bash, Read, Write, Glob, Grep
@@ -31,24 +31,45 @@ logs in once, and the tour drives from there.
 subscribed to that KB, so running a tour while a colleague reads the same KB will drive their
 screen too. There is no per-participant addressing, deliberately — see "What this cannot do".
 
-## The four moves
+## The moves
+
+Four drives and one report:
 
 | move | command | channel |
 |---|---|---|
 | put a resource on their screen | `semiont browse <id> --browser` | `browse:resource-open` |
+| **open an annotation** (panel entry + scroll) | `semiont browse --annotation <id> --browser` | `browse:click` |
 | offer a branch (no scroll) | `semiont beckon --resource <id> --annotation <id> --sparkle` | `beckon:sparkle` |
 | say "start here" (scrolls) | `semiont beckon --resource <id> --annotation <id>` | `beckon:focus` |
 | see where they went | `semiont listen --channel browse:resource-viewed` | report |
+
+**`browse` advances the story; `beckon` offers a choice.** This is the shape of a tour, and
+getting it backwards is the common mistake. The two `browse --browser` forms are how a guide
+moves a participant along on a schedule — to the next resource, or to the passage worth
+reading inside it. `beckon` is punctuation: it marks options and lets the participant pick.
+A tour built entirely from beckons is not a tour, it is a scavenger hunt — it stalls after
+the opening move, waiting for a choice at every step.
+
+**Point versus open.** `beckon:focus` scrolls the viewer to an annotation and stops there.
+`browse --annotation --browser` *opens* it: the annotations panel comes up with that entry
+selected, and the scroll happens too. Point when you want them to notice something; open when
+you want them reading it.
 
 **Sparkle for menus, focus for one thing.** Focus *scrolls the viewer to* the annotation, so
 beckoning three references in a row scroll-fights and only the last survives. Sparkle marks an
 annotation in place. A three-way branch is three sparkles; "begin here" is one focus.
 
-**Only the first move fails on an empty room.** Every emit reports how many subscribers the
-target subject had at dispatch, but the two verbs treat zero differently on purpose: `beckon`
-exits 0 because a beckon is fire-and-forget, while `browse --browser` exits 1 because it asked
-for a specific outcome — a resource on a screen — and zero subscribers means it did not happen.
-That makes the first move a natural gate for the whole tour.
+**The annotation form takes no resourceId** — not on the command line, not on the wire. An
+annotation id names exactly one annotation on exactly one resource, so the id is the whole
+address; a second id would only be something for you to keep consistent. The launcher rejects
+one rather than ignoring it.
+
+**The `browse` moves fail on an empty room; the `beckon` moves do not.** Every emit reports
+how many subscribers the target subject had at dispatch, but the two verbs treat zero
+differently on purpose: `beckon` exits 0 because a beckon is fire-and-forget, while **both**
+`browse --browser` forms exit 1 because each asked for a specific outcome — something on a
+screen — and zero subscribers means it did not happen. Under `set -e` that makes every
+`browse` move a gate, starting with the first.
 
 ## Building the tour
 
@@ -79,21 +100,35 @@ semiont listen --channel session:joined --json | head -1 >/dev/null
 semiont browse res-intro --browser
 sleep 90
 
-# The branch menu: mark both paths, then point at one as the suggested start.
-semiont beckon --resource res-intro --annotation ref-history --sparkle
-semiont beckon --resource res-intro --annotation ref-method  --sparkle
-semiont beckon --resource res-intro --annotation ref-history
+# Keep moving: open the passage that matters, don't just point at it. The
+# panel comes up with this entry selected and the view scrolls to it.
+semiont browse --annotation ann-thesis --browser
+sleep 60
+
+# Advance to the next stop on the guide's schedule.
+semiont browse res-method --browser
+sleep 90
+
+# NOW hand over a choice — this is what beckon is for. Two sparkles mark the
+# options without scroll-fighting; one focus says which to start with.
+semiont beckon --resource res-method --annotation ref-history --sparkle
+semiont beckon --resource res-method --annotation ref-sources --sparkle
+semiont beckon --resource res-method --annotation ref-history
 
 # Branch on where they actually went — including arrivals by link, back button,
 # or a typed URL, not just cues they followed.
 semiont listen --channel browse:resource-viewed --json |
   while read -r ev; do
     case "$(jq -r '.payload.resourceId' <<<"$ev")" in
-      res-history) semiont beckon --resource res-history --annotation ref-sources --sparkle ;;
-      res-method)  semiont browse res-method-detail --browser ;;
+      res-history) semiont browse --annotation ann-origins --browser ;;
+      res-sources) semiont browse res-sources-detail --browser ;;
     esac
   done
 ```
+
+Note the rhythm: **four `browse` moves carry the tour, one `beckon` cluster offers the
+branch.** The guide keeps the story moving on its own schedule and hands over control at the
+moment a choice is genuinely interesting — not at every step.
 
 Timing is `sleep`. Semiont has no scheduler and wants none — the tour's pace is the author's.
 
@@ -125,7 +160,12 @@ Every emit reports how many subscribers the backend had **at dispatch**:
 
 Zero means the signal reached an empty room — worth acting on, because these channels have no
 reply and would otherwise fail silently. A positive count is **not** delivery: a subscriber is
-a connection, not a pair of eyes. Both cases exit 0; an empty room is a fact, not an error.
+a connection, not a pair of eyes.
+
+**Zero is an error for `browse --browser` and a fact for `beckon`**, per the split above:
+both `--browser` forms exit 1 (they asked for a specific outcome that did not happen), while
+`beckon` exits 0 (fire-and-forget by contract). Under `set -e` that makes any `browse
+--browser` a gate and no `beckon` one.
 
 ## What this cannot do
 
@@ -138,8 +178,13 @@ State these to the user rather than letting them discover them mid-demo:
 - **No forced navigation to a resource the viewer cannot see.** `beckon:focus` carries a
   `resourceId` as a *guard*: a viewer on a different resource ignores it. Moving someone is
   `browse --browser`'s job, and it is a separate, deliberate act.
-- **No annotation-level engagement reporting.** You see which resources they arrived at, not
-  which annotations they read.
+- **Opening an annotation the viewer has not loaded does nothing.** It is a silent no-op, not
+  an error — the viewer resolves the annotation by id and finds nothing. So open a resource
+  before opening an annotation inside it, or accept that the cue may land nowhere.
+- **No annotation-level engagement reporting.** You can now *drive* a click, but you still
+  only see which **resources** they arrived at — not which annotations they read. The drive
+  and the report are asymmetric here, deliberately: `browse:resource-viewed` is the only
+  arrival signal.
 
 ## From TypeScript instead
 
@@ -148,25 +193,30 @@ report:
 
 ```ts
 const n = await client.beckon.openResource(resourceId);   // → wire (browse:resource-open)
+await client.beckon.click(annotationId);                  // → wire (browse:click)
 await client.beckon.sparkleAll(annotationId);             // → wire (beckon:sparkle)
 await client.beckon.attention(resourceId, annotationId);  // → wire (beckon:focus)
 client.browse.resourceViewed(resourceId);                 // → wire (the report)
 ```
 
+The pairing is the rule worth remembering: **`browse.X()` does it for me, `beckon.X()` does
+it for everyone else.** `browse.openResource()` and `browse.click()` are this viewer's own
+local fan-out; their `beckon` twins are the wire drives a tour uses.
+
 Every drive resolves with the subscriber count (`-1` = unknown) — the same signal the
 launcher's tour verbs print. `n === 0` means the room is empty, and the script can say so
 instead of touring nobody.
 
-The unmarked local pair stays local by design: `browse.openResource()` and
-`beckon.sparkle()` are this viewer's own fan-out — from a Node script they reach nobody,
-and that is correct (D6: a wire emit there would broadcast one viewer's own click to the
-room).
+The unmarked local members stay local by design: `browse.openResource()`, `browse.click()`
+and `beckon.sparkle()` are this viewer's own fan-out — from a Node script they reach nobody,
+and that is correct. A wire emit there would broadcast one viewer's own click to the whole
+room, which is the drive-versus-report loop the split exists to prevent.
 
 For anything long-running, build on [`semiont-session`](../semiont-session/SKILL.md) rather
 than a bare client: a tour that outlives its access token needs the refresh machinery, and
 `session.subscribe(channel, handler)` is the SDK equivalent of `semiont listen`.
 
-**Either surface drives a tour.** The launcher's four moves are one command each with no
+**Either surface drives a tour.** The launcher's moves are one command each with no
 token lifecycle to own; the SDK path is the same wire with a programmable driver around it.
 
 ## Related

--- a/docs/protocol/skills/semiont-tour/SKILL.md
+++ b/docs/protocol/skills/semiont-tour/SKILL.md
@@ -44,6 +44,12 @@ screen too. There is no per-participant addressing, deliberately — see "What t
 beckoning three references in a row scroll-fights and only the last survives. Sparkle marks an
 annotation in place. A three-way branch is three sparkles; "begin here" is one focus.
 
+**Only the first move fails on an empty room.** Every emit reports how many subscribers the
+target subject had at dispatch, but the two verbs treat zero differently on purpose: `beckon`
+exits 0 because a beckon is fire-and-forget, while `browse --browser` exits 1 because it asked
+for a specific outcome — a resource on a screen — and zero subscribers means it did not happen.
+That makes the first move a natural gate for the whole tour.
+
 ## Building the tour
 
 Read the KB first — every verb takes ids, and `browse` is what produces them:
@@ -66,6 +72,10 @@ set -euo pipefail
 # this fires when a Browser opens an event stream, not when a token is minted.
 semiont listen --channel session:joined --json | head -1 >/dev/null
 
+# Fails (exit 1) if nobody is subscribed, so `set -e` stops the tour rather
+# than narrating to an empty room. Add --launch to start the Browser when none
+# is running — it starts a CONTAINER, and someone must still open a web
+# browser and log in.
 semiont browse res-intro --browser
 sleep 90
 

--- a/packages/core/src/__tests__/bus-invariants.test.ts
+++ b/packages/core/src/__tests__/bus-invariants.test.ts
@@ -105,6 +105,12 @@ const FROZEN_BRIDGED = [
   // are different processes.
   'session:joined',
   'session:left',
+  // TOUR-CLICK P1: the tour's fourth drive — OPEN an annotation (panel entry
+  // selected, then relayed to beckon:focus for the scroll), where focus only
+  // points at one. Bridging is fan-IN only, so the eight in-browser
+  // `browse.click()` emitters stay local exactly as `browse.openResource()`
+  // does; the wire emitter is `beckon.click()`.
+  'browse:click',
 ];
 
 describe('bus channel-classification invariants', () => {

--- a/packages/core/src/bridged-channels.ts
+++ b/packages/core/src/bridged-channels.ts
@@ -52,6 +52,7 @@ export const BRIDGED_BROADCASTS = [
   'browse:resource-viewed',
   'session:joined',
   'session:left',
+  'browse:click',
 ] as const satisfies readonly EventName[];
 
 // ── Derivation ──────────────────────────────────────────────────────────────

--- a/packages/core/src/bus-protocol.ts
+++ b/packages/core/src/bus-protocol.ts
@@ -688,7 +688,7 @@ export const CHANNEL_SCHEMAS = {
   'browse:directory-requested':       'BrowseDirectoryRequest',
   'browse:directory-result':          'BrowseDirectoryResult',
   'browse:directory-failed':          null, // { correlationId; path } & CommandError
-  'browse:click':                     null, // includes runtime `anchorRect?: AnchorRect`
+  'browse:click':                     'BrowseClickEvent', // includes runtime `anchorRect?: AnchorRect`
   'browse:resource-open':             'BrowseResourceOpenEvent',
   'browse:resource-viewed':           'BrowseResourceViewedEvent',
   'browse:entity-type-clicked':       'BrowseEntityTypeClickedEvent',

--- a/packages/react-ui/docs/ANNOTATION-CLICK.md
+++ b/packages/react-ui/docs/ANNOTATION-CLICK.md
@@ -94,7 +94,9 @@ interface EventMap {
   // User clicks annotation on resource overlay
   'browse:click': {
     annotationId: string;
-    motivation: Motivation;
+    // Local-only extra: viewport geometry for anchoring a popup. Never on the
+    // wire — a bridged-in remote click simply arrives without one.
+    anchorRect?: AnchorRect;
   };
 
   // Bidirectional hover: annotation overlay ↔ panel entry
@@ -143,10 +145,10 @@ sequenceDiagram
     participant Entry as ReferenceEntry
 
     User->>Overlay: Click annotation shape
-    Overlay->>Bus: emit('browse:click', {<br/>  annotationId: 'anno-123',<br/>  motivation: 'linking'<br/>})
+    Overlay->>Bus: emit('browse:click', {<br/>  annotationId: 'anno-123'<br/>})
     Bus->>Coord: browse:click event
 
-    Note over Coord: Maps motivation → panel type<br/>'linking' → 'references'
+    Note over Coord: Resolves the annotation by id,<br/>derives its motivation → panel type<br/>'linking' → 'references'
 
     Coord->>Bus: emit('panel:open', {<br/>  activePanel: 'references',<br/>  scrollToAnnotationId: 'anno-123'<br/>})
     Bus->>Page: panel:open event
@@ -405,10 +407,9 @@ export const ReferenceEntry = forwardRef<HTMLDivElement, ReferenceEntryProps>(
         data-focused={isFocused ? 'true' : 'false'}
         onClick={() => {
           // Click → Open panel
-          session?.client.emit('browse:click', {
-            annotationId: reference.id,
-            motivation: reference.motivation
-          });
+          // The id is the whole address; the viewer derives the motivation
+          // from the annotation it names.
+          session?.client.browse.click(reference.id);
         }}
         onMouseEnter={() => {
           // Hover entry → Highlight annotation on resource

--- a/packages/react-ui/docs/COMPONENTS.md
+++ b/packages/react-ui/docs/COMPONENTS.md
@@ -362,7 +362,7 @@ import { CommentEntry, ReferenceEntry } from '@semiont/react-ui';
 
 **The shared contract:**
 - `session`, the annotation (prop named by motivation: `highlight` / `reference` / `comment` / `assessment` / `tag`), and `isFocused` are required; `isHovered?` pulses the row, `ref?` reaches the row element.
-- Click emits `browse:click` via `session.client.browse.click(id, motivation)` — the same event the stock Browser routes to panel focus, so a host-composed list and any Semiont surface on the same session stay in sync for free.
+- Click emits `browse:click` via `session.client.browse.click(id)` — the same event the stock Browser routes to panel focus, so a host-composed list and any Semiont surface on the same session stay in sync for free.
 - Hover (debounced) emits the beckon hover signal that highlights the annotation in an open viewer on the same session.
 - `ReferenceEntry` extras: `onOpenResource?` (host navigation when the resolved reference is followed), `annotateMode?` (resolve / unlink affordances), `isGenerating?`.
 

--- a/packages/react-ui/src/components/image-annotation/AnnotationOverlay.tsx
+++ b/packages/react-ui/src/components/image-annotation/AnnotationOverlay.tsx
@@ -128,7 +128,7 @@ export function AnnotationOverlay({
                   className="semiont-annotation-overlay__shape"
                   data-hovered={isHovered ? 'true' : 'false'}
                   data-selected={isSelected ? 'true' : 'false'}
-                  onClick={(e) => session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect())}
+                  onClick={(e) => session?.client.browse.click(annotation.id, e.currentTarget.getBoundingClientRect())}
                   onMouseEnter={() => handleMouseEnter(annotation.id)}
                   onMouseLeave={handleMouseLeave}
                 />
@@ -141,7 +141,7 @@ export function AnnotationOverlay({
                     style={{ userSelect: 'none' }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect());
+                      session?.client.browse.click(annotation.id, e.currentTarget.getBoundingClientRect());
                     }}
                     onMouseEnter={() => handleMouseEnter(annotation.id)}
                     onMouseLeave={handleMouseLeave}
@@ -175,7 +175,7 @@ export function AnnotationOverlay({
                   className="semiont-annotation-overlay__shape"
                   data-hovered={isHovered ? 'true' : 'false'}
                   data-selected={isSelected ? 'true' : 'false'}
-                  onClick={(e) => session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect())}
+                  onClick={(e) => session?.client.browse.click(annotation.id, e.currentTarget.getBoundingClientRect())}
                   onMouseEnter={() => handleMouseEnter(annotation.id)}
                   onMouseLeave={handleMouseLeave}
                 />
@@ -188,7 +188,7 @@ export function AnnotationOverlay({
                     style={{ userSelect: 'none' }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect());
+                      session?.client.browse.click(annotation.id, e.currentTarget.getBoundingClientRect());
                     }}
                     onMouseEnter={() => handleMouseEnter(annotation.id)}
                     onMouseLeave={handleMouseLeave}
@@ -235,7 +235,7 @@ export function AnnotationOverlay({
                   className="semiont-annotation-overlay__shape"
                   data-hovered={isHovered ? 'true' : 'false'}
                   data-selected={isSelected ? 'true' : 'false'}
-                  onClick={(e) => session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect())}
+                  onClick={(e) => session?.client.browse.click(annotation.id, e.currentTarget.getBoundingClientRect())}
                   onMouseEnter={() => handleMouseEnter(annotation.id)}
                   onMouseLeave={handleMouseLeave}
                 />
@@ -248,7 +248,7 @@ export function AnnotationOverlay({
                     style={{ userSelect: 'none' }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      session?.client.browse.click(annotation.id, annotation.motivation, e.currentTarget.getBoundingClientRect());
+                      session?.client.browse.click(annotation.id, e.currentTarget.getBoundingClientRect());
                     }}
                     onMouseEnter={() => handleMouseEnter(annotation.id)}
                     onMouseLeave={handleMouseLeave}

--- a/packages/react-ui/src/components/image-annotation/SvgDrawingCanvas.tsx
+++ b/packages/react-ui/src/components/image-annotation/SvgDrawingCanvas.tsx
@@ -221,7 +221,7 @@ export function SvgDrawingCanvas({
         });
 
         if (clickedAnnotation) {
-          session?.client.browse.click(clickedAnnotation.id, clickedAnnotation.motivation, hitRect);
+          session?.client.browse.click(clickedAnnotation.id, hitRect);
           setIsDrawing(false);
           setStartPoint(null);
           setCurrentPoint(null);

--- a/packages/react-ui/src/components/image-annotation/__tests__/AnnotationOverlay.click.test.tsx
+++ b/packages/react-ui/src/components/image-annotation/__tests__/AnnotationOverlay.click.test.tsx
@@ -2,7 +2,7 @@
  * A1 anchor thread (HEADLESS-ANNOTATION-PANELS Phase 3) — image overlay pin.
  *
  * The overlay's shape elements own their on-screen geometry: a click passes
- * the element's viewport rect as browse.click's third argument so hosts can
+ * the element's viewport rect as browse.click's second argument so hosts can
  * anchor popovers. Runtime-only view geometry; no schema involvement.
  */
 import { describe, it, expect, vi } from 'vitest';
@@ -43,7 +43,7 @@ function sessionDouble() {
 }
 
 describe('AnnotationOverlay — anchorRect on click', () => {
-  it('passes the shape element rect as browse.click third argument', () => {
+  it('passes the shape element rect as browse.click second argument', () => {
     const { session, click } = sessionDouble();
 
     const { container } = render(
@@ -65,8 +65,7 @@ describe('AnnotationOverlay — anchorRect on click', () => {
 
     expect(click).toHaveBeenCalledTimes(1);
     expect(click.mock.calls[0]?.[0]).toBe('img-ann-1');
-    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
-    const anchorRect = click.mock.calls[0]?.[2];
+    const anchorRect = click.mock.calls[0]?.[1];
     expect(anchorRect).toBeDefined();
     expect(typeof anchorRect.width).toBe('number');
     expect(typeof anchorRect.left).toBe('number');
@@ -77,7 +76,7 @@ describe('AnnotationOverlay — anchorRect on click', () => {
   it.each([
     ['circle', svgAnnotation('img-circle-1', 'commenting', '<svg><circle cx="30" cy="30" r="10"/></svg>')],
     ['polygon', svgAnnotation('img-polygon-1', 'assessing', '<svg><polygon points="10,10 30,10 20,30"/></svg>')],
-  ] as const)('passes the %s element rect as browse.click third argument', (_kind, annotation) => {
+  ] as const)('passes the %s element rect as browse.click second argument', (_kind, annotation) => {
     const { session, click } = sessionDouble();
 
     const { container } = render(
@@ -99,12 +98,12 @@ describe('AnnotationOverlay — anchorRect on click', () => {
 
     expect(click).toHaveBeenCalledTimes(1);
     expect(click.mock.calls[0]?.[0]).toBe(annotation.id);
-    const anchorRect = click.mock.calls[0]?.[2];
+    const anchorRect = click.mock.calls[0]?.[1];
     expect(anchorRect).toBeDefined();
     expect(typeof anchorRect.width).toBe('number');
   });
 
-  it('passes the status-indicator element rect as browse.click third argument', () => {
+  it('passes the status-indicator element rect as browse.click second argument', () => {
     // Only references render a status indicator (🔗/❓).
     const reference = svgAnnotation('img-ref-1', 'linking', '<svg><rect x="10" y="10" width="20" height="20"/></svg>');
     const { session, click } = sessionDouble();
@@ -129,8 +128,7 @@ describe('AnnotationOverlay — anchorRect on click', () => {
     // stopPropagation: the indicator's own handler emits, exactly once.
     expect(click).toHaveBeenCalledTimes(1);
     expect(click.mock.calls[0]?.[0]).toBe('img-ref-1');
-    expect(click.mock.calls[0]?.[1]).toBe('linking');
-    const anchorRect = click.mock.calls[0]?.[2];
+    const anchorRect = click.mock.calls[0]?.[1];
     expect(anchorRect).toBeDefined();
     expect(typeof anchorRect.width).toBe('number');
   });

--- a/packages/react-ui/src/components/image-annotation/__tests__/SvgDrawingCanvas.click.test.tsx
+++ b/packages/react-ui/src/components/image-annotation/__tests__/SvgDrawingCanvas.click.test.tsx
@@ -100,8 +100,7 @@ describe('SvgDrawingCanvas — drawing-path hit-test anchorRect', () => {
 
     expect(click).toHaveBeenCalledTimes(1);
     expect(click.mock.calls[0]?.[0]).toBe('canvas-ann-1');
-    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
-    expect(click.mock.calls[0]?.[2]).toEqual({
+    expect(click.mock.calls[0]?.[1]).toEqual({
       x: 20, y: 20, left: 20, top: 20, width: 40, height: 40, right: 60, bottom: 60,
     });
   });

--- a/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/PdfAnnotationCanvas.tsx
@@ -353,7 +353,7 @@ function PdfPageView({
         });
 
         if (hit) {
-          session?.client.browse.click(hit.annId, hit.annotation.motivation, hitRect);
+          session?.client.browse.click(hit.annId, hitRect);
           setIsDrawing(false);
           setSelection(null);
           return;
@@ -515,7 +515,7 @@ function PdfPageView({
                       cursor: 'pointer',
                       opacity: isSelected ? 1 : isHovered ? 0.9 : 0.7
                     }}
-                    onClick={(e) => session?.client.browse.click(r.annId, r.annotation.motivation, e.currentTarget.getBoundingClientRect())}
+                    onClick={(e) => session?.client.browse.click(r.annId, e.currentTarget.getBoundingClientRect())}
                     onMouseEnter={() => handleMouseEnter(r.annId)}
                     onMouseLeave={handleMouseLeave}
                   />

--- a/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
+++ b/packages/react-ui/src/components/pdf-annotation/__tests__/PdfAnnotationCanvas.test.tsx
@@ -275,7 +275,7 @@ describe('PdfAnnotationCanvas', () => {
     });
   });
 
-  test('passes the annotation rect as browse.click third argument (A1 anchor)', async () => {
+  test('passes the annotation rect as browse.click second argument (A1 anchor)', async () => {
     const click = vi.fn();
     const session = {
       client: { browse: { click }, beckon: { hover: vi.fn() } },
@@ -328,8 +328,7 @@ describe('PdfAnnotationCanvas', () => {
 
     expect(click).toHaveBeenCalledTimes(1);
     expect(click.mock.calls[0]?.[0]).toBe('ann-1');
-    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
-    const anchorRect = click.mock.calls[0]?.[2];
+    const anchorRect = click.mock.calls[0]?.[1];
     expect(anchorRect).toBeDefined();
     expect(typeof anchorRect.width).toBe('number');
   });
@@ -401,8 +400,7 @@ describe('PdfAnnotationCanvas', () => {
 
     expect(click).toHaveBeenCalledTimes(1);
     expect(click.mock.calls[0]?.[0]).toBe('ann-hit-1');
-    expect(click.mock.calls[0]?.[1]).toBe('highlighting');
-    expect(click.mock.calls[0]?.[2]).toMatchObject({
+    expect(click.mock.calls[0]?.[1]).toMatchObject({
       left: displayRect.x,
       top: displayRect.y,
       width: displayRect.width,

--- a/packages/react-ui/src/components/resource/BrowseView.tsx
+++ b/packages/react-ui/src/components/resource/BrowseView.tsx
@@ -155,7 +155,7 @@ export const BrowseView = memo(function BrowseView({
         if (annotation) {
           // The emission site owns the geometry: the clicked span's viewport
           // rect rides the event so hosts can anchor popovers (A1).
-          session.client.browse.click(annotation.id, annotation.motivation, annotationElement.getBoundingClientRect());
+          session.client.browse.click(annotation.id, annotationElement.getBoundingClientRect());
         }
       }
     };

--- a/packages/react-ui/src/components/resource/ResourceViewer.tsx
+++ b/packages/react-ui/src/components/resource/ResourceViewer.tsx
@@ -8,7 +8,7 @@ import { BrowseView, type ReferenceHover } from './BrowseView';
 import type { BrowseMediaRenderers } from './browse-renderers';
 import { PopupContainer } from '../annotation-popups/SharedPopupElements';
 import { JsonLdView } from '../annotation-popups/JsonLdView';
-import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, components, EventMap, AnchorRect } from '@semiont/core';
+import type { Annotation, AnnotationId, ResourceDescriptor as SemiontResource, EventMap, AnchorRect } from '@semiont/core';
 import { getExactText, getTargetSelector, getPrimaryMediaType, isHighlight, isAssessment, isReference, isComment, isTag, getBodySource } from '@semiont/core';
 import type { SemiontSession } from '@semiont/sdk';
 import { useSessionEventSubscriptions } from '../../hooks/useSessionEventSubscriptions';
@@ -102,7 +102,10 @@ interface Props {
  * panel opening invokes the host's `onOpenPanel` callback — the host owns
  * the panel and any `panel:open` emission.
  *
- * @subscribes browse:click - User clicked on annotation. Payload: { annotationId: string, motivation, anchorRect? }
+ * @subscribes browse:click - An annotation was clicked — locally, or driven over
+ *   the wire by another participant. Payload: { annotationId: string, anchorRect? };
+ *   the motivation is derived from the annotation the id names, and an id this
+ *   viewer has not loaded is a no-op.
  */
 export function ResourceViewer({
   resource,
@@ -270,38 +273,34 @@ export function ResourceViewer({
   }, [annotateMode, selectedClick, onOpenResource]);
 
   // Annotation click coordinator - handles panel opening and scrolling
-  const handleAnnotationClickEvent = useCallback(({ annotationId, motivation, anchorRect }: {
+  const handleAnnotationClickEvent = useCallback(({ annotationId, anchorRect }: {
     annotationId: string;
-    motivation: components['schemas']['Motivation'];
     anchorRect?: AnchorRect;
   }) => {
-    // Find the annotation metadata
-    const metadata = Object.values(ANNOTATORS).find(a => a.matchesAnnotation({ motivation } as Annotation));
+    // Resolve the annotation FIRST. The id is the whole address, and the
+    // motivation is derived from the annotation it names rather than carried
+    // beside it (TOUR-CLICK D2) — one fact, one encoding. Resolving first also
+    // means a click naming an annotation this viewer has not loaded (a remote
+    // drive that arrived while the participant was elsewhere) finds nothing
+    // and does nothing, which is why the channel needs no resourceId guard.
+    const allAnnotations = [...highlights, ...references, ...assessments, ...comments, ...tags];
+    const annotation = allAnnotations.find(a => a.id === annotationId);
+    if (!annotation) return;
 
-    if (!metadata?.hasSidePanel) {
-      // Annotation doesn't have a side panel - let handleAnnotationClick handle it
-      const allAnnotations = [...highlights, ...references, ...assessments, ...comments, ...tags];
-      const annotation = allAnnotations.find(a => a.id === annotationId);
-      if (annotation) {
-        handleAnnotationClick(annotation);
-      }
-      return;
-    }
+    // The real annotation, not a `{ motivation } as Annotation` stand-in.
+    const metadata = Object.values(ANNOTATORS).find(a => a.matchesAnnotation(annotation));
 
-    if (selectedClick !== 'detail') {
-      // Only open panels in detail mode - for other modes, let handleAnnotationClick handle it
-      const allAnnotations = [...highlights, ...references, ...assessments, ...comments, ...tags];
-      const annotation = allAnnotations.find(a => a.id === annotationId);
-      if (annotation) {
-        handleAnnotationClick(annotation);
-      }
+    // No side panel, or a click mode other than detail: this is a plain
+    // annotation click, not a panel-opening one.
+    if (!metadata?.hasSidePanel || selectedClick !== 'detail') {
+      handleAnnotationClick(annotation);
       return;
     }
 
     // All annotations open the unified annotations panel — the host owns the panel.
     // The panel internally switches tabs based on the motivation → tab mapping in UnifiedAnnotationsPanel.
     // View geometry passes through untouched: the emitter owned it, the host anchors with it.
-    onOpenPanel?.({ panel: 'annotations', scrollToAnnotationId: annotationId, motivation, ...(anchorRect ? { anchorRect } : {}) });
+    onOpenPanel?.({ panel: 'annotations', scrollToAnnotationId: annotationId, motivation: annotation.motivation, ...(anchorRect ? { anchorRect } : {}) });
   }, [highlights, references, assessments, comments, tags, handleAnnotationClick, selectedClick, onOpenPanel]);
 
   // Single subscription call per file (see scripts/compliance/audit-hooks-ordering.ts).

--- a/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/BrowseView.test.tsx
@@ -427,7 +427,7 @@ describe('BrowseView Component', () => {
         { id: 'comment-1', type: 'comment', motivation: 'commenting' },
       ] as const;
 
-      for (const { id, type, motivation } of clickCases) {
+      for (const { id, type } of clickCases) {
         const el = document.createElement('span');
         el.setAttribute('data-annotation-id', id);
         el.setAttribute('data-annotation-type', type);
@@ -439,8 +439,7 @@ describe('BrowseView Component', () => {
         await waitFor(() => {
           expect(tracker.events.some(e =>
             e.event === 'browse:click' &&
-            e.payload?.annotationId === id &&
-            e.payload?.motivation === motivation
+            e.payload?.annotationId === id
           )).toBe(true);
         });
       }

--- a/packages/react-ui/src/components/resource/__tests__/ResourceViewer.embeddable.test.tsx
+++ b/packages/react-ui/src/components/resource/__tests__/ResourceViewer.embeddable.test.tsx
@@ -15,7 +15,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { SemiontSession } from '@semiont/sdk';
-import type { ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import type { Annotation, ResourceDescriptor as SemiontResource, ResourceId } from '@semiont/core';
+import { annotationId } from '@semiont/core';
 import { createTestSemiontWrapper } from '../../../test-utils';
 import { ResourceViewer } from '../ResourceViewer';
 
@@ -46,6 +47,23 @@ const resource: SemiontResource & { content: string } = {
 
 const annotations = { highlights: [], references: [], assessments: [], comments: [], tags: [] };
 
+/**
+ * A highlight the viewer has actually loaded. Required since TOUR-CLICK D2: the
+ * click handler resolves the annotation by id and derives the motivation from
+ * it, so a click for an id absent from this collection is a no-op. Before that,
+ * the wire carried the motivation and the viewer never looked — which is why
+ * the anchorRect test below used to pass against an empty collection.
+ */
+const loadedHighlight: Annotation = {
+  '@context': 'http://www.w3.org/ns/anno.jsonld',
+  type: 'Annotation',
+  id: annotationId('ann-1'),
+  motivation: 'highlighting',
+  target: { source: 'res-1', selector: { type: 'TextPositionSelector', start: 0, end: 10 } },
+};
+
+const annotationsWithHighlight = { ...annotations, highlights: [loadedHighlight] };
+
 describe('ResourceViewer — embeddable (bring-your-own-session, no providers)', () => {
   // GREEN: the whole browse-mode subtree (ResourceViewer → BrowseView →
   // AnnotateToolbar) renders provider-free from a bare session.
@@ -73,7 +91,7 @@ describe('ResourceViewer — embeddable (bring-your-own-session, no providers)',
       <ResourceViewer
         session={session}
         resource={resource}
-        annotations={annotations}
+        annotations={annotationsWithHighlight}
         onOpenResource={vi.fn()}
         onOpenPanel={onOpenPanel}
       />,
@@ -86,7 +104,6 @@ describe('ResourceViewer — embeddable (bring-your-own-session, no providers)',
     act(() => {
       eventBus.get('browse:click').next({
         annotationId: 'ann-1',
-        motivation: 'highlighting',
         anchorRect,
       });
     });
@@ -95,8 +112,35 @@ describe('ResourceViewer — embeddable (bring-your-own-session, no providers)',
       expect(onOpenPanel).toHaveBeenCalledWith(expect.objectContaining({
         panel: 'annotations',
         scrollToAnnotationId: 'ann-1',
+        // Derived from the annotation the id names, never carried on the wire.
+        motivation: 'highlighting',
         anchorRect: expect.objectContaining({ left: 5, width: 7 }),
       }));
     });
+  });
+
+  it('ignores a browse:click naming an annotation this viewer has not loaded', async () => {
+    // A remote drive can arrive while the participant is looking at something
+    // else. Resolving the annotation FIRST makes that a no-op by construction,
+    // which is why the channel carries no resourceId guard (TOUR-CLICK D3).
+    const { session, eventBus } = createTestSemiontWrapper();
+    const onOpenPanel = vi.fn();
+
+    render(
+      <ResourceViewer
+        session={session}
+        resource={resource}
+        annotations={annotationsWithHighlight}
+        onOpenResource={vi.fn()}
+        onOpenPanel={onOpenPanel}
+      />,
+    );
+
+    act(() => {
+      eventBus.get('browse:click').next({ annotationId: 'ann-not-here' });
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onOpenPanel).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-ui/src/components/resource/panels/AssessmentEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssessmentEntry.tsx
@@ -88,7 +88,7 @@ export function AssessmentEntry({
       data-type="assessment"
       data-focused={isFocused ? 'true' : 'false'}
       onClick={() => {
-        session?.client.browse.click(assessment.id, assessment.motivation);
+        session?.client.browse.click(assessment.id);
       }}
       {...hoverProps}
     >

--- a/packages/react-ui/src/components/resource/panels/AssistSection.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssistSection.tsx
@@ -91,7 +91,14 @@ export function AssistSection({
       progress={progress}
       progressProps={{
         onDismiss: handleDismissProgress,
-        translations: assistProgressTranslations(ta),
+        translations: {
+          cancel: t('cancel'),
+          inProgress: t('annotating'),
+          close: ta('close'),
+          message: assistProgressCopy(ta),
+          subject: assistSubjectCopy(ta),
+          paramLabel: assistParamLabel(ta),
+        },
       }}
       form={
         <>

--- a/packages/react-ui/src/components/resource/panels/AssistSection.tsx
+++ b/packages/react-ui/src/components/resource/panels/AssistSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { assistProgressTranslations } from '../../../lib/assist-progress-copy';
+import { assistProgressCopy, assistSubjectCopy, assistParamLabel } from '../../../lib/assist-progress-copy';
 import { useTranslations } from '../../../contexts/TranslationContext';
 import type { SemiontSession } from '@semiont/sdk';
 import type { Motivation, components } from '@semiont/core';

--- a/packages/react-ui/src/components/resource/panels/CommentEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/CommentEntry.tsx
@@ -87,7 +87,7 @@ export function CommentEntry({
       data-type="comment"
       data-focused={isFocused ? 'true' : 'false'}
       onClick={() => {
-        session?.client.browse.click(comment.id, comment.motivation);
+        session?.client.browse.click(comment.id);
       }}
       {...hoverProps}
     >

--- a/packages/react-ui/src/components/resource/panels/HighlightEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/HighlightEntry.tsx
@@ -51,7 +51,7 @@ export function HighlightEntry({
       data-type="highlight"
       data-focused={isFocused ? 'true' : 'false'}
       onClick={() => {
-        session?.client.browse.click(highlight.id, highlight.motivation);
+        session?.client.browse.click(highlight.id);
       }}
       {...hoverProps}
     >

--- a/packages/react-ui/src/components/resource/panels/ReferenceEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/ReferenceEntry.tsx
@@ -117,7 +117,7 @@ export function ReferenceEntry({
       data-type="reference"
       data-focused={isFocused ? 'true' : 'false'}
       onClick={() => {
-        session?.client.browse.click(reference.id, reference.motivation);
+        session?.client.browse.click(reference.id);
       }}
       {...hoverProps}
     >

--- a/packages/react-ui/src/components/resource/panels/TagEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/TagEntry.tsx
@@ -52,7 +52,7 @@ export function TagEntry({
     <div
       ref={ref}
       onClick={() => {
-        session?.client.browse.click(tag.id, tag.motivation);
+        session?.client.browse.click(tag.id);
       }}
       {...hoverProps}
       className={`semiont-annotation-entry${isHovered ? ' semiont-annotation-pulse' : ''}`}

--- a/packages/react-ui/src/components/resource/panels/__tests__/AssessmentEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/AssessmentEntry.test.tsx
@@ -185,7 +185,6 @@ describe('AssessmentEntry', () => {
 
       expect(clickHandler).toHaveBeenCalledWith({
         annotationId: 'assessment-1',
-        motivation: 'assessing',
       });
 
       subscription.unsubscribe();

--- a/packages/react-ui/src/components/resource/panels/__tests__/CommentEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/CommentEntry.test.tsx
@@ -264,8 +264,7 @@ describe('CommentEntry Component', () => {
       await userEvent.click(commentDiv);
 
       expect(clickHandler).toHaveBeenCalledWith({
-        annotationId: 'comment-1',
-        motivation: 'commenting'
+        annotationId: 'comment-1'
       });
 
       // Clean up

--- a/packages/react-ui/src/components/resource/panels/__tests__/HighlightEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/HighlightEntry.test.tsx
@@ -147,7 +147,6 @@ describe('HighlightEntry', () => {
 
       expect(clickHandler).toHaveBeenCalledWith({
         annotationId: 'highlight-1',
-        motivation: 'highlighting',
       });
 
       subscription.unsubscribe();

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferenceEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferenceEntry.test.tsx
@@ -236,7 +236,6 @@ describe('ReferenceEntry', () => {
 
       expect(clickHandler).toHaveBeenCalledWith({
         annotationId: 'ref-1',
-        motivation: 'linking',
       });
 
       subscription.unsubscribe();

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.headless.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferencesPanel.headless.test.tsx
@@ -82,7 +82,7 @@ describe('ReferencesPanel — headless (session prop, no providers)', () => {
     expect(entryText).toBeInTheDocument();
 
     fireEvent.click(entryText);
-    expect(client.browse.click).toHaveBeenCalledWith('ref-1', 'linking');
+    expect(client.browse.click).toHaveBeenCalledWith('ref-1');
   });
 
   describe('incoming references — terminal load failure', () => {

--- a/packages/react-ui/src/components/resource/panels/__tests__/TagEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/TagEntry.test.tsx
@@ -183,7 +183,6 @@ describe('TagEntry', () => {
 
       expect(clickHandler).toHaveBeenCalledWith({
         annotationId: 'tag-1',
-        motivation: 'tagging',
       });
 
       subscription.unsubscribe();

--- a/packages/react-ui/src/lib/__tests__/codemirror-handlers.test.ts
+++ b/packages/react-ui/src/lib/__tests__/codemirror-handlers.test.ts
@@ -64,7 +64,7 @@ describe('handleAnnotationClick', () => {
 
     const result = handleAnnotationClick(child, segmentsById, session);
     expect(result).toBe(true);
-    expect(session.click).toHaveBeenCalledWith('ann-1', 'highlighting');
+    expect(session.click).toHaveBeenCalledWith('ann-1');
   });
 });
 
@@ -115,18 +115,9 @@ describe('handleWidgetClick', () => {
       handled: true,
       action: 'browse-click',
       annotationId: 'ann-1',
-      motivation: 'linking',
     });
   });
 
-  it('defaults motivation to linking when not set', () => {
-    const widget = createElement('div', {
-      class: 'reference-preview-widget',
-      'data-widget-annotation-id': 'ann-1',
-    });
-    const result = handleWidgetClick(widget);
-    expect(result.motivation).toBe('linking');
-  });
 });
 
 describe('dispatchWidgetClick', () => {
@@ -155,10 +146,9 @@ describe('dispatchWidgetClick', () => {
       handled: true,
       action: 'browse-click',
       annotationId: 'ann-1',
-      motivation: 'linking' as any,
     };
     dispatchWidgetClick(result, session);
-    expect(session.click).toHaveBeenCalledWith('ann-1', 'linking');
+    expect(session.click).toHaveBeenCalledWith('ann-1');
   });
 });
 

--- a/packages/react-ui/src/lib/codemirror-handlers.ts
+++ b/packages/react-ui/src/lib/codemirror-handlers.ts
@@ -6,7 +6,6 @@
  * elements and a SemiontSession — no CodeMirror API dependency.
  */
 
-import type { Motivation } from '@semiont/core';
 import { annotationId as toAnnotationId, resourceId as toResourceId } from '@semiont/core';
 import type { SemiontSession } from '@semiont/sdk';
 import type { TextSegment } from './codemirror-logic';
@@ -30,7 +29,7 @@ export function handleAnnotationClick(
   const segment = segmentsById.get(annotationId);
   if (!segment?.annotation) return false;
 
-  session.client.browse.click(toAnnotationId(annotationId), segment.annotation.motivation);
+  session.client.browse.click(toAnnotationId(annotationId));
   return true;
 }
 
@@ -42,7 +41,6 @@ export interface WidgetClickResult {
   action?: 'navigate' | 'browse-click';
   resourceId?: string;
   annotationId?: string;
-  motivation?: Motivation;
 }
 
 /**
@@ -74,7 +72,6 @@ export function handleWidgetClick(target: HTMLElement): WidgetClickResult {
     handled: true,
     action: 'browse-click',
     annotationId,
-    motivation: (widget.dataset.widgetMotivation as Motivation) || 'linking',
   };
 }
 
@@ -87,7 +84,7 @@ export function dispatchWidgetClick(result: WidgetClickResult, session: SemiontS
   if (result.action === 'navigate' && result.resourceId) {
     session.client.browse.openResource(toResourceId(result.resourceId));
   } else if (result.action === 'browse-click' && result.annotationId) {
-    session.client.browse.click(toAnnotationId(result.annotationId), result.motivation || 'linking');
+    session.client.browse.click(toAnnotationId(result.annotationId));
   }
 }
 

--- a/packages/sdk-go/bus/bridged_gen.go
+++ b/packages/sdk-go/bus/bridged_gen.go
@@ -22,6 +22,7 @@ var BridgedBroadcasts = []Channel{
 	BrowseResourceViewed,
 	SessionJoined,
 	SessionLeft,
+	BrowseClick,
 }
 
 // BridgedChannels: everything a transport delivers — the broadcasts plus

--- a/packages/sdk-go/bus/channels_gen.go
+++ b/packages/sdk-go/bus/channels_gen.go
@@ -390,6 +390,9 @@ const (
 	// not emittable (no registered schema)
 	BrowseDirectoryFailed Channel = "browse:directory-failed"
 
+	// payload: BrowseClickEvent
+	BrowseClick Channel = "browse:click"
+
 	// payload: BrowseResourceOpenEvent
 	BrowseResourceOpen Channel = "browse:resource-open"
 
@@ -619,6 +622,7 @@ var ChannelSchemas = map[Channel]string{
 	BrowseAgentsResult:               "BrowseAgentsResult",
 	BrowseDirectoryRequested:         "BrowseDirectoryRequest",
 	BrowseDirectoryResult:            "BrowseDirectoryResult",
+	BrowseClick:                      "BrowseClickEvent",
 	BrowseResourceOpen:               "BrowseResourceOpenEvent",
 	BrowseResourceViewed:             "BrowseResourceViewedEvent",
 	BrowseEntityTypeClicked:          "BrowseEntityTypeClickedEvent",

--- a/packages/sdk-go/bus/transport.go
+++ b/packages/sdk-go/bus/transport.go
@@ -1,0 +1,54 @@
+package bus
+
+// transport.go — the seam. `Transport` is what a consumer needs from the bus,
+// stated as an interface so it can be substituted: an HTTP client in
+// production, a fake in a test, something else later.
+//
+// It mirrors the TypeScript `ITransport` (packages/core/src/transport.ts) in
+// CONTRACT, deliberately not in shape. That interface carries `on`, `stream`,
+// `bridgeInto`, `subscribeToResource` — rxjs Observables and browser
+// connection lifecycle. Reproducing them here would be cargo-culting a foreign
+// idiom into a language that has channels and `context`. What must match, and
+// what the comments below pin, are the wire operations and their semantics:
+// the -1 sentinel, and Request's subscribe-before-emit ordering.
+//
+// Sized for its consumer, per Go practice — four methods, not twelve.
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type Transport interface {
+	// BaseURL is what this transport speaks to. For HTTP, an origin; other
+	// implementations may return an opaque identifier.
+	BaseURL() string
+
+	// Emit publishes one event and reports how many subscribers the target
+	// subject had AT DISPATCH.
+	//
+	// -1 means UNKNOWN — an older backend, an unreadable body, or a transport
+	// where the question does not apply. It is deliberately distinct from 0,
+	// which means the server counted zero: reporting "nobody is listening" on
+	// the strength of a parse failure would be a lie, and it is the same
+	// sentinel `ITransport.emit` returns on the TypeScript side. Callers that
+	// render this to a human must keep the three cases apart.
+	Emit(ctx context.Context, ch Channel, payload any, scope string) (int, error)
+
+	// Subscribe opens a live stream. It returns once the server has ANSWERED,
+	// which is the only "you are subscribed" signal the protocol offers.
+	Subscribe(ctx context.Context, channels, scoped []Channel, scope string) (*Subscription, error)
+
+	// Request performs the correlated request/reply exchange. The ordering is
+	// part of the contract, not an implementation detail: subscribe to the
+	// reply channels FIRST, then emit. Emitting first races the subscription
+	// and loses fast replies.
+	Request(ctx context.Context, op Channel, payload any, opts *RequestOptions) (json.RawMessage, error)
+}
+
+// Client is the HTTP implementation. Asserted at compile time so a signature
+// change on either side is a build failure rather than a runtime surprise.
+var _ Transport = (*Client)(nil)
+
+// BaseURL reports the origin this client was built against.
+func (c *Client) BaseURL() string { return c.base }

--- a/packages/sdk-go/bustest/fake.go
+++ b/packages/sdk-go/bustest/fake.go
@@ -1,0 +1,100 @@
+// Package bustest provides a fake bus.Transport for tests — the Go counterpart
+// of core's FaultyTransport, and the reason `bus.Transport` exists as an
+// interface at all.
+//
+// Named for the `net/http/httptest` convention: a testing companion beside the
+// package it doubles, kept out of that package's own surface.
+//
+// It records what was sent and answers with what the test scripted. Consumers
+// that would otherwise need a live HTTP server — the launcher's verbs — can be
+// exercised in process with no binary, no socket, and no ports.
+package bustest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/The-AI-Alliance/semiont/packages/sdk-go/bus"
+)
+
+// Emitted is one recorded call to Emit.
+type Emitted struct {
+	Channel bus.Channel
+	Payload any
+	Scope   string
+}
+
+// Fake implements bus.Transport. The zero value is not ready — use NewFake, so
+// Subscribers defaults to the honest "unknown" rather than a silent 0 that
+// would read as "nobody is listening".
+type Fake struct {
+	mu sync.Mutex
+
+	// Base is what BaseURL reports.
+	Base string
+	// Token is whatever the constructor was handed — asserted by tests that
+	// care the credential reached the transport at all.
+	Token string
+
+	// Subscribers is what Emit returns. -1 (the default from NewFake) is
+	// "unknown", 0 is a genuine empty room; tests choose deliberately.
+	Subscribers int
+	// EmitErr, when set, is returned by Emit instead of a count.
+	EmitErr error
+
+	// Replies scripts Request: operation channel → raw reply payload.
+	Replies map[bus.Channel]json.RawMessage
+	// RequestErr, when set, is returned by Request instead of a reply.
+	RequestErr error
+
+	// Emits records every Emit in order — a fan-out verb that drops its
+	// second command is invisible to a last-call-only assertion.
+	Emits []Emitted
+	// Requests records every Request's operation, in order.
+	Requests []bus.Channel
+}
+
+func NewFake() *Fake {
+	return &Fake{
+		Base:        "http://fake.test",
+		Subscribers: -1, // unknown until a test says otherwise
+		Replies:     map[bus.Channel]json.RawMessage{},
+	}
+}
+
+func (f *Fake) BaseURL() string { return f.Base }
+
+func (f *Fake) Emit(_ context.Context, ch bus.Channel, payload any, scope string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Emits = append(f.Emits, Emitted{Channel: ch, Payload: payload, Scope: scope})
+	if f.EmitErr != nil {
+		return -1, f.EmitErr
+	}
+	return f.Subscribers, nil
+}
+
+func (f *Fake) Subscribe(context.Context, []bus.Channel, []bus.Channel, string) (*bus.Subscription, error) {
+	// Streaming is not modelled: a fake that returned an empty, never-closing
+	// stream would make a `listen` test hang rather than fail. Say so instead.
+	return nil, fmt.Errorf("bustest.Fake does not implement Subscribe — use the fake runtime for streaming verbs")
+}
+
+func (f *Fake) Request(_ context.Context, op bus.Channel, _ any, _ *bus.RequestOptions) (json.RawMessage, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Requests = append(f.Requests, op)
+	if f.RequestErr != nil {
+		return nil, f.RequestErr
+	}
+	if reply, ok := f.Replies[op]; ok {
+		return reply, nil
+	}
+	// An unscripted operation is a test bug, and a silent empty reply would let
+	// the verb under test "pass" against a reply it never received.
+	return nil, fmt.Errorf("bustest.Fake has no scripted reply for %q", op)
+}
+
+var _ bus.Transport = (*Fake)(nil)

--- a/packages/sdk-go/bustest/fake.go
+++ b/packages/sdk-go/bustest/fake.go
@@ -26,6 +26,15 @@ type Emitted struct {
 	Scope   string
 }
 
+// Requested is one recorded call to Request. The PAYLOAD is recorded, not just
+// the operation: most of what a verb gets wrong is what it put in the request —
+// a missing filter, a selector built from the wrong flag, an id that never made
+// it onto the wire.
+type Requested struct {
+	Channel bus.Channel
+	Payload any
+}
+
 // Fake implements bus.Transport. The zero value is not ready — use NewFake, so
 // Subscribers defaults to the honest "unknown" rather than a silent 0 that
 // would read as "nobody is listening".
@@ -52,8 +61,8 @@ type Fake struct {
 	// Emits records every Emit in order — a fan-out verb that drops its
 	// second command is invisible to a last-call-only assertion.
 	Emits []Emitted
-	// Requests records every Request's operation, in order.
-	Requests []bus.Channel
+	// Requests records every Request, in order, with its payload.
+	Requests []Requested
 }
 
 func NewFake() *Fake {
@@ -82,10 +91,10 @@ func (f *Fake) Subscribe(context.Context, []bus.Channel, []bus.Channel, string) 
 	return nil, fmt.Errorf("bustest.Fake does not implement Subscribe — use the fake runtime for streaming verbs")
 }
 
-func (f *Fake) Request(_ context.Context, op bus.Channel, _ any, _ *bus.RequestOptions) (json.RawMessage, error) {
+func (f *Fake) Request(_ context.Context, op bus.Channel, payload any, _ *bus.RequestOptions) (json.RawMessage, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.Requests = append(f.Requests, op)
+	f.Requests = append(f.Requests, Requested{Channel: op, Payload: payload})
 	if f.RequestErr != nil {
 		return nil, f.RequestErr
 	}
@@ -95,6 +104,28 @@ func (f *Fake) Request(_ context.Context, op bus.Channel, _ any, _ *bus.RequestO
 	// An unscripted operation is a test bug, and a silent empty reply would let
 	// the verb under test "pass" against a reply it never received.
 	return nil, fmt.Errorf("bustest.Fake has no scripted reply for %q", op)
+}
+
+// Ops is the recorded operations in order — the common assertion, without
+// making every caller reach through the payload it does not care about.
+func (f *Fake) Ops() []bus.Channel {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]bus.Channel, len(f.Requests))
+	for i, r := range f.Requests {
+		out[i] = r.Channel
+	}
+	return out
+}
+
+// JSON renders a recorded payload the way it went on the wire, for substring
+// assertions about fields a verb built.
+func JSON(payload any) string {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Sprintf("<unmarshalable: %v>", err)
+	}
+	return string(b)
 }
 
 var _ bus.Transport = (*Fake)(nil)

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -1591,12 +1591,9 @@ type BrowseAnnotationsResult struct {
 	Response      GetAnnotationsResponse `json:"response"`
 }
 
-// BrowseClickEvent Emitted when an annotation is clicked in the browse panel
+// BrowseClickEvent An annotation was clicked — open it: the viewer selects its entry in the annotations panel and relays a focus signal to scroll to it. The annotation id is the whole address; it identifies exactly one annotation on exactly one resource, so no resource field is carried and none is needed to scope the event. Motivation is NOT on the wire either: the viewer derives it from the annotation the id names, so the wire states the fact once. A viewer that has not loaded that annotation finds nothing and does nothing. Emitted locally by every clickable annotation surface, and over the wire by a driver opening an annotation on another participant's screen.
 type BrowseClickEvent struct {
 	AnnotationId string `json:"annotationId"`
-
-	// Motivation Semiont-supported W3C Web Annotation motivations - https://www.w3.org/TR/annotation-vocab/#motivation
-	Motivation Motivation `json:"motivation"`
 }
 
 // BrowseDirectoryRequest Request to browse a directory listing

--- a/packages/sdk/docs/REACTIVE-MODEL.md
+++ b/packages/sdk/docs/REACTIVE-MODEL.md
@@ -215,7 +215,7 @@ The bus is the SDK's substrate for cross-participant coordination. Three legitim
 
 ```ts
 client.beckon.hover(annotationId);
-client.browse.click(annotationId, 'commenting');
+client.browse.click(annotationId);
 const ctx = await client.gather.annotation(rId, aId);
 ```
 

--- a/packages/sdk/src/__tests__/browse-click-anchor.test.ts
+++ b/packages/sdk/src/__tests__/browse-click-anchor.test.ts
@@ -32,10 +32,10 @@ describe('browse.click anchorRect payload contract', () => {
     const payloads: object[] = [];
     bus.get('browse:click').subscribe((p) => payloads.push(p));
 
-    browse.click(annotationId('a1'), 'linking');
+    browse.click(annotationId('a1'));
 
     expect(payloads).toHaveLength(1);
-    expect(payloads[0]).toEqual({ annotationId: 'a1', motivation: 'linking' });
+    expect(payloads[0]).toEqual({ annotationId: 'a1' });
     expect('anchorRect' in payloads[0]!).toBe(false);
   });
 
@@ -49,12 +49,11 @@ describe('browse.click anchorRect payload contract', () => {
     const anchorRect: AnchorRect = {
       x: 1, y: 2, width: 3, height: 4, top: 2, right: 4, bottom: 6, left: 1,
     };
-    browse.click(annotationId('a1'), 'highlighting', anchorRect);
+    browse.click(annotationId('a1'), anchorRect);
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]).toEqual({
       annotationId: 'a1',
-      motivation: 'highlighting',
       anchorRect,
     });
   });

--- a/packages/sdk/src/namespaces/__tests__/ui-signals.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/ui-signals.test.ts
@@ -99,17 +99,25 @@ describe('UI signal wrappers', () => {
   });
 
   describe('browse.click', () => {
-    it('emits browse:click with annotationId and motivation (local bus)', () => {
+    it('emits browse:click with the annotationId alone (local bus)', () => {
       const bus = new EventBus();
       const spy = busSpy(bus, 'browse:click');
-      const browse = new BrowseNamespace(makeMockTransport(), bus, makeMockContent());
+      const transport = makeMockTransport();
+      const browse = new BrowseNamespace(transport, bus, makeMockContent());
 
-      browse.click(AID, 'linking');
+      browse.click(AID);
 
+      // No motivation: the id addresses exactly one annotation, and the viewer
+      // derives the motivation from the annotation it names (TOUR-CLICK D2).
+      // Carrying it too would state one fact twice on a wire that also carries
+      // the id it comes from.
       expect(spy).toHaveBeenCalledExactlyOnceWith('browse:click', {
         annotationId: AID,
-        motivation: 'linking',
       });
+      // NEVER the wire: browse:click is bridged (TOUR-CLICK P1), so a transport
+      // emit here would broadcast this viewer's own click to every participant
+      // — the D6 feedback loop. The wire path is `beckon.click()`.
+      expect(transport.emit).not.toHaveBeenCalled();
     });
   });
 
@@ -206,6 +214,26 @@ describe('UI signal wrappers', () => {
       });
       // The drive is for OTHER participants; it must not loop back locally
       // (arrivals come in bridged, like any remote emit).
+      expect(localSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('beckon.click (wire drive)', () => {
+    it('emits browse:click over the TRANSPORT and resolves the subscriber count', async () => {
+      const bus = new EventBus();
+      const localSpy = busSpy(bus, 'browse:click');
+      const transport = makeMockTransport();
+      (transport.emit as ReturnType<typeof vi.fn>).mockResolvedValue(4);
+      const beckon = new BeckonNamespace(transport, bus);
+
+      await expect(beckon.click(AID)).resolves.toBe(4);
+
+      expect(transport.emit).toHaveBeenCalledExactlyOnceWith('browse:click', {
+        annotationId: AID,
+      });
+      // Same cross-namespace rule as openResource: `browse.click()` opens it
+      // for me, `beckon.click()` opens it for everyone else. No audience
+      // marker — beckon has no local `click` sibling to disambiguate from.
       expect(localSpy).not.toHaveBeenCalled();
     });
   });

--- a/packages/sdk/src/namespaces/beckon.ts
+++ b/packages/sdk/src/namespaces/beckon.ts
@@ -29,6 +29,20 @@ export class BeckonNamespace implements IBeckonNamespace {
   }
 
   /**
+   * Open an annotation on every OTHER participant's screen (wire:
+   * `browse:click` — the viewer selects its panel entry and scrolls to it).
+   * Strictly richer than `attention()`, which only points.
+   *
+   * The local counterpart is `browse.click()`: this viewer's own. No audience
+   * marker on the name — beckon has no local `click` sibling forcing the
+   * distinction, the same reason `openResource` needs none and `sparkleAll`
+   * does.
+   */
+  click(annotationId: AnnotationId): Promise<number> {
+    return this.transport.emit('browse:click', { annotationId });
+  }
+
+  /**
    * Sparkle an annotation on every participant's viewer (wire:
    * `beckon:sparkle`). The `All` marker exists because `sparkle()` — the
    * unmarked sibling — is this viewer's own local affordance and must stay

--- a/packages/sdk/src/namespaces/browse.ts
+++ b/packages/sdk/src/namespaces/browse.ts
@@ -11,7 +11,6 @@ import type {
   AnchorRect,
   AnnotationId,
   GraphConnection,
-  Motivation,
   TagSchema,
   CollaboratorEntry,
   components,
@@ -470,8 +469,17 @@ export class BrowseNamespace implements IBrowseNamespace {
 
   // ── UI signals (local bus fan-out) ────────────────────────────────────
 
-  click(annotationId: AnnotationId, motivation: Motivation, anchorRect?: AnchorRect): void {
-    this.bus.get('browse:click').next({ annotationId, motivation, ...(anchorRect ? { anchorRect } : {}) });
+  /**
+   * Open an annotation for THIS viewer (local: panel entry selected, relayed
+   * to `beckon:focus` for the scroll). The wire counterpart is
+   * `beckon.click()`: open it for everyone else.
+   *
+   * No `motivation` parameter — the id addresses exactly one annotation and
+   * the viewer derives the motivation from it (TOUR-CLICK D2). `anchorRect` is
+   * viewport geometry and stays a local-only extra; it never crosses a wire.
+   */
+  click(annotationId: AnnotationId, anchorRect?: AnchorRect): void {
+    this.bus.get('browse:click').next({ annotationId, ...(anchorRect ? { anchorRect } : {}) });
   }
 
   openResource(resourceId: ResourceId): void {

--- a/packages/sdk/src/namespaces/types.ts
+++ b/packages/sdk/src/namespaces/types.ts
@@ -18,7 +18,7 @@
  *   → `StreamObservable<T>` (progress + result; subscribe yields every
  *   emit, await yields the last one)
  * - Ephemeral signals, local (beckon.hover/sparkle, browse.click, …) → `void`
- * - Wire drives at other participants (beckon.attention/openResource/
+ * - Wire drives at other participants (beckon.attention/click/openResource/
  *   sparkleAll) → `Promise<number>`: the /bus/emit subscriber count
  *   (`-1` = unknown) — information, not an ack (X5's third shape)
  *
@@ -40,6 +40,7 @@ import type {
   GraphConnection,
   JobId,
   Motivation,
+  AnchorRect,
   GatheredContext,
   ProgressEvent,
   TagSchema,
@@ -274,8 +275,11 @@ export interface BrowseNamespace {
   resourcesByName(query: string, limit?: number): Promise<ResourceDescriptor[]>;
   files(dirPath?: string, sort?: 'name' | 'mtime' | 'annotationCount'): Promise<components['schemas']['BrowseFilesResponse']>;
 
-  // UI signals (fire-and-forget, broadcast to other participants via the bus)
-  click(annotationId: AnnotationId, motivation: Motivation): void;
+  // UI signals — THIS viewer's own local fan-out, never the wire. The
+  // cross-namespace pair is the rule: `browse.X()` does it for me,
+  // `beckon.X()` does it for everyone else. (`resourceViewed` is the one
+  // exception and goes to the wire — it is a REPORT, not a drive.)
+  click(annotationId: AnnotationId, anchorRect?: AnchorRect): void;
   openResource(resourceId: ResourceId): void;
   resourceViewed(resourceId: ResourceId): void;
 }
@@ -493,6 +497,7 @@ export interface BeckonNamespace {
   // Wire drives — beckon OTHER participants (guided-tour moves). Each
   // resolves with the subscriber count (`-1` = unknown; ITransport.emit).
   attention(resourceId: ResourceId, annotationId: AnnotationId): Promise<number>;
+  click(annotationId: AnnotationId): Promise<number>;
   openResource(resourceId: ResourceId): Promise<number>;
   sparkleAll(annotationId: AnnotationId): Promise<number>;
   // Local signals — this viewer's own fan-out; never the wire.

--- a/packages/sdk/src/state/flows/__tests__/beckon-state-unit.test.ts
+++ b/packages/sdk/src/state/flows/__tests__/beckon-state-unit.test.ts
@@ -69,7 +69,7 @@ describe('createBeckonStateUnit', () => {
     const focuses: string[] = [];
     tc.bus.get('beckon:focus').subscribe(e => focuses.push(e.annotationId!));
 
-    tc.bus.get('browse:click').next({ annotationId: 'ann-click', motivation: 'highlighting' });
+    tc.bus.get('browse:click').next({ annotationId: 'ann-click' });
     expect(focuses).toEqual(['ann-click']);
     stateUnit.dispose();
   });
@@ -80,7 +80,7 @@ describe('createBeckonStateUnit', () => {
     stateUnit.hoveredAnnotationId$.subscribe(v => values.push(v));
 
     tc.bus.get('beckon:hover').next({ annotationId: 'ann-hovered' });
-    tc.bus.get('browse:click').next({ annotationId: 'ann-clicked', motivation: 'highlighting' });
+    tc.bus.get('browse:click').next({ annotationId: 'ann-clicked' });
     expect(values).toEqual([null, 'ann-hovered']);
     stateUnit.dispose();
   });

--- a/specs/src/bus/registry.json
+++ b/specs/src/bus/registry.json
@@ -2398,8 +2398,9 @@
     },
     {
       "channel": "browse:click",
-      "shape": "custom",
-      "validate": null,
+      "shape": "schema",
+      "schema": "BrowseClickEvent",
+      "validate": "BrowseClickEvent",
       "ts": "components['schemas']['BrowseClickEvent'] & { anchorRect?: AnchorRect }",
       "docs": {
         "lead": [
@@ -3700,7 +3701,8 @@
       "browse:resource-open",
       "browse:resource-viewed",
       "session:joined",
-      "session:left"
+      "session:left",
+      "browse:click"
     ]
   }
 }

--- a/specs/src/components/schemas/BrowseClickEvent.json
+++ b/specs/src/components/schemas/BrowseClickEvent.json
@@ -1,13 +1,10 @@
 {
   "type": "object",
-  "description": "Emitted when an annotation is clicked in the browse panel",
+  "description": "An annotation was clicked — open it: the viewer selects its entry in the annotations panel and relays a focus signal to scroll to it. The annotation id is the whole address; it identifies exactly one annotation on exactly one resource, so no resource field is carried and none is needed to scope the event. Motivation is NOT on the wire either: the viewer derives it from the annotation the id names, so the wire states the fact once. A viewer that has not loaded that annotation finds nothing and does nothing. Emitted locally by every clickable annotation surface, and over the wire by a driver opening an annotation on another participant's screen.",
   "properties": {
     "annotationId": {
       "type": "string"
-    },
-    "motivation": {
-      "$ref": "./Motivation.json"
     }
   },
-  "required": ["annotationId", "motivation"]
+  "required": ["annotationId"]
 }


### PR DESCRIPTION
Three arcs plus a CI fix. The first is the one to read closely — it changes how Go tests are written and cuts the launcher suite by more than half.

---

## 1. A transport seam for `sdk-go`

**First, a premise correction, because the obvious version of it sends you to the wrong code.** The report that prompted this was "the launcher interacts with the wire directly and doesn't go through sdk-go." That's **wrong**: thirteen files under `internal/launcher/` reach the backend through `bus.NewClient` or the generated client. The raw `http.Client` calls people notice are Ollama's `/api/tags`, Anthropic's `/v1/models` (third-party APIs, nothing to do with a Semiont SDK) and `httpOK` liveness probes (a TCP ping, not an API call).

The real asymmetry is narrower and worse: **TypeScript's SDK is transport-agnostic and Go's is not.** TS has `ITransport` in core with three implementations, and namespaces speak only to the interface. Go had `bus.Client` — a concrete struct owning an `*http.Client`, hard-coding HTTP+SSE.

Three consequences, in the order they hurt: no test double, so launcher tests ran **through a socket** (spawn a process, bind a port, script a fake HTTP server); no in-process option ever, which forecloses embedding; and cross-language parity by convention rather than structure — both sides use `-1` for "unknown" only because they were hand-matched.

### What landed

`bus.Transport` — four methods, contract in the comments, with `var _ Transport = (*Client)(nil)` so a signature drift on either side becomes a build failure instead of a runtime surprise.

`bustest.Fake` (named for the `httptest` convention), whose three design choices are each a bug it refuses to allow:

- **Records emits in order**, because a fan-out verb that drops its second command is invisible to a last-call-only assertion.
- **Defaults `Subscribers` to `-1`**, so a test that forgets to set it reads "unknown" rather than a silent `0` meaning "nobody is listening."
- **`Subscribe` returns an explicit error** rather than an empty never-closing stream. A fake that *hangs* a `listen` test instead of failing it is worse than no fake.

The launcher's construction sites all route through one `newTransport`. That's **eleven sites, not one** — the design note had pointed at `verbSession` as the seam, but that returns base+token and each verb constructs separately, so the change is at construction. The count being wrong didn't change the work, but it would have made "one construction point" a false claim.

### The suite: 389 s → 176 s, and one confidently wrong hypothesis

| change | suite | verdict |
|---|---|---|
| baseline | 389 s | |
| transport seam, 16 tests moved in-process | 341 s | worked, small |
| list-then-act teardown (54 spawns → 3) | 342 s | **no gain — hypothesis wrong** |
| `pause()` → wait for the condition | **176 s** | the cause |

**The wrong hypothesis is worth keeping.** A default boot spawns 84 subprocesses, 54 of them a blind `stop`+`rm` across nine container names and three runtimes. That looked like the cost. It wasn't: fork/exec of a small static binary is ~1 ms, so those 54 spawns were ~50 ms, not seconds — the estimate driving the work was off by about **15×**, and removing them changed the suite by −1 s.

**What actually found it was a two-minute probe:** set `pause()` to zero, run four representative tests, restore. `TestStartDefaultBoot` 2.61 s → 0.64 s. One flat `time.Sleep(time.Second)`, called from four sites, was **60–75% of the suite**.

**And the fix is a production fix, not a test fix.** All four call sites were immediately followed by a port check — `pause()` slept a fixed second before *looking* at a port that was almost always already free. It's now `settlePorts()`, polling the real condition with the existing backoff and a 3 s ceiling: free immediately costs nothing, genuinely slow waits as long as needed. That's more correct than a duration which is simultaneously too long on a fast machine and too short on a loaded one — and **every `semiont start` was paying those seconds too.** The refusal path is untouched: a foreign process on the port is still refused promptly with its `held by <pid>` message rather than waited out.

The teardown sweep is kept despite buying no time, because it removed a genuine smell.

---

## 2. The fourth tour move: open an annotation on someone else's screen

A tour could put a **resource** on a participant's screen and **point** at an annotation. It could not **open** one — so after the opening move a script had nothing left but suggestions, and stalled waiting for the participant to choose.

`browse:click` turns out to have been nearly ready: payload schema written, component registered, Go type already generated. It was missing **two registry fields** — a `validate` binding (so `/bus/emit` accepts it) and a bridge entry (so transports deliver it).

**Bridging it does not leak local clicks**, which is what makes this safe. `BRIDGED_CHANNELS` is the *fan-in* set — channels a transport receives — and says nothing about what a client emits. So the seventeen in-browser `browse.click()` call sites stay local, exactly as `browse.openResource()` already does on an already-bridged channel.

**`motivation` was deleted from the payload rather than sourced for it.** The original question was where a remote driver should *get* it; reading the consumers showed the question was wrong. Five of six subscribers ignore it entirely, and the sixth already resolves the annotation by id — so it was a denormalization that existed only because the in-browser emitters had the value in hand while rendering. It's now derived viewer-side. That *removed* work: no flag, no lookup round trip, and two duplicated `find(...)` branches in `ResourceViewer` collapse into one.

**No `resourceId` guard either**, for the same reason: an annotation id already determines its resource, so carrying one would encode a fact twice and hand the driver the job of keeping them consistent. The failure mode is structural instead — a viewer that hasn't loaded that annotation resolves nothing and does nothing.

Surfaces:

```bash
semiont browse --annotation <id> --browser     # no resourceId — the id is the whole address
```
```typescript
await client.beckon.click(annotationId);       // wire; browse.click() stays local
```

The launcher form **rejects** a resourceId rather than ignoring one, since silently discarding it would leave the caller believing it mattered. And the docs now state the rule the tour skill was missing: **`browse` advances the story, `beckon` offers a choice.** Its worked example was rebalanced to match — four `browse` moves carrying the narrative, one `beckon` cluster handing over a branch.

---

## 3. Cold starts: find the Browser, refuse well, launch on request

The tour path assumes a Browser already open and watching. This is the other case.

**The decision that collapsed the design: the launcher never opens a window.** It knows origins, never paths — so the tension with keeping route knowledge out of the launcher disappears rather than being managed. No `open`/`xdg-open`, no GUI persona in the fake runtime, no cross-lane frontend work.

What shipped is three launcher-only phases: Browser detection extracted with a `--browser-url` override; an **informative refusal** when nothing is watching (exit 1, so `set -e` stops a tour rather than narrating to an empty room); and `--launch` to start the Browser on request. `--launch` starts a *container* — it still cannot open a window or log anyone in, and says so.

This changed the tour verbs' reporting: exactly-zero subscribers on `--browser` no longer prints a clean ✓, it refuses. `beckon` still exits 0, because a beckon is fire-and-forget by contract.

---

## 4. The compliance workflow was reporting one problem as three

Every step in that job checks a different invariant, but they all defaulted to `if: success()` — so they were **chained**. On an earlier run of this branch, one stale doc fence skipped five unrelated gates. Two of the skipped steps are the ones that *write* the compliance reports, so the two "Display Full Report" steps then failed on a `cat` of files nobody was going to produce: one real problem surfaced as three red steps, with the cause buried under two that were pure consequence.

Worse, `Fail on Violations` silently skipped too, since its condition reads outputs from audits that never ran — **the compliance gate this job exists for contributed nothing to that run's result.** Gates now depend on the build, not on each other.

---

## Testing

Test-first throughout. The Go seam's RED was `no required module provides package …/sdk-go/bustest` — written against the seam before it existed, which is the only way to be sure the seam is shaped by its consumer rather than by its implementation. On the TypeScript side, RED was `beckon.click is not a function`, and the local fence is now a failing test rather than a doc sentence (`expect(transport.emit).not.toHaveBeenCalled()`).

The two new in-process transport tests run in **0.00 s**; the equivalent coverage through the fake runtime needed a built binary, a start+login, and a port.

Local verification: core bus-invariants 4/4 · sdk tsc + 502/502 + build · react-ui tsc + 2664 passed / 38 skipped · `sdk-go` and launcher `go build`/`vet`/`test` clean · both codegen drift gates reproduced · doc-snippets gate 60 fences / 0 failures · no golden refreshed.

**CI is still running at the time of writing.**

## Not done here

- **Session handoff is parked** — with the launcher never opening a window, there's no delivery vehicle for handing a Browser a session. It needs one before it's worth designing.
- **One RED was never written:** the backend route test that `/bus/emit` accepts a well-formed `browse:click` and rejects a malformed one. The binding is in and the channel works end to end through the TS and Go surfaces, but the gateway's accept/reject behavior for this channel is unpinned.
- **Bridging widened `listen`'s default stream.** Every annotation click in any watching viewer now appears in a bare `semiont listen`. That's arguably the annotation-level engagement signal the tour work couldn't report before — but it's new noise, and whether the human renderer shows it as events or folds it into state is undecided.
- **Annotation-level *reporting* is still absent.** You can now drive a click; you still only learn which *resources* a participant arrived at.
- **The remaining 176 s is accounted for and deliberate** — the black-box tests that genuinely exercise the binary stay black-box.
