### PR TITLE
Fold the from-resource Generate flow into one composite stack; dirty guards on dismissal

### DIFF
--- a/packages/react-ui/src/components/modals/ComposeStep.tsx
+++ b/packages/react-ui/src/components/modals/ComposeStep.tsx
@@ -88,6 +88,10 @@ export function ComposeStep({
         entityTypes: fixedTypes ? referenceEntityTypes : draft.entityTypes,
         language: draft.language,
       });
+    } catch {
+      // The rejection's job ends here: it kept the wizard's close from
+      // running and the host already surfaced the failure. Letting it
+      // escape a React event handler is an unhandled rejection.
     } finally {
       setIsCreating(false);
     }

--- a/packages/react-ui/src/components/modals/ConfigureGatherStep.tsx
+++ b/packages/react-ui/src/components/modals/ConfigureGatherStep.tsx
@@ -43,7 +43,7 @@ export function ConfigureGatherStep({ defaults, onGather, translations: t, child
   };
 
   return (
-    <form onSubmit={handleSubmit} className="semiont-form semiont-form--scrollable">
+    <form onSubmit={handleSubmit} className="semiont-form">
       <p className="semiont-form__helper-text">{t.intro}</p>
 
       <div className="semiont-form__checkbox-field">

--- a/packages/react-ui/src/components/modals/ConfigureGenerationStep.tsx
+++ b/packages/react-ui/src/components/modals/ConfigureGenerationStep.tsx
@@ -40,7 +40,8 @@ export interface ConfigureGenerationStepProps {
   /** Owned by the wizard so Back is lossless (WIZARD-NAVIGATION D3). */
   config: GenerationDraft;
   onConfigChange: (config: GenerationDraft) => void;
-  onBack: () => void;
+  /** Absent in a single-stack host (GATHER-AT-THE-TOP D6) — the footer then renders no retreat. */
+  onBack?: () => void;
   onGenerate: (config: GenerationConfig) => void;
   translations: {
     resourceTitle: string;
@@ -61,7 +62,7 @@ export interface ConfigureGenerationStepProps {
      * and `{{model}}`.
      */
     maxLengthCeiling: string;
-    back: string;
+    back?: string;
     generate: string;
   };
   /**
@@ -269,8 +270,7 @@ export function ConfigureGenerationStep({
       </div>
 
       <WizardFooter
-        backLabel={t.back}
-        onBack={onBack}
+        {...(onBack && t.back ? { backLabel: t.back, onBack } : {})}
         primary={{ label: t.generate, type: 'submit' }}
       />
     </form>

--- a/packages/react-ui/src/components/modals/DiscardPrompt.tsx
+++ b/packages/react-ui/src/components/modals/DiscardPrompt.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+/**
+ * The inline discard band (COMPOSE-IN-MODAL D4, shared by GATHER-AT-THE-TOP
+ * P1): a modal dies on ✕/Escape/backdrop, but typed work must not die with
+ * it. Hosts route ALL dismissal through one handler; when the draft is dirty
+ * that handler shows this band instead of closing. Success paths never come
+ * here — the guard protects dismissal, not completion.
+ */
+interface DiscardPromptProps {
+  prompt: string;
+  discardLabel: string;
+  keepLabel: string;
+  onDiscard: () => void;
+  onKeepEditing: () => void;
+}
+
+export function DiscardPrompt({ prompt, discardLabel, keepLabel, onDiscard, onKeepEditing }: DiscardPromptProps) {
+  return (
+    <div className="semiont-wizard__discard-prompt" role="alert">
+      <span className="semiont-wizard__discard-prompt-text">{prompt}</span>
+      <button
+        type="button"
+        className="semiont-button--danger"
+        onClick={onDiscard}
+      >
+        {discardLabel}
+      </button>
+      <button
+        type="button"
+        className="semiont-button--secondary"
+        onClick={onKeepEditing}
+      >
+        {keepLabel}
+      </button>
+    </div>
+  );
+}

--- a/packages/react-ui/src/components/modals/ReferenceWizardModal.tsx
+++ b/packages/react-ui/src/components/modals/ReferenceWizardModal.tsx
@@ -16,6 +16,7 @@ import type { GenerationDraft } from './ConfigureGenerationStep';
 import { SearchResultsStep } from './SearchResultsStep';
 import { ComposeStep } from './ComposeStep';
 import type { ComposeDraft, ComposeParams } from './ComposeStep';
+import { DiscardPrompt } from './DiscardPrompt';
 import { useLineNumbers } from '../../contexts/LineNumbersContext';
 import type { ScoredResult } from './SearchResultsStep';
 
@@ -240,20 +241,24 @@ export function ReferenceWizardModal({
     onClose();
   }, [annotationId, onComposeSubmit, onClose]);
 
-  // D4: a modal dies on ✕/Escape/backdrop; a non-empty compose draft must not
-  // die with it. Dismissal routes here; typed work raises an inline prompt.
-  const composeDirty = wizardStep.step === 'compose' && (
+  // D4 (widened by GATHER-AT-THE-TOP): a modal dies on ✕/Escape/backdrop, but
+  // typed work must not die with it — WHEREVER the user currently is (drafts
+  // survive stepping away, so the guard must too). Typed text only (D5):
+  // seeded titles, toggles, and sliders never nag.
+  const draftDirty =
     composeDraft.content.trim() !== '' ||
     composeDraft.storagePath.trim() !== '' ||
-    composeDraft.name !== defaultTitle
-  );
+    composeDraft.name !== defaultTitle ||
+    generationDraft.title !== defaultTitle ||
+    generationDraft.storagePath.trim() !== '' ||
+    generationDraft.prompt.trim() !== '';
   const handleDismiss = useCallback(() => {
-    if (composeDirty) {
+    if (draftDirty) {
       setShowDiscardPrompt(true);
       return;
     }
     onClose();
-  }, [composeDirty, onClose]);
+  }, [draftDirty, onClose]);
 
   const handleBackToGather = useCallback(() => {
     setWizardStep({ step: 'gather' });
@@ -369,23 +374,13 @@ export function ReferenceWizardModal({
                 </div>
 
                 {showDiscardPrompt && (
-                  <div className="semiont-wizard__discard-prompt" role="alert">
-                    <span className="semiont-wizard__discard-prompt-text">{t.discardDraftPrompt}</span>
-                    <button
-                      type="button"
-                      className="semiont-button--danger"
-                      onClick={() => { setShowDiscardPrompt(false); onClose(); }}
-                    >
-                      {t.discardDraft}
-                    </button>
-                    <button
-                      type="button"
-                      className="semiont-button--secondary"
-                      onClick={() => setShowDiscardPrompt(false)}
-                    >
-                      {t.keepEditing}
-                    </button>
-                  </div>
+                  <DiscardPrompt
+                    prompt={t.discardDraftPrompt}
+                    discardLabel={t.discardDraft}
+                    keepLabel={t.keepEditing}
+                    onDiscard={() => { setShowDiscardPrompt(false); onClose(); }}
+                    onKeepEditing={() => setShowDiscardPrompt(false)}
+                  />
                 )}
 
                 {wizardStep.step === 'gather' && (

--- a/packages/react-ui/src/components/modals/ReferenceWizardModal.tsx
+++ b/packages/react-ui/src/components/modals/ReferenceWizardModal.tsx
@@ -161,9 +161,16 @@ export function ReferenceWizardModal({
   // provider-free, so the wizard resolves it and passes it down.
   const { showLineNumbers } = useLineNumbers();
 
+  // The dirty baseline is what was SEEDED, not the live prop: defaultTitle
+  // derives from observable wizard state and can re-emit while the modal is
+  // open; an untouched draft must not read as dirty because the baseline
+  // moved under it.
+  const seededTitle = useRef(defaultTitle);
+
   // Reset to gather step when modal opens
   useEffect(() => {
     if (isOpen) {
+      seededTitle.current = defaultTitle;
       setWizardStep({ step: 'gather' });
       setSearchConfig({ limit: 10, useSemanticScoring: true });
       setGenerationDraft({
@@ -248,8 +255,8 @@ export function ReferenceWizardModal({
   const draftDirty =
     composeDraft.content.trim() !== '' ||
     composeDraft.storagePath.trim() !== '' ||
-    composeDraft.name !== defaultTitle ||
-    generationDraft.title !== defaultTitle ||
+    composeDraft.name !== seededTitle.current ||
+    generationDraft.title !== seededTitle.current ||
     generationDraft.storagePath.trim() !== '' ||
     generationDraft.prompt.trim() !== '';
   const handleDismiss = useCallback(() => {

--- a/packages/react-ui/src/components/modals/ResourceGenerateModal.tsx
+++ b/packages/react-ui/src/components/modals/ResourceGenerateModal.tsx
@@ -5,17 +5,13 @@ import type { CollaboratorEntry, GatheredContext } from '@semiont/core';
 import type { ResourceGatherOptions } from '@semiont/sdk';
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
 import { ConfigureGatherStep, type ResourceGatherConfig } from './ConfigureGatherStep';
+import { DiscardPrompt } from './DiscardPrompt';
 import { GatherContextStep } from './GatherContextStep';
-import { WizardFooter } from './WizardFooter';
 import { ConfigureGenerationStep, type GenerationConfig, type GenerationDraft } from './ConfigureGenerationStep';
 
 export interface ResourceGenerateModalTranslations {
-  // Step titles + nav
-  gatherTitle: string;
-  reviewTitle: string;
+  // The one modal title (GATHER-AT-THE-TOP D7)
   configureTitle: string;
-  next: string;
-  back: string;
   // ConfigureGatherStep
   gatherIntro: string;
   includeContent: string;
@@ -52,6 +48,10 @@ export interface ResourceGenerateModalTranslations {
   maxLengthHelp: string;
   maxLengthCeiling: string;
   generate: string;
+  // DiscardPrompt (GATHER-AT-THE-TOP P1)
+  discardDraftPrompt: string;
+  discardDraft: string;
+  keepEditing: string;
 }
 
 export interface ResourceGenerateModalProps {
@@ -97,12 +97,15 @@ export interface ResourceGenerateModalProps {
   translations: ResourceGenerateModalTranslations;
 }
 
-type Step = 'configure-gather' | 'review' | 'configure-generation';
-
 /**
- * Resource-generate flow (GENERATE-FROM-BUTTON): configure gather options →
- * `gather.resource` → review the gathered `GatheredContext` → configure
- * generation → emit. Reuses the kind-aware `GatherContextStep` for the review.
+ * Resource-generate flow (GENERATE-FROM-BUTTON, folded by GATHER-AT-THE-TOP):
+ * one composite stack in a single scroll pane — the gather controls at the
+ * top, the gathered `GatheredContext` below them once gather fires, and the
+ * generation params beneath the evidence once context arrives. Re-gathering
+ * is scroll-up → tweak → Gather; `gatherResource` clears its slots at start,
+ * so the evidence refreshes in place. [gather zone] → [evidence] → [act
+ * zone]: the same grammar the resolve wizard expresses, whose gather zone
+ * happens to be automatic and whose act zone has a strategy choice.
  */
 export function ResourceGenerateModal({
   isOpen,
@@ -128,7 +131,11 @@ export function ResourceGenerateModal({
   });
   const [generationDraft, setGenerationDraft] = useState<GenerationDraft>(freshDraft);
 
-  const [step, setStep] = useState<Step>('configure-gather');
+  // "Has THIS run gathered yet?" — the page's gather slots survive across
+  // opens, so a context prop can be stale at open time. Nothing renders below
+  // the controls until the user fires a gather in this run.
+  const [gatherFired, setGatherFired] = useState(false);
+  const [showDiscardPrompt, setShowDiscardPrompt] = useState(false);
   // Supplied by the owner, which already tracks the list with its failure
   // state. Fetching it here could only model (value | not-yet), so a failed
   // load would render an empty exclusion picker as though the KB had no
@@ -143,9 +150,10 @@ export function ResourceGenerateModal({
   const wasOpen = useRef(false);
   useEffect(() => {
     if (isOpen && !wasOpen.current) {
-      setStep('configure-gather');
+      setGatherFired(false);
       setExcludeEntityTypes([]);
       setGenerationDraft(freshDraft());
+      setShowDiscardPrompt(false);
     }
     wasOpen.current = isOpen;
     // freshDraft reads defaultTitle/locale at call time; the effect keys on the
@@ -154,7 +162,7 @@ export function ResourceGenerateModal({
   }, [isOpen]);
 
   const handleGather = useCallback((config: ResourceGatherConfig) => {
-    setStep('review');
+    setGatherFired(true);
     onGather({
       ...config,
       ...(excludeEntityTypes.length ? { excludeEntityTypes } : {}),
@@ -166,20 +174,34 @@ export function ResourceGenerateModal({
     onClose();
   }, [onGenerateSubmit, resourceId, onClose]);
 
-  const stepTitle = step === 'configure-gather' ? t.gatherTitle : step === 'review' ? t.reviewTitle : t.configureTitle;
+  // D4/D5 (GATHER-AT-THE-TOP P1): typed text must not die with a dismissed
+  // modal. Toggles, depth, and exclusion picks are cheap to redo and never
+  // nag. Generate's completion path above bypasses this — the guard protects
+  // dismissal, not completion.
+  const draftDirty =
+    generationDraft.title !== defaultTitle ||
+    generationDraft.storagePath.trim() !== '' ||
+    generationDraft.prompt.trim() !== '';
+  const handleDismiss = useCallback(() => {
+    if (draftDirty) {
+      setShowDiscardPrompt(true);
+      return;
+    }
+    onClose();
+  }, [draftDirty, onClose]);
 
-  // Configure-generation stacks evidence + form in ONE scroll pane; enter at
-  // the BOTTOM so the parameters show in full, the evidence tucked up under
-  // the modal top. jsdom has no layout (scrollHeight 0) — no-op in tests.
+  // The whole stack is ONE scroll pane; when the params zone appears (context
+  // arrival — including each re-gather), enter at the BOTTOM so the
+  // parameters show in full, the evidence and controls tucked up under the
+  // modal top. jsdom has no layout (scrollHeight 0) — no-op in tests.
   const stepScrollRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = stepScrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [step]);
+    if (el && gatherContext) el.scrollTop = el.scrollHeight;
+  }, [gatherContext]);
 
-  // Shared by review and configure-generation: stepping onward must not hide
-  // what the generation will be grounded in — the context stays in view above
-  // the form.
+  // The evidence zone: what the generation will be grounded in stays in view
+  // above the form.
   const displayTranslations = {
     loadingContext: t.loadingContext,
     failedContext: t.failedContext,
@@ -197,7 +219,7 @@ export function ResourceGenerateModal({
 
   return (
     <Transition appear show={isOpen}>
-      <Dialog as="div" className="semiont-search-modal" onClose={onClose}>
+      <Dialog as="div" className="semiont-search-modal" onClose={handleDismiss}>
         <TransitionChild
           enter="ease-out duration-200"
           enterFrom="opacity-0"
@@ -221,13 +243,23 @@ export function ResourceGenerateModal({
             >
               <DialogPanel className="semiont-search-modal__panel semiont-search-modal__panel--with-border semiont-search-modal__panel--gather semiont-search-modal__panel--wide">
                 <div className="semiont-search-modal__header">
-                  <DialogTitle className="semiont-search-modal__title">{stepTitle}</DialogTitle>
-                  <button onClick={onClose} className="semiont-search-modal__close-button" aria-label="Close">
+                  <DialogTitle className="semiont-search-modal__title">{t.configureTitle}</DialogTitle>
+                  <button onClick={handleDismiss} className="semiont-search-modal__close-button" aria-label="Close">
                     ✕
                   </button>
                 </div>
 
-                {step === 'configure-gather' && (
+                {showDiscardPrompt && (
+                  <DiscardPrompt
+                    prompt={t.discardDraftPrompt}
+                    discardLabel={t.discardDraft}
+                    keepLabel={t.keepEditing}
+                    onDiscard={() => { setShowDiscardPrompt(false); onClose(); }}
+                    onKeepEditing={() => setShowDiscardPrompt(false)}
+                  />
+                )}
+
+                <div className="semiont-wizard__step-scroll" ref={stepScrollRef}>
                   <ConfigureGatherStep
                     defaults={gatherDefaults}
                     onGather={handleGather}
@@ -263,64 +295,42 @@ export function ResourceGenerateModal({
                       </div>
                     )}
                   </ConfigureGatherStep>
-                )}
 
-                {step === 'review' && (
-                  <>
+                  {gatherFired && (
                     <GatherContextStep
                       context={gatherContext}
                       contextLoading={gatherLoading}
                       contextError={gatherError}
                       translations={displayTranslations}
                     />
-                    <WizardFooter
-                      backLabel={t.back}
-                      onBack={() => setStep('configure-gather')}
-                      primary={{
-                        label: t.next,
-                        type: 'button',
-                        onClick: () => setStep('configure-generation'),
-                        disabled: !gatherContext,
+                  )}
+
+                  {gatherFired && gatherContext && (
+                    <ConfigureGenerationStep
+                      {...(generationAgent ? { generationAgent } : {})}
+                      context={gatherContext}
+                      config={generationDraft}
+                      onConfigChange={setGenerationDraft}
+                      onGenerate={handleGenerate}
+                      translations={{
+                        resourceTitle: t.resourceTitle,
+                        resourceTitlePlaceholder: t.resourceTitlePlaceholder,
+                        saveLocation: t.saveLocation,
+                        additionalInstructions: t.additionalInstructions,
+                        additionalInstructionsPlaceholder: t.additionalInstructionsPlaceholder,
+                        language: t.language,
+                        languageHelp: t.languageHelp,
+                        creativity: t.creativity,
+                        creativityFocused: t.creativityFocused,
+                        creativityCreative: t.creativityCreative,
+                        maxLength: t.maxLength,
+                        maxLengthHelp: t.maxLengthHelp,
+                        maxLengthCeiling: t.maxLengthCeiling,
+                        generate: t.generate,
                       }}
                     />
-                  </>
-                )}
-
-                {step === 'configure-generation' && gatherContext && (
-                  <div className="semiont-wizard__step-scroll" ref={stepScrollRef}>
-                  <GatherContextStep
-                    context={gatherContext}
-                    contextLoading={gatherLoading}
-                    contextError={gatherError}
-                    translations={displayTranslations}
-                  />
-                  <ConfigureGenerationStep
-                    {...(generationAgent ? { generationAgent } : {})}
-                    context={gatherContext}
-                    config={generationDraft}
-                    onConfigChange={setGenerationDraft}
-                    onBack={() => setStep('review')}
-                    onGenerate={handleGenerate}
-                    translations={{
-                      resourceTitle: t.resourceTitle,
-                      resourceTitlePlaceholder: t.resourceTitlePlaceholder,
-                      saveLocation: t.saveLocation,
-                      additionalInstructions: t.additionalInstructions,
-                      additionalInstructionsPlaceholder: t.additionalInstructionsPlaceholder,
-                      language: t.language,
-                      languageHelp: t.languageHelp,
-                      creativity: t.creativity,
-                      creativityFocused: t.creativityFocused,
-                      creativityCreative: t.creativityCreative,
-                      maxLength: t.maxLength,
-                      maxLengthHelp: t.maxLengthHelp,
-                      maxLengthCeiling: t.maxLengthCeiling,
-                      back: t.back,
-                      generate: t.generate,
-                    }}
-                  />
-                  </div>
-                )}
+                  )}
+                </div>
               </DialogPanel>
             </TransitionChild>
           </div>

--- a/packages/react-ui/src/components/modals/ResourceGenerateModal.tsx
+++ b/packages/react-ui/src/components/modals/ResourceGenerateModal.tsx
@@ -148,12 +148,18 @@ export function ResourceGenerateModal({
   // name existed (GFR A4). Guarded to the false→true transition so a name
   // arriving mid-flow cannot clobber what the user has typed.
   const wasOpen = useRef(false);
+  // The dirty baseline is what was SEEDED, not the live prop: defaultTitle
+  // can move while the modal is open (the source resource's name loads
+  // asynchronously), and an untouched draft must not read as dirty because
+  // the baseline moved under it.
+  const seededTitle = useRef(defaultTitle);
   useEffect(() => {
     if (isOpen && !wasOpen.current) {
       setGatherFired(false);
       setExcludeEntityTypes([]);
       setGenerationDraft(freshDraft());
       setShowDiscardPrompt(false);
+      seededTitle.current = defaultTitle;
     }
     wasOpen.current = isOpen;
     // freshDraft reads defaultTitle/locale at call time; the effect keys on the
@@ -179,7 +185,7 @@ export function ResourceGenerateModal({
   // nag. Generate's completion path above bypasses this — the guard protects
   // dismissal, not completion.
   const draftDirty =
-    generationDraft.title !== defaultTitle ||
+    generationDraft.title !== seededTitle.current ||
     generationDraft.storagePath.trim() !== '' ||
     generationDraft.prompt.trim() !== '';
   const handleDismiss = useCallback(() => {

--- a/packages/react-ui/src/components/modals/__tests__/ReferenceWizardModal.test.tsx
+++ b/packages/react-ui/src/components/modals/__tests__/ReferenceWizardModal.test.tsx
@@ -355,6 +355,35 @@ describe('ReferenceWizardModal — compose is the fourth in-modal strategy (COMP
   });
 });
 
+// GATHER-AT-THE-TOP P1: the dirty guard widens. D4 — dirtiness is
+// step-independent (typed work guards dismissal wherever the user currently
+// is); D5 — typed text only (title beyond seed, save location, instructions,
+// content). The generation draft gets the same protection compose has.
+describe('ReferenceWizardModal — the dirty guard widens (GATHER-AT-THE-TOP D4/D5)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('a typed generation draft guards dismissal', async () => {
+    const { onClose } = renderWizard();
+    await userEvent.click(screen.getByRole('button', { name: /Generate…/ }));
+    fireEvent.change(screen.getByLabelText(T.saveLocation), { target: { value: 'people/x.md' } });
+
+    await userEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText(T.discardDraftPrompt)).toBeInTheDocument();
+  });
+
+  it('a compose draft still guards after stepping Back to the evidence — D4 kills the step gate', async () => {
+    const { onClose } = renderWizard();
+    await userEvent.click(screen.getByText(new RegExp(T.compose)));
+    fireEvent.change(screen.getByTestId('code-editor'), { target: { value: 'typed work' } });
+    await userEvent.click(screen.getByRole('button', { name: new RegExp(T.back) }));
+
+    await userEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText(T.discardDraftPrompt)).toBeInTheDocument();
+  });
+});
+
 describe('ReferenceWizardModal — a new run starts clean (D3 flip side)', () => {
   it('reopening resets the hint and the step', async () => {
     const { rerender } = renderWizard();

--- a/packages/react-ui/src/components/modals/__tests__/ReferenceWizardModal.test.tsx
+++ b/packages/react-ui/src/components/modals/__tests__/ReferenceWizardModal.test.tsx
@@ -372,6 +372,36 @@ describe('ReferenceWizardModal — the dirty guard widens (GATHER-AT-THE-TOP D4/
     expect(screen.getByText(T.discardDraftPrompt)).toBeInTheDocument();
   });
 
+  it('a defaultTitle drifting while open does not fake a dirty draft', async () => {
+    // The wizard's defaultTitle derives from observable state and can re-emit
+    // while the modal is open. The baseline moves, the user has typed nothing —
+    // dirtiness compares against what was SEEDED, not the live prop.
+    const { rerender, onClose, onComposeSubmit, onGenerateSubmit, onLinkResource } = renderWizard();
+    rerender(
+      <ReferenceWizardModal
+        isOpen
+        onClose={onClose}
+        annotationId="ann-1"
+        resourceId="res-1"
+        defaultTitle="Caspian Sea (moved)"
+        entityTypes={['Location']}
+        entityTypeOptions={['Person', 'Topic', 'Location']}
+        locale="en"
+        context={CONTEXT}
+        contextLoading={false}
+        contextError={null}
+        onGenerateSubmit={onGenerateSubmit}
+        onLinkResource={onLinkResource}
+        onComposeSubmit={onComposeSubmit}
+        translations={T}
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText('Close'));
+    expect(screen.queryByText(T.discardDraftPrompt)).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('a compose draft still guards after stepping Back to the evidence — D4 kills the step gate', async () => {
     const { onClose } = renderWizard();
     await userEvent.click(screen.getByText(new RegExp(T.compose)));

--- a/packages/react-ui/src/components/modals/__tests__/ResourceGenerateModal.test.tsx
+++ b/packages/react-ui/src/components/modals/__tests__/ResourceGenerateModal.test.tsx
@@ -307,6 +307,26 @@ describe('ResourceGenerateModal — dismissal guards typed work (GATHER-AT-THE-T
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('a defaultTitle arriving mid-flow does not fake a dirty draft', () => {
+    // The source resource's name loads asynchronously: the baseline moves
+    // while the modal is open, the user has typed nothing. Dirtiness compares
+    // against what was SEEDED, not the live prop.
+    const { rerender } = renderModal({ defaultTitle: '', gatherContext: RESOURCE_CONTEXT });
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
+    rerender(
+      <ResourceGenerateModal
+        isOpen onClose={onClose} resourceId="res-1" defaultTitle="Loaded Name"
+        locale="en" entityTypeOptions={['Person', 'Topic']} onGenerateSubmit={onGenerateSubmit}
+        gatherContext={RESOURCE_CONTEXT} gatherLoading={false} gatherError={null}
+        onGather={onGather} translations={T}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(screen.queryByText(T.discardDraftPrompt)).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('non-text state alone never nags — exclusions and depth are cheap to redo (D5)', () => {
     renderModal();
     fireEvent.click(screen.getByRole('button', { name: 'Person' })); // pick an exclusion

--- a/packages/react-ui/src/components/modals/__tests__/ResourceGenerateModal.test.tsx
+++ b/packages/react-ui/src/components/modals/__tests__/ResourceGenerateModal.test.tsx
@@ -1,13 +1,16 @@
 /**
- * GENERATE-FROM-BUTTON P2/P4 → FLOW-LIFECYCLE-CONVERGENCE P3 — the
- * resource-generate flow modal.
+ * GENERATE-FROM-BUTTON P2/P4 → FLOW-LIFECYCLE-CONVERGENCE P3 →
+ * GATHER-AT-THE-TOP P2 — the resource-generate flow modal.
  *
- * Drives the step machine: configure-gather → review → configure-generation.
- * Gather state arrives as PROPS (the page reads `gather.resourceContext$` and
- * friends off the state unit) and the gather itself is an `onGather` callback —
- * the modal mocks no hook and reaches for no provider (FLC A6). Entity-type
- * options are owner-supplied, so a failed load cannot surface as an empty
- * vocabulary (see .plans/PANEL-FAILURE-STATES.md).
+ * One composite stack, no step machine: the gather controls sit at the TOP,
+ * the gathered evidence appears below them once gather fires, and the
+ * generation params render beneath the evidence once context arrives —
+ * [gather zone] → [evidence] → [act zone], the same grammar the resolve
+ * wizard expresses. Gather state arrives as PROPS (the page reads
+ * `gather.resourceContext$` and friends off the state unit) and the gather
+ * itself is an `onGather` callback — the modal mocks no hook and reaches for
+ * no provider (FLC A6). Entity-type options are owner-supplied, so a failed
+ * load cannot surface as an empty vocabulary.
  */
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -24,11 +27,7 @@ const RESOURCE_CONTEXT = {
 } as unknown as GatheredContext;
 
 const T = {
-  gatherTitle: 'Configure Gather',
-  reviewTitle: 'Review Context',
   configureTitle: 'Configure Generation',
-  next: 'Next',
-  back: 'Back',
   gatherIntro: 'Choose what to include.',
   includeContent: 'Include content',
   includeSummary: 'Include summary',
@@ -62,6 +61,9 @@ const T = {
   maxLengthHelp: 'Max help',
   maxLengthCeiling: 'Limited to {{maxOutputTokens}} tokens by {{model}}.',
   generate: 'Generate',
+  discardDraftPrompt: 'Discard this draft?',
+  discardDraft: 'Discard',
+  keepEditing: 'Keep editing',
 };
 
 let onClose: Mock<() => void>;
@@ -100,27 +102,34 @@ describe('ResourceGenerateModal', () => {
 
   it('renders nothing when closed', () => {
     renderModal({ isOpen: false });
-    expect(screen.queryByText('Configure Gather')).not.toBeInTheDocument();
+    expect(screen.queryByText(T.configureTitle)).not.toBeInTheDocument();
   });
 
-  it('opens on the configure-gather step with the exclusion options', () => {
-    renderModal();
-    expect(screen.getByText('Configure Gather')).toBeInTheDocument(); // step title
-    expect(screen.getByText('Choose what to include.')).toBeInTheDocument();
-    expect(screen.getByLabelText('Include content')).toBeInTheDocument();
+  it('opens with the gather controls at the top and nothing below them yet', () => {
+    // Stale slots must not leak a previous run's evidence into a fresh open:
+    // even with a context PROP already present, nothing renders below the
+    // controls until THIS run's gather fires.
+    const { baseElement } = renderModal({ gatherContext: RESOURCE_CONTEXT });
+    expect(screen.getByText(T.configureTitle)).toBeInTheDocument(); // the one modal title
+    expect(screen.getByText(T.gatherIntro)).toBeInTheDocument();
+    expect(screen.getByLabelText(T.includeContent)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Person' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Topic' })).toBeInTheDocument();
+    expect(baseElement.querySelector('.semiont-wizard__step-scroll')).not.toBeNull();
+    expect(screen.queryByText(T.graphPaneTitle)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(T.resourceTitle)).not.toBeInTheDocument();
   });
 
-  it('submitting the gather step emits onGather and advances to review (exclusion omitted when none picked)', () => {
+  it('Gather emits onGather and the evidence zone appears in place (exclusion omitted when none picked)', () => {
     // The modal no longer knows how to gather — it says WHAT to gather and the
     // page wires the state unit (FLC D3). No resourceId in the payload: the
     // owner already holds it.
-    renderModal();
+    const { baseElement } = renderModal({ gatherLoading: true });
     fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
     expect(onGather).toHaveBeenCalledWith({ includeContent: true, includeSummary: true, depth: 2, maxResources: 10 });
-    expect(screen.getByText('Review Context')).toBeInTheDocument(); // step title flipped
-    expect(screen.getByRole('button', { name: /Next/ })).toBeDisabled(); // no context yet
+    expect(baseElement.querySelector('.semiont-gather__loading')).not.toBeNull();
+    // The controls stay put above the evidence — no page flip.
+    expect(screen.getByText(T.gatherIntro)).toBeInTheDocument();
   });
 
   it('threads picked entity types into the gather options', () => {
@@ -136,16 +145,13 @@ describe('ResourceGenerateModal', () => {
     });
   });
 
-  it('walks gather → review → configure-generation → emits onGenerateSubmit then closes', () => {
-    renderModal({ gatherContext: RESOURCE_CONTEXT }); // gather already resolved
+  it('params render beneath the evidence once context arrives; Generate emits and closes', () => {
+    renderModal({ gatherContext: RESOURCE_CONTEXT }); // gather resolves immediately
 
-    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // → review
-    const next = screen.getByRole('button', { name: /Next/ });
-    expect(next).toBeEnabled();
-    fireEvent.click(next); // → configure-generation
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
 
-    fireEvent.change(screen.getByLabelText('New resource title'), { target: { value: 'Generated Doc' } });
-    fireEvent.change(screen.getByLabelText('Save location'), { target: { value: 'generated/out.md' } });
+    fireEvent.change(screen.getByLabelText(T.resourceTitle), { target: { value: 'Generated Doc' } });
+    fireEvent.change(screen.getByLabelText(T.saveLocation), { target: { value: 'generated/out.md' } });
     fireEvent.click(screen.getByRole('button', { name: /Generate/ }));
 
     expect(onGenerateSubmit).toHaveBeenCalledTimes(1);
@@ -160,14 +166,13 @@ describe('ResourceGenerateModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('a loading gather shows its progress, an error shows its failure', () => {
+  it('a failed gather shows its failure in place', () => {
     // The props are the state unit's slots verbatim; the modal renders them
     // without owning them (FLC A6).
-    const { rerender, baseElement } = renderModal({ gatherLoading: true });
-    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // → review
-    expect(baseElement.querySelector('.semiont-gather__loading')).not.toBeNull();
+    renderModal({ gatherLoading: true });
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
 
-    rerender(
+    render(
       <ResourceGenerateModal
         isOpen onClose={onClose} resourceId="res-1" defaultTitle="Default Title"
         locale="en" entityTypeOptions={['Person', 'Topic']} onGenerateSubmit={onGenerateSubmit}
@@ -175,24 +180,23 @@ describe('ResourceGenerateModal', () => {
         onGather={onGather} translations={T}
       />,
     );
-    expect(screen.getByText('Failed')).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: /Gather/ }).at(-1)!);
+    expect(screen.getByText(T.failedContext)).toBeInTheDocument();
   });
 
-  it('Back from configure-generation returns to review', () => {
+  it('re-Gather refreshes the evidence in place — the stack stays', () => {
     renderModal({ gatherContext: RESOURCE_CONTEXT });
-    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // → review
-    fireEvent.click(screen.getByRole('button', { name: /Next/ }));   // → configure-generation
-    expect(screen.getByText('Configure Generation')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Back/ }));   // → review
-    expect(screen.getByText('Review Context')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // tweak-and-regather
+    expect(onGather).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(T.graphPaneTitle)).toBeInTheDocument();
+    expect(screen.getByLabelText(T.resourceTitle)).toBeInTheDocument();
   });
 
-  it('Back from review returns to the configure-gather step', () => {
-    renderModal();
-    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // → review
-    expect(screen.getByText('Review Context')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Back/ })); // → configure-gather
-    expect(screen.getByText('Configure Gather')).toBeInTheDocument();
+  it('no Back anywhere — a single stack has nothing to go back to (D6)', () => {
+    renderModal({ gatherContext: RESOURCE_CONTEXT });
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
+    expect(screen.queryAllByRole('button', { name: /Back/ })).toHaveLength(0);
   });
 
   it('the header close button calls onClose', () => {
@@ -222,32 +226,22 @@ describe('ResourceGenerateModal', () => {
         onGather={onGather} translations={T}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // → review
-    fireEvent.click(screen.getByRole('button', { name: /Next/ }));   // → configure-generation
-    expect(screen.getByLabelText('New resource title')).toHaveValue('PB');
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
+    expect(screen.getByLabelText(T.resourceTitle)).toHaveValue('PB');
   });
 
-  it('configure-generation keeps the gathered context in view above the form', () => {
-    // Review stays the look-at-it step; stepping onward must not hide what the
-    // generation will be grounded in. The context renders display-only above
-    // the form (same GatherContextStep the review step uses).
+  it('evidence stays in view above the params — ONE scroll pane, nothing scrolls alone (A3)', () => {
     const { baseElement } = renderModal({ gatherContext: RESOURCE_CONTEXT });
-    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // → review
-    fireEvent.click(screen.getByRole('button', { name: /Next/ }));   // → configure-generation
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
 
-    expect(screen.getByText('Configure Generation')).toBeInTheDocument();
-    expect(screen.getByText('In the graph')).toBeInTheDocument();          // graph pane still up
-    expect(baseElement.querySelector('.semiont-gather__outer')).not.toBeNull(); // the display shell
-    expect(screen.getByLabelText('New resource title')).toBeInTheDocument();   // the form, below
-
-    // ONE scroll pane: evidence + parameters together; no independently
-    // scrollable form squeezing the parameters out of view.
     const scroll = baseElement.querySelector('.semiont-wizard__step-scroll');
     expect(scroll).not.toBeNull();
-    expect(scroll!.querySelector('.semiont-gather__outer')).not.toBeNull();
-    const form = scroll!.querySelector('form.semiont-form');
-    expect(form).not.toBeNull();
-    expect(form!.className).not.toContain('semiont-form--scrollable');
+    expect(scroll!.querySelector('.semiont-gather__outer')).not.toBeNull();      // the evidence
+    expect(screen.getByText(T.graphPaneTitle)).toBeInTheDocument();              // graph pane up
+    expect(screen.getByLabelText(T.resourceTitle)).toBeInTheDocument();          // the form, below
+    for (const form of Array.from(scroll!.querySelectorAll('form.semiont-form'))) {
+      expect(form.className).not.toContain('semiont-form--scrollable');
+    }
   });
 
   it('the panel carries the widened class (GEP P2, D2)', () => {
@@ -269,10 +263,56 @@ describe('ResourceGenerateModal', () => {
       expect(footerButtons.filter((l) => /cancel|✕/i.test(l))).toEqual([]);
     };
 
-    footerPins(); // configure-gather
+    footerPins(); // controls alone
     fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
-    footerPins(); // review
-    fireEvent.click(screen.getByRole('button', { name: /Next/ }));
-    footerPins(); // configure-generation (already WizardFooter — stays that way)
+    footerPins(); // the full stack: Gather footer + Generate footer
+  });
+});
+
+// GATHER-AT-THE-TOP P1: dismissal guards typed work. D5 — typed text only
+// (title beyond the seeded default, save location, instructions); checkbox,
+// depth, and exclusion state is cheap to redo and never nags.
+describe('ResourceGenerateModal — dismissal guards typed work (GATHER-AT-THE-TOP P1)', () => {
+  beforeEach(() => {
+    onClose = vi.fn();
+    onGenerateSubmit = vi.fn();
+    onGather = vi.fn();
+  });
+
+  it('a typed save location guards dismissal; Keep editing stays, Discard closes', () => {
+    renderModal({ gatherContext: RESOURCE_CONTEXT });
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ })); // reveal the stack
+    fireEvent.change(screen.getByLabelText(T.saveLocation), { target: { value: 'generated/out.md' } });
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText(T.discardDraftPrompt)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: T.keepEditing }));
+    expect(screen.queryByText(T.discardDraftPrompt)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(T.saveLocation)).toHaveValue('generated/out.md');
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    fireEvent.click(screen.getByRole('button', { name: T.discardDraft }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a clean draft dismisses without any prompt', () => {
+    renderModal({ gatherContext: RESOURCE_CONTEXT });
+    fireEvent.click(screen.getByRole('button', { name: /Gather/ }));
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(screen.queryByText(T.discardDraftPrompt)).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-text state alone never nags — exclusions and depth are cheap to redo (D5)', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Person' })); // pick an exclusion
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(screen.queryByText(T.discardDraftPrompt)).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
+++ b/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
@@ -794,11 +794,7 @@ export function ResourceViewerPage({
         gatherError={resourceGatherError}
         onGather={(options) => stateUnit?.gather.gatherResource(rUri, options)}
         translations={{
-          gatherTitle: tg('gatherTitle'),
-          reviewTitle: tg('reviewTitle'),
           configureTitle: tg('configureTitle'),
-          next: tg('next'),
-          back: tg('back'),
           gatherIntro: tg('gatherIntro'),
           includeContent: tg('includeContent'),
           includeSummary: tg('includeSummary'),
@@ -832,6 +828,9 @@ export function ResourceViewerPage({
           maxLengthHelp: tg('maxLengthHelp'),
           maxLengthCeiling: tg('maxLengthCeiling'),
           generate: tg('generate'),
+          discardDraftPrompt: tg('discardDraftPrompt'),
+          discardDraft: tg('discardDraft'),
+          keepEditing: tg('keepEditing'),
         }}
       />
     </div>

--- a/packages/react-ui/src/styles/core/forms.css
+++ b/packages/react-ui/src/styles/core/forms.css
@@ -232,12 +232,6 @@
    are now defined in /styles/core/ as they are fundamental UI elements.
    See: core/textareas.css, core/selects.css, core/checkboxes.css */
 
-/* Scrollable form body — keeps form within viewport height */
-.semiont-form--scrollable {
-  overflow-y: auto;
-  max-height: 70vh;
-  padding-right: 0.25rem;
-}
 
 /* Inline row — lays out multiple fields side by side */
 .semiont-form__inline-row {

--- a/packages/react-ui/translations/ar.json
+++ b/packages/react-ui/translations/ar.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "تكوين الجمع",
-    "reviewTitle": "مراجعة السياق",
     "configureTitle": "تكوين التوليد",
-    "next": "التالي",
-    "back": "رجوع",
     "gatherIntro": "اختر ما تريد تضمينه في السياق المُجمَّع.",
     "includeContent": "تضمين محتوى المورد",
     "includeSummary": "تضمين الملخص",
@@ -422,7 +418,10 @@
     "excludedReceipt": "استُبعد {{types}} من هذا الاسترجاع",
     "machineRead": "OCR",
     "score": "درجة",
-    "saveLocation": "موقع الحفظ"
+    "saveLocation": "موقع الحفظ",
+    "discardDraftPrompt": "هل تريد تجاهل هذه المسودة؟",
+    "discardDraft": "تجاهل",
+    "keepEditing": "متابعة التحرير"
   },
   "ReferenceWizard": {
     "gatherTitle": "السياق المُجمَّع",

--- a/packages/react-ui/translations/bn.json
+++ b/packages/react-ui/translations/bn.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "সংগ্রহ কনফিগার করুন",
-    "reviewTitle": "প্রসঙ্গ পর্যালোচনা করুন",
     "configureTitle": "জেনারেশন কনফিগার করুন",
-    "next": "পরবর্তী",
-    "back": "পিছনে",
     "gatherIntro": "সংগৃহীত প্রসঙ্গে কী অন্তর্ভুক্ত করবেন তা বেছে নিন।",
     "includeContent": "সম্পদের বিষয়বস্তু অন্তর্ভুক্ত করুন",
     "includeSummary": "সারসংক্ষেপ অন্তর্ভুক্ত করুন",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} এই রিকল থেকে বাদ",
     "machineRead": "OCR",
     "score": "স্কোর",
-    "saveLocation": "সংরক্ষণের অবস্থান"
+    "saveLocation": "সংরক্ষণের অবস্থান",
+    "discardDraftPrompt": "এই খসড়াটি বাতিল করবেন?",
+    "discardDraft": "বাতিল করুন",
+    "keepEditing": "সম্পাদনা চালিয়ে যান"
   },
   "ReferenceWizard": {
     "gatherTitle": "সংগৃহীত প্রসঙ্গ",

--- a/packages/react-ui/translations/cs.json
+++ b/packages/react-ui/translations/cs.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Konfigurovat shromáždění",
-    "reviewTitle": "Zkontrolovat kontext",
     "configureTitle": "Konfigurovat generování",
-    "next": "Další",
-    "back": "Zpět",
     "gatherIntro": "Vyberte, co zahrnout do shromážděného kontextu.",
     "includeContent": "Zahrnout obsah zdroje",
     "includeSummary": "Zahrnout souhrn",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} vyloučeno z tohoto vyhledání",
     "machineRead": "OCR",
     "score": "Skóre",
-    "saveLocation": "Umístění uložení"
+    "saveLocation": "Umístění uložení",
+    "discardDraftPrompt": "Zahodit tento koncept?",
+    "discardDraft": "Zahodit",
+    "keepEditing": "Pokračovat v úpravách"
   },
   "ReferenceWizard": {
     "gatherTitle": "Shromážděný kontext",

--- a/packages/react-ui/translations/da.json
+++ b/packages/react-ui/translations/da.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Konfigurer indsamling",
-    "reviewTitle": "Gennemgå kontekst",
     "configureTitle": "Konfigurer generering",
-    "next": "Næste",
-    "back": "Tilbage",
     "gatherIntro": "Vælg hvad der skal inkluderes i den indsamlede kontekst.",
     "includeContent": "Inkluder ressourceindhold",
     "includeSummary": "Inkluder resumé",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} udeladt fra denne søgning",
     "machineRead": "OCR",
     "score": "Score",
-    "saveLocation": "Placering"
+    "saveLocation": "Placering",
+    "discardDraftPrompt": "Kassér denne kladde?",
+    "discardDraft": "Kassér",
+    "keepEditing": "Fortsæt redigering"
   },
   "ReferenceWizard": {
     "gatherTitle": "Indsamlet kontekst",

--- a/packages/react-ui/translations/de.json
+++ b/packages/react-ui/translations/de.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Sammeln konfigurieren",
-    "reviewTitle": "Kontext überprüfen",
     "configureTitle": "Generierung konfigurieren",
-    "next": "Weiter",
-    "back": "Zurück",
     "gatherIntro": "Wählen Sie aus, was in den gesammelten Kontext aufgenommen werden soll.",
     "includeContent": "Ressourceninhalt einschließen",
     "includeSummary": "Zusammenfassung einschließen",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} aus diesem Abruf ausgeschlossen",
     "machineRead": "OCR",
     "score": "Bewertung",
-    "saveLocation": "Speicherort"
+    "saveLocation": "Speicherort",
+    "discardDraftPrompt": "Diesen Entwurf verwerfen?",
+    "discardDraft": "Verwerfen",
+    "keepEditing": "Weiter bearbeiten"
   },
   "ReferenceWizard": {
     "gatherTitle": "Gesammelter Kontext",

--- a/packages/react-ui/translations/el.json
+++ b/packages/react-ui/translations/el.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Ρύθμιση Συλλογής",
-    "reviewTitle": "Επισκόπηση Πλαισίου",
     "configureTitle": "Ρύθμιση Παραγωγής",
-    "next": "Επόμενο",
-    "back": "Πίσω",
     "gatherIntro": "Επιλέξτε τι θα συμπεριληφθεί στο συλλεγμένο πλαίσιο.",
     "includeContent": "Συμπερίληψη περιεχομένου πόρου",
     "includeSummary": "Συμπερίληψη περίληψης",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} εξαιρέθηκαν από αυτήν την ανάκληση",
     "machineRead": "OCR",
     "score": "Βαθμολογία",
-    "saveLocation": "Θέση αποθήκευσης"
+    "saveLocation": "Θέση αποθήκευσης",
+    "discardDraftPrompt": "Απόρριψη αυτού του προσχεδίου;",
+    "discardDraft": "Απόρριψη",
+    "keepEditing": "Συνέχεια επεξεργασίας"
   },
   "ReferenceWizard": {
     "gatherTitle": "Συλλεγμένο Πλαίσιο",

--- a/packages/react-ui/translations/en.json
+++ b/packages/react-ui/translations/en.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Configure Gather",
-    "reviewTitle": "Review Context",
     "configureTitle": "Configure Generation",
-    "next": "Next",
-    "back": "Back",
     "gatherIntro": "Choose what to include in the gathered context.",
     "includeContent": "Include resource content",
     "includeSummary": "Include summary",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} excluded from this recall",
     "machineRead": "OCR",
     "score": "Score",
-    "saveLocation": "Save location"
+    "saveLocation": "Save location",
+    "discardDraftPrompt": "Discard this draft?",
+    "discardDraft": "Discard",
+    "keepEditing": "Keep editing"
   },
   "ReferenceWizard": {
     "gatherTitle": "Gathered Context",

--- a/packages/react-ui/translations/es.json
+++ b/packages/react-ui/translations/es.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Configurar Recopilación",
-    "reviewTitle": "Revisar Contexto",
     "configureTitle": "Configurar Generación",
-    "next": "Siguiente",
-    "back": "Atrás",
     "gatherIntro": "Elija qué incluir en el contexto recopilado.",
     "includeContent": "Incluir contenido del recurso",
     "includeSummary": "Incluir resumen",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} excluidos de esta recuperación",
     "machineRead": "OCR",
     "score": "Puntuación",
-    "saveLocation": "Ubicación de guardado"
+    "saveLocation": "Ubicación de guardado",
+    "discardDraftPrompt": "¿Descartar este borrador?",
+    "discardDraft": "Descartar",
+    "keepEditing": "Seguir editando"
   },
   "ReferenceWizard": {
     "gatherTitle": "Contexto Recopilado",

--- a/packages/react-ui/translations/fa.json
+++ b/packages/react-ui/translations/fa.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "پیکربندی جمع‌آوری",
-    "reviewTitle": "بازبینی زمینه",
     "configureTitle": "پیکربندی تولید",
-    "next": "بعدی",
-    "back": "بازگشت",
     "gatherIntro": "آنچه را که باید در زمینه جمع‌آوری‌شده گنجانده شود انتخاب کنید.",
     "includeContent": "شامل محتوای منبع",
     "includeSummary": "شامل خلاصه",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} از این بازیابی کنار گذاشته شد",
     "machineRead": "OCR",
     "score": "امتیاز",
-    "saveLocation": "محل ذخیره"
+    "saveLocation": "محل ذخیره",
+    "discardDraftPrompt": "این پیش‌نویس دور انداخته شود؟",
+    "discardDraft": "دور انداختن",
+    "keepEditing": "ادامه ویرایش"
   },
   "ReferenceWizard": {
     "gatherTitle": "زمینه جمع‌آوری‌شده",

--- a/packages/react-ui/translations/fi.json
+++ b/packages/react-ui/translations/fi.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Määritä keruu",
-    "reviewTitle": "Tarkista konteksti",
     "configureTitle": "Määritä generointi",
-    "next": "Seuraava",
-    "back": "Takaisin",
     "gatherIntro": "Valitse, mitä sisällytetään kerättyyn kontekstiin.",
     "includeContent": "Sisällytä resurssin sisältö",
     "includeSummary": "Sisällytä yhteenveto",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} jätetty pois tästä hausta",
     "machineRead": "OCR",
     "score": "Pisteet",
-    "saveLocation": "Tallennussijainti"
+    "saveLocation": "Tallennussijainti",
+    "discardDraftPrompt": "Hylätäänkö tämä luonnos?",
+    "discardDraft": "Hylkää",
+    "keepEditing": "Jatka muokkausta"
   },
   "ReferenceWizard": {
     "gatherTitle": "Kerätty konteksti",

--- a/packages/react-ui/translations/fr.json
+++ b/packages/react-ui/translations/fr.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Configurer la collecte",
-    "reviewTitle": "Vérifier le contexte",
     "configureTitle": "Configurer la génération",
-    "next": "Suivant",
-    "back": "Retour",
     "gatherIntro": "Choisissez ce qu'il faut inclure dans le contexte collecté.",
     "includeContent": "Inclure le contenu de la ressource",
     "includeSummary": "Inclure le résumé",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} exclus de cette recherche",
     "machineRead": "OCR",
     "score": "Score",
-    "saveLocation": "Emplacement d'enregistrement"
+    "saveLocation": "Emplacement d'enregistrement",
+    "discardDraftPrompt": "Abandonner ce brouillon ?",
+    "discardDraft": "Abandonner",
+    "keepEditing": "Continuer la modification"
   },
   "ReferenceWizard": {
     "gatherTitle": "Contexte collecté",

--- a/packages/react-ui/translations/he.json
+++ b/packages/react-ui/translations/he.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "הגדרת איסוף",
-    "reviewTitle": "סקירת הקשר",
     "configureTitle": "הגדרת יצירה",
-    "next": "הבא",
-    "back": "חזרה",
     "gatherIntro": "בחרו מה לכלול בהקשר הנאסף.",
     "includeContent": "כלול את תוכן המשאב",
     "includeSummary": "כלול סיכום",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} הוחרגו מהאחזור הזה",
     "machineRead": "OCR",
     "score": "ציון",
-    "saveLocation": "מיקום שמירה"
+    "saveLocation": "מיקום שמירה",
+    "discardDraftPrompt": "לבטל את הטיוטה הזו?",
+    "discardDraft": "לבטל",
+    "keepEditing": "להמשיך לערוך"
   },
   "ReferenceWizard": {
     "gatherTitle": "הקשר שנאסף",

--- a/packages/react-ui/translations/hi.json
+++ b/packages/react-ui/translations/hi.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "एकत्रण कॉन्फ़िगर करें",
-    "reviewTitle": "संदर्भ समीक्षा करें",
     "configureTitle": "जनरेशन कॉन्फ़िगर करें",
-    "next": "अगला",
-    "back": "वापस",
     "gatherIntro": "चुनें कि एकत्रित संदर्भ में क्या शामिल करना है।",
     "includeContent": "संसाधन सामग्री शामिल करें",
     "includeSummary": "सारांश शामिल करें",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} इस रिकॉल से बाहर",
     "machineRead": "OCR",
     "score": "स्कोर",
-    "saveLocation": "सहेजने का स्थान"
+    "saveLocation": "सहेजने का स्थान",
+    "discardDraftPrompt": "क्या यह ड्राफ़्ट हटाएँ?",
+    "discardDraft": "हटाएँ",
+    "keepEditing": "संपादन जारी रखें"
   },
   "ReferenceWizard": {
     "gatherTitle": "एकत्रित संदर्भ",

--- a/packages/react-ui/translations/id.json
+++ b/packages/react-ui/translations/id.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Konfigurasi Pengumpulan",
-    "reviewTitle": "Tinjau Konteks",
     "configureTitle": "Konfigurasi Generasi",
-    "next": "Berikutnya",
-    "back": "Kembali",
     "gatherIntro": "Pilih apa yang akan disertakan dalam konteks yang dikumpulkan.",
     "includeContent": "Sertakan konten sumber daya",
     "includeSummary": "Sertakan ringkasan",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} dikecualikan dari pengambilan ini",
     "machineRead": "OCR",
     "score": "Skor",
-    "saveLocation": "Lokasi penyimpanan"
+    "saveLocation": "Lokasi penyimpanan",
+    "discardDraftPrompt": "Buang draf ini?",
+    "discardDraft": "Buang",
+    "keepEditing": "Lanjutkan menyunting"
   },
   "ReferenceWizard": {
     "gatherTitle": "Konteks Terkumpul",

--- a/packages/react-ui/translations/it.json
+++ b/packages/react-ui/translations/it.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Configura Raccolta",
-    "reviewTitle": "Rivedi Contesto",
     "configureTitle": "Configura Generazione",
-    "next": "Avanti",
-    "back": "Indietro",
     "gatherIntro": "Scegli cosa includere nel contesto raccolto.",
     "includeContent": "Includi il contenuto della risorsa",
     "includeSummary": "Includi riepilogo",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} esclusi da questo recupero",
     "machineRead": "OCR",
     "score": "Punteggio",
-    "saveLocation": "Percorso di salvataggio"
+    "saveLocation": "Percorso di salvataggio",
+    "discardDraftPrompt": "Eliminare questa bozza?",
+    "discardDraft": "Elimina",
+    "keepEditing": "Continua a modificare"
   },
   "ReferenceWizard": {
     "gatherTitle": "Contesto Raccolto",

--- a/packages/react-ui/translations/ja.json
+++ b/packages/react-ui/translations/ja.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "収集の設定",
-    "reviewTitle": "コンテキストの確認",
     "configureTitle": "生成の設定",
-    "next": "次へ",
-    "back": "戻る",
     "gatherIntro": "収集するコンテキストに含める内容を選択してください。",
     "includeContent": "リソースのコンテンツを含める",
     "includeSummary": "要約を含める",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} はこのリコールから除外",
     "machineRead": "OCR",
     "score": "スコア",
-    "saveLocation": "保存先"
+    "saveLocation": "保存先",
+    "discardDraftPrompt": "この下書きを破棄しますか？",
+    "discardDraft": "破棄",
+    "keepEditing": "編集を続ける"
   },
   "ReferenceWizard": {
     "gatherTitle": "収集済みコンテキスト",

--- a/packages/react-ui/translations/ko.json
+++ b/packages/react-ui/translations/ko.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "수집 구성",
-    "reviewTitle": "컨텍스트 검토",
     "configureTitle": "생성 구성",
-    "next": "다음",
-    "back": "뒤로",
     "gatherIntro": "수집된 컨텍스트에 포함할 내용을 선택하세요.",
     "includeContent": "리소스 콘텐츠 포함",
     "includeSummary": "요약 포함",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} 이 리콜에서 제외됨",
     "machineRead": "OCR",
     "score": "점수",
-    "saveLocation": "저장 위치"
+    "saveLocation": "저장 위치",
+    "discardDraftPrompt": "이 초안을 삭제할까요?",
+    "discardDraft": "삭제",
+    "keepEditing": "계속 편집"
   },
   "ReferenceWizard": {
     "gatherTitle": "수집된 컨텍스트",

--- a/packages/react-ui/translations/ms.json
+++ b/packages/react-ui/translations/ms.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Konfigurasi Pengumpulan",
-    "reviewTitle": "Semak Konteks",
     "configureTitle": "Konfigurasi Penjanaan",
-    "next": "Seterusnya",
-    "back": "Kembali",
     "gatherIntro": "Pilih perkara yang hendak disertakan dalam konteks yang dikumpul.",
     "includeContent": "Sertakan kandungan sumber",
     "includeSummary": "Sertakan ringkasan",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} dikecualikan daripada dapatan ini",
     "machineRead": "OCR",
     "score": "Skor",
-    "saveLocation": "Lokasi simpanan"
+    "saveLocation": "Lokasi simpanan",
+    "discardDraftPrompt": "Buang draf ini?",
+    "discardDraft": "Buang",
+    "keepEditing": "Terus menyunting"
   },
   "ReferenceWizard": {
     "gatherTitle": "Konteks Dikumpul",

--- a/packages/react-ui/translations/nl.json
+++ b/packages/react-ui/translations/nl.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Verzamelen configureren",
-    "reviewTitle": "Context controleren",
     "configureTitle": "Generatie configureren",
-    "next": "Volgende",
-    "back": "Terug",
     "gatherIntro": "Kies wat je wilt opnemen in de verzamelde context.",
     "includeContent": "Broninhoud opnemen",
     "includeSummary": "Samenvatting opnemen",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} uitgesloten van deze zoekronde",
     "machineRead": "OCR",
     "score": "Score",
-    "saveLocation": "Opslaglocatie"
+    "saveLocation": "Opslaglocatie",
+    "discardDraftPrompt": "Dit concept verwerpen?",
+    "discardDraft": "Verwerpen",
+    "keepEditing": "Doorgaan met bewerken"
   },
   "ReferenceWizard": {
     "gatherTitle": "Verzamelde context",

--- a/packages/react-ui/translations/no.json
+++ b/packages/react-ui/translations/no.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Konfigurer innsamling",
-    "reviewTitle": "Gjennomgå kontekst",
     "configureTitle": "Konfigurer generering",
-    "next": "Neste",
-    "back": "Tilbake",
     "gatherIntro": "Velg hva som skal inkluderes i den samlede konteksten.",
     "includeContent": "Inkluder ressursinnhold",
     "includeSummary": "Inkluder sammendrag",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} utelatt fra dette gjenfinnet",
     "machineRead": "OCR",
     "score": "Poengsum",
-    "saveLocation": "Lagringssted"
+    "saveLocation": "Lagringssted",
+    "discardDraftPrompt": "Forkaste dette utkastet?",
+    "discardDraft": "Forkast",
+    "keepEditing": "Fortsett å redigere"
   },
   "ReferenceWizard": {
     "gatherTitle": "Samlet kontekst",

--- a/packages/react-ui/translations/pl.json
+++ b/packages/react-ui/translations/pl.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Skonfiguruj zbieranie",
-    "reviewTitle": "Przejrzyj kontekst",
     "configureTitle": "Skonfiguruj generowanie",
-    "next": "Dalej",
-    "back": "Wstecz",
     "gatherIntro": "Wybierz, co ma zostać uwzględnione w zebranym kontekście.",
     "includeContent": "Uwzględnij treść zasobu",
     "includeSummary": "Uwzględnij podsumowanie",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} wykluczono z tego pobrania",
     "machineRead": "OCR",
     "score": "Wynik",
-    "saveLocation": "Lokalizacja zapisu"
+    "saveLocation": "Lokalizacja zapisu",
+    "discardDraftPrompt": "Odrzucić ten szkic?",
+    "discardDraft": "Odrzuć",
+    "keepEditing": "Kontynuuj edycję"
   },
   "ReferenceWizard": {
     "gatherTitle": "Zebrany kontekst",

--- a/packages/react-ui/translations/pt.json
+++ b/packages/react-ui/translations/pt.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Configurar Coleta",
-    "reviewTitle": "Revisar Contexto",
     "configureTitle": "Configurar Geração",
-    "next": "Próximo",
-    "back": "Voltar",
     "gatherIntro": "Escolha o que incluir no contexto coletado.",
     "includeContent": "Incluir conteúdo do recurso",
     "includeSummary": "Incluir resumo",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} excluídos desta recuperação",
     "machineRead": "OCR",
     "score": "Pontuação",
-    "saveLocation": "Local de salvamento"
+    "saveLocation": "Local de salvamento",
+    "discardDraftPrompt": "Descartar este rascunho?",
+    "discardDraft": "Descartar",
+    "keepEditing": "Continuar editando"
   },
   "ReferenceWizard": {
     "gatherTitle": "Contexto Coletado",

--- a/packages/react-ui/translations/ro.json
+++ b/packages/react-ui/translations/ro.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Configurare Colectare",
-    "reviewTitle": "Revizuire Context",
     "configureTitle": "Configurare Generare",
-    "next": "Următorul",
-    "back": "Înapoi",
     "gatherIntro": "Alege ce să incluzi în contextul colectat.",
     "includeContent": "Include conținutul resursei",
     "includeSummary": "Include rezumatul",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} excluse din această regăsire",
     "machineRead": "OCR",
     "score": "Scor",
-    "saveLocation": "Locația salvării"
+    "saveLocation": "Locația salvării",
+    "discardDraftPrompt": "Renunți la această ciornă?",
+    "discardDraft": "Renunță",
+    "keepEditing": "Continuă editarea"
   },
   "ReferenceWizard": {
     "gatherTitle": "Context Colectat",

--- a/packages/react-ui/translations/sv.json
+++ b/packages/react-ui/translations/sv.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Konfigurera insamling",
-    "reviewTitle": "Granska kontext",
     "configureTitle": "Konfigurera generering",
-    "next": "Nästa",
-    "back": "Tillbaka",
     "gatherIntro": "Välj vad som ska inkluderas i den insamlade kontexten.",
     "includeContent": "Inkludera resursinnehåll",
     "includeSummary": "Inkludera sammanfattning",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} uteslutna ur denna hämtning",
     "machineRead": "OCR",
     "score": "Poäng",
-    "saveLocation": "Sparplats"
+    "saveLocation": "Sparplats",
+    "discardDraftPrompt": "Kasta detta utkast?",
+    "discardDraft": "Kasta",
+    "keepEditing": "Fortsätt redigera"
   },
   "ReferenceWizard": {
     "gatherTitle": "Samlad kontext",

--- a/packages/react-ui/translations/th.json
+++ b/packages/react-ui/translations/th.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "กำหนดค่าการรวบรวม",
-    "reviewTitle": "ตรวจสอบบริบท",
     "configureTitle": "กำหนดค่าการสร้าง",
-    "next": "ถัดไป",
-    "back": "กลับ",
     "gatherIntro": "เลือกสิ่งที่จะรวมไว้ในบริบทที่รวบรวม",
     "includeContent": "รวมเนื้อหาทรัพยากร",
     "includeSummary": "รวมบทสรุป",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} ถูกยกเว้นจากการเรียกคืนนี้",
     "machineRead": "OCR",
     "score": "คะแนน",
-    "saveLocation": "ตำแหน่งบันทึก"
+    "saveLocation": "ตำแหน่งบันทึก",
+    "discardDraftPrompt": "ละทิ้งฉบับร่างนี้หรือไม่",
+    "discardDraft": "ละทิ้ง",
+    "keepEditing": "แก้ไขต่อ"
   },
   "ReferenceWizard": {
     "gatherTitle": "บริบทที่รวบรวมแล้ว",

--- a/packages/react-ui/translations/tr.json
+++ b/packages/react-ui/translations/tr.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Toplamayı Yapılandır",
-    "reviewTitle": "Bağlamı Gözden Geçir",
     "configureTitle": "Oluşturmayı Yapılandır",
-    "next": "İleri",
-    "back": "Geri",
     "gatherIntro": "Toplanan bağlama nelerin dahil edileceğini seçin.",
     "includeContent": "Kaynak içeriğini dahil et",
     "includeSummary": "Özeti dahil et",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} bu getirimden hariç tutuldu",
     "machineRead": "OCR",
     "score": "Puan",
-    "saveLocation": "Kayıt konumu"
+    "saveLocation": "Kayıt konumu",
+    "discardDraftPrompt": "Bu taslak silinsin mi?",
+    "discardDraft": "Sil",
+    "keepEditing": "Düzenlemeye devam et"
   },
   "ReferenceWizard": {
     "gatherTitle": "Toplanan Bağlam",

--- a/packages/react-ui/translations/uk.json
+++ b/packages/react-ui/translations/uk.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Налаштувати збір",
-    "reviewTitle": "Переглянути контекст",
     "configureTitle": "Налаштувати генерацію",
-    "next": "Далі",
-    "back": "Назад",
     "gatherIntro": "Виберіть, що включити до зібраного контексту.",
     "includeContent": "Включити вміст ресурсу",
     "includeSummary": "Включити підсумок",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} виключено з цього відбору",
     "machineRead": "OCR",
     "score": "Оцінка",
-    "saveLocation": "Розташування збереження"
+    "saveLocation": "Розташування збереження",
+    "discardDraftPrompt": "Відхилити цю чернетку?",
+    "discardDraft": "Відхилити",
+    "keepEditing": "Продовжити редагування"
   },
   "ReferenceWizard": {
     "gatherTitle": "Зібраний контекст",

--- a/packages/react-ui/translations/vi.json
+++ b/packages/react-ui/translations/vi.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "Cấu hình Thu thập",
-    "reviewTitle": "Xem lại Ngữ cảnh",
     "configureTitle": "Cấu hình Tạo sinh",
-    "next": "Tiếp theo",
-    "back": "Quay lại",
     "gatherIntro": "Chọn nội dung để đưa vào ngữ cảnh đã thu thập.",
     "includeContent": "Bao gồm nội dung tài nguyên",
     "includeSummary": "Bao gồm tóm tắt",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} bị loại khỏi lần truy hồi này",
     "machineRead": "OCR",
     "score": "Điểm",
-    "saveLocation": "Vị trí lưu"
+    "saveLocation": "Vị trí lưu",
+    "discardDraftPrompt": "Bỏ bản nháp này?",
+    "discardDraft": "Bỏ",
+    "keepEditing": "Tiếp tục chỉnh sửa"
   },
   "ReferenceWizard": {
     "gatherTitle": "Ngữ cảnh đã thu thập",

--- a/packages/react-ui/translations/zh.json
+++ b/packages/react-ui/translations/zh.json
@@ -380,11 +380,7 @@
   },
   "AnnotateView": {},
   "ResourceGenerate": {
-    "gatherTitle": "配置收集",
-    "reviewTitle": "查看上下文",
     "configureTitle": "配置生成",
-    "next": "下一步",
-    "back": "返回",
     "gatherIntro": "选择要包含在收集的上下文中的内容。",
     "includeContent": "包含资源内容",
     "includeSummary": "包含摘要",
@@ -422,7 +418,10 @@
     "excludedReceipt": "{{types}} 已从本次召回中排除",
     "machineRead": "OCR",
     "score": "评分",
-    "saveLocation": "保存位置"
+    "saveLocation": "保存位置",
+    "discardDraftPrompt": "放弃此草稿？",
+    "discardDraft": "放弃",
+    "keepEditing": "继续编辑"
   },
   "ReferenceWizard": {
     "gatherTitle": "已收集的上下文",


### PR DESCRIPTION
## Description

The from-resource Generate flow (Resource Info panel → Generate) predates the resolve wizard's grammar and walked three discrete step-pages:

```
[Configure gather] --Gather--> [Review evidence] --Next--> [Evidence + Params]
```

This PR folds it into **one composite stack** in a single scroll pane — the same grammar the resolve wizard expresses, **[gather zone] → [evidence] → [act zone]**:

```
┌ Gather controls (depth / max / include / exclusions + Gather)   ← top band
├ Gathered evidence (appears below once gather lands)
└ Generation params + Generate                                    ← entered at bottom
```

- The review step dissolves — its only action was "Next" — and the step machine goes with it. `configureTitle` is the one modal title.
- Re-gathering becomes scroll-up → tweak → Gather; the gather verb clears its state slots at start, so the evidence refreshes in place with the existing loading state. Each context arrival re-enters the pane at the bottom so the params show in full.
- A per-run `gatherFired` flag gates everything below the controls: the page's gather slots survive across opens, so a context prop can be stale at open time — nothing renders below the controls until *this* run's gather fires (pinned).
- Back disappears from this modal — a single stack has nothing to go back to. `onBack`/`back` became optional on `ConfigureGenerationStep`; the wizard keeps its Back.

### Dirty guard on dismissal, both modals

✕/Escape/backdrop with typed work used to drop it silently. The wizard's inline discard band is extracted to a shared `DiscardPrompt`, and:

- `ResourceGenerateModal` routes every dismissal path through one handler — typed text (title beyond the seeded default, save location, instructions) raises the band; toggles, depth, and exclusion picks are cheap to redo and never nag.
- The wizard's guard **widens**: it now covers the generation draft, and its step gate is gone — typing in compose, stepping Back to the evidence, then ✕ used to lose the draft unprompted. That's now a pinned regression.
- Success paths bypass the guard — it protects dismissal, not completion.

### Rider

`ComposeStep`'s submit handler now swallows the rejection after the host has surfaced it. The rejection must propagate past the wizard's close (that's what keeps the modal open on failure), but letting it escape a React event handler made it an unhandled rejection — vitest flagged it on every run of the rejected-submit test.

### Cruft swept

- `gatherTitle` / `reviewTitle` / `next` / `back` usage-grepped to zero and deleted from the `ResourceGenerate` namespace ×29 locales.
- `semiont-form--scrollable` lost its only consumer (the gather form, which must not scroll alone inside the stack) and died with its CSS rule.

## Breaking changes (react-ui public surface)

- `ResourceGenerateModalTranslations`: `gatherTitle`, `reviewTitle`, `next`, `back` removed; `discardDraftPrompt`, `discardDraft`, `keepEditing` added.
- `ConfigureGenerationStep`: `onBack` and `translations.back` are now optional (the footer renders no retreat when absent).

## Testing

TDD at each phase, RED observed before GREEN:

- P1: three keystone pins failing on exactly the unguarded `onClose` — the wizard's typed generation draft, the compose-draft-after-Back regression, the modal's typed save location. Plus clean-dismisses-unprompted and non-text-never-nags pins.
- P2: the modal's test file re-shaped to the composite seam; seven keystones observed failing against the step-machine modal (controls-with-nothing-below, evidence-in-place, params-without-Next, re-Gather, the seeded-title case without Next, the one-scroll-pane assertion across every form, the guard reached without Next).

Verified in node:24-alpine: modals suite 145 passed (38 pre-existing skips), zero unhandled errors; react-ui tsc + build; frontend tsc against the rebuilt dist; translation lints 474×29 (react-ui) and 567×29 (frontend); stylelint, class-live ("no new CSS-class debt"), and css-variable gates; `'review'` greps to zero in the modal.

Live verification on a running stack follows the next frontend rebuild.
