### PR TITLE
Open the Knowledge Base panel when signed out instead of restoring the previously opened panel

### DIFF
--- a/apps/browser/src/app/[locale]/know/__tests__/signed-out-opens-kb-panel.test.tsx
+++ b/apps/browser/src/app/[locale]/know/__tests__/signed-out-opens-kb-panel.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Signed out, the empty state says "Sign in using the Knowledge Base panel" —
+ * so that panel has to be the one that is open. It was not: `activeToolbarPanel`
+ * persists across sessions, so anyone whose last panel was Account came back to
+ * a dead end reading "Sign in to a knowledge base to view your account", while
+ * the main area pointed at a panel the app had not opened.
+ *
+ * `user` is the only auth-requiring panel (ToolbarPanels renders a signed-out
+ * fallback for it and nothing else), so the redirect is narrow: Settings still
+ * works signed out — theme, locale and line numbers are exactly what you can
+ * change without a session — and must NOT be hijacked.
+ *
+ * A real `SemiontBrowser` goes through `SemiontProvider` rather than a faked
+ * `useSemiont`: `useShellStateUnit` resolves from react-ui's dist bundle, whose
+ * internal `useSemiont` call a package-level mock cannot rewire. It also keeps
+ * the real bus, which this depends on — `openPanel` EMITS `panel:open` and the
+ * ShellStateUnit listens for it, so a stubbed bus would leave the fix inert here
+ * while working in the app.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { SemiontProvider, ThemeProvider, WebBrowserStorage } from '@semiont/react-ui';
+import { SemiontBrowser, createHttpSessionFactory } from '@semiont/sdk';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+/** Records the panel the layout hands to the toolbar on each render. */
+const seen: (string | null)[] = [];
+vi.mock('@/components/toolbar/ToolbarPanels', () => ({
+  ToolbarPanels: ({ activePanel }: { activePanel: string | null }) => {
+    seen.push(activePanel);
+    return null;
+  },
+}));
+
+vi.mock('@/components/knowledge/KnowledgeSidebarWrapper', () => ({ KnowledgeSidebarWrapper: () => null }));
+vi.mock('@/components/CookiePreferences', () => ({ CookiePreferences: () => null }));
+vi.mock('@/lib/routing', () => ({
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+  routes: {},
+}));
+
+vi.mock('@semiont/react-ui', async () => {
+  const actual = await vi.importActual<typeof import('@semiont/react-ui')>('@semiont/react-ui');
+  return { ...actual, Toolbar: () => null, Footer: () => null };
+});
+
+import KnowledgeLayout from '../layout';
+
+function renderSignedOut() {
+  const browser = new SemiontBrowser({
+    storage: new WebBrowserStorage(),
+    sessionFactory: createHttpSessionFactory(),
+  });
+  return render(
+    <SemiontProvider browser={browser}>
+      <ThemeProvider>
+        <KnowledgeLayout />
+      </ThemeProvider>
+    </SemiontProvider>,
+  );
+}
+
+describe('signed-out knowledge layout: which panel is open', () => {
+  beforeEach(() => {
+    seen.length = 0;
+    // No KBs, no session: a fresh browser is signed out by construction.
+    localStorage.clear();
+  });
+
+  it('opens the Knowledge Base panel when the persisted panel is the signed-out dead end', () => {
+    localStorage.setItem('activeToolbarPanel', 'user');
+
+    renderSignedOut();
+
+    expect(seen.at(-1)).toBe('knowledge-base');
+  });
+
+  it('leaves Settings alone — it works without a session', () => {
+    localStorage.setItem('activeToolbarPanel', 'settings');
+
+    renderSignedOut();
+
+    expect(seen.at(-1)).toBe('settings');
+  });
+});

--- a/apps/browser/src/app/[locale]/know/layout.tsx
+++ b/apps/browser/src/app/[locale]/know/layout.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { KnowledgeSidebarWrapper } from '@/components/knowledge/KnowledgeSidebarWrapper';
@@ -81,6 +81,21 @@ function UnauthenticatedKnowledgeLayout({ t, keyboardContext }: { t: (key: strin
   const browseStateUnit = useShellStateUnit();
   const activePanel = useObservable(browseStateUnit.activePanel$) ?? null;
   const { theme } = useTheme();
+
+  // The Account panel needs a session. Restored from a previous signed-in visit it
+  // is a dead end — "Sign in to a knowledge base to view your account" — while the
+  // empty state beside it says to sign in using the Knowledge Base panel. Open the
+  // panel we are pointing at. Decided once, not reactively: a deliberate click on
+  // Account while signed out should still show its message, not snap away.
+  const panelCorrected = useRef(false);
+  useEffect(() => {
+    // useObservable yields null on the first render, before the BehaviorSubject's
+    // current value arrives. Spending the one-shot on that null would let the
+    // restored panel through on the render that actually carries it.
+    if (panelCorrected.current || activePanel === null) return;
+    panelCorrected.current = true;
+    if (activePanel === 'user') browseStateUnit.openPanel('knowledge-base');
+  }, [activePanel, browseStateUnit]);
 
   return (
     <div className="h-screen semiont-knowledge-layout semiont-layout-with-footer flex flex-col overflow-hidden">


### PR DESCRIPTION
Open the Knowledge Base panel when signed out instead of restoring the previously open panel
