### PR TITLE
The finished generation lands honestly, then shows its edge

### DIFF
--- a/packages/react-ui/src/components/AssistProgress.tsx
+++ b/packages/react-ui/src/components/AssistProgress.tsx
@@ -65,6 +65,15 @@ export interface AssistProgressProps {
    */
   outcome?: { label: string; onOpen: () => void } | undefined;
   /**
+   * The owner's terminal sentence, rendered in place of the payload message
+   * once `ended` (GENERATION-ARRIVAL P1). The producer's final frame is a
+   * fire-and-forget emit that can lose the race with `job:complete`, so an
+   * ended frame must not trust the last payload to describe the ending —
+   * the owner, which signalled `ended`, supplies the words too. Inert while
+   * the run is live.
+   */
+  endedMessage?: string;
+  /**
    * The run has ENDED. The owner's fact, not the payload's
    * (ASSIST-PROGRESS-CONSOLIDATION D7): terminality is signalled on
    * `job:complete` / `job:fail`, which `AssistShell` already observes via
@@ -104,6 +113,7 @@ export function AssistProgress({
   dataType,
   ended,
   outcome,
+  endedMessage,
   onCancel,
   onDismiss,
   translations: tr,
@@ -163,7 +173,9 @@ export function AssistProgress({
           {ended ? '✅' : '✨'}
         </span>
         <span data-testid="semiont-assist-status">
-          {progress.message ? tr.message(progress.message) : tr.inProgress}
+          {ended && endedMessage
+            ? endedMessage
+            : progress.message ? tr.message(progress.message) : tr.inProgress}
         </span>
       </div>
 
@@ -186,11 +198,13 @@ export function AssistProgress({
         </button>
       )}
 
+      {/* An ended run is 100% done by definition — the last payload's number
+          is a mid-run fact and must not survive the ending (A1). */}
       <div className="semiont-progress-bar" data-testid="semiont-assist-bar">
         <div
           className="semiont-progress-bar__fill"
           data-type={dataType}
-          style={{ width: `${progress.percentage}%` }}
+          style={{ width: `${ended ? 100 : progress.percentage}%` }}
         />
       </div>
 

