### PR TITLE
neo4j annotations leave the driver with ISO timestamps — Search works again on annotation-focus gathers

### DIFF
--- a/packages/graph/src/__tests__/neo4j-projection.test.ts
+++ b/packages/graph/src/__tests__/neo4j-projection.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The neo4j → wire annotation projection, tested at the module seam.
+ *
+ * The writes store temporals natively (`created: datetime($created)`), so the
+ * driver hands the projection a neo4j DateTime OBJECT — and `node` is `any`
+ * here, so only a test can see one leak into `Annotation.created: string`.
+ * That leak shipped: every D11-embedded graph annotation violated the schema,
+ * and the first validated round-trip (`match:search-requested`) 400'd — see
+ * .plans/bugs/match-search-hangs-on-neo4j-datetime-annotations.md.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseAnnotationNode } from '../implementations/neo4j';
+
+/** The driver temporal's contract: a rich object whose toString() is ISO 8601. */
+const driverDateTime = (iso: string) => ({
+  year: { low: 2026, high: 0 },
+  month: { low: 8, high: 0 },
+  toString: () => iso,
+});
+
+const node = (created: unknown, modified?: unknown) => ({
+  properties: {
+    id: 'ann-1',
+    resourceId: 'res-1',
+    type: 'Annotation',
+    motivation: 'linking',
+    selector: JSON.stringify({ type: 'TextQuoteSelector', exact: 'Black Hawk' }),
+    creator: JSON.stringify({ '@type': 'Person', id: 'did:semiont:user:u1', name: 'A' }),
+    created,
+    ...(modified !== undefined ? { modified } : {}),
+  },
+});
+
+describe('parseAnnotationNode — temporals leave as ISO strings, never driver objects', () => {
+  it('serializes a native DateTime `created` to its ISO string', () => {
+    const ann = parseAnnotationNode(node(driverDateTime('2026-08-19T01:02:03.000000000Z')));
+    expect(ann.created).toBe('2026-08-19T01:02:03.000000000Z');
+    expect(typeof ann.created).toBe('string');
+  });
+
+  it('passes an already-string `created` through unchanged', () => {
+    const ann = parseAnnotationNode(node('2026-01-01T00:00:00Z'));
+    expect(ann.created).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('serializes `modified` the same way (the pattern `created` failed to follow)', () => {
+    const ann = parseAnnotationNode(node('2026-01-01T00:00:00Z', driverDateTime('2026-08-19T04:05:06Z')));
+    expect(ann.modified).toBe('2026-08-19T04:05:06Z');
+  });
+});

--- a/packages/graph/src/__tests__/neo4j-projection.test.ts
+++ b/packages/graph/src/__tests__/neo4j-projection.test.ts
@@ -48,3 +48,45 @@ describe('parseAnnotationNode — temporals leave as ISO strings, never driver o
     expect(ann.modified).toBe('2026-08-19T04:05:06Z');
   });
 });
+
+describe('parseAnnotationNode — the rest of the projection contract', () => {
+  it.each([
+    ['id', 'Annotation missing required field: id'],
+    ['resourceId', 'missing required field: resourceId'],
+    ['type', 'missing required field: type'],
+    ['selector', 'missing required field: selector'],
+    ['creator', 'missing required field: creator'],
+    ['motivation', 'missing required field: motivation'],
+  ])('refuses a node missing %s, naming the field', (field, message) => {
+    const n = node('2026-01-01T00:00:00Z');
+    delete (n.properties as Record<string, unknown>)[field];
+    expect(() => parseAnnotationNode(n)).toThrow(message);
+  });
+
+  it('reconstructs entity tags as tagging bodies, filtering empty values', () => {
+    const ann = parseAnnotationNode(node('2026-01-01T00:00:00Z'), ['Person', '', 'Org']);
+    expect(ann.body).toEqual([
+      { type: 'TextualBody', value: 'Person', purpose: 'tagging' },
+      { type: 'TextualBody', value: 'Org', purpose: 'tagging' },
+    ]);
+  });
+
+  it('adds the linking body when the annotation is resolved', () => {
+    const n = node('2026-01-01T00:00:00Z');
+    (n.properties as Record<string, unknown>).source = 'res-target';
+    const ann = parseAnnotationNode(n);
+    expect(ann.body).toContainEqual({ type: 'SpecificResource', source: 'res-target', purpose: 'linking' });
+  });
+
+  it('parses a stored generator, and ignores an unparseable one rather than failing the read', () => {
+    const good = node('2026-01-01T00:00:00Z');
+    (good.properties as Record<string, unknown>).generator = JSON.stringify({ '@type': 'Software', name: 'semiont' });
+    expect(parseAnnotationNode(good).generator).toEqual({ '@type': 'Software', name: 'semiont' });
+
+    const bad = node('2026-01-01T00:00:00Z');
+    (bad.properties as Record<string, unknown>).generator = '{ not json';
+    const ann = parseAnnotationNode(bad);
+    expect(ann.generator).toBeUndefined();
+    expect(ann.id).toBe('ann-1'); // the read itself survives
+  });
+});

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -474,7 +474,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
         throw new Error(`Failed to create annotation: Resource ${targetSource} not found in graph database`);
       }
 
