### PR TITLE
Annotatability becomes a registry capability: asked once, and refused at the write path

### DIFF
--- a/packages/core/src/__tests__/media-types.test.ts
+++ b/packages/core/src/__tests__/media-types.test.ts
@@ -15,6 +15,7 @@ import {
   extensionForMediaType,
   mediaTypeForExtension,
   textExtractionOf,
+  isAnnotatable,
   AUTHORABLE_MEDIA_TYPES,
   EMBEDDABLE_MEDIA_TYPES,
   GENERATABLE_MEDIA_TYPES,
@@ -43,6 +44,37 @@ describe('media-types registry', () => {
       for (const [type, caps] of rows) {
         if (caps.authorable) {
           expect(caps.render, type).toBe('text');
+        }
+      }
+    });
+
+    // The capability implications (MEDIA-CAPABILITY-DISPATCH D4). All three
+    // hold today — they are regression pins on a row edit, not discoveries.
+    // Deliberately absent: the converse, `render !== 'none' → annotatable`.
+    // It holds today too, and pinning it would make AnnotateView's
+    // gate-on-renderability accidentally correct BY RULE; leaving it open
+    // keeps renderable-but-unannotatable a reachable row edit.
+
+    it('never offers composing into something that cannot be annotated', () => {
+      for (const [type, caps] of rows) {
+        if (caps.authorable) {
+          expect(isAnnotatable(type), type).toBe(true);
+        }
+      }
+    });
+
+    it('never generates something that cannot be annotated', () => {
+      for (const [type, caps] of rows) {
+        if (caps.generatable) {
+          expect(isAnnotatable(type), type).toBe(true);
+        }
+      }
+    });
+
+    it('never anchors into something the UI cannot display', () => {
+      for (const [type, caps] of rows) {
+        if (caps.anchoring !== 'none') {
+          expect(caps.render, type).not.toBe('none');
         }
       }
     });
@@ -118,6 +150,48 @@ describe('media-types registry', () => {
       expect(MEDIA_TYPES['application/zip'].anchoring).toBe('none');
       expect(MEDIA_TYPES['image/gif'].anchoring).toBe('none');
       expect(MEDIA_TYPES['text/csv'].anchoring).toBe('none');
+    });
+  });
+
+  describe('annotatable capability (MEDIA-CAPABILITY-DISPATCH P1)', () => {
+    // WHETHER a type can carry annotations. `anchoring` stays the authority on
+    // HOW — derived, never a row field, because two facts that can disagree
+    // have nothing to adjudicate them (D1).
+    it('admits exactly the seven anchoring-bearing rows', () => {
+      expect(Object.keys(MEDIA_TYPES).filter(isAnnotatable)).toEqual([
+        'text/markdown',
+        'text/plain',
+        'text/html',
+        'application/json',
+        'image/png',
+        'image/jpeg',
+        'application/pdf',
+      ]);
+    });
+
+    it('leaves the storage tier out, top-level type notwithstanding', () => {
+      expect(isAnnotatable('image/gif')).toBe(false);
+      expect(isAnnotatable('text/csv')).toBe(false);
+      expect(isAnnotatable('application/zip')).toBe(false);
+      expect(isAnnotatable('video/mp4')).toBe(false);
+    });
+
+    it('tolerates parameters and case, like every other registry read', () => {
+      expect(isAnnotatable('text/markdown; charset=utf-8')).toBe(true);
+      expect(isAnnotatable('IMAGE/PNG')).toBe(true);
+    });
+
+    it('answers false on a registry miss — strict where extraction is lenient (D2)', () => {
+      expect(isAnnotatable('application/x-proprietary')).toBe(false);
+      expect(isAnnotatable('')).toBe(false);
+
+      // The asymmetry with textExtractionOf is deliberate, not an oversight.
+      // Extracting the wrong bytes costs one bad vector and refusing to
+      // extract costs a resource nobody can find, so extraction guesses. An
+      // annotation is a durable write against a coordinate model the system
+      // does not have for an unknown type, so it refuses.
+      expect(textExtractionOf('text/x-obscure-notation')).toBe('decode');
+      expect(isAnnotatable('text/x-obscure-notation')).toBe(false);
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,6 +310,7 @@ export {
   extensionForMediaType,
   mediaTypeForExtension,
   textExtractionOf,
+  isAnnotatable,
   AUTHORABLE_MEDIA_TYPES,
   EMBEDDABLE_MEDIA_TYPES,
   GENERATABLE_MEDIA_TYPES,

--- a/packages/core/src/media-types.ts
+++ b/packages/core/src/media-types.ts
@@ -13,10 +13,15 @@
  *                   embedding, never mojibake)
  * - `authorable`  — offered in the compose editor's format dropdown
  * - `uploadable`  — big tent: true for every registry member
+ * - `generatable` — the generation worker can produce it as a yield artifact
  *
  * Capabilities are orthogonal strategies, not a ladder: images render but
  * yield no text; PDFs yield text but aren't authorable. A "tier" is a
  * derived reading, not a stored fact.
+ *
+ * Questions ANSWERABLE from those rows get a helper, never a row of their own —
+ * `isAnnotatable` reads `anchoring`, and a second stored field would be a fact
+ * that can contradict the one it was derived from.
  *
  * Import-leniency invariant: restore/import preserves archive mediaTypes
  * verbatim, so "every stored mediaType is registry-valid" holds only for
@@ -243,6 +248,23 @@ export function textExtractionOf(format: string): TextExtraction {
   const caps = capabilitiesOf(format);
   if (caps) return caps.extractText;
   return baseMediaType(format).startsWith('text/') ? 'decode' : 'none';
+}
+
+/**
+ * WHETHER a type can carry annotations — `anchoring` remains the authority on
+ * HOW. Derived rather than stored: a parallel `annotatable` row field would be
+ * two facts that can disagree, with nothing to adjudicate
+ * `{ annotatable: true, anchoring: 'none' }`.
+ *
+ * Strict on a registry miss, where `textExtractionOf` above is lenient. The
+ * asymmetry is deliberate. Extracting the wrong bytes costs one bad vector,
+ * and refusing to extract costs a resource nobody can find, so extraction
+ * guesses; an annotation is a durable write against a coordinate model the
+ * system does not have for an unknown type, so it refuses.
+ */
+export function isAnnotatable(format: string): boolean {
+  const caps = capabilitiesOf(format);
+  return caps !== undefined && caps.anchoring !== 'none';
 }
 
 const REGISTRY_KEYS = Object.keys(MEDIA_TYPES) as SupportedMediaType[];

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -41,9 +41,10 @@ async function createAnnotationAndAwait(
   request: CreateAnnotationRequest,
   uid: ReturnType<typeof userId>,
   eventBus: EventBus,
+  kb: KnowledgeBase,
 ) {
   const creator = { '@type': 'Person' as const, '@id': 'did:web:test.local:users:test-user', name: 'Test User' };
-  const result = await AnnotationOperations.createAnnotation(request, uid, creator, eventBus);
+  const result = await AnnotationOperations.createAnnotation(request, uid, creator, eventBus, kb);
   const expectedId = result.annotation.id;
   await firstValueFrom(eventBus.get('mark:added').pipe(
     filter((e) => e.payload?.annotation?.id === expectedId),
@@ -131,7 +132,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       expect(result.annotation.motivation).toBe('linking');
       // target persisted verbatim — selector-less (RESOURCE-LEVEL-ANCHOR P2)
@@ -161,7 +162,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       expect(result.annotation).toBeDefined();
       expect(result.annotation.motivation).toBe('highlighting');
@@ -192,7 +193,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       expect(result.annotation.motivation).toBe('commenting');
       expect(result.annotation.body).toMatchObject({
@@ -223,7 +224,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       expect(result.annotation.motivation).toBe('assessing');
     });
@@ -257,7 +258,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       expect(result.annotation.motivation).toBe('tagging');
       expect(Array.isArray(result.annotation.body)).toBe(true);
@@ -285,7 +286,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       expect(result.annotation.motivation).toBe('linking');
     });
@@ -312,7 +313,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       // Verify W3C annotation structure
       expect(result.annotation['@context']).toBe('http://www.w3.org/ns/anno.jsonld');
@@ -347,7 +348,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       // Check event was emitted
       const events = await testEventStore.log.getEvents(resourceId(testResourceId));
@@ -388,7 +389,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       expect(result.annotation.id).toBeDefined();
       expect(typeof result.annotation.id).toBe('string');
@@ -417,7 +418,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       const target = result.annotation.target;
       if (typeof target !== 'string' && 'selector' in target) {
@@ -458,7 +459,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       const target = result.annotation.target;
       if (typeof target !== 'string' && 'selector' in target) {
@@ -494,7 +495,7 @@ describe('AnnotationOperations', () => {
           userId('user-1'),
           creator,
           eventBus,
-        )
+          kb)
       ).rejects.toThrow('motivation is required');
     });
   });
@@ -525,7 +526,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       const annotationIdStr = createResult.annotation.id.split('/').pop()!;
 
@@ -589,7 +590,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       const annotationIdStr = createResult.annotation.id.split('/').pop()!;
 
@@ -647,7 +648,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       const annotationIdStr = createResult.annotation.id.split('/').pop()!;
 
@@ -709,7 +710,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       const annotationIdStr = createResult.annotation.id.split('/').pop()!;
 
@@ -791,7 +792,7 @@ describe('AnnotationOperations', () => {
         },
         userId('user-1'),
         eventBus,
-      );
+        kb);
 
       const annotationIdStr = createResult.annotation.id;
 

--- a/packages/make-meaning/src/__tests__/handlers/annotation-assembly.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/annotation-assembly.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The write path refuses unannotatable targets — MEDIA-CAPABILITY-DISPATCH P3.
+ *
+ * Annotatability used to be a UI-only notion: the GUI decided what to offer and
+ * nothing decided what to accept, so an SDK or API caller could annotate a ZIP.
+ * The gate goes on `mark:create-request` — the bus command every GUI and SDK
+ * caller travels — and NOT on `mark:create`, which import and replay emit
+ * directly. That placement IS D6's leniency: restore stays lenient by topology,
+ * with no flag and no bypass parameter.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { firstValueFrom, race, timer, take } from 'rxjs';
+import { EventBus, resourceId, type Logger } from '@semiont/core';
+import { registerAnnotationAssemblyHandler } from '../../handlers/annotation-assembly';
+import type { KnowledgeBase } from '../../knowledge-base';
+
+const silentLogger: Logger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(() => silentLogger),
+};
+
+const USER_DID = 'did:web:test:users:test';
+const RID = 'res-under-test';
+
+/** A KB whose one resource carries `mediaType` as its primary representation. */
+function kbServing(mediaType: string | undefined): KnowledgeBase {
+  return {
+    views: {
+      get: vi.fn().mockResolvedValue({
+        resource: {
+          '@context': 'https://schema.org/',
+          '@id': resourceId(RID),
+          name: 'Resource under test',
+          representations: mediaType ? [{ mediaType, storageUri: 'file://x', checksum: 'c' }] : [],
+        },
+      }),
+    },
+  } as unknown as KnowledgeBase;
+}
+
+const request = {
+  motivation: 'commenting',
+  target: { source: RID, selector: { type: 'TextPositionSelector', start: 0, end: 4 } },
+  body: [{ type: 'TextualBody', value: 'note' }],
+};
+
+/** Whichever of the two outcomes arrives first, or 'none' if neither does. */
+async function outcomeOf(bus: EventBus): Promise<{ channel: string; message?: string }> {
+  const created = bus.get('mark:create').pipe(take(1));
+  const failed = bus.get('mark:create-failed').pipe(take(1));
+  return firstValueFrom(
+    race(
+      created.pipe(),
+      failed.pipe(),
+      timer(150),
+    ).pipe(take(1)),
+  ).then((v) =>
+    typeof v === 'number'
+      ? { channel: 'none' }
+      : 'annotation' in (v as object)
+        ? { channel: 'mark:create' }
+        : { channel: 'mark:create-failed', message: (v as { message?: string }).message },
+  );
+}
+
+describe('mark:create-request refuses unannotatable targets (MEDIA-CAPABILITY-DISPATCH P3)', () => {
+  let bus: EventBus;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bus = new EventBus();
+  });
+
+  it('lets an annotatable target through unchanged', async () => {
+    registerAnnotationAssemblyHandler(bus, kbServing('text/markdown'), silentLogger);
+    const pending = outcomeOf(bus);
+    bus.get('mark:create-request').next({ correlationId: 'cid-1', resourceId: RID, request, _userId: USER_DID } as never);
+    expect((await pending).channel).toBe('mark:create');
+  });
+
+  it('refuses a storage-tier target, naming the media type', async () => {
+    // `text/css` is a registry row with `anchoring: 'none'` — known, and declined.
+    registerAnnotationAssemblyHandler(bus, kbServing('text/css'), silentLogger);
+    const pending = outcomeOf(bus);
+    bus.get('mark:create-request').next({ correlationId: 'cid-2', resourceId: RID, request, _userId: USER_DID } as never);
+
+    const outcome = await pending;
+    expect(outcome.channel).toBe('mark:create-failed');
+    expect(outcome.message).toContain('text/css');
+  });
+
+  it('refuses a target the registry has never seen (D2 second population)', async () => {
+    // Import leniency means a KB can hold these, and `textExtractionOf` is
+    // lenient for `text/*` so they embed and turn up in search — a user who
+    // found one will reasonably try to annotate it. The refusal has to read
+    // sanely for a type the registry cannot make vocabulary claims about.
+    registerAnnotationAssemblyHandler(bus, kbServing('text/x-obscure-notation'), silentLogger);
+    const pending = outcomeOf(bus);
+    bus.get('mark:create-request').next({ correlationId: 'cid-3', resourceId: RID, request, _userId: USER_DID } as never);
+
+    const outcome = await pending;
+    expect(outcome.channel).toBe('mark:create-failed');
+    expect(outcome.message).toContain('text/x-obscure-notation');
+    expect(outcome.message).toMatch(/cannot be annotated/);
+  });
+
+  it('leaves import and replay alone — the gate is on the REQUEST channel', async () => {
+    // The regression pin for D6: import and replay emit `mark:create` directly
+    // and must keep working for storage-tier targets. This fires if a later
+    // session ever "tidies" the gate down into Stower's convergence point,
+    // which would need a leniency flag to undo.
+    registerAnnotationAssemblyHandler(bus, kbServing('text/css'), silentLogger);
+    const failures: unknown[] = [];
+    bus.get('mark:create-failed').subscribe((e) => failures.push(e));
+
+    bus.get('mark:create').next({ annotation: { id: 'ann-import-1' }, _userId: USER_DID, resourceId: resourceId(RID) } as never);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/make-meaning/src/__tests__/llm-context.test.ts
+++ b/packages/make-meaning/src/__tests__/llm-context.test.ts
@@ -206,7 +206,7 @@ describe('LLM Context', () => {
         userId('user-1'),
         creator,
         eventBus,
-      );
+        kb);
       await created$;
 
       // The unified context sources annotations from the graph projection; this test's kb wires no

--- a/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
+++ b/packages/make-meaning/src/__tests__/scripting-examples/query-graph.test.ts
@@ -211,7 +211,7 @@ describe('Scripting Example: Query Graph Database', () => {
       userId('test-script'),
       creator,
       eventBus,
-    );
+      makeMeaning.knowledgeSystem.kb);
 
     // EVENTUAL CONSISTENCY: Wait for GraphConsumer to process events and update graph
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -303,7 +303,7 @@ describe('Scripting Example: Query Graph Database', () => {
         userId('test-script'),
         creator,
         eventBus,
-      );
+        makeMeaning.knowledgeSystem.kb);
     }
 
     // EVENTUAL CONSISTENCY: Wait for GraphConsumer to process events and update graph

--- a/packages/make-meaning/src/annotation-operations.ts
+++ b/packages/make-meaning/src/annotation-operations.ts
@@ -16,7 +16,7 @@ import type {
   UserId,
   Logger,
 } from '@semiont/core';
-import { EventBus, annotationId, resourceId as makeResourceId, assembleAnnotation, applyBodyOperations } from '@semiont/core';
+import { EventBus, annotationId, resourceId as makeResourceId, assembleAnnotation, applyBodyOperations, isAnnotatable, getPrimaryRepresentation } from '@semiont/core';
 import { AnnotationContext } from './annotation-context';
 import type { KnowledgeBase } from './knowledge-base';
 
@@ -24,6 +24,29 @@ type Agent = components['schemas']['Agent'];
 import type { Annotation } from '@semiont/core';
 type CreateAnnotationRequest = components['schemas']['CreateAnnotationRequest'];
 type UpdateAnnotationBodyRequest = components['schemas']['UpdateAnnotationBodyRequest'];
+
+/**
+ * Refuse a write whose target cannot carry a coordinate (MEDIA-CAPABILITY-DISPATCH
+ * D6/D8). Exported so the `mark:create-request` handler and this class share ONE
+ * implementation rather than each deciding it — the registry stays the single
+ * fact, and this is the single refusal built on it.
+ *
+ * Two populations land here: a registry row that declines (storage tier) and a
+ * type the registry has never seen (import leniency keeps those in the KB, and
+ * `textExtractionOf` is lenient for `text/*`, so they embed and turn up in
+ * search). The wording states what cannot be done rather than making a
+ * vocabulary claim the registry is not entitled to make about a miss.
+ *
+ * NOT applied to import or replay: those emit `mark:create` directly and never
+ * reach either caller. That topology is D6's leniency — no flag, no bypass.
+ */
+export async function assertAnnotatableTarget(kb: KnowledgeBase, target: string): Promise<void> {
+  const view = await kb.views.get(makeResourceId(target));
+  const mediaType = getPrimaryRepresentation(view?.resource)?.mediaType;
+  if (!mediaType || !isAnnotatable(mediaType)) {
+    throw new Error(`"${mediaType ?? 'unknown'}" cannot be annotated`);
+  }
+}
 
 export interface CreateAnnotationResult {
   annotation: Annotation;
@@ -42,7 +65,12 @@ export class AnnotationOperations {
     userId: UserId,
     creator: Agent,
     eventBus: EventBus,
+    kb: KnowledgeBase,
   ): Promise<CreateAnnotationResult> {
+    // This facade reaches `mark:create` directly, so without this it would be a
+    // published way around the handler's gate (MEDIA-CAPABILITY-DISPATCH D6).
+    await assertAnnotatableTarget(kb, request.target.source);
+
     const { annotation } = assembleAnnotation(request, creator);
     const resId = makeResourceId(request.target.source);
 

--- a/packages/make-meaning/src/handlers/annotation-assembly.ts
+++ b/packages/make-meaning/src/handlers/annotation-assembly.ts
@@ -1,5 +1,7 @@
 import { resourceId, didToAgent, assembleAnnotation } from '@semiont/core';
 import type { EventBus, Logger, components } from '@semiont/core';
+import type { KnowledgeBase } from '../knowledge-base.js';
+import { assertAnnotatableTarget } from '../annotation-operations.js';
 
 type CreateAnnotationRequest = components['schemas']['CreateAnnotationRequest'];
 
@@ -18,12 +20,24 @@ type CreateAnnotationRequest = components['schemas']['CreateAnnotationRequest'];
  *
  * This is a deferred-ack pattern: the result event attests that Stower has
  * persisted the annotation, not merely that the command was well-formed.
+ *
+ * ## The annotatability gate (MEDIA-CAPABILITY-DISPATCH D6)
+ *
+ * This is the ONLY write path that checks — deliberately. Every GUI and SDK
+ * caller travels `mark:create-request`; import and replay emit `mark:create`
+ * directly and so never reach here. That topology IS the leniency: restore
+ * keeps working on any stored type without a flag, a bypass parameter, or an
+ * "import mode". Moving this check down to Stower's convergence point would
+ * force exactly that switch.
  */
-export function registerAnnotationAssemblyHandler(eventBus: EventBus, parentLogger: Logger): void {
+export function registerAnnotationAssemblyHandler(eventBus: EventBus, kb: KnowledgeBase, parentLogger: Logger): void {
   const logger = parentLogger.child({ component: 'annotation-assembly' });
   const inflight = new Map<string, { annotationId: string }>();
 
   eventBus.get('mark:create-request').subscribe((command) => {
+    // Async because the gate reads the target's view; the try/catch below
+    // covers the whole body, so nothing escapes as an unhandled rejection.
+    void (async () => {
     const { correlationId, resourceId: resId, request, _userId } = command as Record<string, unknown>;
     const cid = correlationId as string | undefined;
 
@@ -34,6 +48,10 @@ export function registerAnnotationAssemblyHandler(eventBus: EventBus, parentLogg
       if (!cid) {
         throw new Error('correlationId is required on mark:create-request');
       }
+
+      // Refuse BEFORE assembling — an annotation is a durable write against a
+      // coordinate model the system does not have for this type.
+      await assertAnnotatableTarget(kb, resId as string);
 
       const agent = didToAgent(_userId);
       const { annotation } = assembleAnnotation(request as CreateAnnotationRequest, agent);
@@ -61,6 +79,7 @@ export function registerAnnotationAssemblyHandler(eventBus: EventBus, parentLogg
         message: (error as Error).message,
       });
     }
+    })();
   });
 
   eventBus.get('mark:added').subscribe((event) => {

--- a/packages/make-meaning/src/handlers/index.ts
+++ b/packages/make-meaning/src/handlers/index.ts
@@ -39,7 +39,7 @@ export function registerBusHandlers(
   project: SemiontProject,
   logger: Logger,
 ): void {
-  registerAnnotationAssemblyHandler(eventBus, logger);
+  registerAnnotationAssemblyHandler(eventBus, knowledgeSystem.kb, logger);
   registerAnnotationLookupHandlers(eventBus, knowledgeSystem.kb, knowledgeSystem.gatherer, logger);
   registerBindUpdateBodyHandler(eventBus, logger);
   registerJobCommandHandlers(eventBus, jobQueue, project, logger);

--- a/packages/react-ui/src/lib/__tests__/media-shapes.test.ts
+++ b/packages/react-ui/src/lib/__tests__/media-shapes.test.ts
@@ -35,6 +35,27 @@ describe('media-shapes', () => {
       expect(getSupportedShapes('text/markdown')).toEqual([]);
       expect(getSupportedShapes('text/html')).toEqual([]);
     });
+
+    // MEDIA-CAPABILITY-DISPATCH D5: the dispatch asks the registry, never a
+    // string prefix. These six image rows are storage tier — `anchoring:
+    // 'none'`, `render: 'none'` — so they draw nothing, however their type
+    // name begins.
+    it('returns no shapes for storage-tier image types — the registry, not the prefix, decides', () => {
+      for (const t of ['image/gif', 'image/webp', 'image/svg+xml', 'image/bmp', 'image/tiff', 'image/x-icon']) {
+        expect(getSupportedShapes(t)).toEqual([]);
+      }
+    });
+
+    it('returns no shapes on a registry miss — import leniency means stored types need not be members (D2)', () => {
+      expect(getSupportedShapes('image/x-obscure-raster')).toEqual([]);
+      expect(getSupportedShapes('application/x-nonesuch')).toEqual([]);
+    });
+
+    it('reads through media-type parameters', () => {
+      // capabilitiesOf keys off the base type, so the dispatch inherits that.
+      expect(getSupportedShapes('image/png; charset=binary')).toEqual(['rectangle', 'circle', 'polygon']);
+      expect(getSupportedShapes('image/gif; charset=binary')).toEqual([]);
+    });
   });
 
   describe('isShapeSupported', () => {
@@ -65,14 +86,31 @@ describe('media-shapes', () => {
       expect(getSelectorType('application/pdf')).toBe('fragment');
     });
 
-    it('returns svg for images', () => {
+    it('returns svg for spatially-anchored, image-rendered types', () => {
       expect(getSelectorType('image/png')).toBe('svg');
-      expect(getSelectorType('image/svg+xml')).toBe('svg');
+      expect(getSelectorType('image/jpeg')).toBe('svg');
     });
 
     it('returns text for text types', () => {
       expect(getSelectorType('text/plain')).toBe('text');
       expect(getSelectorType('text/html')).toBe('text');
+    });
+
+    // The `image/svg+xml` case previously asserted 'svg' — that pin encoded
+    // the `startsWith('image/')` drift rather than the registry, which gives
+    // every storage-tier image `anchoring: 'none'`. There is no 'none' member
+    // of SelectorType, so they land on the catch-all; harmless, because
+    // getSupportedShapes answers [] for them and the write path refuses (P3).
+    it('does not claim svg for storage-tier image types (D5)', () => {
+      for (const t of ['image/gif', 'image/webp', 'image/svg+xml', 'image/bmp', 'image/tiff', 'image/x-icon']) {
+        expect(getSelectorType(t)).not.toBe('svg');
+        expect(getSelectorType(t)).toBe('text');
+      }
+    });
+
+    it('does not claim svg or fragment on a registry miss (D2)', () => {
+      expect(getSelectorType('image/x-obscure-raster')).toBe('text');
+      expect(getSelectorType('application/x-nonesuch')).toBe('text');
     });
   });
 

--- a/packages/react-ui/src/lib/media-shapes.ts
+++ b/packages/react-ui/src/lib/media-shapes.ts
@@ -18,12 +18,13 @@ export type SelectorType = 'fragment' | 'svg' | 'text';
  * This set is the host-facing CONTRACT for "which shapes can this medium
  * draw" — gate shape UI on it directly.
  *
- * PDF: only rectangles (FragmentSelector with RFC 3778 viewrect).
- * Images: all shapes (SvgSelector supports rect, circle, polygon).
- * Everything else — including text media and absent/unknown types — supports
- * NONE: those anchor by character offsets (TextPositionSelector /
- * TextQuoteSelector), and no selector can carry a shape. Mirrors
- * `getSelectorType`'s 'text' fallback.
+ * The registry's anchoring model decides, never the type name: a spatially
+ * anchored medium draws what its renderer can carry — rectangles only for
+ * PDF (FragmentSelector, RFC 3778 viewrect; circle and polygon would need an
+ * SvgSelector, which loses page context), all three for images (SvgSelector).
+ * Everything else draws nothing — text media anchor by character offsets and
+ * no selector there can carry a shape, and storage-tier rows are not
+ * annotated at all.
  *
  * @param mediaType - MIME type of the resource (e.g., 'application/pdf', 'image/png')
  * @returns Array of supported shape types for annotation
@@ -34,19 +35,16 @@ export function getSupportedShapes(mediaType: string | undefined | null): ShapeT
     return [];
   }
 
-  // PDF only supports rectangles via FragmentSelector (RFC 3778)
-  // Circle and polygon would require SvgSelector, which loses page context
-  if (capabilitiesOf(mediaType)?.render === 'pdf') {
-    return ['rectangle'];
+  const caps = capabilitiesOf(mediaType);
+  if (caps?.anchoring === 'spatial') {
+    if (caps.render === 'pdf') return ['rectangle'];
+    if (caps.render === 'image') return ['rectangle', 'circle', 'polygon'];
   }
 
-  // Images support all shapes via SvgSelector
-  if (mediaType.startsWith('image/')) {
-    return ['rectangle', 'circle', 'polygon'];
-  }
-
-  // Text (and everything else) anchors by character offsets — there is no
-  // selector to carry a shape, so the medium supports none.
+  // Everything else: text anchoring (no selector carries a shape), storage-tier
+  // rows, and registry misses. Stated as a positive whitelist with a catch-all
+  // ON PURPOSE — the negative form (`caps?.anchoring !== 'none'`) answers true
+  // on a miss, and an unregistered type must not be handed drawing tools.
   return [];
 }
 
@@ -65,7 +63,17 @@ export function isShapeSupported(
 }
 
 /**
- * Get the selector type used for a given media type
+ * Get the selector type used for a given media type.
+ *
+ * Keyed off the registry's anchoring model, in step with
+ * `getSupportedShapes`: spatial + PDF render → FragmentSelector (RFC 3778),
+ * spatial + image render → SvgSelector.
+ *
+ * Everything else answers 'text' — text media because they genuinely anchor
+ * by character offset, storage-tier rows and registry misses because
+ * `SelectorType` has no "not annotatable" member. That catch-all is harmless
+ * rather than a claim: `getSupportedShapes` offers those types no shapes, and
+ * the write path refuses them outright (MEDIA-CAPABILITY-DISPATCH D6).
  *
  * @param mediaType - MIME type of the resource
  * @returns Selector type (fragment, svg, or text)
@@ -75,17 +83,12 @@ export function getSelectorType(mediaType: string | undefined | null): SelectorT
     return 'text'; // Default fallback
   }
 
-  // PDF uses FragmentSelector (RFC 3778)
-  if (capabilitiesOf(mediaType)?.render === 'pdf') {
-    return 'fragment';
+  const caps = capabilitiesOf(mediaType);
+  if (caps?.anchoring === 'spatial') {
+    if (caps.render === 'pdf') return 'fragment';
+    if (caps.render === 'image') return 'svg';
   }
 
-  // Images use SvgSelector
-  if (mediaType.startsWith('image/')) {
-    return 'svg';
-  }
-
-  // Text and other formats use TextPositionSelector/TextQuoteSelector
   return 'text';
 }
 


### PR DESCRIPTION
## Why

"Can this resource be annotated?" was asked in four places, answered four different ways, and enforced nowhere.

The media-type registry already curates an `anchoring` capability per type, but almost nothing read it. `media-shapes.ts` answered the question with `mediaType.startsWith('image/')`; `AnnotateView` answered it with *renderability* (correct only by coincidence — the annotatable-and-rendered types happen to be the ones with renderers); and the `mark:create` write path did not ask at all, so an SDK or API caller could annotate a ZIP.

The drift was already visible in the published contract: the registry gives the six storage-tier image types (`gif`, `webp`, `svg+xml`, `bmp`, `tiff`, `x-icon`) `anchoring: 'none'` and `render: 'none'`, yet `getSupportedShapes('image/gif')` answered `['rectangle','circle','polygon']`. Inside the app the renderer gate contained it; the exported function — documented as "the host-facing CONTRACT" — was simply wrong.

## What changed

**`@semiont/core` — model the capability once.** `isAnnotatable(format)` derives from `anchoring !== 'none'`. Deliberately *not* a parallel `annotatable: boolean` row field: two facts that can disagree, with nothing to adjudicate `{ annotatable: true, anchoring: 'none' }`. `anchoring` stays the single source of truth for *how*; `isAnnotatable` answers *whether*.

A registry miss answers `false`, written as its own conjunct rather than `?.anchoring !== 'none'` — the optional-chain form answers `true` for unknown types and inverts the intent. That strictness is deliberately asymmetric with `textExtractionOf`, which is lenient on a miss; each is right for its own question, and a test pins the two postures on adjacent lines so a later "harmonization" fails with an explanation attached.

Three invariants are pinned (all held on arrival — they are regression pins, not discoveries): `authorable → annotatable`, `generatable → annotatable`, and `annotatable → render !== 'none'`.

**`@semiont/react-ui` — the dispatch asks the registry.** `getSupportedShapes` / `getSelectorType` now key off `anchoring`, then `render` (`spatial`+`pdf` → FragmentSelector, rectangle only; `spatial`+`image` → SvgSelector, all three shapes; everything else → no shapes). Both `startsWith('image/')` branches are deleted rather than supplemented.

Worth a reviewer's attention: **a pre-existing test was asserting the bug.** `media-shapes.test.ts` pinned `getSelectorType('image/svg+xml') === 'svg'`, but `image/svg+xml` is a storage-tier row — that test had frozen the prefix drift as though it were the contract. It is replaced with the registry answer, with the reason recorded inline. Scope was widened from the one example type to all six storage-tier image rows, plus a pin that `image/png; charset=binary` behaves as `image/png` (the dispatch now inherits parameter handling from `capabilitiesOf` instead of relying on the prefix test's accidental equivalent).

**`@semiont/make-meaning` — the write path refuses.** The `mark:create-request` handler resolves the target's media type and refuses before assembling, emitting `mark:create-failed` with a message naming the type. The refusal lives in one exported function, `assertAnnotatableTarget`, shared by the handler and the `AnnotationOperations` facade — one registry fact, one refusal built on it. A missing media type, a storage-tier row, and a registry miss all take the same branch, and the message says what cannot be done rather than making a claim the registry cannot make about a type it has never seen.

**Import and replay stay lenient by construction — no flag, no bypass parameter, no "import mode."** Those paths emit `mark:create` directly and never traverse the interactive handler, so gating the interactive path leaves restore untouched. A test pins exactly this, and it exists to fire if a later change ever moves the gate down to Stower's convergence point, which *would* require the compatibility switch this design avoids.

**The `AnnotationOperations` facade is gated, not deleted.** Tracing it turned up an orphan rather than a live API: it was moved in from the backend (#430), superseded by the bus-command path (#481), then carried through three later refactors with no production callers. Gating closes a published door nobody currently walks through, which is cheaper than removing an export and safer than leaving an ungated writer beside a gated one. `createAnnotation` gained a `kb` parameter; 20 call sites across four test files were threaded.

## Behavior changes

- **Published react-ui contract:** hosts gating shape UI on `getSupportedShapes` will correctly stop offering shapes for the six storage-tier image types. This is the fix, not a side effect — worth a release note.
- **Interactive annotation of a storage-tier resource now fails** where it previously succeeded. Create-time only: existing annotations are untouched, there is no migration and no read-path filter.
- **Unregistered imported types** embed and search but cannot be annotated — the consequence of the strict-on-miss choice above, and the second population the refusal message had to read sanely for.

## Verification

Containerized (`node:24-alpine`), per package:

- **core** — `tsc --noEmit` clean; `media-types.test.ts` 44/44; full core build, then the built `dist/index.d.ts` confirmed to declare `isAnnotatable` and export it from the barrel (checked, not assumed).
- **react-ui** — `tsc --noEmit` clean; media-shapes 24/24; annotation suites 91/91; resource-surface suites 580/580 across 45 files.
- **make-meaning** — `tsc --noEmit` clean; full suite 46 files, 543 passed / 1 expected fail (up from 45/539 — the four new cases). All four REDs were watched failing for the right reason before the change, including the positive case.