--- a/packages/react-ui/src/components/__tests__/AssistProgress.test.tsx
+++ b/packages/react-ui/src/components/__tests__/AssistProgress.test.tsx
@@ -308,3 +308,42 @@ describe('AssistProgress — P3 consolidation', () => {
     expect(screen.getByTestId(PARAMS)).toBeInTheDocument();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GENERATION-ARRIVAL P1 — the honest ended frame. The producer's terminal
+// 100% frame races job:complete and can lose (its emit is a fire-and-forget
+// heartbeat); terminality is the OWNER's fact (D7), so the ended rendering
+// stops trusting the last payload: full bar, and the owner's terminal
+// sentence when it supplies one.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('AssistProgress — the honest ended frame (GENERATION-ARRIVAL P1)', () => {
+  it('A1: an ended frame renders a FULL bar whatever the last payload said', () => {
+    const { container } = render(
+      <AssistProgress ended progress={detecting({ percentage: 95 })} dataType="generation" translations={T3()} />,
+    );
+    const fill = container.querySelector('.semiont-progress-bar__fill') as HTMLElement;
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('a live frame keeps the payload percentage', () => {
+    const { container } = render(
+      <AssistProgress ended={false} progress={detecting({ percentage: 95 })} dataType="generation" translations={T3()} />,
+    );
+    const fill = container.querySelector('.semiont-progress-bar__fill') as HTMLElement;
+    expect(fill.style.width).toBe('95%');
+  });
+
+  it('endedMessage replaces the stale payload copy once ended', () => {
+    render(
+      <AssistProgress ended endedMessage="tr.ended" progress={detecting({ percentage: 95 })} dataType="generation" translations={T3()} />,
+    );
+    expect(screen.getByTestId(STATUS).textContent).toBe('tr.ended');
+  });
+
+  it('endedMessage is inert while the run is live', () => {
+    render(
+      <AssistProgress ended={false} endedMessage="tr.ended" progress={detecting()} dataType="generation" translations={T3()} />,
+    );
+    expect(screen.getByTestId(STATUS).textContent).toBe('tr.code(detecting-entities)');
+  });
+});

--- a/packages/react-ui/src/components/resource/panels/AssistSection.css
+++ b/packages/react-ui/src/components/resource/panels/AssistSection.css
@@ -174,28 +174,38 @@
 }
 
 /* D8: the finished run's artifact, offered as a link. */
+/* The finished run's artifact — the ended frame's primary affordance
+   (GENERATION-ARRIVAL P1, D3's fallback): a button-shaped invitation to open
+   what was made, not an underlined footnote beside the bar. */
 .semiont-assist-progress__outcome {
-  align-self: flex-start;
-  padding: 0;
-  border: none;
-  background: none;
+  align-self: stretch;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--semiont-color-primary-300);
+  border-radius: 0.5rem;
+  background: var(--semiont-color-primary-50);
   cursor: pointer;
   font-size: var(--semiont-text-sm);
-  color: var(--semiont-color-primary-600);
-  text-decoration: underline;
+  font-weight: var(--semiont-font-medium);
+  color: var(--semiont-color-primary-700);
   text-align: left;
 }
 
 .semiont-assist-progress__outcome:hover {
-  color: var(--semiont-color-primary-700);
+  border-color: var(--semiont-color-primary-400);
+  background: var(--semiont-color-primary-100);
+  color: var(--semiont-color-primary-800);
 }
 
 [data-theme="dark"] .semiont-assist-progress__outcome {
-  color: var(--semiont-color-primary-400);
+  border-color: var(--semiont-color-primary-700);
+  background: var(--semiont-color-primary-900);
+  color: var(--semiont-color-primary-300);
 }
 
 [data-theme="dark"] .semiont-assist-progress__outcome:hover {
-  color: var(--semiont-color-primary-300);
+  border-color: var(--semiont-color-primary-600);
+  background: var(--semiont-color-primary-800);
+  color: var(--semiont-color-primary-200);
 }
 
 .semiont-assist-progress__params {

--- a/packages/react-ui/src/components/resource/panels/ResourceInfoPanel.tsx
+++ b/packages/react-ui/src/components/resource/panels/ResourceInfoPanel.tsx
@@ -221,6 +221,13 @@ export function ResourceInfoPanel({
                 label: generationOutcome.resourceName,
                 onOpen: () => session?.client.browse.openResource(generationOutcome.resourceId),
               },
+              // The terminal sentence derives from the OUTCOME, not the final
+              // progress frame — whose fire-and-forget emit can lose the race
+              // with job:complete and leave "creating…" beside a ✅
+              // (GENERATION-ARRIVAL D4/D5).
+              endedMessage: generationOutcome.truncated
+                ? ta('codeCompleteGeneratedTruncated')
+                : ta('codeCompleteGenerated'),
             } : {}),
             translations: assistProgressTranslations(ta),
           }}