-      return this.parseAnnotationNode(result.records[0]!.get('a'), entityTypes);
+      return parseAnnotationNode(result.records[0]!.get('a'), entityTypes);
     } finally {
       await session.close();
     }
@@ -496,7 +496,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
         return null;
       }
       this.logger?.debug('Annotation found', { id });
-      return this.parseAnnotationNode(
+      return parseAnnotationNode(
         result.records[0]!.get('a'),
         result.records[0]!.get('entityTypes')
       );
@@ -600,7 +600,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
         this.logger?.debug('No body update for annotation', { id });
       }
 
-      return this.parseAnnotationNode(
+      return parseAnnotationNode(
         result.records[0]!.get('a'),
         result.records[0]!.get('entityTypes')
       );
@@ -649,7 +649,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       );
 
       const annotations = result.records.map(record =>
-        this.parseAnnotationNode(record.get('a'), record.get('entityTypes'))
+        parseAnnotationNode(record.get('a'), record.get('entityTypes'))
       );
 
       return { annotations, total: annotations.length };
@@ -671,7 +671,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       );
 
       return result.records.map(record =>
-        this.parseAnnotationNode(record.get('a'), record.get('entityTypes'))
+        parseAnnotationNode(record.get('a'), record.get('entityTypes'))
       );
     } finally {
       await session.close();
@@ -705,7 +705,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
         throw new Error('Annotation not found');
       }
 
