### PR TITLE
Go SDK: health check behind an interface, so the launcher stops hand-writing /api/health

### DIFF
--- a/apps/launcher/internal/launcher/browser_target_test.go
+++ b/apps/launcher/internal/launcher/browser_target_test.go
@@ -111,6 +111,46 @@ func TestBrowserTargetPrefersTheOverrideOverTheRecord(t *testing.T) {
 	}
 }
 
+// ── the backend's probe goes through the SDK ────────────────────────────
+
+// The backend is the one role in the status table with a generated client,
+// and its probe must use it — that is the whole of "the launcher does not
+// touch the wire". Asserted by watching the ROUTE: the generic prober fetches
+// the recorded endpoint verbatim, the SDK asks its own /api/health.
+func TestRoleHealthyProbesTheBackendThroughTheSDK(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"healthy"}`))
+	}))
+	defer srv.Close()
+
+	if !roleHealthy("backend", srv.URL+"/api/health") {
+		t.Error("a serving backend must read healthy")
+	}
+	// A sidecar serves /health and has no client of its own; it keeps the
+	// generic prober, and the recorded path must survive untouched.
+	if !roleHealthy("worker", srv.URL+"/health") {
+		t.Error("a serving sidecar must read healthy")
+	}
+	want := []string{"/api/health", "/health"}
+	if len(paths) != 2 || paths[0] != want[0] || paths[1] != want[1] {
+		t.Errorf("probed %v, want %v", paths, want)
+	}
+}
+
+func TestRoleHealthyReportsADeadBackend(t *testing.T) {
+	if roleHealthy("backend", deadOrigin(t)+"/api/health") {
+		t.Error("an unreachable backend must not read healthy")
+	}
+	// A backend record that is not the health route falls back rather than
+	// guessing at an origin it cannot derive.
+	if roleHealthy("backend", deadOrigin(t)) {
+		t.Error("an unreachable backend must not read healthy on the fallback path either")
+	}
+}
+
 // ── P2: what it says when nobody was there ──────────────────────────────
 
 func TestBrowseBrowserRefusesWhenNoOneIsWatching(t *testing.T) {

--- a/apps/launcher/internal/launcher/status.go
+++ b/apps/launcher/internal/launcher/status.go
@@ -452,7 +452,7 @@ func printLocalStack(u *ui, st *stackState, runtime, service string) (healthy bo
 		default:
 			state, rt = containerState(runtimes, handle)
 		}
-		isHealthy := probeHealth(endpoint)
+		isHealthy := roleHealthy(svc.name, endpoint)
 		if svc.name == "inference" && rec == nil && state == "" && isHealthy {
 			rt = "host"
 		}
@@ -791,6 +791,40 @@ func containerState(runtimes []string, name string) (state, rt string) {
 		return strings.TrimSpace(out), r
 	}
 	return "", ""
+}
+
+// roleHealthy probes one role of the stack.
+//
+// The BACKEND goes through the Go SDK. It is the only role in this table that
+// is a semiont service with a generated client, and asking it directly was the
+// last application request the launcher made to the backend over a
+// hand-written path — the thing packages/sdk-go exists to own, and which the
+// TypeScript side has always covered (`healthCheck` on `IBackendOperations`).
+//
+// Everything else keeps the generic prober, and that is not laziness: the
+// sidecars serve `/health` with no client of their own, and the rest are
+// third-party (Ollama, Qdrant, Neo4j, Jaeger) or not HTTP at all. One prober
+// spanning them is the point.
+func roleHealthy(role, endpoint string) bool {
+	if role != "backend" {
+		return probeHealth(endpoint)
+	}
+	base, ok := strings.CutSuffix(endpoint, "/api/health")
+	if !ok || base == "" {
+		// A backend endpoint that is not the health route is a record this
+		// function cannot speak for; the generic prober still can.
+		return probeHealth(endpoint)
+	}
+	cli, err := semiont.NewHealthClient(base)
+	if err != nil {
+		return false
+	}
+	// The budget matches the generic prober's, so one slow role cannot stall
+	// a status report longer than any other.
+	ctx, cancel := context.WithTimeout(context.Background(), healthProbeTimeout)
+	defer cancel()
+	_, err = cli.HealthCheck(ctx)
+	return err == nil
 }
 
 // probeHealth runs one host-side application probe: 2xx for http endpoints,

--- a/apps/launcher/internal/launcher/support.go
+++ b/apps/launcher/internal/launcher/support.go
@@ -252,7 +252,12 @@ func selectRuntime(u *ui, requested string) (string, bool) {
 
 // --- Health waits ---
 
-var healthClient = &http.Client{Timeout: 2 * time.Second}
+// healthProbeTimeout bounds ONE host-side probe. Shared with the SDK-backed
+// backend probe (roleHealthy) so the two cannot drift into a status report
+// where one role is allowed to stall longer than the rest.
+const healthProbeTimeout = 2 * time.Second
+
+var healthClient = &http.Client{Timeout: healthProbeTimeout}
 
 // netDialTimeout: one TCP reachability check (external-role verification).
 func netDialTimeout(addr string) (net.Conn, error) {

--- a/packages/sdk-go/health.go
+++ b/packages/sdk-go/health.go
@@ -1,0 +1,94 @@
+package semiont
+
+// health.go — the backend's liveness surface, stated as an interface.
+//
+// It exists for the same reason `bus.Transport` does: a caller should be able
+// to ask "is the backend up?" without owning how that question travels. The
+// launcher previously answered it with a bare `http.Client` and a hand-written
+// `/api/health` path — the one application request it still made to the
+// backend without going through this SDK.
+//
+// The TypeScript side declares the same operation on `IBackendOperations`
+// (packages/core/src/transport.ts), NOT on `ITransport`: health is a backend
+// operation, not a bus primitive, and it is grouped there under "System"
+// alongside `getStatus`. This file is its Go counterpart, and it stays out of
+// package `bus` for exactly that reason.
+//
+// The route and the response shape come from the GENERATED client, so they
+// track openapi.json rather than a string in this file.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Health is what a caller needs to know whether the backend is serving.
+type Health interface {
+	// HealthCheck asks the backend to report itself.
+	//
+	// A nil error means it ANSWERED with a success status. The returned
+	// report may still be nil in that case: a 2xx whose body does not parse
+	// is a live service behind a schema this client does not recognise, and
+	// calling that "down" would take a backend offline over a field rename.
+	// Liveness is the status code; the body is detail.
+	//
+	// There is no bool: it would collapse "answered, unhealthy" into
+	// "unreachable", and a supervisor deciding whether to wait, warn, or
+	// abort needs those apart. Callers that genuinely only want liveness
+	// compare the error against nil.
+	//
+	// Cancellation and timeouts belong to ctx — this method imposes none of
+	// its own, so a probe with a budget sets a deadline and a boot-time wait
+	// can use a longer one.
+	HealthCheck(ctx context.Context) (*HealthResponse, error)
+}
+
+// HealthClient is the HTTP implementation, over the generated client.
+type HealthClient struct {
+	c *ClientWithResponses
+}
+
+// Asserted at compile time so a signature change on either side is a build
+// failure rather than a runtime surprise.
+var _ Health = (*HealthClient)(nil)
+
+// NewHealthClient builds a Health against a backend ORIGIN — "http://host:port",
+// never a path. The route is the generated client's to know.
+//
+// opts pass through to the generated constructor, so a caller can inject its
+// own HTTP doer; without one, cancel through ctx.
+func NewHealthClient(base string, opts ...ClientOption) (*HealthClient, error) {
+	c, err := NewClientWithResponses(base, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &HealthClient{c: c}, nil
+}
+
+func (h *HealthClient) HealthCheck(ctx context.Context) (*HealthResponse, error) {
+	// The RAW call, not GetApiHealthWithResponse: that wrapper decodes before
+	// it reports, so a 2xx with an unrecognised body comes back as an error
+	// and a live backend reads as down. Status first, body second — which is
+	// the order a liveness check has to ask them in.
+	resp, err := h.c.GetApiHealth(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("backend health: %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// Headers arrived, the body did not. The service answered, so this is
+		// not a health failure — report it alive with no detail.
+		return nil, nil
+	}
+	var out HealthResponse
+	if json.Unmarshal(body, &out) != nil {
+		return nil, nil
+	}
+	return &out, nil
+}

--- a/packages/sdk-go/health_test.go
+++ b/packages/sdk-go/health_test.go
@@ -1,0 +1,80 @@
+package semiont
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// A healthy backend answers, and the parsed body comes back.
+func TestHealthCheckReportsAServingBackend(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/health" {
+			t.Errorf("asked for %q, want /api/health — the route is the generated client's to know", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"healthy"}`))
+	}))
+	defer srv.Close()
+
+	cli, err := NewHealthClient(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := cli.HealthCheck(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if got == nil {
+		t.Fatal("a 2xx with a JSON body must parse")
+	}
+}
+
+// A backend that answers with a failure status is DOWN, and says which status
+// — a caller that only wanted liveness compares against nil, but one deciding
+// whether to wait or abort needs the reason.
+func TestHealthCheckFailsOnANonSuccessStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	cli, _ := NewHealthClient(srv.URL)
+	if _, err := cli.HealthCheck(context.Background()); err == nil {
+		t.Fatal("503 must be an error")
+	}
+}
+
+// A 2xx that does not parse is still a LIVE service. Reporting it as down
+// over a schema mismatch is the opposite of what a liveness check is for.
+func TestHealthCheckTreatsAnUnparsableSuccessAsAlive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	cli, _ := NewHealthClient(srv.URL)
+	if _, err := cli.HealthCheck(context.Background()); err != nil {
+		t.Fatalf("a 2xx is alive whatever the body says: %v", err)
+	}
+}
+
+// The method imposes no budget of its own, so a caller's deadline is the only
+// thing bounding it. A probe whose ctx expired must return rather than hang.
+func TestHealthCheckHonoursTheContextDeadline(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer func() { close(block); srv.Close() }()
+
+	cli, _ := NewHealthClient(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := cli.HealthCheck(ctx); err == nil {
+		t.Fatal("an expired context must surface as an error")
+	}
+}


### PR DESCRIPTION
The launcher is supposed to reach the backend only through `packages/sdk-go`, the way an app reaches it only through the NPM SDK. One call was still going around it: the backend's health probe, which hand-wrote `/api/health` and fired it with a bare `http.Client`.

## The SDK surface

`packages/sdk-go/health.go` adds a `Health` interface — `HealthCheck(ctx) (*HealthResponse, error)` — implemented by `HealthClient` over the generated client, so the route and the response shape come from `openapi.json` rather than a string in the launcher.

It lives in package `semiont`, **not** in `bus`. The TypeScript side declares `healthCheck()` on `IBackendOperations` under "System", not on `ITransport`: health is a backend operation, not a bus primitive. Putting it on `bus.Transport` would also force the bus test double to answer a question it has nothing to do with.

No `bool` in the signature. It would collapse *answered, unhealthy* into *unreachable*, and a supervisor deciding whether to wait, warn, or abort needs those apart. Callers that only want liveness compare the error against `nil`.

## Status before body

`HealthCheck` uses the raw `GetApiHealth` rather than `GetApiHealthWithResponse`, because that wrapper decodes before it reports — so a 2xx carrying a body this client doesn't recognise came back as an error, and a healthy backend read as down.

A liveness check has to ask those in the other order: **the status code is liveness, the body is detail.** A 2xx that doesn't parse now returns `(nil, nil)` — alive, no detail — so a field rename can't take a backend "offline". This was caught by a test written against the intended contract, which the first implementation quietly failed.

## Launcher

`roleHealthy(role, endpoint)` routes the backend's row in the status table through the SDK. Every other role keeps the generic prober, and that's deliberate: the sidecars serve `/health` with no client of their own, and the rest are third-party (Ollama, Qdrant, Neo4j, Jaeger) or not HTTP at all. One prober spanning them is the point.

The test pins the dispatch by watching the route actually requested — `/api/health` for the backend, `/health` untouched for the worker — rather than trusting the branch to be taken.

`healthProbeTimeout` is now a single shared constant, so the SDK-backed probe and the generic one can't drift into a status report where one role is allowed to stall longer than the rest.

## Not converted

The boot-time waits in `flows.go` and `codespace.go` still use the generic prober. `planExec.waitHTTP` prints `wait: <url> (<seconds>s)` into a dry-run golden, and those goldens are the spec; a plan that says "wait on this URL" is also honest, since that is supervision rather than a client call, sharing one deadline discipline with the Ollama and Qdrant waits beside it.

So: every request the launcher makes to the backend **as a client** now goes through the SDK. What remains outside is boot-time supervision.

## Verification

- `packages/sdk-go`: `gofmt -l` empty, `go vet`, `go test ./...` green (4 new tests: serving, non-2xx, unparsable-2xx, context deadline)
- `apps/launcher`: same three, full suite green at ~174s, no golden refresh