--- a/packages/react-ui/src/components/resource/panels/__tests__/ResourceInfoPanel.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ResourceInfoPanel.test.tsx
@@ -337,6 +337,7 @@ describe('ResourceInfoPanel Component', () => {
           generationOutcome={{
             resourceId: makeResourceId('urn:semiont:resource:new1'),
             resourceName: 'Summary of PB',
+            truncated: false,
           }}
           onDismissProgress={onDismissProgress} />
       );
@@ -370,6 +371,37 @@ describe('ResourceInfoPanel Component', () => {
         .toContain('codeCompleteGenerated');
       expect(screen.getByTestId('semiont-assist-status').textContent)
         .not.toContain('Truncated');
+    });
+
+    it('the ended frame speaks completion even when the final progress frame lost the race (GENERATION-ARRIVAL D4/D5)', () => {
+      // The screenshot case: last frame is the 95% "creating" payload, the
+      // terminal 100% frame never arrived — but the outcome did. The sentence
+      // derives from the OUTCOME, not the racing frame.
+      renderWithEventBus(
+        <ResourceInfoPanel {...defaultProps} onGenerate={() => {}}
+          isGenerating={false}
+          generationProgress={{ percentage: 95, message: { code: 'creating-resource' } }}
+          generationOutcome={{
+            resourceId: makeResourceId('urn:semiont:resource:new1'),
+            resourceName: 'Summary of PB',
+            truncated: false,
+          }} />
+      );
+      expect(screen.getByTestId('semiont-assist-status').textContent).toBe('codeCompleteGenerated');
+    });
+
+    it('a truncated outcome says so — the bit rides the outcome, not the racing frame (D5)', () => {
+      renderWithEventBus(
+        <ResourceInfoPanel {...defaultProps} onGenerate={() => {}}
+          isGenerating={false}
+          generationProgress={{ percentage: 95, message: { code: 'creating-resource' } }}
+          generationOutcome={{
+            resourceId: makeResourceId('urn:semiont:resource:new1'),
+            resourceName: 'Summary of PB',
+            truncated: true,
+          }} />
+      );
+      expect(screen.getByTestId('semiont-assist-status').textContent).toBe('codeCompleteGeneratedTruncated');
     });
 
     it('no outcome, no link: the ended frame renders without one until job:complete arrives', () => {

--- a/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
+++ b/packages/react-ui/src/features/resource-viewer/components/ResourceViewerPage.tsx
@@ -30,6 +30,7 @@ import { useCollaborators } from '../../../hooks/useCollaborators';
 import { mediaUrl } from '../../../lib/media-url';
 import { useToast } from '../../../components/Toast';
 import { useOutcomeToasts } from '../../../hooks/useOutcomeToasts';
+import { useGenerationArrival } from '../../../hooks/useGenerationArrival';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { useLineNumbers } from '../../../contexts/LineNumbersContext';
 import { useHoverDelay } from '../../../hooks/useHoverDelay';
@@ -240,6 +241,18 @@ export function ResourceViewerPage({
   const generationProgress = useObservable(stateUnit?.yield.progress$) ?? null;
   const isGenerating = useObservable(stateUnit?.yield.isGenerating$) ?? false;
   const generationOutcome = useObservable(stateUnit?.yield.outcome$) ?? null;
+
+  // GENERATION-ARRIVAL P2: a completion witnessed on this page reveals the
+  // derivation edge the worker minted — the annotations panel opens on
+  // References, scrolls to the provenance reference, and its sparkle is
+  // re-armed (the mark:added glow burned its window unseen). Never navigates
+  // (A2); a held outcome on remount stays quiet (D6, inside the hook).
+  const handleGenerationArrival = useCallback((annId: string) => {
+    browser.emit('panel:open', { panel: 'annotations', scrollToAnnotationId: annId, motivation: 'linking' });
+    triggerSparkleAnimation(annId);
+  }, [browser, triggerSparkleAnimation]);
+  useGenerationArrival(generationOutcome, annotations, handleGenerationArrival);
+
   const gatherContext = useObservable(stateUnit?.gather.context$) ?? null;
   const gatherLoading = useObservable(stateUnit?.gather.loading$) ?? false;
   const gatherError = useObservable(stateUnit?.gather.error$) ?? null;

--- a/packages/react-ui/src/hooks/__tests__/useGenerationArrival.test.tsx
+++ b/packages/react-ui/src/hooks/__tests__/useGenerationArrival.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * GENERATION-ARRIVAL P2 — the reveal's arming logic, pinned at the hook seam.
+ *
+ * A finished from-resource generation mints a provenance reference on the
+ * source (YIELD-FROM-RESOURCE Fork 2b: motivation `linking`, resource-level
+ * target, body pointing at the new resource). When the OUTCOME arrives while
+ * the page is mounted, the hook finds that edge and calls `onReveal` with its
+ * id — exactly once per run (A3/D8). An outcome already held at mount (the
+ * user navigated away and back; `outcome$` is a BehaviorSubject) must NOT
+ * fire (D6): the arrival was not witnessed, so nothing is announced.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { Annotation, AnnotationId } from '@semiont/core';
+import { resourceId as makeResourceId } from '@semiont/core';
+import type { YieldOutcome } from '@semiont/sdk';
+import { useGenerationArrival } from '../useGenerationArrival';
+
+const outcomeFor = (target: string): YieldOutcome => ({
+  resourceId: makeResourceId(target),
+  resourceName: 'Generated Doc',
+  truncated: false,
+});
+
+/** The provenance edge the worker mints: linking, resource-level, resolved from birth. */
+const provenanceRef = (id: string, newResourceId: string): Annotation => ({
+  '@context': 'http://www.w3.org/ns/anno.jsonld',
+  id: id as AnnotationId,
+  type: 'Annotation',
+  motivation: 'linking',
+  created: '2026-08-21T12:00:00Z',
+  modified: '2026-08-21T12:00:00Z',
+  target: { source: 'res-src' },
+  body: { type: 'SpecificResource', source: newResourceId, purpose: 'linking' },
+});
+
+type HookProps = { outcome: YieldOutcome | null; annotations: Annotation[] };
+
+const renderArrival = (initial: HookProps) => {
+  const onReveal = vi.fn<(annotationId: string) => void>();
+  const utils = renderHook(
+    ({ outcome, annotations }: HookProps) => useGenerationArrival(outcome, annotations, onReveal),
+    { initialProps: initial },
+  );
+  return { ...utils, onReveal };
+};
+
+describe('useGenerationArrival', () => {
+  it('a fresh outcome with its provenance edge present reveals once', () => {
+    const { rerender, onReveal } = renderArrival({ outcome: null, annotations: [] });
+    rerender({
+      outcome: outcomeFor('res-new'),
+      annotations: [provenanceRef('ann-prov', 'res-new')],
+    });
+    expect(onReveal).toHaveBeenCalledTimes(1);
+    expect(onReveal).toHaveBeenCalledWith('ann-prov');
+  });
+
+  it('re-renders with the same outcome do not re-reveal (A3)', () => {
+    const o = outcomeFor('res-new');
+    const anns = [provenanceRef('ann-prov', 'res-new')];
+    const { rerender, onReveal } = renderArrival({ outcome: null, annotations: [] });
+    rerender({ outcome: o, annotations: anns });
+    rerender({ outcome: o, annotations: anns });
+    rerender({ outcome: o, annotations: [...anns] });
+    expect(onReveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('an outcome already held at mount never reveals (D6 — the remount case)', () => {
+    // outcome$ is a BehaviorSubject: a remounted page receives the SAME held
+    // object on every render. Identity is the arrival contract — the unit
+    // emits one object per completion — so the held object re-delivered is
+    // not an arrival.
+    const held = outcomeFor('res-new');
+    const anns = [provenanceRef('ann-prov', 'res-new')];
+    const { rerender, onReveal } = renderArrival({ outcome: held, annotations: anns });
+    rerender({ outcome: held, annotations: anns });
+    rerender({ outcome: held, annotations: [...anns] });
+    expect(onReveal).not.toHaveBeenCalled();
+  });
+
+  it('an outcome arriving before its edge waits, then reveals when it lands', () => {
+    // mark:create for the provenance ref is awaited before job:complete, so
+    // in practice the edge is already projected — this pin covers the
+    // ordering anyway (the plan's P2 worklist names it).
+    const { rerender, onReveal } = renderArrival({ outcome: null, annotations: [] });
+    rerender({ outcome: outcomeFor('res-new'), annotations: [] });
+    expect(onReveal).not.toHaveBeenCalled();
+    rerender({
+      outcome: outcomeFor('res-new'),
+      annotations: [provenanceRef('ann-prov', 'res-new')],
+    });
+    expect(onReveal).toHaveBeenCalledTimes(1);
+    expect(onReveal).toHaveBeenCalledWith('ann-prov');
+  });
+
+  it("a second run's outcome reveals its own edge", () => {
+    const { rerender, onReveal } = renderArrival({ outcome: null, annotations: [] });
+    rerender({
+      outcome: outcomeFor('res-new-1'),
+      annotations: [provenanceRef('ann-1', 'res-new-1')],
+    });
+    rerender({
+      outcome: outcomeFor('res-new-2'),
+      annotations: [provenanceRef('ann-1', 'res-new-1'), provenanceRef('ann-2', 'res-new-2')],
+    });
+    expect(onReveal).toHaveBeenCalledTimes(2);
+    expect(onReveal).toHaveBeenLastCalledWith('ann-2');
+  });
+
+  it('an unrelated linking annotation is not the edge — no reveal without a match', () => {
+    const { rerender, onReveal } = renderArrival({ outcome: null, annotations: [] });
+    rerender({
+      outcome: outcomeFor('res-new'),
+      annotations: [provenanceRef('ann-other', 'res-elsewhere')],
+    });
+    expect(onReveal).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-ui/src/hooks/useGenerationArrival.ts
+++ b/packages/react-ui/src/hooks/useGenerationArrival.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+import type { Annotation } from '@semiont/core';
+import { getBodySource } from '@semiont/core';
+import type { YieldOutcome } from '@semiont/sdk';
+
+/**
+ * The reveal's arming logic (GENERATION-ARRIVAL P2).
+ *
+ * A finished from-resource generation mints a provenance reference on the
+ * source (YIELD-FROM-RESOURCE Fork 2b) — the durable edge worth announcing.
+ * When the outcome ARRIVES while this page is mounted, find that edge among
+ * the source's annotations and call `onReveal` with its id, exactly once per
+ * run (A3/D8). The host decides what a reveal IS (open the panel, scroll,
+ * sparkle); this hook only decides WHEN.
+ *
+ * An outcome already held at mount never fires (D6): `outcome$` is a
+ * BehaviorSubject, so navigating away and back re-delivers the old outcome —
+ * an arrival nobody witnessed is not an arrival.
+ */
+export function useGenerationArrival(
+  outcome: YieldOutcome | null,
+  annotations: Annotation[],
+  onReveal: (annotationId: string) => void,
+): void {
+  // Pre-seed with the mount-time outcome so a held value cannot fire (D6).
+  const seen = useRef(outcome);
+  // Armed between the outcome arriving and its edge appearing — usually the
+  // same render (the worker awaits the edge's mark:create before
+  // job:complete), but the ordering is not this hook's to assume.
+  const pending = useRef<YieldOutcome | null>(null);
+  const onRevealRef = useRef(onReveal);
+  useEffect(() => { onRevealRef.current = onReveal; });
+
+  useEffect(() => {
+    if (outcome && outcome !== seen.current) {
+      seen.current = outcome;
+      pending.current = outcome;
+    }
+    if (!pending.current) return;
+
+    const target = String(pending.current.resourceId);
+    const edge = annotations.find(
+      (a) => a.motivation === 'linking' && String(getBodySource(a.body) ?? '') === target,
+    );
+    if (edge) {
+      pending.current = null;
+      onRevealRef.current(edge.id);
+    }
+  }, [outcome, annotations]);
+}

--- a/packages/sdk/src/state/flows/__tests__/yield-state-unit.test.ts
+++ b/packages/sdk/src/state/flows/__tests__/yield-state-unit.test.ts
@@ -216,7 +216,22 @@ describe('createYieldStateUnit', () => {
     progressSubject.next(completeEvent(GEN_RESULT));
     progressSubject.complete();
 
-    expect(out.at(-1)).toEqual({ resourceId: 'res-new-1', resourceName: 'Summary of PB' });
+    expect(out.at(-1)).toEqual({ resourceId: 'res-new-1', resourceName: 'Summary of PB', truncated: false });
+    stateUnit.dispose();
+  });
+
+  it('outcome$ carries the truncated bit — the terminal frame derives its sentence from the OUTCOME, not the racing final progress frame (GENERATION-ARRIVAL D5)', () => {
+    const progressSubject = new Subject<YieldGenerationEvent>();
+    tc = withYield(vi.fn(() => progressSubject.asObservable()));
+    const stateUnit = createYieldStateUnit(tc.client, 'en');
+    const out: unknown[] = [];
+    stateUnit.outcome$.subscribe(v => out.push(v));
+
+    stateUnit.generate(CTX_RES, { title: 'T', storageUri: 's' });
+    progressSubject.next(completeEvent({ ...GEN_RESULT, truncated: true }));
+    progressSubject.complete();
+
+    expect(out.at(-1)).toEqual({ resourceId: 'res-new-1', resourceName: 'Summary of PB', truncated: true });
     stateUnit.dispose();
   });
 

--- a/packages/sdk/src/state/flows/yield-state-unit.ts
+++ b/packages/sdk/src/state/flows/yield-state-unit.ts
@@ -17,6 +17,14 @@ type JobProgress = components['schemas']['JobProgress'];
 export interface YieldOutcome {
   resourceId: ResourceId;
   resourceName: string;
+  /**
+   * The run stopped at the maxTokens ceiling — the artifact is cut off, not
+   * complete. Mirrors `JobGenerationResult.truncated` so the terminal frame
+   * derives its sentence from the OUTCOME rather than the final progress
+   * frame, whose fire-and-forget emit can lose the race with `job:complete`
+   * (GENERATION-ARRIVAL D5).
+   */
+  truncated: boolean;
 }
 
 export interface GenerateDocumentOptions {
@@ -88,6 +96,7 @@ export function createYieldStateUnit(
           outcome$.next({
             resourceId: makeResourceId(e.data.result.resourceId),
             resourceName: e.data.result.resourceName,
+            truncated: e.data.result.truncated,
           });
         }
       },


### PR DESCRIPTION
The finished generation lands honestly, then shows its edge

Completion used to freeze the info panel's progress frame at a ✅ beside "Creating the resource…" and a 95% bar — the producer's terminal 100% frame is a fire-and-forget heartbeat that races the awaited job:complete and can lose. Terminality is the owner's fact, so the ended frame stops trusting the last payload:

- AssistProgress: bar renders full once ended (every motivation); new endedMessage prop renders in place of the stale payload copy
- ResourceInfoPanel derives the sentence from outcome.truncated via the existing codeCompleteGenerated keys — no new translation keys
- sdk: YieldOutcome regains the truncated bit the job result carries (the outcome projection had dropped it); additive, pinned
- the outcome link restyled from underlined footnote to a button-shaped invitation

And the arrival announces the durable thing it made: resource-focus generation mints a provenance reference on the source (the derivation as a first-class edge). When the outcome arrives while the source page is mounted, the annotations panel opens on References, scrolls to that edge, and re-arms its sparkle. useGenerationArrival owns the WHEN (witnessed arrival + edge found, once per run; a held outcome on remount stays quiet); the page owns the WHAT (one panel:open emit + sparkle). Completion never navigates — the edge and the link invite.

TDD: six RED-first hook pins, four ended-frame pins, two sdk pins. Verified in node:24-alpine: sdk 15/15 + tsc + dist; react-ui hook/page/ AssistProgress/ResourceInfoPanel suites + tsc + build; frontend tsc; translation lints 474×29 + 567×29; css-class/variable gates.