-      return this.parseAnnotationNode(
+      return parseAnnotationNode(
         result.records[0]!.get('a'),
         result.records[0]!.get('entityTypes')
       );
@@ -727,7 +727,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       );
 
       return result.records.map(record =>
-        this.parseAnnotationNode(record.get('a'), record.get('entityTypes'))
+        parseAnnotationNode(record.get('a'), record.get('entityTypes'))
       );
     } finally {
       await session.close();
@@ -757,7 +757,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       const result = await session.run(cypher, params);
 
       return result.records.map(record =>
-        this.parseAnnotationNode(record.get('a'), record.get('entityTypes'))
+        parseAnnotationNode(record.get('a'), record.get('entityTypes'))
       );
     } finally {
       await session.close();
@@ -776,7 +776,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       );
 
       return result.records.map(record =>
-        this.parseAnnotationNode(record.get('a'), record.get('entityTypes'))
+        parseAnnotationNode(record.get('a'), record.get('entityTypes'))
       );
     } finally {
       await session.close();
@@ -801,7 +801,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
       this.logger?.debug('Found annotations', { count: result.records.length });
 
       return result.records.map(record =>
-        this.parseAnnotationNode(record.get('a'), record.get('entityTypes'))
+        parseAnnotationNode(record.get('a'), record.get('entityTypes'))
       );
     } finally {
       await session.close();
@@ -838,7 +838,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
             { id: annId }
           );
           if (annResult.records.length > 0) {
-            outgoing.push(this.parseAnnotationNode(
+            outgoing.push(parseAnnotationNode(
               annResult.records[0]!.get('a'),
               annResult.records[0]!.get('entityTypes')
             ));
@@ -857,7 +857,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
             { id: annId }
           );
           if (annResult.records.length > 0) {
-            incoming.push(this.parseAnnotationNode(
+            incoming.push(parseAnnotationNode(
               annResult.records[0]!.get('a'),
               annResult.records[0]!.get('entityTypes')
             ));
@@ -906,7 +906,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
             { ids: annotationIds }
           );
           selResult.records.forEach(rec => {
-            annotations.push(this.parseAnnotationNode(
+            annotations.push(parseAnnotationNode(
               rec.get('a'),
               rec.get('entityTypes')
             ));
@@ -1201,69 +1201,79 @@ export class Neo4jGraphDatabase implements GraphDatabase {
     return resource;
   }
 
-  private parseAnnotationNode(node: any, entityTypes: string[] = []): Annotation {
-    const props = node.properties;
+}
 
-    // Validate required fields
-    if (!props.id) throw new Error('Annotation missing required field: id');
-    if (!props.resourceId) throw new Error(`Annotation ${props.id} missing required field: resourceId`);
-    // props.exact is optional - not all annotation types have selected text (e.g., image annotations)
-    if (!props.type) throw new Error(`Annotation ${props.id} missing required field: type`);
-    if (!props.selector) throw new Error(`Annotation ${props.id} missing required field: selector`);
-    if (!props.creator) throw new Error(`Annotation ${props.id} missing required field: creator`);
+/**
+ * Project a neo4j annotation node to the wire `Annotation`.
+ *
+ * Module-level (not a method) so the projection is unit-testable without a
+ * driver: `node` is untyped at this seam, which is exactly how a native
+ * neo4j DateTime once reached the wire as `created` unseen by tsc.
+ */
+export function parseAnnotationNode(node: any, entityTypes: string[] = []): Annotation {
+  const props = node.properties;
 
-    if (!props.motivation) throw new Error(`Annotation ${props.id} missing required field: motivation`);
+  // Validate required fields
+  if (!props.id) throw new Error('Annotation missing required field: id');
+  if (!props.resourceId) throw new Error(`Annotation ${props.id} missing required field: resourceId`);
+  // props.exact is optional - not all annotation types have selected text (e.g., image annotations)
+  if (!props.type) throw new Error(`Annotation ${props.id} missing required field: type`);
+  if (!props.selector) throw new Error(`Annotation ${props.id} missing required field: selector`);
+  if (!props.creator) throw new Error(`Annotation ${props.id} missing required field: creator`);
 
-    // Parse creator - always stored as JSON string in DB
-    const creator = JSON.parse(props.creator);
+  if (!props.motivation) throw new Error(`Annotation ${props.id} missing required field: motivation`);
 
-    // Reconstruct body array from entity tags and linking body
-    const bodyArray: Array<{type: 'TextualBody'; value: string; purpose: 'tagging'} | {type: 'SpecificResource'; source: string; purpose: 'linking'}> = [];
+  // Parse creator - always stored as JSON string in DB
+  const creator = JSON.parse(props.creator);
 
-    // Add entity tag bodies (TextualBody with purpose: "tagging")
-    for (const entityType of entityTypes) {
-      if (entityType) {  // Filter out nulls
-        bodyArray.push({
-          type: 'TextualBody' as const,
-          value: entityType,
-          purpose: 'tagging' as const,
-        });
-      }
-    }
+  // Reconstruct body array from entity tags and linking body
+  const bodyArray: Array<{type: 'TextualBody'; value: string; purpose: 'tagging'} | {type: 'SpecificResource'; source: string; purpose: 'linking'}> = [];
 
-    // Add linking body (SpecificResource) if annotation is resolved
-    if (props.source) {
+  // Add entity tag bodies (TextualBody with purpose: "tagging")
+  for (const entityType of entityTypes) {
+    if (entityType) {  // Filter out nulls
       bodyArray.push({
-        type: 'SpecificResource' as const,
-        source: props.source,
-        purpose: 'linking' as const,
+        type: 'TextualBody' as const,
+        value: entityType,
+        purpose: 'tagging' as const,
       });
     }
-
-    const annotation: Annotation = {
-      '@context': 'http://www.w3.org/ns/anno.jsonld' as const,
-      'type': 'Annotation' as const,
-      id: props.id,
-      motivation: props.motivation,
-      target: {
-        source: props.resourceId,
-        selector: JSON.parse(props.selector),
-      },
-      body: bodyArray as Annotation['body'],
-      creator,
-      created: props.created, // ISO string from DB
-    };
-
-    // W3C Web Annotation modification tracking
-    if (props.modified) annotation.modified = props.modified.toString();
-    if (props.generator) {
-      try {
-        annotation.generator = JSON.parse(props.generator);
-      } catch (e) {
-        // Ignore parse errors
-      }
-    }
-
-    return annotation;
   }
+
+  // Add linking body (SpecificResource) if annotation is resolved
+  if (props.source) {
+    bodyArray.push({
+      type: 'SpecificResource' as const,
+      source: props.source,
+      purpose: 'linking' as const,
+    });
+  }
+
+  const annotation: Annotation = {
+    '@context': 'http://www.w3.org/ns/anno.jsonld' as const,
+    'type': 'Annotation' as const,
+    id: props.id,
+    motivation: props.motivation,
+    target: {
+      source: props.resourceId,
+      selector: JSON.parse(props.selector),
+    },
+    body: bodyArray as Annotation['body'],
+    creator,
+    // Stored as datetime($created), so the driver returns a native temporal —
+    // toString() is the ISO form (and the identity on rows already strings).
+    created: props.created.toString(),
+  };
+
+  // W3C Web Annotation modification tracking
+  if (props.modified) annotation.modified = props.modified.toString();
+  if (props.generator) {
+    try {
+      annotation.generator = JSON.parse(props.generator);
+    } catch (e) {
+      // Ignore parse errors
+    }
+  }
+
+  return annotation;
 }

--- a/scripts/ci/local-build.sh
+++ b/scripts/ci/local-build.sh
@@ -575,6 +575,13 @@ case "$DRIFT_RC" in
       echo -e "  ${DIM}Do NOT use \`go clean -modcache\` — it deletes cache/download too, costing a${RESET}"
       echo -e "  ${DIM}~100 MB re-fetch of the 21-module oapi-codegen tree and reintroducing the${RESET}"
       echo -e "  ${DIM}network dependency GOPROXY_CACHED exists to remove.${RESET}"
+      echo ""
+      # GOPROXY_CACHED is itself a file:// proxy, so a COLD cache with the network
+      # also down produces this same wording. The purge is safe either way (Go
+      # re-extracts from the downloads), but it will not help that case.
+      echo -e "  ${DIM}If the purge changes nothing, the cache was cold rather than corrupt —${RESET}"
+      echo -e "  ${DIM}the file:// proxy reports the same error for a missing module. Treat it${RESET}"
+      echo -e "  ${DIM}as the network case below.${RESET}"
     else
       echo -e "  A failed module fetch (${BOLD}proxy.golang.org${RESET}) is the usual cause; retry once the"
       echo -e "  network is back, and the pinned generator will be cached in"


### PR DESCRIPTION
## What

Fixes the high-severity half of the Search hang found in live use after #1206: **Search was dead for every annotation-focus gather**, failing with a `/bus/emit 400` the moment the wizard sent the gathered context back through `match:search-requested`. (#1206 already landed the UI half — the failure now surfaces instead of spinning forever. This PR makes Search actually work again.)

## The bug

The neo4j annotation writes store `created: datetime($created)` — a native temporal — but the projection back out of the driver passed `props.created` through raw, under a comment claiming "ISO string from DB". The driver actually returns a DateTime **object** (`{ year: { low: 2026, … }, … }`).

Nothing could see it:

- the projection's input is `any`, so tsc never saw a DateTime flowing into `Annotation.created: string`;
- outbound gather replies are unvalidated, and nothing display-side reads `created`.

Once #1206 embedded full W3C annotations into graph nodes, the malformed annotations finally hit a **validated** round trip: every annotation node failed the node union's annotation arm on `created`, the whole emit 400'd, and the matcher never ran.

## The fix

One line, at the projection so every downstream consumer inherits it:

```ts
created: props.created.toString()
```

`.toString()` is the ISO form on driver temporals and the identity on rows already holding strings — the same pattern the file already uses for `modified` one line down and for the resource projection's `dateCreated`.

**Temporal audit of the file:** the resource projection was already safe; `resolvedAt`/`updatedAt` are written as temporals but never projected. Annotation `created` was the single leak of its class.

## The test seam

`parseAnnotationNode` was a private method that reads only `node.properties` — it's now a module-level export (13 call sites), which is what makes this bug class testable at all: with `any` at the seam, only a pin can catch a temporal leak. The new `neo4j-projection.test.ts` was watched fail **with the exact object shape captured from the live wire** before the fix, and pins DateTime→ISO, string passthrough, and `modified`'s serialization.

## Also in this PR

`scripts/ci/local-build.sh`: the Go module-cache remediation copy now explains the cold-cache case — the file:// proxy reports the same error for a missing module as for a corrupt one, so "purge changed nothing" means cold, not corrupt; treat it as the network case.

## Verification

- `packages/graph`: tsc clean, full suite 123/123, build green (node:24-alpine)
- End-to-end: the live repro (template-kb → unresolved reference → Resolve → Search) should be run once against a deployed stack with this fix — the unit pin proves the projection, not the fleet.
