### PR TITLE
e2e specs that stopped matching the product — and one that never did

### DIFF
--- a/packages/graph/src/__tests__/annotation-codec.test.ts
+++ b/packages/graph/src/__tests__/annotation-codec.test.ts
@@ -272,9 +272,9 @@ describe('each store flattens its own driver shapes before the codec sees them (
     expect(ann.modified).toBeUndefined();
   });
 
-  it('janusgraph: a property missing from the bag is absent, not undefined-valued', () => {
+  it('janusgraph: an empty property list is absent, not undefined-valued', () => {
     const ann = janusVertexToAnnotation({
-      properties: Object.fromEntries(Object.entries(bag).map(([k, v]) => [k, [{ value: v }]])),
+      properties: { ...Object.fromEntries(Object.entries(bag).map(([k, v]) => [k, [{ value: v }]])), modified: [] },
     });
     expect('modified' in ann).toBe(false);
     expect('generator' in ann).toBe(false);

--- a/tests/e2e/specs/16-generate-from-resource.spec.ts
+++ b/tests/e2e/specs/16-generate-from-resource.spec.ts
@@ -20,10 +20,24 @@ import { test, expect } from '../fixtures/auth';
  *
  * Selectors are label-independent where it matters: the Info panel opens via the
  * Toolbar's `button[data-panel="info"]`; the exclusion chips are
- * `.semiont-form__entity-type-button`; step transitions are asserted on the bus
+ * `.semiont-form__entity-type-button`; progress is asserted on the bus
  * (i18n-independent). The few accessible-name selectors use the `ResourceGenerate`
- * / `ResourceInfoPanel` en.json labels (Generate, Gather, Next, Configure Gather,
- * Review Context, Configure Generation).
+ * / `ResourceInfoPanel` en.json labels — now only **Generate** and **Gather**.
+ *
+ * REWRITTEN 2026-08-22 for GATHER-AT-THE-TOP (#1211), which folded the flow from
+ * three step-pages into one composite stack:
+ *
+ *     was:  [Configure gather] --Gather--> [Review evidence] --Next--> [Params]
+ *     now:  gather controls (top) → evidence → generation params (bottom)
+ *
+ * Four assertions died with it and are NOT to be reinstated: the three per-step
+ * titles (D7 deleted those keys ×29 — the strings do not exist in the product),
+ * and `Next` (D1 dissolved the review step, whose only action it was). They are
+ * replaced by structural gates — `.semiont-gather-receipt` and the mount of
+ * `#wizard-title` — which assert the same guarantees without naming copy.
+ *
+ * This spec was NOT updated when #1211 landed and went red on the next full run.
+ * If the flow changes shape again, that is the failure to expect.
  *
  * Requires: the seeded KB has the default entity types (for the P4 exclusion).
  */
@@ -42,7 +56,16 @@ test.describe('generate from resource', () => {
     await page.locator('button[data-panel="info"]').click();
     const infoPanel = page.locator('.semiont-resource-info-panel');
     await expect(infoPanel).toBeVisible({ timeout: 10_000 });
-    const generateBtn = infoPanel.getByRole('button', { name: /generate/i });
+    // `/generate/i` alone is AMBIGUOUS as of GENERATE-FROM-RESOURCE P2, which
+    // re-sited this control into an `AssistShell`. The shell adds a collapsible
+    // SECTION HEADER — `<button aria-expanded>Generate ›</button>` — so the
+    // regex matched two buttons and strict mode rejected the locator outright
+    // (measured 2026-08-22; the control itself was fine).
+    //
+    // Discriminate on the ✨ prefix: it is literal in `ResourceInfoPanel`
+    // (`✨ {t('generate')}`) while the word is translated, so it is the more
+    // stable half of the name — and the section header has no emoji.
+    const generateBtn = infoPanel.getByRole('button', { name: /✨.*generate/i });
     const cloneBtn = infoPanel.getByRole('button', { name: /clone/i });
     await expect(generateBtn).toBeVisible();
     await expect(cloneBtn).toBeVisible();
@@ -51,7 +74,7 @@ test.describe('generate from resource', () => {
     if (!genBox || !cloneBox) throw new Error('Generate/Clone button has no bounding box');
     expect(genBox.y, 'Generate renders above Clone').toBeLessThan(cloneBox.y);
 
-    // ── Click Generate → modal opens on the configure-gather step ──
+    // ── Click Generate → the modal opens as ONE composite stack ──
     await generateBtn.click();
     // Scope to the visible panel, not the headlessui Dialog wrapper: the
     // role="dialog" element is a zero-box positioning wrapper Playwright treats
@@ -59,34 +82,60 @@ test.describe('generate from resource', () => {
     // Generate button still in the background DOM).
     const modal = page.locator('.semiont-search-modal__panel--gather');
     await expect(modal).toBeVisible({ timeout: 10_000 });
-    await expect(modal).toContainText('Configure Gather');
+    // NO step-title assertion here. GATHER-AT-THE-TOP D7 collapsed the three
+    // per-step titles into ONE modal title and deleted the orphan keys ×29, so
+    // `Configure Gather` / `Review Context` / `Configure Generation` no longer
+    // exist anywhere in the product. This spec asserted all three and went red
+    // on the first (measured 2026-08-22). Structure is asserted below instead —
+    // it survives copy changes, which is the whole reason those strings went.
+    await expect(modal.locator('.semiont-wizard__step-scroll')).toBeVisible();
 
     // ── [P4] Exclude an entity type from recall (threaded as excludeEntityTypes) ──
-    const excludeChips = modal.locator('.semiont-form__entity-type-button');
-    await expect(excludeChips.first()).toBeVisible({ timeout: 10_000 });
-    const firstChip = excludeChips.first();
+    // #1211 renamed AND INVERTED this control. It was `.semiont-form__entity-type-button`
+    // with `data-selected='true'` meaning "excluded"; it is now a recall chip where
+    // every type is IN recall until crossed off, so the SAME act flips
+    // `data-included` true → false. Porting the old assertion verbatim would have
+    // asserted the opposite of the intent while still passing.
+    const recallChips = modal.locator('.semiont-form__recall-chip');
+    await expect(recallChips.first()).toBeVisible({ timeout: 10_000 });
+    const firstChip = recallChips.first();
+    await expect(firstChip).toHaveAttribute('data-included', 'true');
     await firstChip.click();
-    await expect(firstChip).toHaveAttribute('data-selected', 'true');
+    await expect(firstChip, 'clicking a recall chip EXCLUDES that type').toHaveAttribute('data-included', 'false');
     // (The selected type rides into the `gather` call as excludeEntityTypes; the
     //  recall-omission effect is LLM-output-dependent, so we assert the threading
     //  via the UI selection + the gather round-trip below, not the recall contents.)
 
     bus.clear();
 
-    // ── Gather → real gather.resource round-trips, review step renders the context ──
+    // ── Gather → real gather.resource round-trips, evidence unfolds in place ──
     await modal.getByRole('button', { name: /gather/i }).click();
     await bus.expectRequestResponse('gather:resource-requested', 'gather:resource-complete', 60_000);
 
-    // review step: title flips + Next enables only once the GatheredContext is in
-    // (the modal disables Next while `!context`), so an enabled Next == the
-    // kind-aware GatherContextStep rendered the resource context.
-    await expect(modal).toContainText('Review Context');
-    const nextBtn = modal.getByRole('button', { name: /^next/i });
-    await expect(nextBtn).toBeEnabled({ timeout: 30_000 });
+    // The spent controls fold into a receipt (D1: re-gathering is scroll-up →
+    // tweak → Gather, not a step back). Its presence is gated on `gatherFired`,
+    // so it is the structural proof that the gather actually ran — no copy.
+    const receipt = modal.locator('.semiont-gather-receipt');
+    await expect(receipt).toBeVisible({ timeout: 30_000 });
 
-    // ── Advance to configure-generation ──
-    await nextBtn.click();
-    await expect(modal).toContainText('Configure Generation');
+    // `ConfigureGenerationStep` mounts only under `gatherFired && gatherContext`,
+    // so the params appearing IS "the GatheredContext arrived and the kind-aware
+    // evidence rendered" — exactly the guarantee the deleted `Next`-enables-when-
+    // `!context` assertion carried, re-expressed against the composite stack.
+    const titleInput = modal.locator('#wizard-title');
+    await expect(titleInput).toBeAttached({ timeout: 30_000 });
+
+    // The fold itself: gather at the TOP, generation params at the BOTTOM of one
+    // scroll pane. This is the structural claim GATHER-AT-THE-TOP makes, and the
+    // one thing no copy assertion could ever have caught.
+    const receiptBox = await receipt.boundingBox();
+    const paramsBox = await titleInput.boundingBox();
+    if (!receiptBox || !paramsBox) throw new Error('receipt/params has no bounding box');
+    expect(receiptBox.y, 'gather receipt sits above the generation params').toBeLessThan(paramsBox.y);
+
+    // NOTE: no Back button to assert — D6 removed it; in a single stack there is
+    // nothing to go back to. If a Back reappears here, that is a regression of D6.
+    await expect(modal.getByRole('button', { name: /^back$/i })).toHaveCount(0);
 
     // ConfigureGenerationStep is an HTML `<form>` with two `required` fields —
     // `#wizard-title` (pre-filled) and `#wizard-storagePath` (EMPTY by default).
@@ -94,9 +143,10 @@ test.describe('generate from resource', () => {
     // the browser block submission (no `onGenerate`, no job) — exactly as spec 09
     // documents. Fill both (unique per-run title so successive runs don't pile up
     // same-named derived resources at the top of Discover).
+    // `titleInput` is already declared above — it doubles as the gate proving the
+    // GatheredContext arrived (ConfigureGenerationStep mounts only under
+    // `gatherFired && gatherContext`), so it is attached by the time we get here.
     const runId = Date.now();
-    const titleInput = modal.locator('#wizard-title');
-    await expect(titleInput).toBeAttached({ timeout: 5_000 });
     await titleInput.fill(`e2e-spec-16-${runId}`);
     await modal.locator('#wizard-storagePath').fill(`generated/e2e-16-${runId}.md`);
 

--- a/tests/e2e/specs/16-generate-from-resource.spec.ts
+++ b/tests/e2e/specs/16-generate-from-resource.spec.ts
@@ -24,20 +24,9 @@ import { test, expect } from '../fixtures/auth';
  * (i18n-independent). The few accessible-name selectors use the `ResourceGenerate`
  * / `ResourceInfoPanel` en.json labels — now only **Generate** and **Gather**.
  *
- * REWRITTEN 2026-08-22 for GATHER-AT-THE-TOP (#1211), which folded the flow from
- * three step-pages into one composite stack:
- *
- *     was:  [Configure gather] --Gather--> [Review evidence] --Next--> [Params]
- *     now:  gather controls (top) → evidence → generation params (bottom)
- *
- * Four assertions died with it and are NOT to be reinstated: the three per-step
- * titles (D7 deleted those keys ×29 — the strings do not exist in the product),
- * and `Next` (D1 dissolved the review step, whose only action it was). They are
- * replaced by structural gates — `.semiont-gather-receipt` and the mount of
- * `#wizard-title` — which assert the same guarantees without naming copy.
- *
- * This spec was NOT updated when #1211 landed and went red on the next full run.
- * If the flow changes shape again, that is the failure to expect.
+ * The flow is ONE composite stack as of GATHER-AT-THE-TOP (#1211): gather
+ * controls (top) → evidence → generation params (bottom). There is no review
+ * step, no Next, and no per-step titles, so progress is asserted structurally.
  *
  * Requires: the seeded KB has the default entity types (for the P4 exclusion).
  */

--- a/tests/e2e/specs/16-generate-from-resource.spec.ts
+++ b/tests/e2e/specs/16-generate-from-resource.spec.ts
@@ -6,11 +6,10 @@ import { test, expect } from '../fixtures/auth';
  *
  * Flow (ResourceViewerPage → ResourceInfoPanel → ResourceGenerateModal):
  *   Resource Info panel → **Generate** button (above Clone)
- *     → modal opens on `configure-gather`
+ *     → modal opens as one composite stack (GATHER-AT-THE-TOP #1211)
  *     → [P4] exclude an entity type from recall
  *     → Gather → real `gather:resource-requested`→`-complete` round-trip
- *     → `review` step renders the resource `GatheredContext` (kind-aware GatherContextStep)
- *     → Next → `configure-generation`
+ *     → evidence unfolds below; generation params mount under it
  *     → Generate → `yield.fromContext` (resource focus) runs the `generation` job → new derived resource.
  *
  * Covers the seams unit tests can't reach under the #900 native-binding skew:

--- a/tests/e2e/specs/16-generate-from-resource.spec.ts
+++ b/tests/e2e/specs/16-generate-from-resource.spec.ts
@@ -45,15 +45,8 @@ test.describe('generate from resource', () => {
     await page.locator('button[data-panel="info"]').click();
     const infoPanel = page.locator('.semiont-resource-info-panel');
     await expect(infoPanel).toBeVisible({ timeout: 10_000 });
-    // `/generate/i` alone is AMBIGUOUS as of GENERATE-FROM-RESOURCE P2, which
-    // re-sited this control into an `AssistShell`. The shell adds a collapsible
-    // SECTION HEADER — `<button aria-expanded>Generate ›</button>` — so the
-    // regex matched two buttons and strict mode rejected the locator outright
-    // (measured 2026-08-22; the control itself was fine).
-    //
-    // Discriminate on the ✨ prefix: it is literal in `ResourceInfoPanel`
-    // (`✨ {t('generate')}`) while the word is translated, so it is the more
-    // stable half of the name — and the section header has no emoji.
+    // The AssistShell adds a collapsible "Generate ›" section header, so match
+    // the ✨ prefix — literal in ResourceInfoPanel, unlike the translated word.
     const generateBtn = infoPanel.getByRole('button', { name: /✨.*generate/i });
     const cloneBtn = infoPanel.getByRole('button', { name: /clone/i });
     await expect(generateBtn).toBeVisible();
@@ -71,20 +64,11 @@ test.describe('generate from resource', () => {
     // Generate button still in the background DOM).
     const modal = page.locator('.semiont-search-modal__panel--gather');
     await expect(modal).toBeVisible({ timeout: 10_000 });
-    // NO step-title assertion here. GATHER-AT-THE-TOP D7 collapsed the three
-    // per-step titles into ONE modal title and deleted the orphan keys ×29, so
-    // `Configure Gather` / `Review Context` / `Configure Generation` no longer
-    // exist anywhere in the product. This spec asserted all three and went red
-    // on the first (measured 2026-08-22). Structure is asserted below instead —
-    // it survives copy changes, which is the whole reason those strings went.
     await expect(modal.locator('.semiont-wizard__step-scroll')).toBeVisible();
 
     // ── [P4] Exclude an entity type from recall (threaded as excludeEntityTypes) ──
-    // #1211 renamed AND INVERTED this control. It was `.semiont-form__entity-type-button`
-    // with `data-selected='true'` meaning "excluded"; it is now a recall chip where
-    // every type is IN recall until crossed off, so the SAME act flips
-    // `data-included` true → false. Porting the old assertion verbatim would have
-    // asserted the opposite of the intent while still passing.
+    // Inverted UI: every type is IN recall until crossed off, so clicking
+    // EXCLUDES it — data-included flips true → false.
     const recallChips = modal.locator('.semiont-form__recall-chip');
     await expect(recallChips.first()).toBeVisible({ timeout: 10_000 });
     const firstChip = recallChips.first();
@@ -101,29 +85,22 @@ test.describe('generate from resource', () => {
     await modal.getByRole('button', { name: /gather/i }).click();
     await bus.expectRequestResponse('gather:resource-requested', 'gather:resource-complete', 60_000);
 
-    // The spent controls fold into a receipt (D1: re-gathering is scroll-up →
-    // tweak → Gather, not a step back). Its presence is gated on `gatherFired`,
-    // so it is the structural proof that the gather actually ran — no copy.
+    // The spent controls fold into a receipt, gated on `gatherFired`.
     const receipt = modal.locator('.semiont-gather-receipt');
     await expect(receipt).toBeVisible({ timeout: 30_000 });
 
-    // `ConfigureGenerationStep` mounts only under `gatherFired && gatherContext`,
-    // so the params appearing IS "the GatheredContext arrived and the kind-aware
-    // evidence rendered" — exactly the guarantee the deleted `Next`-enables-when-
-    // `!context` assertion carried, re-expressed against the composite stack.
+    // ConfigureGenerationStep mounts only under `gatherFired && gatherContext`,
+    // so the params appearing means the GatheredContext arrived.
     const titleInput = modal.locator('#wizard-title');
     await expect(titleInput).toBeAttached({ timeout: 30_000 });
 
-    // The fold itself: gather at the TOP, generation params at the BOTTOM of one
-    // scroll pane. This is the structural claim GATHER-AT-THE-TOP makes, and the
-    // one thing no copy assertion could ever have caught.
+    // The fold: gather at the top, generation params at the bottom.
     const receiptBox = await receipt.boundingBox();
     const paramsBox = await titleInput.boundingBox();
     if (!receiptBox || !paramsBox) throw new Error('receipt/params has no bounding box');
     expect(receiptBox.y, 'gather receipt sits above the generation params').toBeLessThan(paramsBox.y);
 
-    // NOTE: no Back button to assert — D6 removed it; in a single stack there is
-    // nothing to go back to. If a Back reappears here, that is a regression of D6.
+    // No Back in a single stack (D6).
     await expect(modal.getByRole('button', { name: /^back$/i })).toHaveCount(0);
 
     // ConfigureGenerationStep is an HTML `<form>` with two `required` fields —
@@ -132,9 +109,6 @@ test.describe('generate from resource', () => {
     // the browser block submission (no `onGenerate`, no job) — exactly as spec 09
     // documents. Fill both (unique per-run title so successive runs don't pile up
     // same-named derived resources at the top of Discover).
-    // `titleInput` is already declared above — it doubles as the gate proving the
-    // GatheredContext arrived (ConfigureGenerationStep mounts only under
-    // `gatherFired && gatherContext`), so it is attached by the time we get here.
     const runId = Date.now();
     await titleInput.fill(`e2e-spec-16-${runId}`);
     await modal.locator('#wizard-storagePath').fill(`generated/e2e-16-${runId}.md`);

--- a/tests/e2e/specs/16-generate-from-resource.spec.ts
+++ b/tests/e2e/specs/16-generate-from-resource.spec.ts
@@ -18,19 +18,15 @@ import { test, expect } from '../fixtures/auth';
  * (gather + generation) make this slow — hence the long timeout.
  *
  * Selectors are label-independent where it matters: the Info panel opens via the
- * Toolbar's `button[data-panel="info"]`; the exclusion chips are
- * `.semiont-form__entity-type-button`; progress is asserted on the bus
+ * Toolbar's `button[data-panel="info"]`; the recall chips are
+ * `.semiont-form__recall-chip`; progress is asserted on the bus
  * (i18n-independent). The few accessible-name selectors use the `ResourceGenerate`
  * / `ResourceInfoPanel` en.json labels — now only **Generate** and **Gather**.
- *
- * The flow is ONE composite stack as of GATHER-AT-THE-TOP (#1211): gather
- * controls (top) → evidence → generation params (bottom). There is no review
- * step, no Next, and no per-step titles, so progress is asserted structurally.
  *
  * Requires: the seeded KB has the default entity types (for the P4 exclusion).
  */
 test.describe('generate from resource', () => {
-  test('Generate button → gather round-trips → review → generation yields a derived resource', async ({ signedInPage: page, bus }) => {
+  test('Generate button → gather round-trips → generation yields a derived resource', async ({ signedInPage: page, bus }) => {
     test.setTimeout(180_000);
 
     // Open the first resource.

--- a/tests/e2e/specs/22-pdf-scanned-decline.spec.ts
+++ b/tests/e2e/specs/22-pdf-scanned-decline.spec.ts
@@ -111,8 +111,9 @@ test.describe('assisted detection on an unreadable scanned PDF', () => {
 
     // (2) the user is told why, as INFO. The bus log records only a payload
     // prefix, so the *reason* is asserted where it actually reaches a
-    // human — the toast text `DECLINE_MESSAGES['no-text-layer']` produces.
-    await expect(page.getByText(/scan whose text could not be recognized/i))
+    // human — the toast from `decline_no-text-layer` (en.json). Matched loosely:
+    // the copy uses a curly apostrophe in "couldn’t", which is not worth pinning.
+    await expect(page.getByText(/scan whose text.*recognized/i))
       .toBeVisible({ timeout: 15_000 });
     await expect(page.getByText(/annotation complete/i)).toBeHidden();
 

--- a/tests/e2e/specs/23-pdf-anchored-text.spec.ts
+++ b/tests/e2e/specs/23-pdf-anchored-text.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/auth';
 import type { Page } from '@playwright/test';
-import { BACKEND_URL } from '../playwright.config';
+import { SemiontClient, resourceId as ridBrand } from '@semiont/sdk';
+import { BACKEND_URL, E2E_EMAIL, E2E_PASSWORD } from '../playwright.config';
 
 import { openResourceByName } from '../fixtures/discover';
 /**
@@ -48,15 +49,32 @@ const MAP = {
 
 const resourceIdFromUrl = (page: Page) => page.url().split('/').pop()!.split('?')[0];
 
-/** The signed-in session's bearer, wherever the app parked it. */
-async function bearerToken(page: Page): Promise<string> {
-  return page.evaluate(() => {
-    for (const key of Object.keys(localStorage)) {
-      const match = (localStorage.getItem(key) ?? '').match(/[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/);
-      if (match) return match[0];
-    }
-    return '';
+/**
+ * Read the STORED annotations for a resource the way any client would.
+ *
+ * This replaces a `bearerToken(page)` helper that scanned every localStorage
+ * key for the first value matching a JWT *shape* and used it as a bearer.
+ * It was guessing, and the guess was never right: the app puts NO token in
+ * localStorage — every `setItem` in react-ui is a UI preference (theme, panel
+ * widths, `assist-section-expanded-*`), and the sdk uses sessionStorage only
+ * for cache persistence. So the helper returned either some unrelated
+ * dot-separated string or `''`, and `Bearer ` produced a 401.
+ *
+ * That made this assertion a lottery on `Object.keys(localStorage)` order,
+ * which is why `:100` passed and `:127` failed in the SAME file on
+ * 2026-08-22 — not a token expiring. It had been latent since it was written.
+ */
+async function storedAnnotations(resourceId: string) {
+  const client = await SemiontClient.signInHttp({
+    baseUrl: BACKEND_URL,
+    email: E2E_EMAIL,
+    password: E2E_PASSWORD,
   });
+  try {
+    return await client.browse.annotations(ridBrand(resourceId)).fresh();
+  } finally {
+    client.dispose();
+  }
 }
 
 /** PDF points -> canvas pixels for a 792pt-tall page rendered 1:1. */
@@ -146,11 +164,28 @@ test.describe('scanned PDF annotations quote the server-derived map', () => {
     // carries a quote built from a map the browser could not have read. A
     // panel renders `getExactText` off this; the selector is the thing that
     // has to be right.
-    const stored = await page.request.get(`${BACKEND_URL}/resources/${resourceIdFromUrl(page)}/jsonld`, {
-      headers: { Authorization: `Bearer ${await bearerToken(page)}` },
+    // Read it back through the SDK, as any client would — a separate signed-in
+    // client, so this proves the quote PERSISTED rather than that the browser
+    // still holds it in memory.
+    const stored = await storedAnnotations(resourceIdFromUrl(page));
+    expect(stored.length, 'the drawn rectangle persisted an annotation').toBeGreaterThan(0);
+
+    // Structural, not a substring of serialized JSON-LD: `Annotation.selector`
+    // is the typed union, so assert the TextQuoteSelector member carries the
+    // quote. The old raw-text assertion (`"TextQuoteSelector","exact":"…"`)
+    // pinned key ORDER in the serializer, which nothing promises.
+    const quotes = stored.flatMap((a) => {
+      const sel = (a.target as { selector?: unknown }).selector;
+      const all = Array.isArray(sel) ? sel : sel ? [sel] : [];
+      return all
+        .filter((s): s is { type: string; exact: string } =>
+          typeof s === 'object' && s !== null && (s as { type?: string }).type === 'TextQuoteSelector')
+        .map((s) => s.exact);
     });
-    expect(stored.status()).toBe(200);
-    expect(await stored.text()).toContain(`"TextQuoteSelector","exact":"${QUOTE}"`);
+    expect(
+      quotes,
+      'a TextQuoteSelector quoting the SERVER-derived map — text the browser never had',
+    ).toContain(QUOTE);
 
     // And the same text reaches the reader. The annotations panel is already
     // open in annotate mode — clicking the toolbar button would CLOSE it.

--- a/tests/e2e/specs/23-pdf-anchored-text.spec.ts
+++ b/tests/e2e/specs/23-pdf-anchored-text.spec.ts
@@ -49,21 +49,9 @@ const MAP = {
 
 const resourceIdFromUrl = (page: Page) => page.url().split('/').pop()!.split('?')[0];
 
-/**
- * Read the STORED annotations for a resource the way any client would.
- *
- * This replaces a `bearerToken(page)` helper that scanned every localStorage
- * key for the first value matching a JWT *shape* and used it as a bearer.
- * It was guessing, and the guess was never right: the app puts NO token in
- * localStorage — every `setItem` in react-ui is a UI preference (theme, panel
- * widths, `assist-section-expanded-*`), and the sdk uses sessionStorage only
- * for cache persistence. So the helper returned either some unrelated
- * dot-separated string or `''`, and `Bearer ` produced a 401.
- *
- * That made this assertion a lottery on `Object.keys(localStorage)` order,
- * which is why `:100` passed and `:127` failed in the SAME file on
- * 2026-08-22 — not a token expiring. It had been latent since it was written.
- */
+/** Read the STORED annotations the way any client would — a separate signed-in
+ *  client, so a pass proves the quote persisted rather than that the browser
+ *  still holds it. */
 async function storedAnnotations(resourceId: string) {
   const client = await SemiontClient.signInHttp({
     baseUrl: BACKEND_URL,
@@ -164,16 +152,9 @@ test.describe('scanned PDF annotations quote the server-derived map', () => {
     // carries a quote built from a map the browser could not have read. A
     // panel renders `getExactText` off this; the selector is the thing that
     // has to be right.
-    // Read it back through the SDK, as any client would — a separate signed-in
-    // client, so this proves the quote PERSISTED rather than that the browser
-    // still holds it in memory.
     const stored = await storedAnnotations(resourceIdFromUrl(page));
     expect(stored.length, 'the drawn rectangle persisted an annotation').toBeGreaterThan(0);
 
-    // Structural, not a substring of serialized JSON-LD: `Annotation.selector`
-    // is the typed union, so assert the TextQuoteSelector member carries the
-    // quote. The old raw-text assertion (`"TextQuoteSelector","exact":"…"`)
-    // pinned key ORDER in the serializer, which nothing promises.
     const quotes = stored.flatMap((a) => {
       const sel = (a.target as { selector?: unknown }).selector;
       const all = Array.isArray(sel) ? sel : sel ? [sel] : [];


### PR DESCRIPTION
Three e2e specs and one unit test. Two were failing and two were passing — and in
both pairs the assertion had drifted from what the test claimed to check.

**Areas:** `tests/e2e`, `packages/graph` (tests only — no product code changes).

## e2e 16 — generate-from-resource

#1211 folded the from-resource Generate flow from three step-pages into one
composite stack. This spec still walked the old flow and broke in three places:

- **`/generate/i` became ambiguous.** The Generate control now sits inside a
  collapsible section whose header carries the same name, so the locator matched
  two buttons and strict mode rejected it. Matches the ✨ prefix instead — literal
  in the component, where the word is translated.
- **The per-step titles and `Next` are gone.** Replaced with structural gates: the
  gather receipt appears once gather fires, and the generation params mount only
  once the gathered context arrives — the same guarantee the old "Next enables when
  context lands" assertion carried, without naming copy.
- **The exclusion chips were renamed *and inverted*:**
  `.semiont-form__entity-type-button[data-selected]` →
  `.semiont-form__recall-chip[data-included]`, where every type is in recall until
  crossed off. Porting the old assertion verbatim would have asserted the opposite
  of the intent and still passed.

The stale header comment was corrected too — it documented the three-step flow and
the old chip class.

## e2e 22 — scanned-PDF decline

Waited on `could not be recognized`; the shipped copy reads `couldn’t`, with a
U+2019 apostrophe, so a literal correction would also have missed. Now matches the
distinctive phrase and tolerates the contraction. The assertion's job is "the user
is told the scan was unreadable", not "the sentence is exactly this".

## e2e 23 — anchored-text (latent, never worked)

Its `bearerToken(page)` helper scanned every localStorage key for the first value
matching a JWT *shape* and used it as a bearer. **The app stores no token there** —
every `setItem` is a UI preference, and the SDK uses sessionStorage for caches only
— so the helper returned an unrelated string or empty, and the request 401'd. It
passed whenever the scan happened to land on something the backend accepted, which
is why it looked like an order-dependent flake.

Replaced with a real `SemiontClient.signInHttp`. That is both correct and stronger:
a separate signed-in client proves the quote **persisted** rather than that the
browser still holds it. The assertion also moved off a JSON-LD substring
(`"TextQuoteSelector","exact":"…"`, which pinned serializer key order) onto the
typed selector union.

## graph — annotation codec

`janusgraph: a property missing from the bag is absent` omitted the property
entirely, so it never exercised the empty-property-list path it was named for. Now
passes `modified: []` explicitly, and is renamed to say what it tests.

## Verification

Full e2e suite **39/39 green** against a locally built stack (was 36/39, with
16/22/23 red).

Worth noting for follow-up: specs 20/22/23 had been carried as a single "known
order flake". None of them was order-dependent — 22 was copy drift, 23 was the
latent bug above, and 20 was never broken. The label had been discouraging anyone
from looking.
