### PR TITLE
Abandoned inference: abort in-flight calls, checkpointed resume, failure classes, duration-derived budgets

### DIFF
--- a/apps/archivist/README.md
+++ b/apps/archivist/README.md
@@ -3,8 +3,8 @@
 **The service that keeps the system of record.**
 
 The event log is Semiont's system of record; everything else — views, graph, vectors — is a
-projection of it. The Archivist is the service that accessions that record, serves it, and
-owns the files it lives in.
+projection of it. The Archivist accessions that record, serves it, and is **the only process
+that touches the knowledge base tree**. Every other service reaches it over the wire.
 
 | | |
 | --- | --- |
@@ -18,46 +18,68 @@ owns the files it lives in.
 
 Three actors, and they move together on purpose:
 
-- **Stower** — accessions the record: appends events and maintains the projections derived
-  from them. The **only** caller that appends events.
+- **Stower** — accessions the record: appends events and maintains the projections derived from
+  them. The **only** caller that appends events.
 - **Browser** — serves it: answers every `browse:*` read from those projections and the graph.
-- **CloneTokenManager** — handles the items themselves, in the content store.
+- **CloneTokenManager** — validates clone tokens so a copy inherits its source's metadata.
+  Byte-free: it resolves storage URIs, never content.
 
-Plus the annotation-assembly handler, the entity-type bootstrap, and the startup view rebuild.
+Plus the annotation-assembly and annotation-context handlers, the entity-type bootstrap, and the
+startup view rebuild — this is the one rebuild owner.
 
-**Why these three cannot be split.** Stower writes the events and projections that Browser
-reads; separating them would open a cross-process read-after-write window over the same
-state. And git is single-writer — the working-tree store shells out to `git add`/`git mv`,
-so two processes writing one index means `index.lock` contention, a hard failure rather than
-a retry. The Archivist owns the tree; every other writer passes `noGit: true`.
+**Why these cannot be split.** Stower writes the events and projections Browser reads;
+separating them opens a cross-process read-after-write window over the same state. And git is
+single-writer — the working-tree store shells out to `git add`/`git mv`, so two processes on one
+index means `index.lock` contention, a hard failure rather than a retry. The Archivist owns the
+tree; every other writer passes `noGit: true`.
 
 ## What it owns on disk
 
-**It is the only service that mounts the knowledge base.** `/kb` is the working tree
-(`SEMIONT_ROOT=/kb`), and it owns the XDG state tree where the event log and materialized
-views live. Anchored text (`/anchored-text`) it reads **read-only** — the Smelter writes that.
+**It is the only container that mounts the knowledge base** — pinned by
+`TestExactlyOneContainerMountsTheKB` in the launcher, not merely intended. `/kb` is the working
+tree (`SEMIONT_ROOT`), and it owns the XDG state tree holding the event log and materialized
+views. Anchored text (`/anchored-text`) it mounts **read-only** — the Smelter writes that.
 
-Because it holds the bytes, its HTTP surface is how they travel: the gateway proxies external
-content requests through it, and internal readers dial it directly.
+## Its two surfaces
 
-## What it talks to
+**The bus** — it subscribes over SSE and emits through `POST /bus/emit`, like every other
+participant. Persisted events ride out as ordinary facts (twice: global and resource-scoped),
+not through a private ingest route. See [EVENT-BUS.md](../../docs/protocol/EVENT-BUS.md).
 
-The bus (SSE in, `POST /bus/emit` out), Neo4j for one query (`browse:referenced-by`), and an
-embedding provider for Browser's semantic-search fallback.
+**HTTP** — because it holds the bytes and the record, this is how both travel:
 
-**Its facts ride the ordinary bus.** Persisted events are emitted through `/bus/emit` like
-every other participant — twice per fact, global and resource-scoped — rather than through a
-private ingest route. See [EVENT-BUS.md](../../docs/protocol/EVENT-BUS.md).
+| | |
+| --- | --- |
+| `GET /health` | liveness; the only unauthenticated path |
+| `GET /kb/branch` | which line of work this knowledge base is on |
+| `GET /events/:resourceId?fromSequence=N` | sequence-ranged replay — backs the gateway's SSE resume |
+| `GET /resources/:id/content` | a representation's bytes, streamed, with its stored media type |
+| `PUT /content/:storageUri` | accept bytes, streamed and checksum-verified before they land |
 
-## Resume replay
+Everything but `/health` authenticates with `SEMIONT_WORKER_SECRET`. With no secret configured
+those paths return 503 — absence fails loudly; it is never served open.
 
-`/bus/subscribe`'s `Last-Event-ID` replay reads the event log **from here**, over
-`host:port` plus the worker secret. If that fetch fails, the gateway degrades to a scoped
-`bus:resume-gap` rather than silently serving nothing.
+**⚠️ Standing rule: this surface serves the KB tree, and nothing else.** `browse:*`, `match:*`
+and `gather:*` stay on the bus. An endpoint that is not a KB-tree read or write does not belong
+here.
+
+The gateway proxies external content requests through these; internal readers (Smelter,
+Librarian, Worker) dial them directly via `archivistContentReads`.
+
+## Running it
+
+Mount the KB at `/kb` and the shared state and anchored-text directories at their declared
+paths; the image fixes the container-side paths so the launcher passes no path env. Set
+`SEMIONT_WORKER_SECRET` — it authenticates to the gateway with it and requires it on its own
+surface. `SEMIONT_SKIP_REBUILD=true` skips the startup view rebuild.
+
+Start it **after the gateway** (it mints an agent token there) and **before the sidecars** (they
+dial it). Its `/health` answers only once the actors and bus pumps are up, which is what makes
+that ordering enforceable.
 
 ## Related
 
 - [`@semiont/make-meaning`](../../packages/make-meaning/) — the actors and this entry point
-- [Librarian](../librarian/) — the deliberate pair: the Archivist holds the record and
-  answers *"what is there?"*; the Librarian searches it and answers *"what is relevant?"*
+- [Librarian](../librarian/) — the deliberate pair: the Archivist holds the record and answers
+  *"what is there?"*; the Librarian searches it and answers *"what is relevant?"*
 - [Knowledge System](../../docs/system/KNOWLEDGE-SYSTEM.md) — the event-store architecture

--- a/apps/browser/README.md
+++ b/apps/browser/README.md
@@ -1,303 +1,96 @@
 # Semiont Browser
 
-A type-safe React SPA built with Vite + React Router, featuring W3C Web Annotation support, real-time document collaboration, and AI-powered annotation detection and generation.
-
-## Overview
-
-The Semiont browser provides a rich annotation experience for building semantic knowledge graphs. Users can annotate documents with highlights, entity tags, and document links - all following the W3C Web Annotation Data Model for full interoperability.
-
-**Key Features**:
-- W3C Web Annotation compliance
-- Multi-format document support (text, markdown, images, PDFs)
-- Text-based annotations for text/markdown documents
-- Spatial annotations for images and PDFs
-- AI-powered annotation detection for text (asynchronous)
-- AI-powered document generation (asynchronous)
-- Type-safe API integration with `@semiont/http-transport`
-- Real-time progress tracking via Server-Sent Events (SSE)
-
-## npm Package
-
 [![npm version](https://img.shields.io/npm/v/@semiont/browser.svg)](https://www.npmjs.com/package/@semiont/browser)
-[![npm downloads](https://img.shields.io/npm/dm/@semiont/browser.svg)](https://www.npmjs.com/package/@semiont/browser)
+[![ghcr](https://img.shields.io/badge/ghcr-semiont--browser-blue)](https://github.com/The-AI-Alliance/semiont/pkgs/container/semiont-browser)
 
-The Browser is published as `@semiont/browser` on npm as a pre-built Vite SPA with a minimal Node.js static file server. It also ships as the `semiont-browser` container image, which is how a stack actually serves it — the launcher runs that image, and `server.js` serves the pre-built SPA inside it.
+The human entry point to Semiont: a React single-page app for browsing, annotating, and
+generating resources in a knowledge base.
 
-## Quick Start
+It is a client and nothing more. It stores no data, owns no schema, and has no backend of its
+own — everything it displays comes from a knowledge base it has connected to. In a running
+stack it is a container: the launcher starts `semiont-browser`, which serves the pre-built SPA
+on port 3000.
 
-### Using the `semiont` launcher (recommended)
+## What this app owns
+
+The shell, and little else — routes, locale, providers, page assembly, and the few components
+that make sense nowhere else (navigation, toolbar wiring, cookie preferences).
+
+| | |
+|---|---|
+| `@semiont/react-ui` | the annotation UI itself — components, panels, state units |
+| `@semiont/sdk` | every knowledge-base operation |
+| this app | routes, i18n, providers, page assembly |
+
+The boundary is real, not aspirational: this app is a fraction the size of `react-ui`, and
+contains **no `fetch` calls at all**. The browser never reaches an API directly; it goes
+through the SDK.
+
+Route surfaces are `know/` (browse, annotate, compose, generate), `admin/`, `moderate/`,
+`auth/`, and the static `about`, `privacy` and `terms` pages.
+
+## Knowledge bases are a runtime choice
+
+The browser is not built against a backend. It holds a registry of knowledge bases and
+activates one at a time, with its own session and its own sign-in per knowledge base. Adding
+one is something a person does in the Knowledge Base panel, not something an operator
+configures.
+
+`server.js` also serves `/discovery/*` from a read-only directory the launcher mounts, so the
+app can offer the knowledge bases already running on the machine. That prefix returns its file
+or a 404 and never falls back to `index.html` — a 200 carrying the SPA would be
+indistinguishable from data.
+
+## How it ships
+
+One build, three consumers:
+
+- **Container** — `semiont-browser`, the usual case. Entrypoint `node server.js`; npm is
+  removed from the runtime image.
+- **npm** — `@semiont/browser`: the built `dist/` plus `server.js`, with no runtime
+  dependencies.
+- **Desktop** — `apps/desktop` uses this app's `dist/` as its Tauri frontend.
+
+`server.js` is a static file server: files out of `dist/`, SPA fallback to `index.html` for
+non-file routes, directory-traversal guards on both paths, and the `/discovery` prefix above.
+
+## Configuration
+
+Almost none, deliberately.
+
+| | | |
+|---|---|---|
+| `PORT` | runtime | port `server.js` listens on (default `3000`) |
+| `/discovery` | runtime | read-only mount for the launcher's KB discovery document |
+| `VITE_OTEL_OTLP_ENDPOINT` | build time | OTLP endpoint, baked into the bundle |
+
+`VITE_` values are compile-time substitutions. Changing one needs a rebuild, not a restart.
+
+## Development
 
 ```bash
-# From inside a knowledge-base repo — start everything
-semiont start
-
-# Your services are now running:
-# - Browser: http://localhost:3000
-# - Gateway: http://localhost:4000
-# - Database: PostgreSQL in Docker container
+npm run dev          # Vite dev server (expects a gateway)
+npm run dev:mock     # ...against a mock API instead
+npm run build        # typecheck, then vite build
+npm run typecheck    # tsc --noEmit
+npm test             # vitest
+npm run test:a11y    # accessibility suite
 ```
 
-### Manual Setup
-
-```bash
-# Install dependencies
-npm install
-
-# Start development server (requires gateway running)
-npm run dev
-
-# Start with mock API (no gateway required)
-npm run dev:mock
-```
-
-**See**: [Development Guide](./docs/DEVELOPMENT.md) for complete setup and workflows.
-
-## 🐳 Container Image
-
-[![ghcr](https://img.shields.io/badge/ghcr-latest-blue)](https://github.com/The-AI-Alliance/semiont/pkgs/container/semiont-browser)
-[![Accessibility Tests](https://github.com/The-AI-Alliance/semiont/actions/workflows/accessibility-tests.yml/badge.svg)](https://github.com/The-AI-Alliance/semiont/actions/workflows/accessibility-tests.yml)
-[![WCAG 2.1 AA](https://img.shields.io/badge/WCAG-2.1%20AA-blue.svg)](https://www.w3.org/WAI/WCAG2AA-Conformance)
-
-Pull and run the published Browser container image:
-
-```bash
-# Pull latest development build
-docker pull ghcr.io/the-ai-alliance/semiont-browser:dev
-
-# Run Browser container
-docker run -d \
-  -p 3000:3000 \
-  --name semiont-browser \
-  ghcr.io/the-ai-alliance/semiont-browser:dev
-```
-
-**Multi-platform Support:** linux/amd64, linux/arm64
-
-**Docker Compose Example:** See [docs/system/administration/IMAGES.md](../../docs/system/administration/IMAGES.md#docker-compose-example) for complete setup with gateway and database.
-
-## Technology Stack
-
-- **Framework**: [Vite](https://vitejs.dev/) + [React Router v7](https://reactrouter.com/)
-- **UI**: React 18 with TypeScript
-- **Styling**: [Tailwind CSS](https://tailwindcss.com/)
-- **i18n**: [i18next](https://www.i18next.com/) + react-i18next
-- **State Management**: [TanStack Query](https://tanstack.com/query) (React Query)
-- **API Client**: Type-safe client generated from OpenAPI spec
-- **Testing**: [Vitest](https://vitest.dev/) + React Testing Library + [MSW v2](https://mswjs.io/)
-- **Performance**: Bundle analysis
-
-**Full stack details**: [Browser Architecture](./docs/ARCHITECTURE.md)
-
-### Component Library
-
-The browser uses **[@semiont/react-ui](../../packages/react-ui)** - a framework-agnostic React component library providing:
-
-- **Authentication Components**: SignInForm, SignUpForm, AuthErrorDisplay, WelcomePage
-- **Layout Components**: PageLayout, UnifiedHeader, LeftSidebar, Footer
-- **Resource Components**: ResourceViewer, BrowseView, AnnotateView
-- **Format-Specific Viewers**: PdfViewer, PdfAnnotationCanvas for PDF documents
-- **Annotation Components**: Annotation panels, toolbars, and widgets
-- **React Query Hooks**: Type-safe API integration hooks
-- **Built-in Translations**: English and Spanish included with dynamic loading
-
-The library is framework-independent, accepting framework-specific implementations (like Link components) as props. This allows the same components to work with Vite, or any React framework.
-
-### Internationalization
-
-The browser supports multiple languages through a hybrid approach:
-
-- **Browser-specific translations**: `apps/browser/messages-source/*.json` (source of truth)
-- **Component translations**: `packages/react-ui/translations/*.json` (source of truth)
-- **Generated output**: `scripts/merge-translations.js` merges both into `messages/` and `public/messages/` before every build/test/dev run
-- **Dynamic loading**: Non-English locales are loaded on-demand via `i18next-http-backend`
-
-Current supported languages:
-- English (en)
-- Spanish (es)
-- 27+ additional languages (partial coverage)
-
-**See**: [@semiont/react-ui documentation](../../packages/react-ui/README.md)
-
-## Project Structure
-
-```
-src/
-├── App.tsx             # React Router route tree
-├── main.tsx            # Entry point
-├── app/[locale]/       # Locale-prefixed page components
-│   ├── auth/          # Authentication pages
-│   ├── know/          # Document management pages
-│   ├── moderate/      # Moderation pages
-│   └── admin/         # Admin pages
-├── components/         # Reusable UI components
-├── hooks/             # Custom React hooks
-├── i18n/              # i18next config and routing wrappers
-├── lib/               # Core utilities
-├── mocks/             # MSW mock handlers
-└── types/             # TypeScript type definitions
-```
-
-## Core Features
-
-### Document Management
-- Create, search, and view markdown documents
-- Wiki-style links (`[[page name]]`) for internal navigation
-- Full-text search with real-time results
-- Document archiving and cloning
-
-**See**: [Features Guide](../../docs/browser/FEATURES.md)
-
-### W3C Web Annotations
-- **Highlights**: Mark important text passages
-- **Document References**: Link text to other documents (citation, definition, elaboration, etc.)
-- **Entity Tags**: Tag text with entity types (Person, Organization, Location, etc.)
-- **Multi-body support**: Combine entity tags and document links in one annotation
-- **JSON-LD export**: Full W3C compliance for data portability
-
-**See**: [Annotations Guide](./docs/ANNOTATIONS.md), [API Integration Guide](./docs/API-INTEGRATION.md#w3c-web-annotation-model)
-
-### Asynchronous AI Features
-
-Some operations run asynchronously via background job workers:
-
-**Annotation Detection** - Detect annotations in documents using AI:
-- Multiple detection types: highlights, assessments, comments, tags, entity references
-- Real-time progress via SSE
-- Automatic annotation creation
-
-**Document Generation** - AI-generated documents from annotations:
-- Generate document based on annotation context
-- Real-time progress via SSE
-- Automatic document linking
-
-**See**: [API Integration Guide](./docs/API-INTEGRATION.md#asynchronous-operations) for implementation details.
+Translations are generated. `messages-source/` holds this app's strings;
+`scripts/merge-translations.js` merges them with `@semiont/react-ui`'s on the `pre*` hooks and
+writes `messages/` (untracked) and `public/messages/`. Edit `messages-source/`, never
+`messages/`.
 
 ## Documentation
 
-### Getting Started
-- **[Local Setup](../../docs/browser/LOCAL.md)** - Run the browser locally (container, npm, or desktop app)
-- **[Development Guide](./docs/DEVELOPMENT.md)** - Local development, CLI usage, common tasks, debugging
-- **[Testing Guide](./docs/TESTING.md)** - Test structure, running tests, writing tests
-- **[Deployment Guide](./docs/DEPLOYMENT.md)** - Publishing and deployment workflows
+[Architecture](./docs/ARCHITECTURE.md) ·
+[Development](./docs/DEVELOPMENT.md) ·
+[Container](./docs/CONTAINER.md) ·
+[Deployment](./docs/DEPLOYMENT.md) ·
+[Testing](./docs/TESTING.md) ·
+[Authentication](./docs/AUTHENTICATION.md) ·
+[Internationalization](./docs/INTERNATIONALIZATION.md) ·
+[Accessibility](./docs/ACCESSIBILITY.md)
 
-### Architecture & Design
-- **[Browser Architecture](./docs/ARCHITECTURE.md)** - High-level system design, state management, routing
-- **[Rendering Architecture](../../packages/react-ui/docs/RENDERING-ARCHITECTURE.md)** - Document rendering pipeline
-- **[API Integration](./docs/API-INTEGRATION.md)** - API client usage, async operations, W3C annotations
-
-### Features & UI
-- **[Features](../../docs/browser/FEATURES.md)** - Document management, annotations, search, AI features
-- **[Annotations](./docs/ANNOTATIONS.md)** - W3C annotation system and UI components
-- **[Style Guide](./docs/style-guide.md)** - UI/UX patterns and component guidelines
-
-### Security & Auth
-- **[Authentication](./docs/AUTHENTICATION.md)** - OAuth, JWT, session management, 401 handling
-- **[Authorization](./docs/AUTHORIZATION.md)** - Permission system, 403 error handling
-
-### Performance & Accessibility
-- **[Performance Optimization](./docs/PERFORMANCE.md)** - Bundle optimization, monitoring
-- **[Accessibility](./docs/ACCESSIBILITY.md)** - Implementation patterns, ARIA, focus management, automated testing (user-facing claim: [docs/browser/ACCESSIBILITY.md](../../docs/browser/ACCESSIBILITY.md))
-- **[Keyboard Navigation](./docs/KEYBOARD-NAV.md)** - Implementation: hooks, focus traps, roving tabindex (user-facing reference: [docs/browser/KEYBOARD-NAV.md](../../docs/browser/KEYBOARD-NAV.md))
-
-### Specialized Topics
-- **[CodeMirror Integration](../../packages/react-ui/docs/CODEMIRROR-INTEGRATION.md)** - Editor implementation details
-- **[CodeMirror Widgets](../../packages/react-ui/docs/CODEMIRROR-WIDGETS.md)** - Custom editor widgets
-- **[Annotation Rendering](../../packages/react-ui/docs/ANNOTATION-RENDERING-PRINCIPLES.md)** - Annotation rendering principles
-- **[Adding Languages](./docs/ADDING-LANGUAGE.md)** - Internationalization
-- **[Archive & Clone](./docs/ARCHIVE-CLONE.md)** - Document archiving and cloning
-- **[Future Implementations](./docs/FUTURE.md)** - Mobile apps, browser extensions, desktop apps, integrations
-
-## Common Commands
-
-From `apps/browser/`:
-
-```bash
-# Development
-npm run dev              # Vite dev server
-npm run dev:mock         # Against a mock API (no gateway needed)
-npm run dev:fast         # Skip the prebuild typecheck
-npm run build            # Production build (typechecks first)
-
-# Testing
-npm test                 # Everything
-npm run test:unit        # Excludes integration
-npm run test:integration # Integration only
-npm run test:security    # Admin page/layout + validation
-npm run test:a11y        # Accessibility assertions
-npm run test:coverage    # With an HTML report in coverage/
-npm run test:watch       # Watch mode
-
-# Types
-npm run typecheck        # tsc --noEmit
-npm run typecheck:all    # Source + test tsconfigs
-```
-
-Running the whole stack is the launcher's job, not npm's:
-
-```bash
-semiont start                       # Bring the stack up
-semiont status                      # Container state + per-service health
-semiont start --service browser    # Restart just this service
-semiont logs --service browser
-```
-
-**See**: [Development Guide](./docs/DEVELOPMENT.md) and
-[docs/development/TESTING.md](../../docs/development/TESTING.md).
-
-## Contributing
-
-We welcome contributions! Please read:
-
-1. **[Development Guide](./docs/DEVELOPMENT.md)** - Setting up local environment
-2. **[Testing Guide](./docs/TESTING.md)** - Writing and running tests
-3. **[Style Guide](./docs/style-guide.md)** - UI/UX patterns
-
-**Key Requirements**:
-- **Functional, side-effect free code is strongly preferred**
-- TypeScript must compile without errors (strict mode)
-- All tests must pass
-- Include tests for new functionality
-- Follow existing patterns in the codebase
-
-### Code Style
-
-- Use functional components with hooks
-- Avoid class components and mutations
-- Prefer pure functions
-- Use descriptive component and variable names
-- No unnecessary comments - code should be self-documenting
-
-### Pull Request Requirements
-
-- Tests must pass (all test suites)
-- TypeScript must compile without errors (strict mode)
-- Follow functional programming principles
-- Include tests for new components
-- Update documentation if UI changes significantly
-- Check bundle size impact with `npm run analyze`
-
-## Quick Links
-
-### System Documentation
-- [System Documentation](../../docs/system/README.md) - Overall platform architecture
-- [W3C Web Annotation](../../docs/protocol/W3C-WEB-ANNOTATION.md) - Annotation data flow across all layers
-- [Jobs Package](../../packages/jobs/) - Background job processing (async operations)
-
-### Other Services
-- [Gateway README](../gateway/README.md) - Gateway API server
-- [MCP Server README](../../packages/mcp-server/README.md) - AI integration via Model Context Protocol
-- [API Client README](../../packages/http-transport/README.md) - Type-safe TypeScript client
-- [Launcher README](../launcher/README.md) - The host-installed `semiont` command
-
-### External Resources
-- [Vite Documentation](https://vitejs.dev/)
-- [React Router v7 Documentation](https://reactrouter.com/)
-- [i18next Documentation](https://www.i18next.com/)
-- [TanStack Query Documentation](https://tanstack.com/query)
-- [Tailwind CSS Documentation](https://tailwindcss.com/docs)
-- [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/)
-
----
-
-**Last Updated**: 2026-03-29
-**For Help**: See [Documentation](./docs/) or file an issue
+The full set is in [`docs/`](./docs/).

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,8 +1,8 @@
 # Semiont Desktop
 
-Native desktop application wrapping the Semiont browser SPA using [Tauri](https://tauri.app/). It bundles the same UI as the container image with a thin native shell, so there's no container runtime to install and no local network permission to grant.
+An installable native build of the Semiont browser UI. A thin [Tauri](https://tauri.app/) shell wraps the same SPA that runs in the web build — a native window and menu around the compiled UI — so Semiont launches from the OS like any other app, no browser tab required.
 
-You still need a knowledge base gateway running somewhere — point the app at it the same way you would the browser version.
+The desktop build ships only the UI. It holds no data and no application logic: like the web build, it talks to a knowledge base **gateway** over HTTP, which you point it at on first launch.
 
 ## Install
 
@@ -10,21 +10,19 @@ Download the latest build for your platform from the [Releases page](https://git
 
 ### macOS
 
-The macOS DMGs are not signed with an Apple Developer ID, so Gatekeeper quarantines them on download. Before opening the DMG, strip the quarantine attribute:
+DMGs are published for both Apple Silicon (`aarch64`) and Intel (`x86_64`). They are not signed with an Apple Developer ID, so Gatekeeper quarantines them on download. Strip the quarantine attribute before opening:
 
 ```bash
 xattr -cr ~/Downloads/Semiont_*.dmg
 ```
 
-Then open the DMG normally and drag Semiont.app to Applications. Without this step you'll see "Semiont is damaged and can't be opened" — that's Gatekeeper, not actual damage.
-
-Builds are published for both Apple Silicon (`aarch64`) and Intel (`x86_64`) Macs.
+Then open the DMG and drag Semiont.app to Applications. Without this step you'll see "Semiont is damaged and can't be opened" — that's Gatekeeper, not actual damage.
 
 ### Linux
 
-Two artifacts are published for x86_64:
+Two x86_64 artifacts are published:
 
-- **`.deb`** — for Debian, Ubuntu, and derivatives:
+- **`.deb`** — Debian, Ubuntu, and derivatives:
   ```bash
   sudo apt install ./Semiont_*_amd64.deb
   ```
@@ -36,69 +34,63 @@ Two artifacts are published for x86_64:
 
 ## Connecting to a gateway
 
-On first launch, enter the gateway host and port (e.g. `localhost:4000`) in the Knowledge Bases panel. The app talks to the gateway over plain HTTP — same as the browser version — so any gateway reachable from your machine works.
+On first launch, enter the gateway host and port (e.g. `localhost:4000`) in the Knowledge Bases panel. The app talks to the gateway over plain HTTP, so any gateway reachable from your machine works.
 
 ## Building from source
 
-The rest of this document covers developing and building the desktop app from source. Most users only need the [Install](#install) section above.
+Most users only need the installers above. To build locally:
 
 ### Prerequisites
 
-For local development (without containers):
-- [Rust](https://rustup.rs/)
+- [Rust](https://rustup.rs/) and the Tauri CLI (`cargo install tauri-cli`)
 - Xcode Command Line Tools (macOS)
-- Tauri CLI: `cargo install tauri-cli`
+- Or, for the containerized path: just a container runtime (Apple Container, Docker, or Podman)
 
-For containerized builds: just a container runtime (Apple Container, Docker, or Podman).
+### Develop
 
-### Development
-
-Start the Browser dev server in one terminal, then the desktop shell in another:
+Run the browser dev server, then open the desktop shell against it:
 
 ```bash
-# Terminal 1: Browser
+# Terminal 1: browser UI
 cd apps/browser && npm run dev
 
-# Terminal 2: desktop
+# Terminal 2: desktop shell
 cd apps/desktop && cargo tauri dev
 ```
 
-The desktop app opens a native window pointing at the Vite dev server.
-Hot reload works — changes to the browser are reflected immediately.
+The window points at the Vite dev server, so hot reload works.
 
 ### Build
 
-#### Containerized (no Rust on host)
+The bundler emits installers for the platform it runs on:
 
-```bash
-apps/desktop/build.sh
-```
+- **macOS** (Rust on host) → `.dmg`
+  ```bash
+  npm run build -w semiont-browser
+  cd apps/desktop && cargo tauri build
+  # → src-tauri/target/release/bundle/dmg/Semiont_x.y.z_aarch64.dmg
+  ```
+- **Linux** → `.deb` and `.AppImage`, from the same two commands on a Linux host, or without Rust via the containerized build:
+  ```bash
+  apps/desktop/build.sh
+  # → src-tauri/target/release/bundle/{deb,appimage}/
+  ```
 
-#### Local (Rust required)
-
-```bash
-cd apps/browser && npm run build
-cd apps/desktop && cargo tauri build
-```
-
-Output: `src-tauri/target/release/bundle/dmg/Semiont_x.y.z_aarch64.dmg`
+Official multi-platform builds — both Mac architectures and Linux — come from CI and land on the Releases page.
 
 ## Architecture
 
-The desktop app is a thin native shell around `apps/browser/dist/`. No browser
-code lives here — this directory only contains the Tauri configuration, Rust entry
-point, and build scripts.
+A thin native shell around `apps/browser/dist/`. No UI code lives here — only the Tauri configuration, the Rust entry point, and the build scripts.
 
 ```
 apps/desktop/
 ├── src-tauri/
-│   ├── Cargo.toml          # Rust dependencies
-│   ├── tauri.conf.json     # Window config, build paths, app identity
+│   ├── Cargo.toml          # Rust dependencies (tauri + opener)
+│   ├── tauri.conf.json     # window config, bundle targets, app identity
 │   ├── build.rs            # Tauri build hook
-│   ├── src/
-│   │   └── main.rs         # Entry point (opens window, loads SPA)
-│   └── icons/              # App icons (.icns, .ico, .png)
-├── build.sh                # Containerized build script
+│   ├── src/main.rs         # entry point: opens the window + native menu, loads the SPA
+│   └── icons/              # app icons (.icns, .ico, .png)
+├── build.sh                # containerized Linux build
 ├── package.json
 └── README.md
 ```

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -1,480 +1,136 @@
 # Semiont Gateway
 
-A type-safe Node.js gateway API providing comprehensive document management, W3C Web Annotation support, and graph-based knowledge organization. Built with Hono framework, featuring spec-first OpenAPI validation, JWT authentication, and integration with graph databases for managing document relationships and entity references.
+The HTTP entry point to a Semiont knowledge base. It is the one address clients
+and sidecar services dial, and in almost every deployment it runs as the
+`semiont-gateway` container on port 4000.
 
-## Quick Links
+Its job is narrow on purpose: **authenticate callers, relay the bus, and proxy
+content bytes.** It holds no part of the knowledge base. The five actors that
+make meaning live in other processes, the resource tree belongs to the
+Archivist, and the event log is reached over HTTP like everything else.
 
-### 📚 Documentation
-- **[Architecture](./docs/ARCHITECTURE.md)** - Infrastructure management patterns, design principles
-- **[Development Guide](./docs/DEVELOPMENT.md)** - Local development, CLI usage, manual setup
-- **[Semiont Protocol](../../docs/protocol/README.md)** - The eight verbs and the bus this gateway serves
-- **[Authentication](./docs/AUTHENTICATION.md)** - JWT tokens, OAuth, MCP authentication
-- **[Event-Bus Protocol](../../docs/protocol/EVENT-BUS.md)** - SSE streaming, channels, scoping, correlation
-- **[Logging](./docs/LOGGING.md)** - Winston logging, log levels, debugging 401s
-- **[Testing Guide](./docs/TESTING.md)** - Running tests, writing tests, coverage
-- **[Deployment Guide](../../docs/system/administration/DEPLOYMENT.md)** - Production deployment, rollbacks, monitoring
+## What it owns, and what it does not
 
-### 🔗 Related Resources
-- **[W3C Web Annotation Implementation](../../docs/protocol/W3C-WEB-ANNOTATION.md)** - How annotations flow through all gateway layers (event store, materialized views, graph database)
-- **[API Client Package](../../packages/http-transport/)** - Type-safe TypeScript client for consuming the gateway API
-- **[Core Package](../../packages/core/)** - Shared types, utilities, and business logic
-- **[OpenAPI Specification](../../specs/README.md)** - Hand-written OpenAPI 3.0 schema (spec-first, source in [../../specs/src/](../../specs/src/))
+The gateway is defined more by subtraction than addition, so this table is the
+fastest way to understand it.
 
-## npm Package
+| It owns | It does not |
+|---|---|
+| **Identity** — issues and verifies user and agent tokens, mints `did:web` agent identities | Host any actor (Stower, Browser, Gatherer, Matcher, CloneTokenManager) |
+| **Postgres** — users, sessions, admin state. Its only datastore | Mount the knowledge base. No `/kb`, no working tree, no `.git` |
+| **The bus relay** — `POST /bus/emit` in, `POST /bus/subscribe` (SSE) out | Connect to Neo4j, Qdrant, or an inference provider |
+| **The job queue** — file-backed, on the shared state mount | Read or write projections, views, or content directly |
+| **The content proxy** — forwards resource bytes to the Archivist | Store bytes. They never touch this process's disk |
 
-[![npm version](https://img.shields.io/npm/v/@semiont/gateway.svg)](https://www.npmjs.com/package/@semiont/gateway)
-[![npm downloads](https://img.shields.io/npm/dm/@semiont/gateway.svg)](https://www.npmjs.com/package/@semiont/gateway)
+The invariant, enforced by tests rather than convention: the gateway **dials no
+meaning-tier service and writes no meaning-tier state.**
+`TestExactlyOneContainerMountsTheKB` pins the mount half in the launcher's
+golden run arguments — exactly one container mounts the KB, and it is the
+Archivist.
 
-The gateway is published as `@semiont/gateway` on npm with pre-built dist and Prisma schema. The published gateway image installs it at build time, pinned to `SEMIONT_VERSION`, and runs it directly — nothing installs it into a project.
+## Running it
 
-## Quick Start
-
-### 🚀 Instant setup with the `semiont` launcher (recommended)
+Normally you do not run it directly. The launcher starts it with the rest of the
+stack:
 
 ```bash
-# From inside a knowledge-base repo — starts everything
 semiont start
-
-# 🎉 Ready to develop in ~30 seconds!
 ```
 
-**Your services are now running:**
-- **Browser**: http://localhost:3000
-- **Gateway**: http://localhost:4000
-- **API Docs**: http://localhost:4000/api
-- **Database**: PostgreSQL in Docker container
+That resolves to roughly this, which is worth reading once because it is the
+whole deployment contract:
 
-For complete development setup, see [Development Guide](./docs/DEVELOPMENT.md).
-
-### 🛠 Manual Setup (Alternative)
-
-```bash
-# Install dependencies
-npm install
-
-# Run database migrations
-npx prisma db push
-
-# Start development server
-npm run dev
 ```
-
-## 🐳 Container Image
-
-[![ghcr](https://img.shields.io/badge/ghcr-latest-blue)](https://github.com/The-AI-Alliance/semiont/pkgs/container/semiont-gateway)
-
-Pull and run the published gateway container image:
-
-```bash
-# Pull latest development build
-docker pull ghcr.io/the-ai-alliance/semiont-gateway:dev
-
-# Run with configuration
-docker run -d \
-  -p 4000:4000 \
-  -v $(pwd):/app/kb \
-  -v $(pwd)/.semiont/semiontconfig/anthropic.toml:/home/semiont/.semiontconfig:ro \
-  -e SEMIONT_ROOT=/app/kb \
-  --name semiont-gateway \
+container run -d --name semiont-gateway \
+  --publish 4000:4000 \
+  --volume <config-stage>/gateway.toml:/home/semiont/.semiontconfig:ro \
+  --volume <state>:/semiont-state \
+  --env XDG_STATE_HOME=/semiont-state \
+  --env POSTGRES_HOST=<host> --env NEO4J_HOST=<host> \
+  --env QDRANT_HOST=<host>   --env OLLAMA_HOST=<host> \
+  --env SEMIONT_WORKER_SECRET=<secret> \
+  --env JWT_SECRET=<key> \
   ghcr.io/the-ai-alliance/semiont-gateway:latest
 ```
 
-**Configuration requirements:**
-- `SEMIONT_ROOT` — the KB root, containing `.semiont/config` and `.semiont/events/`
-- A config TOML mounted at `/home/semiont/.semiontconfig` — this is what
-  `semiont start` does for you, staging a per-service copy of the KB's
-  `.semiont/semiontconfig/<name>.toml`. The environment block comes from
-  `[defaults] environment` inside that file.
+Two things in there are easy to misread:
 
-Secrets (`JWT_SECRET`, `SEMIONT_WORKER_SECRET`, inference API keys) are passed as
-environment variables — never in the config file.
+- **The three non-Postgres host variables do not mean it connects to those
+  services.** The config loader expands every `${VAR}` in the staged TOML
+  eagerly, so every referenced variable must be defined even for sections this
+  process never consumes.
+- **There is no KB volume**, and that absence is the point. It is also enforced:
+  the launcher's `gatewayArgs` takes no KB root, so re-adding the mount is a
+  signature change, not a line someone can slip in.
 
-**Multi-platform Support:** linux/amd64, linux/arm64
+Required in the environment: `JWT_SECRET` (≥32 chars) and
+`SEMIONT_WORKER_SECRET`. `DATABASE_URL` is optional — set it to override the
+value derived from config.
 
-See [Container Documentation](../../docs/system/CONTAINER-TOPOLOGY.md) for advanced usage, Docker Compose, and Kubernetes deployment.
+## Boot and shutdown
 
-## Technology Stack
+The container entrypoint runs three steps before the server exists:
 
-- **Architecture**: EventBus-first with HTTP transport (routes delegate to RxJS EventBus actors)
-- **Runtime**: Node.js with TypeScript
-- **Web Framework**: [Hono](https://hono.dev/) - Fast, lightweight web framework
-- **Database**: PostgreSQL with [Prisma ORM](https://prisma.io/)
-- **Graph Database**: Neptune (AWS production) / In-memory (local development)
-- **Vector Database**: Qdrant (optional) / In-memory — semantic search via `@semiont/vectors`
-- **Authentication**: JWT with OAuth 2.0 (Google)
-- **Validation**: [Ajv](https://ajv.js.org/) for OpenAPI schema validation
-- **API Documentation**: Hand-written OpenAPI 3.0 specification (spec-first approach)
-- **Document Processing**: Multi-format support (text, markdown, images, PDFs) with wiki-link and annotation detection for text formats
-- **MCP Integration**: Model Context Protocol server for AI assistant access
+1. **Derive `DATABASE_URL`** (`dist/cli/db-url.js`) from the staged config, so
+   the password never appears in `container inspect`.
+2. **`prisma migrate deploy`** — a separate process, which is why the URL is
+   derived outside the server rather than inside it.
+3. **`node dist/index.js`** — as PID 1, so it receives `SIGTERM` directly.
 
-## Architecture Highlights
+Startup then refuses rather than degrades. A missing `services.gateway`, an
+absent `JWT_SECRET`, a knowledge base that declares no identity, or a missing
+sign-in policy each stop the process before it listens — a gateway that accepts
+connections it cannot authenticate is the failure mode these checks exist to
+prevent.
 
-### EventBus-Delegated Routes
+`SIGTERM`/`SIGINT` close the listener, stop the job-status subscription, tear
+down the bus, and disconnect Postgres before exiting.
 
-All knowledge-domain HTTP routes are thin wrappers that delegate to the **EventBus**. Routes emit a request event with a `correlationId`, await the correlated response or failure event, and translate the result to HTTP. This means the entire knowledge domain can operate without HTTP — the EventBus is the primary API surface.
+## Configuration
 
-```typescript
-// Typical route pattern — thin HTTP wrapper over EventBus
-router.get('/resources', async (c) => {
-  const response = await eventBusRequest(
-    eventBus,
-    'browse:resources-requested',      // request event
-    { correlationId, search, limit },   // payload
-    'browse:resources-result',          // success event
-    'browse:resources-failed',          // failure event
-  );
-  return c.json(response);
-});
-```
+One file: `~/.semiontconfig`, bind-mounted read-only by the launcher, which
+stages it per service from the knowledge base's own config. The process reads it
+with no project root — there is no tree to read from — so everything it needs
+arrives in that file, including the launcher-staged `[kb]` identity card
+carrying the KB's committed name, `did:web` domain, and sign-in policy.
 
-**EventBus-delegated routes** (read operations via request-response). The gateway
-constructs **no actors** — it emits onto the bus and the owning service answers:
+Secrets are not in the file. They come from the environment.
 
-- Resource listing, metadata, annotations, events, history → `browse:*` (**Browser**, in the Archivist)
-- Referenced-by queries → `browse:referenced-by-requested` (**Browser**, in the Archivist)
-- Entity type and tag-schema listing → `browse:entity-types-requested` / `browse:tag-schemas-requested` (**Browser**, in the Archivist)
-- Clone token operations → `yield:clone-*` (**CloneTokenManager**, in the Archivist)
-- LLM context → `gather:*` (**Gatherer**, in the Librarian)
-- Candidate search → `match:search-requested` (**Matcher**, in the Librarian)
-- Job status → `job:status-requested` (the gateway's own job-queue subscription — one of the few things it still answers itself)
+## HTTP surface
 
-**Fire-and-forget mutations** (already event-driven) — all handled by **Stower**, in the Archivist:
-- Annotation create/delete/update → `mark:*`
-- Resource create → `yield:create`
-- Entity type addition → `frame:add-entity-type`
+| Router | Serves |
+|---|---|
+| `root.ts` | Service metadata, OpenAPI spec, Swagger UI |
+| `health.ts` | `/api/health` — always 200; liveness, not readiness |
+| `auth.ts` | Token issuance and refresh, OAuth and password sign-in |
+| `status.ts` | `/api/status` — KB identity, version, branch |
+| `admin.ts` | User administration |
+| `resources/` | W3C-shaped resource and annotation endpoints; binary upload proxied to the Archivist |
+| `bus.ts` | `/bus/emit` and `/bus/subscribe` — the relay |
 
-**HTTP-only routes** (excluded from EventBus by design):
-- Auth (password, Google, refresh, MCP, terms, logout) — PostgreSQL/Prisma dependent
-- Admin (users CRUD, stats, OAuth config) — PostgreSQL/Prisma dependent
-- Health/Status — infrastructure monitoring
-- Binary content retrieval (`GET /resources/:id` with `Accept: text/*`, `image/*`, `application/pdf`) — large file transfer
-- Resource creation (`POST /resources` with multipart) — binary file upload
+Emitted payloads are validated against the schema the bus registry binds to each
+channel, so an ill-formed event is a 400 at the edge rather than a confused
+subscriber downstream.
 
-The `eventBusRequest()` helper in `src/utils/event-bus-request.ts` implements the correlationId-based request-response pattern used by all delegated routes.
+## Development
 
-### W3C Web Annotation Support
-
-Semiont implements the [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/) for full interoperability:
-
-- **W3C-compliant annotation CRUD** with multi-body arrays
-- **Event-sourced architecture** with immutable audit trail (Event Store)
-- **Fast query views** for current state (Materialized View Storage)
-- **Graph database integration** for relationship traversal (Graph Database)
-
-**Key Features**:
-- Multi-body annotations combining entity type tags (`TextualBody`) and document links (`SpecificResource`)
-- Stub and resolved references for progressive knowledge graph building
-- JSON-LD export for semantic web integration
-- Full audit trail via event sourcing
-
-For complete details, see [W3C Web Annotation Implementation](../../docs/protocol/W3C-WEB-ANNOTATION.md).
-
-### Data Architecture
-
-```
-Vector Store (semantic similarity search — Qdrant, optional)
-   ↑
-Graph Database (relationships, backlinks, graph traversal)
-   ↑
-Materialized Views (fast queries, current state)
-   ↑
-Event Store (immutable event log, source of truth)
-   ↑
-Content Storage (binary/text documents, sharded)
-```
-
-**Job Worker Integration**: Background workers process long-running AI operations (annotation detection, document generation) and emit events to the Event Store, which materializes views and updates the graph database via the event-driven architecture.
-
-See [System Documentation](../../docs/system/README.md) for complete details.
-
-### Background Job Processing
-
-Asynchronous job processing for long-running AI operations that can't block HTTP requests:
-
-**Current Status**: Prototype implementation embedded in gateway process (not yet a standalone CLI-managed service)
-
-**Job Types**:
-- **Annotation Detection**: Detect annotations in documents using AI inference (highlights, assessments, comments, tags, entity references), emit `mark:added` events
-- **Document Generation**: Create new documents from annotations using AI, emit `document.created` events
-
-**Architecture**:
-- Filesystem-based job queue with atomic operations
-- FIFO job processing with automatic retry logic
-- Progress tracking with Server-Sent Events (SSE) streaming
-- Workers emit events to Event Store
-- Jobs continue even if client disconnects
-
-**Key Benefits**:
-- Decouple long-running operations from HTTP request lifecycle
-- Enable real-time progress updates via SSE
-- Full audit trail via event sourcing
-- Automatic retry on failures
-
-**Future State**: Will become a standalone service with CLI integration, platform abstraction, and support for Redis/SQS queue backends.
-
-See [Jobs Package](../../packages/jobs/) for implementation details.
-
-### Secure-by-Default Authentication
-
-- **All API routes require authentication by default**
-- **Explicit public endpoint list** for exceptions
-- **JWT Bearer token authentication**
-- **OAuth 2.0 (Google)** for user login
-- **MCP support** for AI assistant integration
-
-See [Authentication Guide](./docs/AUTHENTICATION.md) for implementation details.
-
-### API Routing Architecture
-
-Clean separation of concerns:
-- **Gateway owns**: `/api/*` - all API endpoints, including the OAuth credential exchange and JWT minting (`POST /api/tokens/google`)
-- **Browser**: the static Vite + React SPA - no server routes (#557 removed Next.js)
-- **No routing conflicts** - simple ALB host/path rules
-
-Only `POST /bus/emit` and `GET /bus/subscribe` carry domain traffic; the rest of `/api/*` is auth, admin, media, exchange, and health. See the [Semiont Protocol](../../docs/protocol/README.md) for the bus surface and the [OpenAPI spec](../../specs/README.md) for endpoint schemas.
-
-## Project Structure
-
-```
-apps/gateway/
-├── docs/                      # Documentation
-│   ├── ARCHITECTURE.md       # Gateway architecture
-│   ├── AUTHENTICATION.md     # Auth implementation
-│   ├── DEVELOPMENT.md        # Local development guide
-│   ├── LOGGING.md            # Logging guide
-│   └── TESTING.md            # Testing guide
-├── src/
-│   ├── __tests__/            # Test suites
-│   ├── auth/                 # Authentication (JWT, OAuth)
-│   ├── cli/                  # Bundled entrypoints: db-url, useradd, rebuild-graph, rebuild-projections
-│   ├── lib/                  # SSE helpers
-│   ├── middleware/           # HTTP middleware (auth, logging, security headers, OpenAPI validation)
-│   ├── routes/               # Modular route definitions (thin EventBus wrappers)
-│   ├── types/                # Type definitions
-│   ├── utils/                # Shared utilities
-│   │   └── event-bus-request.ts  # correlationId request-response helper
-│   ├── db.ts                 # Prisma client setup
-│   ├── index.ts              # Main application
-│   └── logger.ts             # Winston-based logger
-├── prisma/
-│   ├── migrations/           # Database migrations
-│   └── schema.prisma         # Database schema
-├── scripts/                  # start.sh
-└── README.md                 # This file
-
-Note: OpenAPI specification source is maintained at `../../specs/src/` (project root).
-Content storage lives in `packages/content` (WorkingTreeStore) and materialized views
-in `packages/event-sourcing` — not in this app.
-```
-
-## Core Design Principles
-
-### 1. Centralized Infrastructure Management
-
-**All infrastructure components are created once and managed by MakeMeaningService:**
-
-```typescript
-// ✅ CORRECT: Access infrastructure via context
-const { knowledgeSystem: { kb } } = c.get('makeMeaning');
-
-// ❌ WRONG: Never create infrastructure in routes or services
-const graphDb = await getGraphDatabase(config);  // NEVER DO THIS
-const content = new WorkingTreeStore(...);  // NEVER DO THIS
-```
-
-**Architecture:**
-- **MakeMeaningService** (`@semiont/make-meaning`) owns ALL infrastructure:
-  - `knowledgeSystem: KnowledgeSystem` - the KB actors (Stower, Gatherer, Matcher, Browser, CloneTokenManager) and `kb: KnowledgeBase`:
-    - `kb.eventStore: EventStore` - Immutable event log and materialized views
-    - `kb.content: WorkingTreeStore` - Working-tree file content (`file://` URIs, SHA-256 integrity checksums)
-    - `kb.graph: GraphDatabase` - Graph database for relationships and traversal
-    - `kb.weaver: Weaver` - Event-to-graph synchronization
-  - `jobQueue: JobQueue` - Background job processing
-  - Inference clients are created per-actor inside make-meaning (Gatherer, Matcher) - never in gateway code
-  - Background workers run in a separate worker-pool process (see [Architecture](./docs/ARCHITECTURE.md))
-
-**Implementation Pattern:**
-- Infrastructure created ONCE in [index.ts:104](src/index.ts#L104) via `startMakeMeaning(project, config, eventBus, logger)`
-- Routes access via `c.get('makeMeaning')` from Hono context
-- Services receive infrastructure as parameters (dependency injection)
-- NO route or service creates its own infrastructure instances
-
-**Why This Matters:**
-- Prevents duplicate connections and resource leaks
-- Ensures consistent configuration across the application
-- Simplifies testing with single mock injection point
-- Clear ownership and lifecycle management
-- Centralized shutdown via `makeMeaning.stop()`
-
-See [Make-Meaning Package](../../packages/make-meaning/) for implementation details.
-
-### 2. Type Safety First
-- TypeScript throughout with strict mode
-- Compile-time validation
-- Type-safe API client generation
-
-### 3. Runtime Validation
-- All inputs validated with Zod schemas
-- Fail-fast on invalid data
-- Detailed error messages
-
-### 4. Functional Programming
-- Pure functions preferred
-- Immutable data structures
-- No side effects in business logic
-
-### 5. Event Sourcing
-- Immutable event log as source of truth
-- Projections for fast queries
-- Complete audit trail
-
-### 6. Security by Default
-- All routes protected unless explicitly public
-- Multi-layer JWT validation
-- Environment variable validation at startup
-
-## API Documentation
-
-### Interactive API Explorer
-- **Local**: http://localhost:4000/api
-- **Production**: https://your-domain.com/api
-
-Features:
-- 🔍 Interactive endpoint testing
-- 📝 Request/response examples
-- 🔐 Authentication testing with JWT tokens
-- 📊 Schema visualization
-
-### OpenAPI Specification
-- **Endpoint**: `/api/openapi.json` - Raw OpenAPI 3.0 spec (generated bundle)
-- **Source**: [../../specs/src/](../../specs/src/) - Hand-written specification files
-- **Spec-first approach** - Hand-written specification, gateway validates against it
-- **Type generation** - Browser types generated from spec via `openapi-typescript`
-- **Validation** - Gateway uses Ajv to validate requests against schemas
-
-## Common Tasks
-
-### Maintenance
 ```bash
-# Rebuild Neo4j graph from event log (clears graph and replays all events)
-SEMIONT_ROOT=/path/to/kb npm run rebuild-graph
-
-# Rebuild a single resource in the graph
-SEMIONT_ROOT=/path/to/kb npm run rebuild-graph -- <resourceId>
-```
-
-The command reads the KB's `.semiont/semiontconfig/<name>.toml` for database credentials, graph, and vector store settings — the environment block named by its `[defaults] environment`.
-
-The vector store has no gateway CLI: the smelter worker (`@semiont/make-meaning/smelter-main`) reconciles Qdrant against the KS catalog on every startup — re-embedding missing resources and annotations and deleting orphaned vectors. To recover from a wiped Qdrant volume, just restart the smelter; to force a full re-embed, wipe the Qdrant volume first and then restart it.
-
-### Development
-```bash
-# Start development environment
-semiont start
-
-# Run tests
-npm test
-
-# Type check
+npm run dev            # watch mode
 npm run typecheck
-
-# Database GUI
-npx prisma studio
+npm test               # unit
+npm run test:integration   # needs Docker (testcontainers)
+npm run prisma:studio  # database GUI
 ```
 
-See [Development Guide](./docs/DEVELOPMENT.md) for complete workflows.
+The package publishes as [`@semiont/gateway`](https://www.npmjs.com/package/@semiont/gateway);
+the container image installs that package and runs it directly, with no CLI
+layer in between.
 
-### Testing
-```bash
-# Run all tests
-npm test
+## Further reading
 
-# Run specific test suites
-npm run test:unit          # Unit tests only
-npm run test:integration   # Integration tests
-npm run test:security      # Security tests
-
-# Watch mode
-npm run test:watch
-```
-
-See [Testing Guide](./docs/TESTING.md) for testing patterns.
-
-### Deployment
-
-The gateway ships as the published `semiont-gateway` container image; a KB stack runs it via the
-host-installed `semiont` launcher (see [apps/launcher](../launcher/README.md)) or
-`docker compose` against the KB's `.semiont/compose/gateway.yml`.
-
-See [Deployment Guide](../../docs/system/administration/DEPLOYMENT.md) for complete procedures.
-
-## Contributing
-
-We welcome contributions! Please read:
-
-1. [Architecture](./docs/ARCHITECTURE.md) - **Critical design patterns and constraints**
-2. [Development Guide](./docs/DEVELOPMENT.md) - Setting up local environment
-3. [Testing Guide](./docs/TESTING.md) - Writing and running tests
-
-**Key Requirements**:
-- **Follow infrastructure management pattern** - NEVER create EventStore, GraphDatabase, WorkingTreeStore, or InferenceClient instances (see [Architecture](./docs/ARCHITECTURE.md))
-- Functional programming (pure functions, no mutations)
-- All tests must pass
-- TypeScript must compile without errors (strict mode)
-- Include tests for new functionality
-
-## Troubleshooting
-
-### Common Issues
-
-**"Cannot connect to database"**
-```bash
-# Check PostgreSQL is running
-semiont status
-```
-
-**"JWT_SECRET too short"**
-- Each key must be at least 32 characters (`JWT_SECRET` may be a comma-separated
-  rotation ring; the check is per key)
-- Generate: `openssl rand -hex 32`
-
-**"Port already in use"**
-```bash
-# Stop all services
-semiont stop
-```
-
-For detailed troubleshooting, see [Development Guide](./docs/DEVELOPMENT.md#troubleshooting).
-
-## Further Reading
-
-### Gateway Documentation
-- [Local Setup](../../docs/system/LOCAL-GATEWAY.md) - Run the gateway locally (container or npm)
-- [Architecture](./docs/ARCHITECTURE.md) - **Infrastructure management patterns (REQUIRED READING)**
-- [Development Guide](./docs/DEVELOPMENT.md) - Complete local development setup
-- [Semiont Protocol](../../docs/protocol/README.md) - The eight verbs and the bus this gateway serves
-- [Authentication](./docs/AUTHENTICATION.md) - JWT, OAuth, MCP implementation
-- [Event-Bus Protocol](../../docs/protocol/EVENT-BUS.md) - SSE streaming, channels, scoping, correlation
-- [Database](../../docs/system/administration/DATABASE.md) - PostgreSQL setup for user authentication
-- [Filesystem](../../docs/system/FILESYSTEM.md) - Storage patterns and providers
-- [Knowledge System](../../docs/system/KNOWLEDGE-SYSTEM.md) - Storage architecture across all layers
-- [Logging](./docs/LOGGING.md) - Winston logging, log levels, debugging
-- [Testing](./docs/TESTING.md) - Testing philosophy and patterns
-- [Deployment](../../docs/system/administration/DEPLOYMENT.md) - Production deployment guide
-
-### System Documentation
-- [System Documentation](../../docs/system/README.md) - Overall platform architecture
-- [W3C Web Annotation](../../docs/protocol/W3C-WEB-ANNOTATION.md) - Annotation data flow
-- [Event Sourcing Package](../../packages/event-sourcing/) - Event log and materialized views
-- [Graph Package](../../packages/graph/) - Relationship traversal
-- [Jobs Package](../../packages/jobs/) - Background job processing (prototype)
-
-### External Resources
-- [Hono Documentation](https://hono.dev/)
-- [Prisma Documentation](https://prisma.io/docs)
-- [Zod Documentation](https://zod.dev/)
-- [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/)
-
----
-
-**Last Updated**: 2026-03-11
+- [ARCHITECTURE.md](docs/ARCHITECTURE.md) — internal structure
+- [AUTHENTICATION.md](docs/AUTHENTICATION.md) — tokens, agents, sign-in
+- [DEVELOPMENT.md](docs/DEVELOPMENT.md) — working on the gateway
+- [TESTING.md](docs/TESTING.md) — suites and what each covers
+- [LOGGING.md](docs/LOGGING.md) — log shape and levels
+- [Services overview](../../docs/system/services/OVERVIEW.md) — where the gateway sits among the services

--- a/apps/librarian/README.md
+++ b/apps/librarian/README.md
@@ -12,6 +12,9 @@ concluding is the Generator's job.
 | Code | [`packages/make-meaning`](../../packages/make-meaning/) |
 | npm | not published — container only |
 
+Only the image recipe lives in this directory; the entry-point source is
+[`librarian-main.ts`](../../packages/make-meaning/src/librarian-main.ts).
+
 ## What it runs
 
 The two LLM-bound actors:
@@ -22,33 +25,44 @@ The two LLM-bound actors:
 - **Matcher** — context-driven candidate search for the bind flow: multi-source retrieval,
   composite structural scoring, and optional LLM semantic scoring.
 
-Plus the gather-summary handler, which registers here **beside the actor it calls** rather
-than in the gateway — the same fact-consumers-follow-the-actor rule the Archivist's
+Plus the gather-summary handler, which registers here beside the actor it calls rather than
+in the gateway — the same fact-consumers-follow-the-actor rule the Archivist's
 annotation-assembly handler follows.
 
 ## What it talks to
 
-The bus (SSE in, `POST /bus/emit` out), Neo4j and Qdrant as the retrieval sources, and an
-embedding provider for query embedding.
+- **The gateway** — agent auth, then the bus: SSE in, `POST /bus/emit` out. Requests arrive
+  and replies leave this way; nothing dials the Librarian (its only HTTP route is
+  `/health`).
+- **The Archivist** — content bytes, fetched on demand during gather. Bytes ride the byte
+  path; this process never opens the working tree.
+- **Neo4j and Qdrant** — the retrieval sources.
+- **An embedding provider** (query embedding) and **per-actor inference clients**
+  (Gatherer and Matcher each resolve their own from `actors.*` config).
 
-**It mounts no knowledge base.** Unlike the Archivist it holds no file-backed state — every
-byte it needs arrives over the bus or from the two datastores, which is what makes it
-independently scalable if retrieval ever becomes the bottleneck.
+The `weave:applied` / `smelt:settled` progress signals arrive over the same SSE feed and
+drive local folds, so the graph-lag grace and the vector settle barrier behave exactly as
+they did in-process.
+
+## What it owns on disk
+
+Nothing. It appends no events, serves no bytes, and never mounts the KB tree. Its one
+filesystem read is the materialized views the Archivist maintains, through the shared state
+mount — read-only, never rebuilt here — located by the `[kb] name` in the staged config.
+The whole environment contract is two variables: `SEMIONT_WORKER_SECRET` (agent auth) and
+`XDG_STATE_HOME` (the shared state mount).
 
 ## Why it is separate from the Archivist
 
-The two are a deliberate pair, and the distinction is the one the professions themselves
-draw. **The Archivist preserves and serves unique records; the Librarian helps seekers find
-and use material.** Naming them as a pair is also what keeps "Librarian" honest — contrasted
-with the Archivist it names one half of a real division of labour, rather than reducing a
-whole profession to retrieval.
-
-Practically: these two actors are the LLM-bound ones. Their latency and failure modes are
-inference-shaped, not storage-shaped, and keeping them off the record-keeping service means
-a slow model never blocks a write.
+The two are a deliberate pair: the Archivist preserves and serves unique records; the
+Librarian helps seekers find and use material. These two actors are the LLM-bound ones —
+their latency and failure modes are inference-shaped, not storage-shaped — so a slow model
+never blocks a write, and retrieval capacity scales with request volume while the Archivist
+scales with corpus.
 
 ## Related
 
 - [`@semiont/make-meaning`](../../packages/make-meaning/) — the actors and this entry point
-- [Archivist](../archivist/) — the other half of the pair
+- [Archivist](../archivist/) — the other half of the pair: it holds the record and answers
+  *"what is there?"*; the Librarian searches it and answers *"what is relevant?"*
 - [Gather flow](../../docs/protocol/flows/GATHER.md) · [Match flow](../../docs/protocol/flows/MATCHER.md)

--- a/apps/smelter/README.md
+++ b/apps/smelter/README.md
@@ -6,21 +6,52 @@ embeds it, and keeps the vector store reconciled with reality.
 | | |
 | --- | --- |
 | Image | `ghcr.io/the-ai-alliance/semiont-smelter` |
-| Port | 9091 |
+| Port | 9091 (`/health`, and nothing else — all real traffic is the bus) |
 | Entry point | `@semiont/make-meaning/dist/smelter-main.js` |
 | Code | [`packages/make-meaning`](../../packages/make-meaning/) |
 | npm | not published — container only |
 
+## The source is not in this directory
+
+Only the image recipe lives here. The entry point is
+`packages/make-meaning/src/smelter-main.ts`, and the image installs the published
+`@semiont/make-meaning` and runs `dist/smelter-main.js` out of it. That is deliberate: the
+entry point is thin wiring over the pipeline it starts, and moving it here would mean
+promoting ~18 of that package's internals to public API to satisfy a directory layout.
+
+Change the CMD only against that file.
+
 ## What it does
 
-Subscribes to domain events, reads the bytes, chunks text, embeds via `@semiont/vectors`,
-and indexes into Qdrant. It also **owns anchored-text extraction** — the coordinate map that
-lets an annotation anchor to a position in a PDF or an image — and writes it to
-`/anchored-text`, which the Archivist and gateway mount read-only.
+Subscribes to domain events over SSE, reads the bytes, chunks text, embeds via
+`@semiont/vectors`, and indexes into Qdrant. Everything it emits goes back over the bus.
+
+It also **owns anchored-text extraction** — the coordinate map that lets an annotation anchor
+to a position in a PDF or a scan — and holds that store outright, as its sole writer, on its
+own mount. Deriving and holding are the same process on purpose: it reaches its own output
+without a round trip. Nothing else mounts that directory; other processes read the map over
+the bus (`browse:anchored-text-requested`), which the Archivist answers.
 
 **Bytes arrive verbatim over HTTP from the Archivist**, not from a local mount. That is not
 incidental: every vector upsert is stamped with the embedded bytes' checksum, so any
 transformation in transit would break change detection.
+
+## Configuration
+
+Reads `~/.semiontconfig` (TOML), section chosen by `[defaults] environment`. Required:
+
+| Key | |
+| --- | --- |
+| `services.gateway.publicURL` | the bus it subscribes to and emits on |
+| `services.embedding.{type,model}` | the embedding provider |
+
+Two environment variables:
+
+- **`SEMIONT_WORKER_SECRET`** — JWT auth with the knowledge system, and the bearer this
+  process shows the Archivist.
+- **`SEMIONT_ANCHORED_TEXT_DIR`** — where the anchored-text store lives. No default, and it
+  refuses to boot without one. A default would write a full OCR pass per representation into
+  a directory nobody mounted, lose it on the next stop, and re-derive forever.
 
 ## Startup reconcile
 
@@ -29,13 +60,9 @@ missing or stale, deleting orphans. That is what makes recovery boring: a wiped 
 volume, or events missed while the service was down, heal by restarting it. No replay
 command, no manual step.
 
-## What it talks to
-
-The bus (SSE in, `POST /bus/emit` out), Qdrant, an embedding provider, and the Archivist's
-HTTP surface for bytes.
-
 ## Related
 
 - [`@semiont/make-meaning`](../../packages/make-meaning/) — the pipeline and this entry point
 - [`@semiont/vectors`](../../packages/vectors/) — chunking, embedding, and the store adapters
+- [Archivist](../archivist/) — serves the bytes, and answers anchored-text reads
 - [Weaver](../weaver/) — the other projection pipeline: same shape, graph instead of vectors

--- a/apps/weaver/README.md
+++ b/apps/weaver/README.md
@@ -1,40 +1,95 @@
 # semiont-weaver
 
-**Projects the event log into the graph.** One of the two projection pipelines — addressed by
-no one, replying to nothing.
+**Projects the event log into the graph.** One of the two projection pipelines — the graph
+half of what the Smelter does for vectors.
 
 | | |
 | --- | --- |
 | Image | `ghcr.io/the-ai-alliance/semiont-weaver` |
-| Port | 9092 |
+| Port | 9092 (`/health`, and nothing else — all real traffic is the bus) |
 | Entry point | `@semiont/make-meaning/dist/weaver-main.js` |
 | Code | [`packages/make-meaning`](../../packages/make-meaning/) |
 | npm | not published — container only |
 
+## The source is not in this directory
+
+Only the image recipe lives here. The entry point is
+`packages/make-meaning/src/weaver-main.ts`, and the image installs the published
+`@semiont/make-meaning` and runs `dist/weaver-main.js` out of it. That is deliberate: the
+entry point is thin wiring over the pipeline it starts, and moving it here would mean
+promoting ~18 of that package's internals to public API to satisfy a directory layout.
+
+Change the CMD only against that file.
+
+The image also bundles `neo4j-driver`, which the Smelter's does not. It is a lazy peer of
+`@semiont/graph`, loaded at connect time, and the weaver is the one make-meaning entry point
+that actually dials the graph.
+
 ## What it does
 
-Subscribes to graph-relevant domain events and writes them into Neo4j: resources,
-annotations, references, entity types, and the edges between them. That projection is what
-`browse:referenced-by` and path search read.
+Subscribes to graph-relevant domain events over SSE and writes them into the graph store:
+resources, annotations, references, entity types, and the edges between them. That projection
+is what `browse:referenced-by` answers from, and what gather's knowledge-graph traversal
+walks.
 
-## The rebuild is explicit, and that matters
+It is a pure network peer. Its only privileged attachment beyond the bus is the graph
+database — no knowledge base mount, no event-store attachment. Even the history it replays
+arrives as `browse:*` bus reads.
 
-Materialized views rematerialize at startup, so a restart is enough for them. **The graph
-does not.** It rebuilds only on an explicit `weave:rebuild` command.
+## Readers wait on its signals
 
-So after a change to what the graph projection *stores*, a stack that restarts but skips the
-rebuild serves the **old shape** from the graph while views serve the new one — including any
-flat copy the graph denormalizes for query. Re-run the rebuild, and verify the projection
-actually carries what you expect rather than trusting the command's success line.
+Every apply emits `weave:applied` with the resource and the sequence it has reached. The
+gateway folds those into per-resource progress, and the read-after-write barrier in gather's
+knowledge-graph build waits on that signal rather than polling.
 
-## A pure network peer
+So a stopped weaver is not a quiet degradation. Reads that need a just-written node block at
+the barrier and then fail — the graph stays empty, and gathers 404.
 
-Its only privileged attachment beyond the bus is the graph database. Events and rebuild
-commands arrive over SSE; history reads (`browse:*`) and `weave:applied` signals ride the same
-bus. It mounts no knowledge base and holds no file-backed state.
+`weave:rebuild` is the one command it accepts: optionally scoped to a single resource,
+strictly serialized, answered with a correlated `weave:rebuild-ok` or `weave:rebuild-failed`.
+A rebuild that dropped events fails rather than claiming success.
+
+## Configuration
+
+Reads `~/.semiontconfig` (TOML), section chosen by `[defaults] environment`. Required:
+
+| Key | |
+| --- | --- |
+| `services.gateway.publicURL` | the bus it subscribes to and emits on |
+| `services.graph.type` | the graph sink — must be server-backed |
+
+`type = "memory"` is refused at startup: the in-memory graph lives in one process's heap and
+cannot be shared with the gateway's readers.
+
+Two environment variables:
+
+- **`SEMIONT_WORKER_SECRET`** — JWT auth with the knowledge system. It authenticates as the
+  stable identity `(semiont, weaver)` — `did:web:<host>:agents:semiont:weaver`.
+- **`XDG_STATE_HOME`** — where the catch-up checkpoint is written (default `~/.local/state`).
+  The checkpoint is an optimization, never a correctness input: losing it degrades the next
+  catch-up to a full replay.
+
+## Startup catch-up and reconcile
+
+On boot it runs two passes, both fatal on failure — a weaver that cannot catch up is
+projecting a graph of unknown freshness. Both are idempotent, so a restart re-runs them, and
+`/health` reports each one's phase and summary.
+
+**Catch-up** replays what it missed while down, from the checkpoint forward (full replay if
+the checkpoint is gone). **Reconcile** then diffs the projection against what the views serve
+and heals divergence from the log — the backstop for damage the accounting cannot witness: a
+wiped graph volume, an out-of-band mutation.
+
+So a restart heals missed events and drift. **It does not re-derive events it has already
+applied.** Reconcile compares a fixed set of facts — node presence, archived flag, entity
+types, the annotation id set, and annotation bodies — so a change to what the projection
+*stores* outside that set, such as a new denormalized property on a node, is invisible to it.
+After that kind of change, run `weave:rebuild`, and verify the projection actually carries
+what you expect rather than trusting the command's success line.
 
 ## Related
 
 - [`@semiont/make-meaning`](../../packages/make-meaning/) — the pipeline and this entry point
 - [`@semiont/graph`](../../packages/graph/) — the store adapters and the annotation codec
+- [Gateway](../gateway/) — the bus it rides, and the reader whose barrier waits on its signals
 - [Smelter](../smelter/) — the other projection pipeline: same shape, vectors instead of graph

--- a/docs/system/services/OVERVIEW.md
+++ b/docs/system/services/OVERVIEW.md
@@ -4,15 +4,23 @@ A deployment-focused overview of Semiont's services. For API documentation, see 
 
 ## Service catalog
 
-Five services run Semiont code. Each is a published container image; see [Container Images](../administration/IMAGES.md) and [Container Topology](../CONTAINER-TOPOLOGY.md).
+Seven services run Semiont code. Each is a published container image; see [Container Images](../administration/IMAGES.md) and [Container Topology](../CONTAINER-TOPOLOGY.md).
 
 | Service | Port | What runs | Bundled package | Docs |
 |---|---|---|---|---|
 | **browser** | 3000 | Static server for the Semiont Browser SPA | `semiont-browser` | [README](../../../apps/browser/README.md) |
-| **gateway** | 4000 | API server + unified bus gateway; Stower, Browser, Gatherer, Matcher | `semiont-gateway` | [README](../../../apps/gateway/README.md) |
-| **worker** | 9090 | Annotation/generation worker pool | `@semiont/jobs` | [API](../../../packages/jobs/docs/API.md) |
-| **smelter** | 9091 | Embedding/vector pipeline actor | `@semiont/make-meaning` | [Package](../../../packages/make-meaning/) |
-| **weaver** | 9092 | Graph-projection actor | `@semiont/make-meaning` | [Package](../../../packages/make-meaning/) |
+| **gateway** | 4000 | Auth, the bus relay, and the content proxy. **Hosts no actors** | `semiont-gateway` | [README](../../../apps/gateway/README.md) |
+| **archivist** | 9093 | Keeps the system of record — Stower, Browser, CloneTokenManager | `@semiont/make-meaning` | [README](../../../apps/archivist/README.md) |
+| **librarian** | 9094 | Searches it — Gatherer, Matcher | `@semiont/make-meaning` | [README](../../../apps/librarian/README.md) |
+| **worker** | 9090 | Annotation/generation worker pool | `@semiont/jobs` | [README](../../../apps/worker/README.md) |
+| **smelter** | 9091 | Embedding/vector pipeline; owns anchored-text extraction | `@semiont/make-meaning` | [README](../../../apps/smelter/README.md) |
+| **weaver** | 9092 | Graph-projection pipeline | `@semiont/make-meaning` | [README](../../../apps/weaver/README.md) |
+
+**The gateway holds no part of the knowledge base.** It authenticates callers, relays the
+bus, and proxies content bytes to the Archivist; its only datastore is PostgreSQL. The five
+meaning-tier actors live in the Archivist and the Librarian. That split is enforced by a test,
+not by convention — `TestExactlyOneContainerMountsTheKB` pins it in the launcher's golden run
+arguments: exactly one container mounts the KB, and it is the Archivist.
 
 For what the actors inside those containers are responsible for, see [Knowledge System](../KNOWLEDGE-SYSTEM.md).
 
@@ -33,7 +41,7 @@ For what the actors inside those containers are responsible for, see [Knowledge 
 | Store | Package | Where it lives |
 |---|---|---|
 | **Event log** | `@semiont/event-sourcing` | `.semiont/events/` in the KB git repo — the system of record ([Storage Layout](../../../packages/event-sourcing/docs/STORAGE-LAYOUT.md)) |
-| **Content store** | `@semiont/content` | Content-addressed blobs ([API](../../../packages/content/docs/API.md)) |
+| **Content store** | `@semiont/content` | The git working tree — files where they live, addressed by a `file://` storage URI on the resource's primary representation ([API](../../../packages/content/docs/API.md)) |
 | **Graph** | `@semiont/graph` | Neo4j or in-memory ([API](../../../packages/graph/docs/API.md), [Architecture](../../../packages/graph/docs/ARCHITECTURE.md)) |
 | **Vectors** | `@semiont/vectors` | Qdrant or in-memory ([Package](../../../packages/vectors/)) |
 | **Users** | Prisma / PostgreSQL | The `users` table, nothing else |
@@ -65,7 +73,7 @@ semiont stop --service worker      # Stop one service
 semiont clean                      # Remove persistent state (PostgreSQL, Qdrant, Neo4j)
 ```
 
-`--service` takes one of `gateway`, `worker`, `smelter`, `weaver`, `browser`, `database`, `graph`, `vectors`, `inference`, or `traces`. Omitting it means the whole stack — there is no `--service all`. `semiont stop` deliberately leaves persistent state behind so the next `start` reuses it; `semiont clean` is the only thing that removes it.
+`--service` takes one of `gateway`, `worker`, `smelter`, `weaver`, `archivist`, `librarian`, `browser`, `database`, `graph`, `vectors`, `inference`, `embedding`, or `traces`. Omitting it means the whole stack — there is no `--service all`. `semiont stop` deliberately leaves persistent state behind so the next `start` reuses it; `semiont clean` is the only thing that removes it.
 
 Run `semiont <command> --help` for a command's options and `semiont --help` for the full verb list.
 
@@ -80,6 +88,10 @@ container exec -it semiont-gateway sh    # or: docker exec -it semiont-gateway s
 ### Configuration
 
 Services are configured per environment in the KB's `.semiont/semiontconfig/<name>.toml`. `semiont init` generates one and `semiont start --config <name>` selects it; the shape is:
+
+The launcher **appends** `[environments.<env>.archivist]` (host + port) to each staged
+per-service config — that stanza records where this stack's Archivist listens, so it is
+launcher-staged topology, not something a KB author writes by hand.
 
 ```toml
 [defaults]
@@ -146,31 +158,42 @@ See the [Configuration Guide](../administration/CONFIGURATION.md) for the full s
 
 ```mermaid
 graph LR
-    DB[PostgreSQL] --> BE[Gateway]
-    GRAPH[Neo4j] --> BE
-    VECTORS[Qdrant] --> BE
-    BE --> FE[Browser]
-    BE --> W[Worker]
-    BE --> SM[Smelter]
-    BE --> WV[Weaver]
+    DB[PostgreSQL] --> GW[Gateway]
+    GW --> AR[Archivist]
+    GW --> LB[Librarian]
+    GW --> W[Worker]
+    GW --> SM[Smelter]
+    GW --> WV[Weaver]
+    GW --> BR[Browser]
+    GRAPH[Neo4j] --> AR
+    GRAPH --> LB
+    GRAPH --> WV
+    VECTORS[Qdrant] --> LB
+    VECTORS --> SM
 ```
 
-`semiont start` handles this ordering: the infrastructure containers come up first, then the gateway, then everything that talks to the gateway's bus.
+`semiont start` handles this ordering: the infrastructure containers come up first, then the
+gateway, then everything that talks to the gateway's bus. Note that the datastores attach to
+the **meaning-tier** services now, not to the gateway.
 
 ### Runtime dependencies
 
 - **Browser** → nothing. It serves static assets; the SPA in the user's browser talks to the gateway directly.
-- **Gateway** → PostgreSQL (users), event log, graph, vector store, inference
-- **Worker** → gateway bus, inference
-- **Smelter** → gateway bus, vector store, embeddings
-- **Weaver** → gateway bus, graph
+- **Gateway** → PostgreSQL, and the Archivist (it proxies content bytes there). Nothing else — no graph, no vectors, no inference
+- **Archivist** → gateway bus, the KB working tree and state (**the only service that mounts them**), Neo4j for one query, an embedding provider
+- **Librarian** → gateway bus, Neo4j, Qdrant, inference + embeddings
+- **Worker** → gateway bus, inference, the Archivist's HTTP surface for bytes
+- **Smelter** → gateway bus, Qdrant, embeddings, the Archivist's HTTP surface for bytes
+- **Weaver** → gateway bus, Neo4j
 - **MCP server** → gateway bus
 
 ## Service communication
 
-Every actor that runs Semiont code is a bus participant. The gateway exposes exactly two runtime endpoints carrying domain traffic — `POST /bus/emit` and `GET /bus/subscribe` (SSE, with dynamic channel subscription and Last-Event-ID replay). Every other HTTP route serves auth, admin, exchange, binary content, or infrastructure.
+Every actor that runs Semiont code is a bus participant. The gateway exposes exactly two runtime endpoints carrying domain traffic — `POST /bus/emit` and `POST /bus/subscribe` (SSE; the subscription matrix is a request body, which is why it is a POST, with per-scope Last-Event-ID replay). Every other HTTP route serves auth, admin, binary content, or infrastructure.
 
-The worker, smelter, and weaver authenticate via `POST /api/tokens/agent`, exchanging `SEMIONT_WORKER_SECRET` plus a `(provider, model)` identity for a JWT carrying a typed Software-agent DID.
+The sidecar services authenticate via `POST /api/tokens/agent`, exchanging `SEMIONT_WORKER_SECRET` plus a `(provider, model)` identity for a JWT carrying a typed Software-agent DID.
+
+**Replay is served by the Archivist, not the gateway.** The gateway keeps `/bus/subscribe` but no longer holds the event log, so a `Last-Event-ID` resume fetches from the Archivist over `host:port` plus the worker secret. If that fetch fails, the subscription degrades to a scoped `bus:resume-gap` rather than silently serving nothing.
 
 See [Container Topology](../CONTAINER-TOPOLOGY.md) for the full picture.
 
@@ -184,6 +207,8 @@ See [Container Topology](../CONTAINER-TOPOLOGY.md) for the full picture.
 | worker | `http://localhost:9090/health` |
 | smelter | `http://localhost:9091/health` |
 | weaver | `http://localhost:9092/health` |
+| archivist | `http://localhost:9093/health` |
+| librarian | `http://localhost:9094/health` |
 | database | TCP connect on 5432 |
 | graph | `http://localhost:7474` |
 | vectors | `http://localhost:6333/readyz` |
@@ -196,7 +221,7 @@ The gateway's `/api/health` reports database reachability and the environment na
 
 ## Observability
 
-Local stacks run Jaeger by default (`--no-observe` skips it). The gateway, worker, smelter, and weaver export OTLP traces and metrics to it; the UI is at http://localhost:16686. Application logs go to stdout as structured JSON — read them with `semiont logs`.
+Local stacks run Jaeger by default (`--no-observe` skips it). Every Semiont service — gateway, archivist, librarian, worker, smelter, weaver — exports OTLP traces and metrics to it; the UI is at http://localhost:16686. Application logs go to stdout as structured JSON — read them with `semiont logs`.
 
 ## Platform support
 

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -91,9 +91,15 @@ interface InferenceClient {
   readonly modelId: string;  // configured model name
 
   limits(): Promise<InferenceLimits>;
-  generateText(prompt, maxTokens, temperature, options?): Promise<string>;
-  generateTextWithMetadata(prompt, maxTokens, temperature, options?): Promise<InferenceResponse>;
+  generateText(prompt, maxTokens, temperature, signal?): Promise<string>;
+  generateTextWithMetadata(prompt, maxTokens, temperature, signal?): Promise<InferenceResponse>;
+  generateStructured<T>(prompt, maxTokens, temperature, elementSchema, signal?): Promise<StructuredResponse<T>>;
 }
+```
+
+Every generation method takes a trailing optional `AbortSignal`: aborting tears down the underlying transport (and, on Anthropic, the SDK's internal retry loop) so a cancelled call rejects promptly instead of surviving as a billed background request. Implementations must honor it — accepting and ignoring the signal is a defect.
+
+```typescript
 
 interface InferenceLimits {
   contextTokens: number;     // context window (Anthropic: max input; Ollama: shared input+output)

--- a/packages/inference/docs/API.md
+++ b/packages/inference/docs/API.md
@@ -55,20 +55,23 @@ interface InferenceClient {
   generateText(
     prompt: string,
     maxTokens: number,
-    temperature: number
+    temperature: number,
+    signal?: AbortSignal
   ): Promise<string>;
 
   generateTextWithMetadata(
     prompt: string,
     maxTokens: number,
-    temperature: number
+    temperature: number,
+    signal?: AbortSignal
   ): Promise<InferenceResponse>;
 
   generateStructured<T>(
     prompt: string,
     maxTokens: number,
     temperature: number,
-    elementSchema: ElementSchema
+    elementSchema: ElementSchema,
+    signal?: AbortSignal
   ): Promise<StructuredResponse<T>>;
 }
 
@@ -79,6 +82,8 @@ interface InferenceResponse {
 ```
 
 `generateText` is `generateTextWithMetadata` with the metadata dropped.
+
+**Cancellation** (`signal`, trailing optional on every generation method): aborting tears down the underlying transport — Ollama's `fetch`, or the Anthropic SDK request on both its paths, where the SDK also checks the signal between its internal retries — so a cancelled call rejects promptly (`AbortError` / `APIUserAbortError`) rather than surviving as a billed background request. Implementations must honor the signal; accepting and ignoring it is a defect (the mock rejects on an aborted signal for exactly this reason). `limits()` takes no signal — discovery is quick and isn't wrapped by any caller timeout.
 
 ### InferenceLimits / limits()
 

--- a/packages/inference/src/__tests__/anthropic.test.ts
+++ b/packages/inference/src/__tests__/anthropic.test.ts
@@ -118,6 +118,65 @@ describe('AnthropicInferenceClient - plain text mode unchanged', () => {
   });
 });
 
+describe('AnthropicInferenceClient - cancellation threads to the SDK (ABANDONED-INFERENCE P1)', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    retrieveMock.mockReset();
+    streamMock.mockReset();
+    retrieveMock.mockResolvedValue(CAPABLE_MODEL);
+  });
+
+  it('forwards the AbortSignal into the SDK request options (create path)', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      usage: {},
+    });
+    const controller = new AbortController();
+
+    const client = new AnthropicInferenceClient('test-key', 'claude-x');
+    await client.generateText('p', 100, 0, controller.signal);
+
+    // The SDK aborts the live attempt AND checks the signal between its own
+    // internal retries — forwarding it is what turns our timeout from an
+    // abandonment into a cancellation.
+    const opts = createMock.mock.calls[0][1] as { signal?: AbortSignal } | undefined;
+    expect(opts?.signal).toBe(controller.signal);
+  });
+
+  it('forwards the AbortSignal on the structured path too', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'text', text: '[]' }],
+      stop_reason: 'end_turn',
+      usage: {},
+    });
+    const controller = new AbortController();
+
+    const client = new AnthropicInferenceClient('test-key', 'claude-x');
+    await client.generateStructured('p', 100, 0, TEST_ELEMENT, controller.signal);
+
+    const opts = createMock.mock.calls[0][1] as { signal?: AbortSignal } | undefined;
+    expect(opts?.signal).toBe(controller.signal);
+  });
+
+  it('forwards the AbortSignal on the internal-streaming path (large budgets)', async () => {
+    streamMock.mockReturnValue({
+      finalMessage: async () => ({
+        content: [{ type: 'text', text: '[]' }],
+        stop_reason: 'end_turn',
+        usage: {},
+      }),
+    });
+    const controller = new AbortController();
+
+    const client = new AnthropicInferenceClient('test-key', 'claude-x');
+    await client.generateStructured('p', 64_000, 0, TEST_ELEMENT, controller.signal);
+
+    const opts = streamMock.mock.calls[0][1] as { signal?: AbortSignal } | undefined;
+    expect(opts?.signal).toBe(controller.signal);
+  });
+});
+
 describe('AnthropicInferenceClient - limits() discovery', () => {
   beforeEach(() => {
     createMock.mockReset();

--- a/packages/inference/src/__tests__/anthropic.test.ts
+++ b/packages/inference/src/__tests__/anthropic.test.ts
@@ -188,8 +188,8 @@ describe('AnthropicInferenceClient - limits() discovery', () => {
     retrieveMock.mockResolvedValue({ max_input_tokens: 200_000, max_tokens: 64_000 });
 
     const client = new AnthropicInferenceClient('test-key', 'claude-x');
-    expect(await client.limits()).toEqual({ contextTokens: 200_000, maxOutputTokens: 64_000 });
-    expect(await client.limits()).toEqual({ contextTokens: 200_000, maxOutputTokens: 64_000 });
+    expect(await client.limits()).toEqual({ contextTokens: 200_000, maxOutputTokens: 64_000, outputTokensPerHour: 128_000 });
+    expect(await client.limits()).toEqual({ contextTokens: 200_000, maxOutputTokens: 64_000, outputTokensPerHour: 128_000 });
 
     // Discovered once, cached across calls.
     expect(retrieveMock).toHaveBeenCalledTimes(1);
@@ -204,7 +204,7 @@ describe('AnthropicInferenceClient - limits() discovery', () => {
 
     // A later call retries instead of replaying the cached rejection.
     retrieveMock.mockResolvedValueOnce({ max_input_tokens: 1000, max_tokens: 100 });
-    expect(await client.limits()).toEqual({ contextTokens: 1000, maxOutputTokens: 100 });
+    expect(await client.limits()).toEqual({ contextTokens: 1000, maxOutputTokens: 100, outputTokensPerHour: 128_000 });
     expect(retrieveMock).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/inference/src/__tests__/integration.test.ts
+++ b/packages/inference/src/__tests__/integration.test.ts
@@ -211,6 +211,30 @@ describe('@semiont/inference - integration', () => {
     });
   });
 
+  describe('MockInferenceClient honors AbortSignal (no accept-and-drop)', () => {
+    // The A1 trap: an adapter that accepts the signal and ignores it is worse
+    // than one that lacks it, because cancellation tests pass against it while
+    // proving nothing. The mock must behave like a real adapter here.
+    it('rejects with AbortError when called with an already-aborted signal', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        mockClient.generateText('p', 100, 0, controller.signal),
+      ).rejects.toMatchObject({ name: 'AbortError' });
+      await expect(
+        mockClient.generateStructured('p', 100, 0, { type: 'object' }, controller.signal),
+      ).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    it('resolves normally under a live (un-aborted) signal', async () => {
+      const controller = new AbortController();
+      mockClient.setResponses(['fine']);
+
+      await expect(mockClient.generateText('p', 100, 0, controller.signal)).resolves.toBe('fine');
+    });
+  });
+
   describe('MockInferenceClient.limits', () => {
     it('defaults to generous limits so existing consumers never chunk', async () => {
       const limits = await mockClient.limits();

--- a/packages/inference/src/__tests__/ollama.test.ts
+++ b/packages/inference/src/__tests__/ollama.test.ts
@@ -99,6 +99,20 @@ describe('OllamaInferenceClient - limits() discovery', () => {
   });
 });
 
+describe('OllamaInferenceClient - cancellation threads to the transport (ABANDONED-INFERENCE P1)', () => {
+  it('passes the AbortSignal into the generate fetch', async () => {
+    const fetchMock = stubRoutedFetch();
+    const controller = new AbortController();
+
+    const client = new OllamaInferenceClient('llama3', 'http://localhost:11434');
+    await client.generateText('p', 100, 0, controller.signal);
+
+    const generateCall = callsTo(fetchMock, '/api/generate')[0];
+    const init = generateCall[1] as { signal?: AbortSignal };
+    expect(init.signal).toBe(controller.signal);
+  });
+});
+
 describe('OllamaInferenceClient - managed num_ctx', () => {
   it('sets num_ctx explicitly, covering prompt estimate + output budget within the window', async () => {
     const fetchMock = stubRoutedFetch();

--- a/packages/inference/src/implementations/anthropic.ts
+++ b/packages/inference/src/implementations/anthropic.ts
@@ -98,19 +98,26 @@ export class AnthropicInferenceClient implements InferenceClient {
     };
   }
 
-  private requestMessage(params: Anthropic.MessageCreateParamsNonStreaming): Promise<Anthropic.Message> {
+  private requestMessage(params: Anthropic.MessageCreateParamsNonStreaming, signal?: AbortSignal): Promise<Anthropic.Message> {
+    // The signal rides the SDK's RequestOptions: an abort tears down the live
+    // attempt AND is checked between the SDK's internal retries, so a
+    // cancelled call cannot survive as a background zombie inside the SDK's
+    // own retry/backoff loop (ABANDONED-INFERENCE P0 caught one completing
+    // 24–34 minutes after abandonment). For visibility into those internal
+    // retries themselves, the SDK's ANTHROPIC_LOG=debug env knob logs every
+    // attempt — nothing to re-implement here.
     if (params.max_tokens > NONSTREAMING_MAX_OUTPUT_TOKENS) {
-      return this.client.messages.stream(params).finalMessage();
+      return this.client.messages.stream(params, { signal }).finalMessage();
     }
-    return this.client.messages.create(params);
+    return this.client.messages.create(params, { signal });
   }
 
-  async generateText(prompt: string, maxTokens: number, temperature: number): Promise<string> {
-    const response = await this.generateTextWithMetadata(prompt, maxTokens, temperature);
+  async generateText(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<string> {
+    const response = await this.generateTextWithMetadata(prompt, maxTokens, temperature, signal);
     return response.text;
   }
 
-  async generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number): Promise<InferenceResponse> {
+  async generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<InferenceResponse> {
     this.logger?.debug('Generating text with inference client', {
       model: this.modelId,
       promptLength: prompt.length,
@@ -126,7 +133,7 @@ export class AnthropicInferenceClient implements InferenceClient {
     };
 
     const start = performance.now();
-    const response = await this.recordedRequest(params, start);
+    const response = await this.recordedRequest(params, start, signal);
 
     const textContent = response.content.find(c => c.type === 'text');
     if (!textContent || textContent.type !== 'text') {
@@ -151,7 +158,8 @@ export class AnthropicInferenceClient implements InferenceClient {
     this.logger?.info('Text generation completed', {
       model: this.modelId,
       textLength: text.length,
-      stopReason: response.stop_reason
+      stopReason: response.stop_reason,
+      requestId: requestIdOf(response),
     });
 
     return {
@@ -165,6 +173,7 @@ export class AnthropicInferenceClient implements InferenceClient {
     maxTokens: number,
     temperature: number,
     elementSchema: ElementSchema,
+    signal?: AbortSignal,
   ): Promise<StructuredResponse<T>> {
     // Capability gate (D3/D4): model choice is deployment config, so the
     // client asks the provider whether the configured model can honour
@@ -207,7 +216,7 @@ export class AnthropicInferenceClient implements InferenceClient {
     };
 
     const start = performance.now();
-    const response = await this.recordedRequest(params, start);
+    const response = await this.recordedRequest(params, start, signal);
 
     const textContent = response.content.find(c => c.type === 'text');
     if (!textContent || textContent.type !== 'text') {
@@ -263,7 +272,8 @@ export class AnthropicInferenceClient implements InferenceClient {
     this.logger?.info('Structured generation completed', {
       model: this.modelId,
       items: parsed.length,
-      stopReason: response.stop_reason
+      stopReason: response.stop_reason,
+      requestId: requestIdOf(response),
     });
 
     return {
@@ -273,9 +283,9 @@ export class AnthropicInferenceClient implements InferenceClient {
   }
 
   /** Issue the request, recording an error metric if the transport throws. */
-  private async recordedRequest(params: Anthropic.MessageCreateParamsNonStreaming, start: number): Promise<Anthropic.Message> {
+  private async recordedRequest(params: Anthropic.MessageCreateParamsNonStreaming, start: number, signal?: AbortSignal): Promise<Anthropic.Message> {
     try {
-      return await this.requestMessage(params);
+      return await this.requestMessage(params, signal);
     } catch (err) {
       recordInferenceUsage({
         provider: this.type,
@@ -297,4 +307,17 @@ export class AnthropicInferenceClient implements InferenceClient {
       outputTokens: response.usage?.output_tokens,
     });
   }
+}
+
+/**
+ * The provider's request id, for correlating our logs with Anthropic's and
+ * telling one attempt from another. The SDK attaches `_request_id` to the
+ * returned message at runtime but does not declare it on the `Message` type,
+ * so it is read through a guard rather than a cast.
+ */
+function requestIdOf(response: unknown): string | undefined {
+  if (isObject(response) && typeof response['_request_id'] === 'string') {
+    return response['_request_id'];
+  }
+  return undefined;
 }

--- a/packages/inference/src/implementations/anthropic.ts
+++ b/packages/inference/src/implementations/anthropic.ts
@@ -5,13 +5,21 @@ import { isObject, type Logger } from '@semiont/core';
 import { recordInferenceUsage } from '@semiont/observability';
 import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredResponse } from '../interface.js';
 
-// The SDK refuses non-streaming create() calls whose projected duration
-// exceeds its 10-minute timeout: it throws when
-// (60min × max_tokens) / 128_000 > 10min, i.e. above 128_000/6 ≈ 21,333
-// output tokens (client.js, calculateNonstreamingTimeout). Above that we
-// stream internally and assemble the final message — same request shape,
-// same response handling, same interface.
-const NONSTREAMING_MAX_OUTPUT_TOKENS = Math.floor(128_000 / 6);
+// The SDK's worst-case output-rate model: client.js's
+// calculateNonstreamingTimeout projects a call's maximum duration as
+// (60min × max_tokens) / 128_000 and refuses non-streaming create() calls
+// projected past its 10-minute timeout. ONE constant, two derivations: the
+// streaming switch below, and `limits().outputTokensPerHour` — the single
+// duration statement this provider surface makes, which detection's
+// duration budget derives from (ABANDONED-INFERENCE P4). Invalidated if
+// the SDK revises its rate model: check calculateNonstreamingTimeout on
+// SDK upgrades.
+const OUTPUT_TOKENS_PER_HOUR = 128_000;
+
+// Above ~21,333 output tokens (the 10-minute projection) we stream
+// internally and assemble the final message — same request shape, same
+// response handling, same interface.
+const NONSTREAMING_MAX_OUTPUT_TOKENS = Math.floor(OUTPUT_TOKENS_PER_HOUR / 6);
 
 // Structured generation rides `output_config.format` — response-level
 // structured output: the response TEXT is the schema-conforming JSON, with a
@@ -93,7 +101,11 @@ export class AnthropicInferenceClient implements InferenceClient {
       isObject(raw['capabilities']['structured_outputs']) &&
       raw['capabilities']['structured_outputs']['supported'] === true;
     return {
-      limits: { contextTokens: info.max_input_tokens, maxOutputTokens: info.max_tokens },
+      limits: {
+        contextTokens: info.max_input_tokens,
+        maxOutputTokens: info.max_tokens,
+        outputTokensPerHour: OUTPUT_TOKENS_PER_HOUR,
+      },
       structuredOutputsSupported,
     };
   }

--- a/packages/inference/src/implementations/mock.ts
+++ b/packages/inference/src/implementations/mock.ts
@@ -28,12 +28,13 @@ export class MockInferenceClient implements InferenceClient {
     return this.injectedLimits;
   }
 
-  async generateText(prompt: string, maxTokens: number, temperature: number): Promise<string> {
-    const response = await this.generateTextWithMetadata(prompt, maxTokens, temperature);
+  async generateText(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<string> {
+    const response = await this.generateTextWithMetadata(prompt, maxTokens, temperature, signal);
     return response.text;
   }
 
-  async generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number): Promise<InferenceResponse> {
+  async generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<InferenceResponse> {
+    throwIfAborted(signal);
     this.calls.push({ prompt, maxTokens, temperature });
     return this.nextResponse();
   }
@@ -50,7 +51,9 @@ export class MockInferenceClient implements InferenceClient {
     maxTokens: number,
     temperature: number,
     elementSchema: ElementSchema,
+    signal?: AbortSignal,
   ): Promise<StructuredResponse<T>> {
+    throwIfAborted(signal);
     this.calls.push({ prompt, maxTokens, temperature, elementSchema });
     const { text, stopReason } = this.nextResponse();
 
@@ -92,5 +95,18 @@ export class MockInferenceClient implements InferenceClient {
     this.responses = responses;
     this.stopReasons = stopReasons || responses.map(() => 'end_turn');
     this.responseIndex = 0;
+  }
+}
+
+/**
+ * The mock honors the signal like a real adapter (ABANDONED-INFERENCE P1's
+ * accept-and-drop trap: an adapter that takes the parameter and ignores it
+ * lets cancellation tests pass while proving nothing). The mock resolves
+ * synchronously, so an entry check is the whole contract — rejecting the way
+ * an aborted `fetch` does, with an `AbortError`-named DOMException.
+ */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new DOMException('This operation was aborted', 'AbortError');
   }
 }

--- a/packages/inference/src/implementations/ollama.ts
+++ b/packages/inference/src/implementations/ollama.ts
@@ -74,13 +74,13 @@ export class OllamaInferenceClient implements InferenceClient {
     return { contextTokens, maxOutputTokens: contextTokens };
   }
 
-  async generateText(prompt: string, maxTokens: number, temperature: number): Promise<string> {
-    const response = await this.generateTextWithMetadata(prompt, maxTokens, temperature);
+  async generateText(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<string> {
+    const response = await this.generateTextWithMetadata(prompt, maxTokens, temperature, signal);
     return response.text;
   }
 
-  async generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number): Promise<InferenceResponse> {
-    return this.generate(prompt, maxTokens, temperature, undefined);
+  async generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<InferenceResponse> {
+    return this.generate(prompt, maxTokens, temperature, undefined, signal);
   }
 
   async generateStructured<T>(
@@ -88,6 +88,7 @@ export class OllamaInferenceClient implements InferenceClient {
     maxTokens: number,
     temperature: number,
     elementSchema: ElementSchema,
+    signal?: AbortSignal,
   ): Promise<StructuredResponse<T>> {
     // Grammar-constrained sampling: the schema goes to Ollama's `format`
     // parameter, which constrains generation itself — same mechanism as the
@@ -95,7 +96,7 @@ export class OllamaInferenceClient implements InferenceClient {
     // parsed here, and anything that does not read as an array is a THROW,
     // never a coerced [] — "could not read the model" must stay distinct
     // from "the model found nothing."
-    const response = await this.generate(prompt, maxTokens, temperature, elementSchema);
+    const response = await this.generate(prompt, maxTokens, temperature, elementSchema, signal);
 
     let parsed: unknown;
     try {
@@ -130,6 +131,7 @@ export class OllamaInferenceClient implements InferenceClient {
     maxTokens: number,
     temperature: number,
     elementSchema: ElementSchema | undefined,
+    signal?: AbortSignal,
   ): Promise<InferenceResponse> {
     this.logger?.debug('Generating text with Ollama', {
       model: this.modelId,
@@ -184,10 +186,14 @@ export class OllamaInferenceClient implements InferenceClient {
 
     let res: Response;
     try {
+      // True cancellation (ABANDONED-INFERENCE P1): the signal tears down the
+      // socket, so an aborted call cannot keep generating on the server's
+      // dime after its job is gone.
       res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal,
       });
     } catch (err) {
       recordInferenceUsage({

--- a/packages/inference/src/interface.ts
+++ b/packages/inference/src/interface.ts
@@ -55,6 +55,17 @@ export interface InferenceLimits {
   contextTokens: number;
   /** Maximum output tokens per generation. */
   maxOutputTokens: number;
+  /**
+   * The provider's own worst-case output-rate model, in output tokens per
+   * hour, when it publishes one. Anthropic's SDK projects a call's maximum
+   * duration as `max_tokens / rate` (client.js `calculateNonstreamingTimeout`,
+   * 128_000/hour) and refuses non-streaming calls projected past 10 minutes —
+   * the one duration statement that provider surface makes. Consumers with
+   * their own call deadline derive a duration-safe output budget from it
+   * (ABANDONED-INFERENCE P4). Absent for providers whose rates are
+   * unknowable (Ollama — local hardware), where no duration bound applies.
+   */
+  outputTokensPerHour?: number;
 }
 
 export interface InferenceClient {

--- a/packages/inference/src/interface.ts
+++ b/packages/inference/src/interface.ts
@@ -8,8 +8,8 @@ export interface InferenceResponse {
 /**
  * Raw JSON Schema for ONE array element of a structured generation — a plain
  * object, not a TS type and not a validator instance. Both providers consume
- * JSON Schema directly (Anthropic nests it under the forced tool's
- * `input_schema`; Ollama sends it as `format: { type: 'array', items: … }`),
+ * JSON Schema directly (Anthropic as the array-root schema under
+ * `output_config.format`; Ollama as `format: { type: 'array', items: … }`),
  * so anything richer would abstract one shape with two consumers.
  *
  * Constrain it to what both providers enforce: objects,
@@ -74,14 +74,24 @@ export interface InferenceClient {
   limits(): Promise<InferenceLimits>;
 
   /**
-   * Generate text from a prompt (simple interface)
+   * Generate text from a prompt (simple interface).
+   *
+   * `signal` (here and on every generation method — a trailing optional
+   * parameter, deliberately not an options bag; STRUCTURED-INFERENCE removed
+   * that shape on purpose): true cancellation, ABANDONED-INFERENCE P1.
+   * Implementations MUST thread it to their transport so an abort tears down
+   * the underlying request — and, for SDKs with internal retry loops, ends
+   * those too — rejecting promptly. Accepting the parameter and ignoring it
+   * is a defect worse than not having it: cancellation tests pass against
+   * such an adapter while zombie requests keep running (and billing) in
+   * production.
    */
-  generateText(prompt: string, maxTokens: number, temperature: number): Promise<string>;
+  generateText(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<string>;
 
   /**
    * Generate text with detailed response information
    */
-  generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number): Promise<InferenceResponse>;
+  generateTextWithMetadata(prompt: string, maxTokens: number, temperature: number, signal?: AbortSignal): Promise<InferenceResponse>;
 
   /**
    * Generate a JSON array whose elements satisfy `elementSchema`, as parsed
@@ -101,5 +111,6 @@ export interface InferenceClient {
     maxTokens: number,
     temperature: number,
     elementSchema: ElementSchema,
+    signal?: AbortSignal,
   ): Promise<StructuredResponse<T>>;
 }

--- a/packages/jobs/src/__tests__/failure-class.test.ts
+++ b/packages/jobs/src/__tests__/failure-class.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Failure classification — ABANDONED-INFERENCE P3 (A4, HD2).
+ *
+ * The taxonomy is deliberately small and one-sided: only KNOWN-deterministic
+ * failures skip the retry budget; everything unrecognized stays retryable
+ * (`undefined`), because mis-classifying a transient failure as deterministic
+ * silently halves reliability, while the reverse merely costs one wasted
+ * attempt — today's behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyFailure, DeterministicJobError } from '../failure-class';
+import { InferenceTimeoutError } from '../workers/inference-call';
+
+describe('classifyFailure (A4)', () => {
+  it('our own deterministic marker classifies deterministic', () => {
+    expect(classifyFailure(new DeterministicJobError('response truncated'))).toBe('deterministic');
+  });
+
+  it('our timeout bound classifies transient — a stall says nothing about the request', () => {
+    expect(classifyFailure(new InferenceTimeoutError('timed out'))).toBe('transient');
+  });
+
+  it('aborts are transient — the transport was torn down, not the request judged', () => {
+    expect(classifyFailure(Object.assign(new Error('aborted'), { name: 'APIUserAbortError' }))).toBe('transient');
+    expect(classifyFailure(new DOMException('This operation was aborted', 'AbortError'))).toBe('transient');
+  });
+
+  it('environmental provider statuses are transient: 408, 429, 5xx', () => {
+    for (const status of [408, 429, 500, 529]) {
+      expect(classifyFailure(Object.assign(new Error(`http ${status}`), { status }))).toBe('transient');
+    }
+  });
+
+  it('request-rejection statuses are deterministic: the same request cannot succeed twice', () => {
+    for (const status of [400, 401, 403, 413, 422]) {
+      expect(classifyFailure(Object.assign(new Error(`http ${status}`), { status }))).toBe('deterministic');
+    }
+  });
+
+  it('everything unrecognized is unclassified — retryable by default (HD2 gates only KNOWN-deterministic)', () => {
+    expect(classifyFailure(new Error('MessageStream terminated'))).toBeUndefined();
+    expect(classifyFailure(new TypeError('fetch failed'))).toBeUndefined();
+    expect(classifyFailure('a string')).toBeUndefined();
+    expect(classifyFailure(undefined)).toBeUndefined();
+  });
+});

--- a/packages/jobs/src/__tests__/job-claim-adapter.test.ts
+++ b/packages/jobs/src/__tests__/job-claim-adapter.test.ts
@@ -276,3 +276,47 @@ describe('createJobClaimAdapter', () => {
     });
   });
 });
+
+// ── Checkpoint surfaces on the claimed job (ABANDONED-INFERENCE P2) ───
+
+describe('claimed-job checkpoint (A3)', () => {
+  let h: ReturnType<typeof fakeBus>;
+
+  beforeEach(() => {
+    h = fakeBus();
+  });
+
+  it('surfaces metadata.completedUnits on the ActiveJob', async () => {
+    const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+    adapter.start();
+
+    h.pushEvent('job:queued', { jobId: 'jc1', jobType: 'reference-annotation', resourceId: 'r1' });
+    await new Promise((r) => setTimeout(r, 0));
+    h.pushEvent('job:claimed', {
+      correlationId: h.emits[0]!.payload.correlationId,
+      response: { params: {}, metadata: { userId: 'u1', completedUnits: ['Person', 'Date'] } },
+    });
+
+    const active = await firstValueFrom(adapter.activeJob$.pipe(skip(1), take(1)));
+    expect(active?.completedUnits).toEqual(['Person', 'Date']);
+
+    adapter.dispose();
+  });
+
+  it('defaults completedUnits to empty when the record carries none', async () => {
+    const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+    adapter.start();
+
+    h.pushEvent('job:queued', { jobId: 'jc2', jobType: 'reference-annotation', resourceId: 'r1' });
+    await new Promise((r) => setTimeout(r, 0));
+    h.pushEvent('job:claimed', {
+      correlationId: h.emits[0]!.payload.correlationId,
+      response: { params: {}, metadata: { userId: 'u1' } },
+    });
+
+    const active = await firstValueFrom(adapter.activeJob$.pipe(skip(1), take(1)));
+    expect(active?.completedUnits).toEqual([]);
+
+    adapter.dispose();
+  });
+});

--- a/packages/jobs/src/__tests__/job-queue.test.ts
+++ b/packages/jobs/src/__tests__/job-queue.test.ts
@@ -815,4 +815,35 @@ describe('JobQueue', () => {
       expect(failed?.metadata.completedUnits).toEqual(['Person']);
     });
   });
+
+  describe('failJob classification (ABANDONED-INFERENCE P3, A4)', () => {
+    test('a deterministic failure goes straight to failed — budget remaining or not', async () => {
+      // retryCount 0, maxRetries 3: plenty of budget, and it must not be spent.
+      await jobQueue.createJob(createRunningDetectionJob('job-det'));
+
+      const outcome = await jobQueue.failJob(jobId('job-det'), 'request exceeds size limits', undefined, 'deterministic');
+
+      expect(outcome).toBe('failed');
+      expect((await jobQueue.getJob(jobId('job-det')))?.status).toBe('failed');
+    });
+
+    test('an explicit transient failure retries exactly as an unclassified one does', async () => {
+      await jobQueue.createJob(createRunningDetectionJob('job-transient'));
+
+      const outcome = await jobQueue.failJob(jobId('job-transient'), 'timed out', undefined, 'transient');
+
+      expect(outcome).toBe('retried');
+      expect((await jobQueue.getJob(jobId('job-transient')))?.status).toBe('pending');
+    });
+
+    test('a deterministic failure still keeps its checkpoint on the terminal record (D3)', async () => {
+      await jobQueue.createJob(createRunningDetectionJob('job-det-ckpt'));
+
+      const outcome = await jobQueue.failJob(jobId('job-det-ckpt'), 'schema rejected', ['Person', 'Date'], 'deterministic');
+
+      expect(outcome).toBe('failed');
+      const failed = await jobQueue.getJob(jobId('job-det-ckpt'));
+      expect(failed?.metadata.completedUnits).toEqual(['Person', 'Date']);
+    });
+  });
 });

--- a/packages/jobs/src/__tests__/job-queue.test.ts
+++ b/packages/jobs/src/__tests__/job-queue.test.ts
@@ -779,4 +779,40 @@ describe('JobQueue', () => {
       expect((await jobQueue.getJob(jobId('job-heartbeat')))?.status).toBe('running');
     });
   });
+
+  describe('failJob checkpoint (ABANDONED-INFERENCE P2, A3 iv)', () => {
+    test('records completedUnits on the retried job — the checkpoint survives the rebuild', async () => {
+      await jobQueue.createJob(createRunningDetectionJob('job-ckpt'));
+
+      const outcome = await jobQueue.failJob(jobId('job-ckpt'), 'Location stalled', ['Person', 'Date']);
+
+      expect(outcome).toBe('retried');
+      const retried = await jobQueue.getJob(jobId('job-ckpt'));
+      expect(retried?.status).toBe('pending');
+      expect(retried?.metadata.completedUnits).toEqual(['Person', 'Date']);
+    });
+
+    test('unions with units recorded by earlier attempts — attempt 3 keeps attempt 1', async () => {
+      const job = createRunningDetectionJob('job-ckpt-union');
+      job.metadata.completedUnits = ['Person'];
+      await jobQueue.createJob(job);
+
+      await jobQueue.failJob(jobId('job-ckpt-union'), 'Date stalled', ['Date']);
+
+      const retried = await jobQueue.getJob(jobId('job-ckpt-union'));
+      expect(retried?.metadata.completedUnits?.slice().sort()).toEqual(['Date', 'Person']);
+    });
+
+    test('the terminal failed record carries the units too — the waste is visible (D3)', async () => {
+      const job = createRunningDetectionJob('job-ckpt-terminal');
+      job.metadata.retryCount = 3; // maxRetries is 3 — exhausted
+      await jobQueue.createJob(job);
+
+      const outcome = await jobQueue.failJob(jobId('job-ckpt-terminal'), 'stalled again', ['Person']);
+
+      expect(outcome).toBe('failed');
+      const failed = await jobQueue.getJob(jobId('job-ckpt-terminal'));
+      expect(failed?.metadata.completedUnits).toEqual(['Person']);
+    });
+  });
 });

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -260,26 +260,30 @@ describe('processReferenceJob', () => {
     ]);
 
     const progress = vi.fn();
-    const result = await processReferenceJob(
+    const committed: unknown[] = [];
+    const outcome = await processReferenceJob(
       'Paris and Berlin',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
       textBuild('Paris and Berlin'),
       progress,
       LOGGER,
+      async (_unit, annotations) => {
+        committed.push(...annotations);
+      },
     );
 
-    expect(result.annotations).toHaveLength(2);
-    expect((result.annotations[0] as any).motivation).toBe('linking');
+    expect(committed).toHaveLength(2);
+    expect((committed[0] as any).motivation).toBe('linking');
     // Canonical unresolved-linking body — single-item array with the
     // entity type as a tagging TextualBody, stamped with format and the
     // body locale (defaults to 'en'). The bind flow later appends a
     // SpecificResource to resolve. Do not emit `[]` — that breaks the
     // append contract and trips the Annotation.body oneOf.
-    expect((result.annotations[0] as any).body).toEqual([
+    expect((committed[0] as any).body).toEqual([
       { type: 'TextualBody', value: 'Location', purpose: 'tagging', format: 'text/plain', language: 'en' },
     ]);
-    expect(result.result).toEqual({ kind: 'reference-annotation', totalFound: 2, totalEmitted: 2, errors: 0 });
+    expect(outcome.result).toEqual({ kind: 'reference-annotation', totalFound: 2, totalEmitted: 2, errors: 0 });
   });
 
   it('counts errors when reconciliation drops an entity (text not in source)', async () => {
@@ -290,33 +294,40 @@ describe('processReferenceJob', () => {
       { exact: 'BADTEXT', start: 99, end: 106, entityType: 'Thing' } as any,
     ]);
 
-    const result = await processReferenceJob(
+    const committed: unknown[] = [];
+    const outcome = await processReferenceJob(
       'good stuff',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Thing')] },
       textBuild('good stuff'),
       vi.fn(),
       LOGGER,
+      async (_unit, annotations) => {
+        committed.push(...annotations);
+      },
     );
 
-    expect(result.annotations).toHaveLength(1);
-    expect(result.result).toEqual({ kind: 'reference-annotation', totalFound: 2, totalEmitted: 1, errors: 1 });
+    expect(committed).toHaveLength(1);
+    expect(outcome.result).toEqual({ kind: 'reference-annotation', totalFound: 2, totalEmitted: 1, errors: 1 });
   });
 
-  it('returns zero counts when no entities are found', async () => {
+  it('returns zero counts when no entities are found — and still commits the empty unit', async () => {
     vi.mocked(extractEntities).mockResolvedValue([]);
 
-    const result = await processReferenceJob(
+    const onUnitComplete = vi.fn(async () => {});
+    const outcome = await processReferenceJob(
       'content',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
       textBuild('content'),
       vi.fn(),
       LOGGER,
+      onUnitComplete,
     );
 
-    expect(result.annotations).toHaveLength(0);
-    expect(result.result).toEqual({ kind: 'reference-annotation', totalFound: 0, totalEmitted: 0, errors: 0 });
+    // Legitimately-empty is a completed unit (A3 v) — a retry must skip it.
+    expect(onUnitComplete).toHaveBeenCalledExactlyOnceWith('Location', []);
+    expect(outcome.result).toEqual({ kind: 'reference-annotation', totalFound: 0, totalEmitted: 0, errors: 0 });
   });
 });
 
@@ -794,15 +805,21 @@ describe('annotation attribution composition', () => {
       { exact: 'x', start: 0, end: 1, category: 'c' },
     ]);
 
+    const referenceCommitted: unknown[] = [];
     const sources = await Promise.all([
       processCommentJob('x', makeInferenceClient(), { resourceId: RID, density: 1 }, textBuild('x'), vi.fn()),
       processAssessmentJob('x', makeInferenceClient(), { resourceId: RID, density: 1 }, textBuild('x'), vi.fn()),
-      processReferenceJob('x', makeInferenceClient(), { resourceId: RID, entityTypes: [entityType('Person')] }, textBuild('x'), vi.fn(), LOGGER),
+      processReferenceJob('x', makeInferenceClient(), { resourceId: RID, entityTypes: [entityType('Person')] }, textBuild('x'), vi.fn(), LOGGER,
+        async (_unit, annotations) => { referenceCommitted.push(...annotations); }),
       processTagJob('x', makeInferenceClient(), { resourceId: RID, schema: 'schema-1', categories: ['c'], sourceLanguage: 'en' } as never, textBuild('x'), vi.fn()),
     ]);
 
-    for (const result of sources) {
-      const ann = result.annotations[0] as Record<string, unknown>;
+    const firstAnnotations = [
+      ...sources.flatMap((s) => ('annotations' in s ? [s.annotations[0]] : [])),
+      referenceCommitted[0],
+    ];
+    for (const first of firstAnnotations) {
+      const ann = first as Record<string, unknown>;
       expect(ann['creator']).toBeDefined();
       expect(ann['generator']).toBeDefined();
       expect(Array.isArray(ann['wasAttributedTo'])).toBe(true);
@@ -870,16 +887,20 @@ describe('locale threading', () => {
         { exact: 'Paris', start: 0, end: 5, entityType: 'Location' } as any,
       ]);
 
-      const result = await processReferenceJob(
+      const committed: unknown[] = [];
+      await processReferenceJob(
         'Paris',
         makeInferenceClient(),
         { resourceId: RID, entityTypes: [entityType('Location')], language: 'fr' },
         textBuild('Paris'),
         vi.fn(),
         LOGGER,
+        async (_unit, annotations) => {
+          committed.push(...annotations);
+        },
       );
 
-      expect((result.annotations[0] as any).body).toEqual([
+      expect((committed[0] as any).body).toEqual([
         { type: 'TextualBody', value: 'Location', purpose: 'tagging', format: 'text/plain', language: 'fr' },
       ]);
     });
@@ -982,7 +1003,7 @@ describe('locale threading', () => {
         'content', client,
         { resourceId: RID, entityTypes: [entityType('Location')], sourceLanguage: 'fr' },
         textBuild('content'), vi.fn(),
-        LOGGER,
+        LOGGER, async () => {},
       );
 
       expect(extractEntities).toHaveBeenCalledWith(
@@ -1215,18 +1236,22 @@ describe('Layer 2: worker-parser integration via real reconcileSelector', () => 
       { exact: 'NoSuchPerson', start: 99, end: 111, entityType: 'Person' } as any,
     ]);
 
-    const result = await processReferenceJob(
+    const committed: unknown[] = [];
+    const outcome = await processReferenceJob(
       'Alice went to Paris.',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Person')] },
       textBuild('Alice went to Paris.'),
       vi.fn(),
       LOGGER,
+      async (_unit, annotations) => {
+        committed.push(...annotations);
+      },
     );
 
-    expect(result.result).toEqual({ kind: 'reference-annotation', totalFound: 2, totalEmitted: 1, errors: 1 });
-    expect(result.annotations).toHaveLength(1);
-    const ann = result.annotations[0] as any;
+    expect(outcome.result).toEqual({ kind: 'reference-annotation', totalFound: 2, totalEmitted: 1, errors: 1 });
+    expect(committed).toHaveLength(1);
+    const ann = committed[0] as any;
     const posSel = ann.target.selector.find((s: any) => s.type === 'TextPositionSelector');
     const quoteSel = ann.target.selector.find((s: any) => s.type === 'TextQuoteSelector');
     expect((ann.target.source as string)).toBe(RID);
@@ -1309,18 +1334,22 @@ describe('annotation de-duplication', () => {
       { exact: 'Paris', entityType: 'Location' },
     ] as any);
 
-    const result = await processReferenceJob(
+    const committed: unknown[] = [];
+    const outcome = await processReferenceJob(
       'A trip to Paris.',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
       textBuild('A trip to Paris.'),
       vi.fn(),
       LOGGER,
+      async (_unit, annotations) => {
+        committed.push(...annotations);
+      },
     );
 
-    expect(result.annotations).toHaveLength(1);
-    expect(result.result.totalEmitted).toBe(1);
-    expect(result.result.totalFound).toBe(3);
+    expect(committed).toHaveLength(1);
+    expect(outcome.result.totalEmitted).toBe(1);
+    expect(outcome.result.totalFound).toBe(3);
   });
 
   it('reference: same span but different entity types are kept (not duplicates)', async () => {
@@ -1330,17 +1359,21 @@ describe('annotation de-duplication', () => {
       .mockResolvedValueOnce([{ exact: 'Mercury', entityType: 'Planet' }] as any)
       .mockResolvedValueOnce([{ exact: 'Mercury', entityType: 'Element' }] as any);
 
-    const result = await processReferenceJob(
+    const committed: unknown[] = [];
+    const outcome = await processReferenceJob(
       'The metal Mercury is dense.',
       makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Planet'), entityType('Element')] },
       textBuild('The metal Mercury is dense.'),
       vi.fn(),
       LOGGER,
+      async (_unit, annotations) => {
+        committed.push(...annotations);
+      },
     );
 
-    expect(result.annotations).toHaveLength(2);
-    expect(result.result.totalEmitted).toBe(2);
+    expect(committed).toHaveLength(2);
+    expect(outcome.result.totalEmitted).toBe(2);
   });
 
   it('highlight: duplicate identical highlights collapse to one', async () => {
@@ -1438,7 +1471,7 @@ describe('progress messages are codes, not prose (A6)', () => {
     await processReferenceJob(
       'Paris', makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
-      textBuild('Paris'), progress, LOGGER,
+      textBuild('Paris'), progress, LOGGER, async () => {},
     );
 
     const messages = messagesFrom(progress);
@@ -1578,7 +1611,7 @@ describe('request parameters ride every event', () => {
     await processReferenceJob(
       'Paris', makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
-      textBuild('Paris'), progress, LOGGER,
+      textBuild('Paris'), progress, LOGGER, async () => {},
     );
 
     const extras = extrasFrom(progress);
@@ -1608,7 +1641,7 @@ describe('what is in flight is reported one way (CLEAN-PROGRESS A4/A5)', () => {
     await processReferenceJob(
       'Paris', makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location'), entityType('Person')] },
-      textBuild('Paris'), progress, LOGGER,
+      textBuild('Paris'), progress, LOGGER, async () => {},
     );
 
     const detecting = extrasFrom(progress).filter((e) => e?.current);
@@ -1654,7 +1687,7 @@ describe('what is in flight is reported one way (CLEAN-PROGRESS A4/A5)', () => {
     await processReferenceJob(
       'Paris', makeInferenceClient(),
       { resourceId: RID, entityTypes: [entityType('Location')] },
-      textBuild('Paris'), progress, LOGGER,
+      textBuild('Paris'), progress, LOGGER, async () => {},
     );
 
     const dead = ['processedEntityTypes', 'totalEntityTypes', 'currentEntityType',
@@ -1662,5 +1695,91 @@ describe('what is in flight is reported one way (CLEAN-PROGRESS A4/A5)', () => {
     for (const extra of extrasFrom(progress)) {
       for (const field of dead) expect(extra ?? {}).not.toHaveProperty(field);
     }
+  });
+});
+
+// ── Checkpointed resume (ABANDONED-INFERENCE P2, A3) ──────────────────
+// The unit is the entity type. A unit either completed — its annotations
+// handed to `onUnitComplete` and accepted — or it contributes nothing.
+// Emission moves INTO the loop via the callback (the post-run batch was
+// N2's mechanism); the processor returns only the result.
+
+describe('processReferenceJob — unit commits (A3)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('commits each completed unit through onUnitComplete — including empty ones — and stops at the failing unit', async () => {
+    vi.mocked(extractEntities).mockImplementation(async (_c, types) => {
+      const t = String(types[0]);
+      if (t === 'Person') return [{ exact: 'Greeley', start: 0, end: 7, entityType: 'Person' }] as never;
+      if (t === 'Date') return [] as never; // legitimately-empty unit (RED v)
+      throw new Error('Location stalled');
+    });
+
+    const committed: Array<{ unit: string; count: number }> = [];
+    const onUnitComplete = vi.fn(async (unit: string, annotations: unknown[]) => {
+      committed.push({ unit, count: annotations.length });
+    });
+
+    await expect(
+      processReferenceJob(
+        'Greeley went west',
+        makeInferenceClient(),
+        { resourceId: RID, entityTypes: [entityType('Person'), entityType('Date'), entityType('Location')] },
+        textBuild('Greeley went west'),
+        vi.fn(),
+        LOGGER,
+        onUnitComplete,
+      ),
+    ).rejects.toThrow('Location stalled');
+
+    // Units 1..k committed in order, the failing unit contributed nothing.
+    expect(committed).toEqual([
+      { unit: 'Person', count: 1 },
+      { unit: 'Date', count: 0 },
+    ]);
+  });
+
+  it('a rejected unit commit fails the run — the unit is not silently kept', async () => {
+    vi.mocked(extractEntities).mockResolvedValue([
+      { exact: 'Greeley', start: 0, end: 7, entityType: 'Person' },
+    ] as never);
+
+    await expect(
+      processReferenceJob(
+        'Greeley went west',
+        makeInferenceClient(),
+        { resourceId: RID, entityTypes: [entityType('Person')] },
+        textBuild('Greeley went west'),
+        vi.fn(),
+        LOGGER,
+        vi.fn(async () => {
+          throw new Error('emit refused');
+        }),
+      ),
+    ).rejects.toThrow('emit refused');
+  });
+
+  it('returns only the result — the callback owns emission, nothing is returned twice', async () => {
+    vi.mocked(extractEntities).mockResolvedValue([
+      { exact: 'Greeley', start: 0, end: 7, entityType: 'Person' },
+    ] as never);
+
+    const seen: unknown[][] = [];
+    const outcome = await processReferenceJob(
+      'Greeley went west',
+      makeInferenceClient(),
+      { resourceId: RID, entityTypes: [entityType('Person')] },
+      textBuild('Greeley went west'),
+      vi.fn(),
+      LOGGER,
+      vi.fn(async (_unit: string, annotations: unknown[]) => {
+        seen.push(annotations);
+      }),
+    );
+
+    expect(Object.keys(outcome)).toEqual(['result']);
+    expect(outcome.result).toEqual({ kind: 'reference-annotation', totalFound: 1, totalEmitted: 1, errors: 0 });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toHaveLength(1);
   });
 });

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -169,7 +169,11 @@ function makeConfig(session: SemiontSession): WorkerProcessConfig {
   };
 }
 
-function makeJob(type: ActiveJob['type'], paramsOverride: Record<string, unknown> = {}): ActiveJob {
+function makeJob(
+  type: ActiveJob['type'],
+  paramsOverride: Record<string, unknown> = {},
+  completedUnits: string[] = [],
+): ActiveJob {
   return {
     jobId: JID,
     type,
@@ -178,6 +182,7 @@ function makeJob(type: ActiveJob['type'], paramsOverride: Record<string, unknown
     // Generation params must satisfy the wire's required trio (the worker
     // guard enforces it); overrides still win.
     params: { resourceId: RID, ...(type === 'generation' ? GEN_REQUIRED : {}), ...paramsOverride },
+    completedUnits,
   } as ActiveJob;
 }
 
@@ -266,21 +271,9 @@ describe('handleJob orchestration', () => {
     });
   });
 
-  describe('reference-annotation', () => {
-    it('emits job:start, mark:create per annotation, then job:complete', async () => {
-      vi.mocked(processReferenceJob).mockResolvedValue({
-        annotations: [{ id: 'r1' }, { id: 'r2' }, { id: 'r3' }] as never,
-        result: { totalFound: 3, totalEmitted: 3, errors: 0 } as never,
-      });
-      const h = makeFakeSessionAndAdapter();
-
-      await handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation'));
-
-      expect(h.busEmits.map(e => e.channel))
-        .toEqual(['job:start', 'mark:create', 'mark:create', 'mark:create', 'job:complete']);
-      expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
-    });
-  });
+  // The reference-annotation branch commits per unit through
+  // `onUnitComplete` — covered by the 'checkpointed resume' describes at
+  // the end of this file, which superseded the old post-run-batch test.
 
   describe('tag-annotation', () => {
     it('emits job:start, mark:create per annotation, then job:complete', async () => {
@@ -745,7 +738,7 @@ describe('handleJob orchestration', () => {
       const h = makeFakeSessionAndAdapter();
 
       await expect(
-        handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation'))
+        handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation', { entityTypes: ['Person'] }))
       ).rejects.toThrow('inference blew up');
 
       // On failure, handleJob itself does NOT emit job:complete.
@@ -769,7 +762,7 @@ describe('handleJob orchestration', () => {
       } as never);
 
       await expect(
-        handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation'))
+        handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation', { entityTypes: ['Person'] }))
       ).rejects.toThrow(/has no extractable text/);
 
       expect(h.session.client.browse.resourceContent).not.toHaveBeenCalled();
@@ -800,7 +793,7 @@ describe('handleJob orchestration', () => {
         arm: () => { vi.mocked(processAssessmentJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
         lastCall: () => vi.mocked(processAssessmentJob).mock.calls[0] },
       { jobType: 'reference-annotation',
-        arm: () => { vi.mocked(processReferenceJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
+        arm: () => { vi.mocked(processReferenceJob).mockResolvedValue({ result: {} as never }); },
         lastCall: () => vi.mocked(processReferenceJob).mock.calls[0] },
       { jobType: 'tag-annotation',
         arm: () => { vi.mocked(processTagJob).mockResolvedValue({ annotations: [] as never, result: {} as never }); },
@@ -819,7 +812,13 @@ describe('handleJob orchestration', () => {
       }),
       } as never);
 
-      await handleJob(h.adapter, makeConfig(h.session), makeJob(jobType));
+      await handleJob(
+        h.adapter,
+        makeConfig(h.session),
+        // The reference branch reads entityTypes before dispatching to the
+        // (mocked) processor — give it the params a real job always carries.
+        makeJob(jobType, jobType === 'reference-annotation' ? { entityTypes: ['Person'] } : {}),
+      );
 
       // pdf-text-layer fetches the representation bytes, never resourceContent.
       expect(getBinary).toHaveBeenCalled();
@@ -1060,7 +1059,7 @@ describe('startWorkerProcess', () => {
     const h = makeFakeSessionAndAdapter();
     startWorkerProcess(makeConfig(h.session));
 
-    activeJob$.next(makeJob('reference-annotation', { referenceId: 'ann-1' }));
+    activeJob$.next(makeJob('reference-annotation', { referenceId: 'ann-1', entityTypes: ['Person'] }));
     await new Promise((r) => setTimeout(r, 10));
 
     // Outer handler emits job:fail on the bus and calls adapter.failJob.
@@ -1097,3 +1096,102 @@ describe('referenceIdOf', () => {
   });
 });
 
+
+// ── Checkpointed resume (ABANDONED-INFERENCE P2, A3) ──────────────────
+// The worker owns the unit commit: it passes `onUnitComplete` into
+// `processReferenceJob`, emits the unit's mark:creates as they complete
+// (the post-run batch was N2's mechanism), accumulates the completed unit
+// names, carries them on job:fail, and skips checkpointed units on a
+// retried claim.
+
+describe('reference-annotation — checkpointed resume', () => {
+  it('emits per unit through the commit callback, with no post-run re-emission', async () => {
+    vi.mocked(processReferenceJob).mockImplementation(
+      async (_content, _client, _params, _build, _progress, _logger, onUnitComplete) => {
+        await onUnitComplete('Person', [{ id: 'r1' }] as never);
+        await onUnitComplete('Date', [] as never);
+        await onUnitComplete('Location', [{ id: 'r2' }, { id: 'r3' }] as never);
+        return { result: { kind: 'reference-annotation', totalFound: 3, totalEmitted: 3, errors: 0 } as never };
+      },
+    );
+    const h = makeFakeSessionAndAdapter();
+
+    await handleJob(h.adapter, makeConfig(h.session), makeJob('reference-annotation', { entityTypes: ['Person', 'Date', 'Location'] }));
+
+    // Exactly the callback's emissions — one per annotation, in unit order,
+    // and nothing re-emitted after the processor returns.
+    expect(h.busEmits.map(e => e.channel))
+      .toEqual(['job:start', 'mark:create', 'mark:create', 'mark:create', 'job:complete']);
+    expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
+  });
+
+  it('a retried claim skips checkpointed units — the processor never sees them (A3 ii)', async () => {
+    vi.mocked(processReferenceJob).mockImplementation(
+      async () => ({ result: { kind: 'reference-annotation', totalFound: 0, totalEmitted: 0, errors: 0 } as never }),
+    );
+    const h = makeFakeSessionAndAdapter();
+
+    await handleJob(
+      h.adapter,
+      makeConfig(h.session),
+      makeJob('reference-annotation', { entityTypes: ['Person', 'Date', 'Location'] }, ['Person', 'Date']),
+    );
+
+    const params = vi.mocked(processReferenceJob).mock.calls[0]![2] as { entityTypes: unknown[] };
+    expect(params.entityTypes.map(String)).toEqual(['Location']);
+  });
+});
+
+describe('startWorkerProcess — job:fail carries the checkpoint (A3 i/iv feed)', () => {
+  it('accumulates committed units and puts them on the job:fail payload', async () => {
+    const { BehaviorSubject } = await import('rxjs');
+    const activeJob$ = new BehaviorSubject<ActiveJob | null>(null);
+    const failJob = vi.fn();
+
+    vi.doMock('../job-claim-adapter', () => ({
+      createJobClaimAdapter: vi.fn(() => ({
+        activeJob$: activeJob$.asObservable(),
+        isProcessing$: { subscribe: vi.fn() },
+        jobsCompleted$: { subscribe: vi.fn() },
+        errors$: { subscribe: vi.fn() },
+        start: vi.fn(),
+        stop: vi.fn(),
+        completeJob: vi.fn(),
+        failJob,
+        dispose: vi.fn(),
+        vitals: vi.fn(),
+        touchActivity: vi.fn(),
+      })),
+    }));
+    vi.resetModules();
+    const { startWorkerProcess } = await import('../worker-process');
+
+    // Two units commit, then the third stalls — the failure payload must
+    // name what completed so the retry can skip it.
+    vi.mocked(processReferenceJob).mockImplementation(
+      async (_content, _client, _params, _build, _progress, _logger, onUnitComplete) => {
+        await onUnitComplete('Person', [{ id: 'a1' }] as never);
+        await onUnitComplete('Date', [] as never);
+        throw new Error('Location stalled');
+      },
+    );
+
+    const h = makeFakeSessionAndAdapter();
+    startWorkerProcess(makeConfig(h.session));
+
+    activeJob$.next(makeJob('reference-annotation', { entityTypes: ['Person', 'Date', 'Location'] }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const failEmit = h.busEmits.find((e) => e.channel === 'job:fail');
+    expect(failEmit).toBeDefined();
+    expect(failEmit!.payload).toMatchObject({
+      jobId: JID,
+      error: 'Location stalled',
+      completedUnits: ['Person', 'Date'],
+    });
+    expect(failJob).toHaveBeenCalledWith(JID, 'Location stalled');
+
+    vi.doUnmock('../job-claim-adapter');
+    vi.resetModules();
+  });
+});

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -1195,3 +1195,51 @@ describe('startWorkerProcess — job:fail carries the checkpoint (A3 i/iv feed)'
     vi.resetModules();
   });
 });
+
+describe('startWorkerProcess — job:fail carries the failure class (ABANDONED-INFERENCE P3, A4)', () => {
+  it('a provider request-rejection is classified deterministic on the payload', async () => {
+    const { BehaviorSubject } = await import('rxjs');
+    const activeJob$ = new BehaviorSubject<ActiveJob | null>(null);
+
+    vi.doMock('../job-claim-adapter', () => ({
+      createJobClaimAdapter: vi.fn(() => ({
+        activeJob$: activeJob$.asObservable(),
+        isProcessing$: { subscribe: vi.fn() },
+        jobsCompleted$: { subscribe: vi.fn() },
+        errors$: { subscribe: vi.fn() },
+        start: vi.fn(),
+        stop: vi.fn(),
+        completeJob: vi.fn(),
+        failJob: vi.fn(),
+        dispose: vi.fn(),
+        vitals: vi.fn(),
+        touchActivity: vi.fn(),
+      })),
+    }));
+    vi.resetModules();
+    const { startWorkerProcess } = await import('../worker-process');
+
+    // The SDK shape for "your request is the problem": an Error carrying a
+    // 4xx status. Attempt 2 of this exact request cannot succeed.
+    vi.mocked(processReferenceJob).mockRejectedValueOnce(
+      Object.assign(new Error('request exceeds size limits'), { status: 413 }),
+    );
+
+    const h = makeFakeSessionAndAdapter();
+    startWorkerProcess(makeConfig(h.session));
+
+    activeJob$.next(makeJob('reference-annotation', { entityTypes: ['Person'] }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const failEmit = h.busEmits.find((e) => e.channel === 'job:fail');
+    expect(failEmit).toBeDefined();
+    expect(failEmit!.payload).toMatchObject({
+      jobId: JID,
+      error: 'request exceeds size limits',
+      failureClass: 'deterministic',
+    });
+
+    vi.doUnmock('../job-claim-adapter');
+    vi.resetModules();
+  });
+});

--- a/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
+++ b/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { AnnotationDetection } from '../../workers/annotation-detection';
 import { MockInferenceClient, type InferenceClient } from '@semiont/inference';
+import { DeterministicJobError } from '../../failure-class';
 import type { TagSchema } from '@semiont/core';
 
 // Test schema — supplied directly to detectTags (the dispatcher resolves
@@ -367,9 +368,11 @@ describe('AnnotationDetection', () => {
         ['max_tokens'],
       );
 
-      await expect(
-        AnnotationDetection.detectHighlights(testContent, mockClient)
-      ).rejects.toThrow(/truncat/i);
+      const pending = AnnotationDetection.detectHighlights(testContent, mockClient);
+      await expect(pending).rejects.toThrow(/truncat/i);
+      // Deterministic class pinned on BOTH detection paths — see the matching
+      // pin in entity-extractor.test.ts.
+      await expect(pending).rejects.toBeInstanceOf(DeterministicJobError);
     });
   });
 
@@ -469,9 +472,9 @@ describe('AnnotationDetection', () => {
         SMALL_SHARED_LIMITS,
       );
 
-      await expect(
-        AnnotationDetection.detectHighlights(bigContent, client),
-      ).rejects.toThrow(/truncat/i);
+      const pending = AnnotationDetection.detectHighlights(bigContent, client);
+      await expect(pending).rejects.toThrow(/truncat/i);
+      await expect(pending).rejects.toBeInstanceOf(DeterministicJobError);
     });
 
     it('makes one call with a derived (non-literal) output budget when content fits', async () => {

--- a/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { deriveDetectionBudget } from '../../../workers/detection/detection-chunking';
+import { INFERENCE_TIMEOUT_MS } from '../../../workers/inference-call';
 
 describe('deriveDetectionBudget', () => {
   it('splits a shared window 1:2 input:output after the scaffold', () => {
@@ -65,5 +66,53 @@ describe('deriveDetectionBudget', () => {
     expect(() =>
       deriveDetectionBudget({ contextTokens: 300, maxOutputTokens: 300 }, 250),
     ).toThrow(/window too small/i);
+  });
+});
+
+// ── Duration bound (ABANDONED-INFERENCE P4, A5 — HD3) ─────────────────
+// Capacity says what CAN fit in one call; duration says what SHOULD. On
+// separate-ceilings providers the capacity budget allows ~935K-token
+// chunks — calls that stream for 20+ minutes, the UX HD3 rejects. The
+// bound DERIVES end to end: the provider SDK's own worst-case rate model
+// (128K output tokens/hour — the calculateNonstreamingTimeout constant,
+// surfaced through limits()) times our own 10-minute call bound. No
+// hand-tuned cap; #1121's principle extends to a second bound.
+
+describe('deriveDetectionBudget — duration bound (A5)', () => {
+  const anthropic1M = { contextTokens: 1_000_000, maxOutputTokens: 64_000, outputTokensPerHour: 128_000 };
+  const anthropic1MNoRate = { contextTokens: 1_000_000, maxOutputTokens: 64_000 };
+
+  it('caps per-call output at the provider rate × the inference bound', () => {
+    const budget = deriveDetectionBudget(anthropic1M, 1_000);
+
+    expect(budget.outputBudget).toBe(Math.floor(128_000 * (INFERENCE_TIMEOUT_MS / 3_600_000)));
+  });
+
+  it('scales input by the same factor — ratio preserved, so a capacity-sized document now splits (A5)', () => {
+    const uncapped = deriveDetectionBudget(anthropic1MNoRate, 1_000);
+    const capped = deriveDetectionBudget(anthropic1M, 1_000);
+
+    const factor = capped.outputBudget / uncapped.outputBudget;
+    expect(capped.chunking.chunkSize).toBe(Math.floor(uncapped.chunking.chunkSize * factor));
+    // The A5 clause itself: a document sized to the old single-call budget
+    // no longer fits one call.
+    expect(uncapped.chunking.chunkSize).toBeGreaterThan(capped.chunking.chunkSize);
+  });
+
+  it('is a floor on chunk count, never a raise — no-op when capacity is already tighter', () => {
+    const tinyOutput = { contextTokens: 200_000, maxOutputTokens: 8_000 };
+
+    expect(deriveDetectionBudget({ ...tinyOutput, outputTokensPerHour: 128_000 }, 1_000))
+      .toEqual(deriveDetectionBudget(tinyOutput, 1_000));
+  });
+
+  it('providers publishing no rate are byte-identical to today — Ollama stays capacity-governed', () => {
+    const shared = { contextTokens: 32_768, maxOutputTokens: 32_768 };
+
+    const budget = deriveDetectionBudget(shared, 500);
+    const available = 32_768 - 500;
+    const inputBudget = Math.floor(available / 3);
+    expect(budget.chunking.chunkSize).toBe(inputBudget);
+    expect(budget.outputBudget).toBe(available - inputBudget);
   });
 });

--- a/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MockInferenceClient, type InferenceClient } from '@semiont/inference';
 import { extractEntities } from '../../../workers/detection/entity-extractor';
+import { DeterministicJobError } from '../../../failure-class';
 
 // Create mock client directly
 const mockInferenceClient = new MockInferenceClient(['[]']);
@@ -117,9 +118,14 @@ describe('extractEntities', () => {
 
     mockInferenceClient.setResponses([JSON.stringify(mockResponse)], ['max_tokens']);
 
-    await expect(
-      extractEntities(text, ['Person'], mockInferenceClient, false, LOGGER),
-    ).rejects.toThrow(/truncat/i);
+    // Same input truncates the same way, so the throw must carry the
+    // deterministic class — a plain Error here classifies as retryable and
+    // burns the retry budget re-issuing a guaranteed-to-truncate request
+    // (ABANDONED-INFERENCE P3; the annotation-detection path already does
+    // this and the two must not diverge).
+    const pending = extractEntities(text, ['Person'], mockInferenceClient, false, LOGGER);
+    await expect(pending).rejects.toThrow(/truncat/i);
+    await expect(pending).rejects.toBeInstanceOf(DeterministicJobError);
   });
 
   it('should handle entity types with examples', async () => {
@@ -266,9 +272,9 @@ describe('extractEntities', () => {
         SMALL_SHARED_LIMITS,
       );
 
-      await expect(
-        extractEntities(bigText, ['Person'], client, false, LOGGER),
-      ).rejects.toThrow(/truncat/i);
+      const pending = extractEntities(bigText, ['Person'], client, false, LOGGER);
+      await expect(pending).rejects.toThrow(/truncat/i);
+      await expect(pending).rejects.toBeInstanceOf(DeterministicJobError);
     });
 
     it('passes duplicate entities from adjacent chunks through — dedupe stays in the processor', async () => {

--- a/packages/jobs/src/__tests__/workers/inference-call.test.ts
+++ b/packages/jobs/src/__tests__/workers/inference-call.test.ts
@@ -26,6 +26,7 @@ vi.mock('@semiont/observability', async (importOriginal) => ({
   withSpan: withSpanMock,
 }));
 import {
+  InferenceTimeoutError,
   boundedGenerateStructured,
   boundedGenerateWithMetadata,
   INFERENCE_TIMEOUT_MS,
@@ -327,6 +328,18 @@ describe('bounded inference calls', () => {
 
     const pending = AnnotationDetection.detectHighlights('some content', client);
     const assertion = expect(pending).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+    await assertion;
+  });
+});
+
+describe('typed timeout (ABANDONED-INFERENCE P3)', () => {
+  it('the bound rejects with InferenceTimeoutError so classification never string-matches our own error', async () => {
+    vi.useFakeTimers();
+    const client = clientWith({ generateTextWithMetadata: vi.fn(never) });
+
+    const pending = boundedGenerateWithMetadata(client, 'p', 100, 0.1);
+    const assertion = expect(pending).rejects.toBeInstanceOf(InferenceTimeoutError);
     await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
     await assertion;
   });

--- a/packages/jobs/src/__tests__/workers/inference-call.test.ts
+++ b/packages/jobs/src/__tests__/workers/inference-call.test.ts
@@ -65,8 +65,10 @@ describe('bounded inference calls', () => {
       boundedGenerateStructured(client, 'p', 100, 0.1, ELEMENT),
     ).resolves.toEqual({ items: [], stopReason: 'end_turn' });
 
-    expect(client.generateTextWithMetadata).toHaveBeenCalledWith('p', 100, 0.1);
-    expect(client.generateStructured).toHaveBeenCalledWith('p', 100, 0.1, ELEMENT);
+    // The trailing AbortSignal is part of the pass-through now: every call
+    // carries one so the bound can cancel it (ABANDONED-INFERENCE P1).
+    expect(client.generateTextWithMetadata).toHaveBeenCalledWith('p', 100, 0.1, expect.any(AbortSignal));
+    expect(client.generateStructured).toHaveBeenCalledWith('p', 100, 0.1, ELEMENT, expect.any(AbortSignal));
   });
 
   it('rejects with a timeout error when the model call never resolves', async () => {
@@ -220,6 +222,102 @@ describe('bounded inference calls', () => {
       const call = withSpanMock.mock.calls.find(([name]) => name === 'inference:text');
       expect(call).toBeDefined();
       await expect((call![1] as () => Promise<unknown>)()).rejects.toThrow('model exploded');
+    });
+  });
+
+  // ABANDONED-INFERENCE P1: a bound that cannot cancel is half a bound. The
+  // 10-minute guillotine used to free only the claim loop — the request it
+  // abandoned kept running (and billing) as a zombie, one of which was caught
+  // completing 24–34 minutes after abandonment (P0, 2026-08-24).
+  describe('true cancellation (A1/A2)', () => {
+    it('A1: the bound aborts the underlying request on expiry — not merely abandons it', async () => {
+      vi.useFakeTimers();
+      let captured: AbortSignal | undefined;
+      const client = clientWith({
+        generateTextWithMetadata: vi.fn((_p: string, _m: number, _t: number, signal?: AbortSignal) => {
+          captured = signal;
+          return never();
+        }),
+      });
+
+      const pending = boundedGenerateWithMetadata(client, 'p', 100, 0.1);
+      const assertion = expect(pending).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+      await assertion;
+
+      // The signal must exist (threaded through the client surface) AND have
+      // fired — an adapter that was never handed one cannot abort anything.
+      expect(captured).toBeDefined();
+      expect(captured!.aborted).toBe(true);
+    });
+
+    it('A1: the structured path threads and fires the signal too', async () => {
+      vi.useFakeTimers();
+      let captured: AbortSignal | undefined;
+      const client = clientWith({
+        generateStructured: vi.fn((_p: string, _m: number, _t: number, _s: unknown, signal?: AbortSignal) => {
+          captured = signal;
+          return never();
+        }),
+      });
+
+      const pending = boundedGenerateStructured(client, 'p', 100, 0.1, { type: 'object' });
+      const assertion = expect(pending).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+      await assertion;
+
+      expect(captured).toBeDefined();
+      expect(captured!.aborted).toBe(true);
+    });
+
+    it('A1: a call that answers in time gets a signal that never fires', async () => {
+      let captured: AbortSignal | undefined;
+      const client = clientWith({
+        generateTextWithMetadata: vi.fn(async (_p: string, _m: number, _t: number, signal?: AbortSignal) => {
+          captured = signal;
+          return { text: 'ok', stopReason: 'end_turn' };
+        }),
+      });
+
+      await expect(boundedGenerateWithMetadata(client, 'p', 100, 0.1)).resolves.toEqual({ text: 'ok', stopReason: 'end_turn' });
+      expect(captured).toBeDefined();
+      expect(captured!.aborted).toBe(false);
+    });
+
+    it('A2: aborting is logged, naming what was aborted and its bound (D3: cost belongs in the log)', async () => {
+      vi.useFakeTimers();
+      const warn = vi.fn();
+      const logger = { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn(), child: vi.fn() };
+      const client = clientWith({ generateTextWithMetadata: vi.fn(never) });
+
+      const pending = boundedGenerateWithMetadata(
+        client, 'p', 100, 0.1, undefined,
+        logger as unknown as Parameters<typeof boundedGenerateWithMetadata>[5],
+      );
+      const assertion = expect(pending).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+      await assertion;
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      const [message, fields] = warn.mock.calls[0] as [string, Record<string, unknown>];
+      expect(message).toMatch(/abort/i);
+      expect(fields).toMatchObject({
+        provider: 'test',
+        model: 'test-model',
+        boundMs: INFERENCE_TIMEOUT_MS,
+      });
+    });
+
+    it('A2: nothing is logged for a call that completes inside the bound', async () => {
+      const warn = vi.fn();
+      const logger = { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn(), child: vi.fn() };
+      const client = clientWith({});
+
+      await boundedGenerateWithMetadata(
+        client, 'p', 100, 0.1, undefined,
+        logger as unknown as Parameters<typeof boundedGenerateWithMetadata>[5],
+      );
+      expect(warn).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/jobs/src/failure-class.ts
+++ b/packages/jobs/src/failure-class.ts
@@ -1,0 +1,66 @@
+/**
+ * Failure classification — ABANDONED-INFERENCE P3 (A4, HD2).
+ *
+ * A retried deterministic failure always costs exactly double: the second
+ * attempt of the same request cannot succeed. HD2's ruling is one-sided —
+ * only KNOWN-deterministic failures skip the retry budget; everything
+ * unrecognized stays retryable (`undefined`), because mis-classifying a
+ * transient failure as deterministic silently halves reliability, while the
+ * reverse merely costs one wasted attempt (today's behavior).
+ *
+ * Classification happens HERE, in the worker, where errors are still typed —
+ * at the gateway's `job:fail` handler the failure is already a flattened
+ * string, and message-regex classification is the drift this module exists
+ * to avoid. The class rides the `job:fail` payload; `failJob` consumes it.
+ */
+
+import { isNumber, isObject, isString } from '@semiont/core';
+import { InferenceTimeoutError } from './workers/inference-call';
+
+export type FailureClass = 'transient' | 'deterministic';
+
+/**
+ * Marker for failures WE know cannot succeed on a second identical attempt —
+ * thrown at the sites that judge the work itself rather than the transport:
+ * response truncation despite the derived budget, a media type with nothing
+ * to extract. Throw it instead of `Error` wherever that knowledge exists.
+ */
+export class DeterministicJobError extends Error {
+  override readonly name = 'DeterministicJobError';
+}
+
+/**
+ * The taxonomy, and its provider coupling — THE part that will drift:
+ *
+ * - `@anthropic-ai/sdk` errors carry a numeric `status`. 408/429/5xx are
+ *   environmental (throttles, overload, gateway weather) → transient. The
+ *   remaining 4xx mean the request itself was rejected — invalid, too
+ *   large, unauthorized — and re-sending it unchanged is guaranteed waste
+ *   → deterministic.
+ * - Aborts (`APIUserAbortError` from the SDK, `AbortError` from fetch/mock)
+ *   are our own bound or shutdown tearing the transport down — nothing was
+ *   judged → transient.
+ * - Ollama surfaces plain `Error`s (no status) and network failures as
+ *   `TypeError: fetch failed`; the SDK's `MessageStream terminated` is a
+ *   dropped connection. All land `undefined` → retryable, the safe default.
+ * - `@semiont/inference` throws plain `Error`s for its own validation paths
+ *   today, so those stay unclassified; if it ever grows typed errors, they
+ *   belong in this mapping.
+ */
+export function classifyFailure(error: unknown): FailureClass | undefined {
+  if (error instanceof DeterministicJobError) return 'deterministic';
+  if (error instanceof InferenceTimeoutError) return 'transient';
+  if (!isObject(error)) return undefined;
+
+  const name = isString(error.name) ? error.name : '';
+  if (name === 'DeterministicJobError') return 'deterministic';
+  if (name === 'APIUserAbortError' || name === 'AbortError') return 'transient';
+
+  const status = isNumber(error.status) ? error.status : undefined;
+  if (status !== undefined) {
+    if (status === 408 || status === 429 || status >= 500) return 'transient';
+    if (status >= 400) return 'deterministic';
+  }
+
+  return undefined;
+}

--- a/packages/jobs/src/fs-job-queue.ts
+++ b/packages/jobs/src/fs-job-queue.ts
@@ -258,7 +258,7 @@ export class FsJobQueue implements JobQueue {
    * re-announced); after that it lands in `failed` with the error.
    * Returns null (and changes nothing) if the job isn't running.
    */
-  async failJob(jobId: JobId, error: string, completedUnits?: string[]): Promise<'retried' | 'failed' | null> {
+  async failJob(jobId: JobId, error: string, completedUnits?: string[], failureClass?: 'transient' | 'deterministic'): Promise<'retried' | 'failed' | null> {
     const job = await this.getJob(jobId);
     if (!job || job.status !== 'running') {
       return null;
@@ -276,7 +276,11 @@ export class FsJobQueue implements JobQueue {
       ? { ...job.metadata, completedUnits: checkpoint }
       : job.metadata;
 
-    if (job.metadata.retryCount < job.metadata.maxRetries) {
+    // A known-deterministic failure skips the budget outright: the same
+    // request cannot succeed on a second attempt, so a retry is guaranteed
+    // waste at full price (ABANDONED-INFERENCE P3, A4). Unclassified and
+    // transient failures retry as before.
+    if (failureClass !== 'deterministic' && job.metadata.retryCount < job.metadata.maxRetries) {
       const retried: PendingJob<any> = {
         status: 'pending',
         metadata: { ...metadata, retryCount: job.metadata.retryCount + 1 },
@@ -284,6 +288,10 @@ export class FsJobQueue implements JobQueue {
       };
       await this.updateJob(retried, 'running');
       return 'retried';
+    }
+
+    if (failureClass === 'deterministic' && job.metadata.retryCount < job.metadata.maxRetries) {
+      this.logger.info('Job failed without retry — deterministic failure', { jobId, error });
     }
 
     const failed: FailedJob<any> = {

--- a/packages/jobs/src/fs-job-queue.ts
+++ b/packages/jobs/src/fs-job-queue.ts
@@ -258,17 +258,28 @@ export class FsJobQueue implements JobQueue {
    * re-announced); after that it lands in `failed` with the error.
    * Returns null (and changes nothing) if the job isn't running.
    */
-  async failJob(jobId: JobId, error: string): Promise<'retried' | 'failed' | null> {
+  async failJob(jobId: JobId, error: string, completedUnits?: string[]): Promise<'retried' | 'failed' | null> {
     const job = await this.getJob(jobId);
     if (!job || job.status !== 'running') {
       return null;
     }
 
     this.lastProgressWrite.delete(jobId);
+
+    // Checkpointed resume (ABANDONED-INFERENCE P2): union this attempt's
+    // completed units with earlier attempts' — attempt 3 must keep what
+    // attempt 1 finished. Stored in metadata so the spread below (and in
+    // every later rebuild) carries it forward; the terminal failed record
+    // keeps it too, so the waste of a discarded run stays visible (D3).
+    const checkpoint = [...new Set([...(job.metadata.completedUnits ?? []), ...(completedUnits ?? [])])];
+    const metadata = checkpoint.length > 0
+      ? { ...job.metadata, completedUnits: checkpoint }
+      : job.metadata;
+
     if (job.metadata.retryCount < job.metadata.maxRetries) {
       const retried: PendingJob<any> = {
         status: 'pending',
-        metadata: { ...job.metadata, retryCount: job.metadata.retryCount + 1 },
+        metadata: { ...metadata, retryCount: job.metadata.retryCount + 1 },
         params: job.params,
       };
       await this.updateJob(retried, 'running');
@@ -277,7 +288,7 @@ export class FsJobQueue implements JobQueue {
 
     const failed: FailedJob<any> = {
       status: 'failed',
-      metadata: job.metadata,
+      metadata,
       params: job.params,
       startedAt: job.startedAt,
       completedAt: new Date().toISOString(),

--- a/packages/jobs/src/job-claim-adapter.ts
+++ b/packages/jobs/src/job-claim-adapter.ts
@@ -21,7 +21,7 @@
  */
 
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { busRequest, type BusRequestPrimitive, type EventMap } from '@semiont/core';
+import { busRequest, isArray, isString, type BusRequestPrimitive, type EventMap } from '@semiont/core';
 import type { WorkerBus } from '@semiont/sdk';
 
 /**
@@ -56,6 +56,13 @@ export interface ActiveJob {
   resourceId: string;
   userId: string;
   params: Record<string, unknown>;
+  /**
+   * Entity-type units earlier failed attempts fully emitted
+   * (ABANDONED-INFERENCE P2 checkpointed resume) — carried on the claimed
+   * record's metadata by `failJob`. The worker skips them, so a retry
+   * neither redoes nor duplicates completed work. Empty on first attempts.
+   */
+  completedUnits: string[];
 }
 
 export interface JobClaimAdapterOptions {
@@ -162,8 +169,12 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
       // it to the claimed-job shape the worker reads.
       const job = (await busRequest(requestBus, 'job:claim', { jobId: assignment.jobId }, 10_000)) as {
         params?: Record<string, unknown>;
-        metadata?: { userId?: string };
+        metadata?: { userId?: string; completedUnits?: unknown };
       };
+
+      const completedUnits = isArray(job.metadata?.completedUnits)
+        ? job.metadata.completedUnits.filter(isString)
+        : [];
 
       return {
         jobId: assignment.jobId,
@@ -171,6 +182,7 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
         resourceId: assignment.resourceId,
         userId: (job.metadata?.userId ?? '') as string,
         params: (job.params ?? {}) as Record<string, unknown>,
+        completedUnits,
       };
     } catch {
       // A claim-failed reply (job not pending / already claimed / queue error)

--- a/packages/jobs/src/job-queue-interface.ts
+++ b/packages/jobs/src/job-queue-interface.ts
@@ -12,9 +12,11 @@ export interface JobQueue {
   /**
    * Move a running job back to `pending` (retry, re-announced) while
    * `retryCount < maxRetries`, else to `failed`. Returns what happened,
-   * or null if the job isn't running.
+   * or null if the job isn't running. `completedUnits` — the units the
+   * failing attempt fully emitted — are unioned into the record's
+   * checkpoint (ABANDONED-INFERENCE P2) so a retry skips them.
    */
-  failJob(jobId: JobId, error: string): Promise<'retried' | 'failed' | null>;
+  failJob(jobId: JobId, error: string, completedUnits?: string[]): Promise<'retried' | 'failed' | null>;
   /** Write progress into a running job's file (throttled, best-effort). */
   recordProgress(jobId: JobId, progress: Record<string, unknown>): Promise<void>;
   /**

--- a/packages/jobs/src/job-queue-interface.ts
+++ b/packages/jobs/src/job-queue-interface.ts
@@ -14,9 +14,11 @@ export interface JobQueue {
    * `retryCount < maxRetries`, else to `failed`. Returns what happened,
    * or null if the job isn't running. `completedUnits` — the units the
    * failing attempt fully emitted — are unioned into the record's
-   * checkpoint (ABANDONED-INFERENCE P2) so a retry skips them.
+   * checkpoint (ABANDONED-INFERENCE P2) so a retry skips them. A
+   * `failureClass` of 'deterministic' goes straight to `failed` with any
+   * budget remaining — a second identical attempt cannot succeed (P3).
    */
-  failJob(jobId: JobId, error: string, completedUnits?: string[]): Promise<'retried' | 'failed' | null>;
+  failJob(jobId: JobId, error: string, completedUnits?: string[], failureClass?: 'transient' | 'deterministic'): Promise<'retried' | 'failed' | null>;
   /** Write progress into a running job's file (throttled, best-effort). */
   recordProgress(jobId: JobId, progress: Record<string, unknown>): Promise<void>;
   /**

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -458,6 +458,15 @@ export async function processAssessmentJob(
   };
 }
 
+/**
+ * Reference detection commits per UNIT — one entity type — through
+ * `onUnitComplete` (ABANDONED-INFERENCE P2, checkpointed resume): the
+ * callback receives the unit's deduped annotations, and only after it
+ * resolves does the unit count as complete. Emission belongs to the
+ * callback alone; the processor returns only the result — returning the
+ * annotations as well would recreate the post-run batch that N2 showed
+ * discards completed work wholesale.
+ */
 export async function processReferenceJob(
   content: string,
   inferenceClient: InferenceClient,
@@ -465,14 +474,14 @@ export async function processReferenceJob(
   buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
   logger: Logger,
-): Promise<ProcessorResult<DetectionResult>> {
+  onUnitComplete: (entityType: string, annotations: Annotation[]) => Promise<void>,
+): Promise<{ result: DetectionResult }> {
   const entityTypeNames = params.entityTypes.map(String);
   const requestParams = [{ label: 'entity-types' as const, value: entityTypeNames.join(', ') }];
   const completedItems: Array<{ value: string; foundCount: number }> = [];
   let totalFound = 0;
   let totalEmitted = 0;
   let errors = 0;
-  const allAnnotations: Annotation[] = [];
 
   onProgress(10, { code: 'loading' }, { requestParams });
 
@@ -518,9 +527,6 @@ export async function processReferenceJob(
       },
     );
 
-    totalFound += extractedEntities.length;
-    completedItems.push({ value: entityTypeName, foundCount: extractedEntities.length });
-
     // Unresolved reference body: the entity type as a tagging TextualBody,
     // stamped with the body locale to match the comment/assess/tag pattern.
     // The bind flow later appends a SpecificResource (purpose: 'linking')
@@ -530,6 +536,7 @@ export async function processReferenceJob(
       { type: 'TextualBody' as const, value: entityTypeName, purpose: 'tagging' as const, format: 'text/plain' satisfies SupportedMediaType, language: bodyLanguage },
     ];
 
+    const built: Annotation[] = [];
     for (const entity of extractedEntities) {
       const reconciled = reconcileSelector(content, {
         exact: entity.exact,
@@ -552,22 +559,26 @@ export async function processReferenceJob(
         });
       }
       const ann = buildAnnotation('linking', toMatch(reconciled), unresolvedBody);
-      allAnnotations.push(ann);
-      totalEmitted++;
+      built.push(ann);
     }
+
+    // De-dupe within the unit — identical spans under the same entity type
+    // collapse; cross-unit duplicates cannot exist, because the body
+    // carries the type name. Then COMMIT: the awaited callback emits the
+    // unit's annotations, and only after it resolves does the unit count
+    // anywhere — a unit whose commit fails contributes nothing (unit
+    // atomicity, A3).
+    const unitAnnotations = dedupeAnnotations(built);
+    await onUnitComplete(entityTypeName, unitAnnotations);
+    totalEmitted += unitAnnotations.length;
+    totalFound += extractedEntities.length;
+    completedItems.push({ value: entityTypeName, foundCount: extractedEntities.length });
   }
 
-  // De-dupe identical events before reporting. `totalEmitted` was the
-  // running per-push count used for mid-loop progress; the stored/reported
-  // count is the deduped length — repeated entities that collapsed onto
-  // the same span (same entity type) become a single annotation.
-  const annotations = dedupeAnnotations(allAnnotations);
-
-  onProgress(100, { code: 'complete-created', count: annotations.length, kind: 'reference' }, { requestParams });
+  onProgress(100, { code: 'complete-created', count: totalEmitted, kind: 'reference' }, { requestParams });
 
   return {
-    annotations,
-    result: { kind: 'reference-annotation', totalFound, totalEmitted: annotations.length, errors },
+    result: { kind: 'reference-annotation', totalFound, totalEmitted, errors },
   };
 }
 

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -40,6 +40,16 @@ export interface JobMetadata {
   created: string;
   retryCount: number;
   maxRetries: number;
+  /**
+   * Checkpointed resume (ABANDONED-INFERENCE P2, HD1): the entity-type
+   * units whose annotations were fully emitted by earlier failed
+   * attempts. Written only by `failJob`, unioned across attempts — and
+   * because `failJob` rebuilds the retried record by spreading metadata,
+   * the checkpoint survives every subsequent rebuild for free. A retried
+   * claim skips these units, so completed work is neither redone nor
+   * duplicated.
+   */
+  completedUnits?: string[];
 }
 
 /**

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -34,6 +34,7 @@ import type { InferenceClient } from '@semiont/inference';
 import type { Logger, components } from '@semiont/core';
 import { extractPdfTextLayer, type AnchoredTextStore, type ContentReads } from '@semiont/content';
 import { prepareDetection } from './workers/detection/prepare-detection';
+import { classifyFailure, DeterministicJobError } from './failure-class';
 import { SpanKind, recordJobOutcome, withSpan } from '@semiont/observability';
 import {
   processHighlightJob,
@@ -158,7 +159,10 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
       })
       .catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
-        logger.error('Job failed', { jobId: job.jobId, error: message, stack: error instanceof Error ? error.stack : undefined });
+        // Classify HERE, while the error is still typed — on the wire it is
+        // only a string (ABANDONED-INFERENCE P3; taxonomy in failure-class.ts).
+        const failureClass = classifyFailure(error);
+        logger.error('Job failed', { jobId: job.jobId, error: message, failureClass, stack: error instanceof Error ? error.stack : undefined });
         const completedUnits = completedUnitsByJob.get(job.jobId);
         completedUnitsByJob.delete(job.jobId);
         const failAnnotationId = referenceIdOf(job);
@@ -170,6 +174,7 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
             ...(failAnnotationId ? { annotationId: failAnnotationId } : {}),
             error: message,
             ...(completedUnits && completedUnits.length > 0 ? { completedUnits } : {}),
+            ...(failureClass !== undefined ? { failureClass } : {}),
           }).catch(() => {});
         }
         adapter.failJob(job.jobId, message);
@@ -293,7 +298,9 @@ async function handleJobInner(
 
     if ('declined' in source) {
       if (source.declined === 'no-extractor') {
-        throw new Error(`Cannot run ${jobType} on resource ${resourceId}: media type '${mediaType ?? 'unknown'}' has no extractable text to analyze`);
+        // A media type with nothing to extract is a user error, not weather —
+        // retrying cannot change it (ABANDONED-INFERENCE P3, A4).
+        throw new DeterministicJobError(`Cannot run ${jobType} on resource ${resourceId}: media type '${mediaType ?? 'unknown'}' has no extractable text to analyze`);
       }
       await emitEvent(session, 'job:complete', {
         ...lifecycleBase,

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -142,24 +142,38 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
     jobTypes: config.jobTypes,
   });
 
+  // Checkpointed resume (ABANDONED-INFERENCE P2): units a reference run
+  // completes are accumulated here so the failure path can carry them on
+  // job:fail — the queue records them and a retry skips them. Shared
+  // between handleJob (which fills it) and the catch below (which reads
+  // it); cleared on every terminal outcome.
+  const completedUnitsByJob = new Map<string, string[]>();
+
   adapter.activeJob$.subscribe((job) => {
     if (!job) return;
     logger.info('Processing job', { jobId: job.jobId, type: job.type, resourceId: job.resourceId });
-    handleJob(adapter, config, job).catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.error('Job failed', { jobId: job.jobId, error: message, stack: error instanceof Error ? error.stack : undefined });
-      const failAnnotationId = referenceIdOf(job);
-      if (isJobType(job.type)) {
-        emitEvent(session, 'job:fail', {
-          resourceId: job.resourceId,
-          jobId: job.jobId,
-          jobType: job.type,
-          ...(failAnnotationId ? { annotationId: failAnnotationId } : {}),
-          error: message,
-        }).catch(() => {});
-      }
-      adapter.failJob(job.jobId, message);
-    });
+    handleJob(adapter, config, job, completedUnitsByJob)
+      .then(() => {
+        completedUnitsByJob.delete(job.jobId);
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error('Job failed', { jobId: job.jobId, error: message, stack: error instanceof Error ? error.stack : undefined });
+        const completedUnits = completedUnitsByJob.get(job.jobId);
+        completedUnitsByJob.delete(job.jobId);
+        const failAnnotationId = referenceIdOf(job);
+        if (isJobType(job.type)) {
+          emitEvent(session, 'job:fail', {
+            resourceId: job.resourceId,
+            jobId: job.jobId,
+            jobType: job.type,
+            ...(failAnnotationId ? { annotationId: failAnnotationId } : {}),
+            error: message,
+            ...(completedUnits && completedUnits.length > 0 ? { completedUnits } : {}),
+          }).catch(() => {});
+        }
+        adapter.failJob(job.jobId, message);
+      });
   });
 
   adapter.start();
@@ -173,13 +187,18 @@ export async function handleJob(
   adapter: JobClaimAdapter,
   config: WorkerProcessConfig,
   job: ActiveJob,
+  // The subscription in startWorkerProcess passes its shared accumulator so
+  // the failure path can read what the reference branch committed
+  // (checkpointed resume); standalone callers may omit it — a fresh map
+  // changes no behavior, only discards the checkpoint on return.
+  completedUnitsByJob: Map<string, string[]> = new Map(),
 ): Promise<void> {
   const start = performance.now();
   let outcome: 'completed' | 'failed' = 'completed';
   try {
     return await withSpan(
       `job:${job.type}`,
-      () => handleJobInner(adapter, config, job),
+      () => handleJobInner(adapter, config, job, completedUnitsByJob),
       {
         kind: SpanKind.CONSUMER,
         attrs: {
@@ -201,6 +220,7 @@ async function handleJobInner(
   adapter: JobClaimAdapter,
   config: WorkerProcessConfig,
   job: ActiveJob,
+  completedUnitsByJob: Map<string, string[]>,
 ): Promise<void> {
   const { session, inferenceClient, generator } = config;
   const { userId, jobId } = job;
@@ -351,12 +371,30 @@ async function handleJobInner(
     adapter.completeJob();
 
   } else if (jobType === 'reference-annotation') {
-    const { annotations, result } = await processReferenceJob(
-      ready!.text, inferenceClient, asJobParams<DetectionParams>(job.params), ready!.buildAnnotation, onProgress, config.logger,
+    // Checkpointed resume (ABANDONED-INFERENCE P2). A retried claim skips
+    // the units earlier attempts completed; every remaining unit commits
+    // through the callback the moment it finishes — the awaited emissions
+    // ARE the acceptance that lets the unit count as complete, and the
+    // accumulator feeds the job:fail payload if a later unit dies. The
+    // post-run batch this replaces was N2's discard-everything mechanism.
+    const params = asJobParams<DetectionParams>(job.params);
+    const skip = new Set(job.completedUnits);
+    const remaining = {
+      ...params,
+      entityTypes: params.entityTypes.filter((t) => !skip.has(String(t))),
+    };
+    const committed: string[] = [];
+    completedUnitsByJob.set(job.jobId, committed);
+
+    const { result } = await processReferenceJob(
+      ready!.text, inferenceClient, remaining, ready!.buildAnnotation, onProgress, config.logger,
+      async (unit, annotations) => {
+        for (const ann of annotations) {
+          await emitEvent(session, 'mark:create', { annotation: ann, resourceId });
+        }
+        committed.push(unit);
+      },
     );
-    for (const ann of annotations) {
-      await emitEvent(session, 'mark:create', { annotation: ann, resourceId });
-    }
     await emitEvent(session, 'job:complete', {
       ...lifecycleBase,
       result,

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -13,8 +13,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
 import { chunkText, estimateTokens } from '@semiont/core';
 import { boundedGenerateStructured } from './inference-call';
-import { DeterministicJobError } from '../failure-class';
-import { deriveDetectionBudget } from './detection/detection-chunking';
+import { assertNotTruncated, deriveDetectionBudget } from './detection/detection-chunking';
 import { MotivationPrompts } from './detection/motivation-prompts';
 import {
   MotivationParsers,
@@ -28,22 +27,6 @@ import {
   type TagMatch,
 } from './detection/motivation-parsers';
 import type { TagSchema } from '@semiont/core';
-
-/**
- * A `max_tokens` stop reason means the model's JSON was cut off mid-stream.
- * Post-tool-use that still yields a syntactically-valid but incomplete array
- * (structured output serializes whatever was generated), so it would parse
- * cleanly and silently under-report. Fail the job loudly instead — parity
- * with the entity-extractor path. With derived budgets this fires only on
- * pathological annotation density.
- */
-function assertNotTruncated(response: { stopReason: string }, motivation: string, chunk: number, totalChunks: number, outputBudget: number): void {
-  if (response.stopReason === 'max_tokens') {
-    // Same input truncates the same way — a retry is guaranteed waste, so
-    // this is a DeterministicJobError (ABANDONED-INFERENCE P3, A4).
-    throw new DeterministicJobError(`${motivation} detection response truncated (max_tokens) on chunk ${chunk}/${totalChunks} despite the derived output budget of ${outputBudget} tokens — failing the job rather than under-reporting annotations.`);
-  }
-}
 
 /**
  * Per-chunk detection loop shared by the four motivations.
@@ -86,7 +69,7 @@ async function detectInChunks<T>(
       // Still alive, same position (a long single call is otherwise silent).
       () => onActivity?.(i, chunks.length),
     );
-    assertNotTruncated(response, motivation, i + 1, chunks.length, outputBudget);
+    assertNotTruncated(response, `${motivation} detection`, i + 1, chunks.length, outputBudget);
     collected.push(...parse(response.items));
     if (i < chunks.length - 1) {
       onActivity?.(i + 1, chunks.length);

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -13,6 +13,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
 import { chunkText, estimateTokens } from '@semiont/core';
 import { boundedGenerateStructured } from './inference-call';
+import { DeterministicJobError } from '../failure-class';
 import { deriveDetectionBudget } from './detection/detection-chunking';
 import { MotivationPrompts } from './detection/motivation-prompts';
 import {
@@ -38,7 +39,9 @@ import type { TagSchema } from '@semiont/core';
  */
 function assertNotTruncated(response: { stopReason: string }, motivation: string, chunk: number, totalChunks: number, outputBudget: number): void {
   if (response.stopReason === 'max_tokens') {
-    throw new Error(`${motivation} detection response truncated (max_tokens) on chunk ${chunk}/${totalChunks} despite the derived output budget of ${outputBudget} tokens — failing the job rather than under-reporting annotations.`);
+    // Same input truncates the same way — a retry is guaranteed waste, so
+    // this is a DeterministicJobError (ABANDONED-INFERENCE P3, A4).
+    throw new DeterministicJobError(`${motivation} detection response truncated (max_tokens) on chunk ${chunk}/${totalChunks} despite the derived output budget of ${outputBudget} tokens — failing the job rather than under-reporting annotations.`);
   }
 }
 

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -3,8 +3,8 @@
  * provider's published limits. No hand-tuned chunk constants, no density or
  * yield modeling: document content never enters this arithmetic. The guard
  * for the pathological tail (a chunk whose annotation JSON still overflows
- * the output budget) is the per-chunk fail-loud `max_tokens` throw in the
- * callers, not a prediction here.
+ * the output budget) is `assertNotTruncated` below — invoked per chunk by
+ * the callers on every response, not a prediction here.
  *
  * Provider shapes (see `@semiont/inference` interface.ts):
  * - Shared window (Ollama): the provider publishes
@@ -21,7 +21,26 @@
 
 import type { ChunkingConfig } from '@semiont/core';
 import type { InferenceLimits } from '@semiont/inference';
+import { DeterministicJobError } from '../../failure-class';
 import { INFERENCE_TIMEOUT_MS } from '../inference-call';
+
+/**
+ * A `max_tokens` stop reason means the model's JSON was cut off mid-stream.
+ * Structured output serializes whatever was generated, so that still yields
+ * a syntactically-valid but incomplete array — it would parse cleanly and
+ * silently under-report. Fail the job loudly instead. With derived budgets
+ * this fires only on pathological annotation density.
+ *
+ * ONE decider for every detection path (entity extraction and the four
+ * motivations) — the classification must not diverge between them: same
+ * input truncates the same way, so a retry is guaranteed waste and the
+ * throw carries the deterministic class (ABANDONED-INFERENCE P3, A4).
+ */
+export function assertNotTruncated(response: { stopReason: string }, label: string, chunk: number, totalChunks: number, outputBudget: number): void {
+  if (response.stopReason === 'max_tokens') {
+    throw new DeterministicJobError(`${label} response truncated (max_tokens) on chunk ${chunk}/${totalChunks} despite the derived output budget of ${outputBudget} tokens — failing the job rather than under-reporting annotations.`);
+  }
+}
 
 /**
  * `reconcileSelector` disambiguates a span with up to 64 chars of prefix and

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -21,6 +21,7 @@
 
 import type { ChunkingConfig } from '@semiont/core';
 import type { InferenceLimits } from '@semiont/inference';
+import { INFERENCE_TIMEOUT_MS } from '../inference-call';
 
 /**
  * `reconcileSelector` disambiguates a span with up to 64 chars of prefix and
@@ -75,6 +76,27 @@ export function deriveDetectionBudget(
       // window): fall back to the shared split rather than starving input.
       inputBudget = Math.floor(available / 3);
       outputBudget = available - inputBudget;
+    }
+  }
+
+  // Duration floor (ABANDONED-INFERENCE P4, HD3): when the provider
+  // publishes its worst-case output rate, cap each call's output at what
+  // that rate finishes inside our own inference bound — a call projected
+  // past the 10-minute guillotine is planned-to-fail — and scale input by
+  // the same factor, so the input:output ratio (and with it the per-chunk
+  // truncation risk profile) is exactly the capacity solution's. Capacity
+  // says what CAN fit in one call; this says what SHOULD. Derived end to
+  // end — rate from `limits()`, deadline from INFERENCE_TIMEOUT_MS — so
+  // #1121's no-hand-tuned-caps principle is extended, not violated; it is
+  // a floor on chunk count, never a raise (a tighter capacity budget is
+  // left alone). Side effect worth knowing: on Anthropic this lands every
+  // detection call at or under the SDK's non-streaming threshold — off the
+  // MessageStream path the original `terminated` failure arrived on.
+  if (limits.outputTokensPerHour !== undefined) {
+    const durationSafeOutput = Math.floor(limits.outputTokensPerHour * (INFERENCE_TIMEOUT_MS / 3_600_000));
+    if (outputBudget > durationSafeOutput) {
+      inputBudget = Math.floor(inputBudget * (durationSafeOutput / outputBudget));
+      outputBudget = durationSafeOutput;
     }
   }
 

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -177,6 +177,7 @@ Example output:
       // Still alive, same position: a long single call would otherwise emit
       // nothing at all between start and finish.
       () => onActivity?.(i, chunks.length),
+      logger,
     );
     logger.debug('Got entity extraction response', {
       chunk: i + 1,

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -1,7 +1,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
 import { chunkText, estimateTokens, getLocaleEnglishName, isObject, isString, type Logger } from '@semiont/core';
 import { boundedGenerateStructured } from '../inference-call';
-import { deriveDetectionBudget } from './detection-chunking';
+import { assertNotTruncated, deriveDetectionBudget } from './detection-chunking';
 
 /**
  * Entity reference extracted from text — pre-reconciliation.
@@ -185,15 +185,10 @@ Example output:
       items: response.items.length,
     });
 
-    // Truncation is data loss, not "no entities" — check it BEFORE consuming.
-    // A truncated structured response can still carry a valid partial array,
-    // so the items themselves cannot signal the loss. Fail loudly; with
-    // derived budgets this fires only on pathological density.
-    if (response.stopReason === 'max_tokens') {
-      const errorMsg = `Entity extraction response truncated (max_tokens) on chunk ${i + 1}/${chunks.length} despite the derived output budget of ${outputBudget} tokens — failing the job rather than dropping annotations.`;
-      logger.error(errorMsg, { items: response.items.length });
-      throw new Error(errorMsg);
-    }
+    // Truncation is data loss, not "no entities" — check it BEFORE consuming:
+    // a truncated structured response can still carry a valid partial array,
+    // so the items themselves cannot signal the loss.
+    assertNotTruncated(response, 'Entity extraction', i + 1, chunks.length, outputBudget);
 
     for (const e of response.items) {
       // No dedupe here: overlap duplicates from adjacent chunks pass through

--- a/packages/jobs/src/workers/generation/resource-generation.ts
+++ b/packages/jobs/src/workers/generation/resource-generation.ts
@@ -343,7 +343,7 @@ ${formatRequirements}`;
     temperature: finalTemperature,
     maxTokens: finalMaxTokens
   });
-  const response = await boundedGenerateWithMetadata(client, prompt, finalMaxTokens, finalTemperature);
+  const response = await boundedGenerateWithMetadata(client, prompt, finalMaxTokens, finalTemperature, undefined, logger);
   logger.debug('Got response from inference', { responseLength: response.text.length, stopReason: response.stopReason });
 
   const result = parseResponse(response.text);

--- a/packages/jobs/src/workers/inference-call.ts
+++ b/packages/jobs/src/workers/inference-call.ts
@@ -35,6 +35,15 @@ import { withSpan } from '@semiont/observability';
 export const INFERENCE_TIMEOUT_MS = 10 * 60_000;
 
 /**
+ * The bound's own rejection, typed so classification (ABANDONED-INFERENCE
+ * P3) never string-matches our own error message. A timeout says nothing
+ * about the request — it classifies transient.
+ */
+export class InferenceTimeoutError extends Error {
+  override readonly name = 'InferenceTimeoutError';
+}
+
+/**
  * How often an in-flight call reports that it is still alive
  * (DETECTION-HEARTBEAT D2).
  *
@@ -96,7 +105,7 @@ async function withTimeout<T>(
         boundMs: INFERENCE_TIMEOUT_MS,
       });
       controller.abort();
-      reject(new Error(
+      reject(new InferenceTimeoutError(
         `Inference call timed out after ${INFERENCE_TIMEOUT_MS / 60_000} minutes (${meta.label}) — failing the job to keep the claim loop live`,
       ));
     }, INFERENCE_TIMEOUT_MS);

--- a/packages/jobs/src/workers/inference-call.ts
+++ b/packages/jobs/src/workers/inference-call.ts
@@ -11,15 +11,19 @@
  * gateway's retry budget — a timeout is transient-shaped, so retrying
  * is correct) and frees the claim loop.
  *
- * This is a timeout, not a cancellation: the `InferenceClient` surface has no
- * AbortSignal support, so on timeout the underlying HTTP request is
- * abandoned, not aborted — it settles (or dies at the socket level)
- * in the background, with its eventual rejection swallowed. Adding
- * `signal` to `@semiont/inference` would upgrade this to a true
- * abort; the timeout stays either way as the last line.
+ * This is a timeout AND a cancellation (ABANDONED-INFERENCE P1): on expiry
+ * the bound aborts the underlying request through the `InferenceClient`
+ * signal, so the transport — and, on the Anthropic path, the SDK's internal
+ * retry loop — is torn down rather than left running as a billed zombie
+ * (P0 caught one completing 24–34 minutes after its job was gone). The
+ * timeout stays as the last line either way, exactly as before; the abort is
+ * the addition, not the replacement (D1). The eventual settlement of the
+ * aborted promise is still swallowed so it cannot surface as an unhandled
+ * rejection.
  */
 
 import type { ElementSchema, InferenceClient, InferenceResponse, StructuredResponse } from '@semiont/inference';
+import type { Logger } from '@semiont/core';
 import { withSpan } from '@semiont/observability';
 
 /**
@@ -71,12 +75,29 @@ function spanned<T>(client: InferenceClient, kind: string, maxTokens: number, wo
   });
 }
 
-async function withTimeout<T>(work: Promise<T>, label: string, onHeartbeat?: InferenceHeartbeat): Promise<T> {
+async function withTimeout<T>(
+  work: (signal: AbortSignal) => Promise<T>,
+  meta: { provider: string; model: string; label: string },
+  onHeartbeat?: InferenceHeartbeat,
+  logger?: Logger,
+): Promise<T> {
+  const controller = new AbortController();
   let timer!: ReturnType<typeof setTimeout>;
   const timedOut = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
+      // True cancellation: tear the request down at the transport so it
+      // cannot keep running (and billing) against a job that no longer
+      // exists — and name the abort in the log, because an invisible
+      // abandonment is what let a zombie burn 24+ minutes unrecorded (D3).
+      logger?.warn('Aborting in-flight inference call at the timeout bound', {
+        provider: meta.provider,
+        model: meta.model,
+        label: meta.label,
+        boundMs: INFERENCE_TIMEOUT_MS,
+      });
+      controller.abort();
       reject(new Error(
-        `Inference call timed out after ${INFERENCE_TIMEOUT_MS / 60_000} minutes (${label}) — failing the job to keep the claim loop live`,
+        `Inference call timed out after ${INFERENCE_TIMEOUT_MS / 60_000} minutes (${meta.label}) — failing the job to keep the claim loop live`,
       ));
     }, INFERENCE_TIMEOUT_MS);
     timer.unref?.();
@@ -98,13 +119,15 @@ async function withTimeout<T>(work: Promise<T>, label: string, onHeartbeat?: Inf
     heartbeat.unref?.();
   }
 
+  const pending = work(controller.signal);
   try {
-    return await Promise.race([work, timedOut]);
+    return await Promise.race([pending, timedOut]);
   } catch (err) {
-    // If the timeout won, the abandoned call may still settle later —
-    // swallow its eventual rejection so it can't surface as an
-    // unhandled one and kill the process.
-    work.catch(() => {});
+    // The aborted call settles promptly now (AbortError from the transport)
+    // rather than minutes later — but its rejection still lands after the
+    // race is lost, so it is still swallowed here to keep it from surfacing
+    // as an unhandled one and killing the process.
+    pending.catch(() => {});
     throw err;
   } finally {
     clearTimeout(timer);
@@ -120,11 +143,13 @@ export function boundedGenerateWithMetadata(
   maxTokens: number,
   temperature: number,
   onHeartbeat?: InferenceHeartbeat,
+  logger?: Logger,
 ): Promise<InferenceResponse> {
   return spanned(client, 'text', maxTokens, () => withTimeout(
-    client.generateTextWithMetadata(prompt, maxTokens, temperature),
-    `${client.type}:${client.modelId}`,
+    (signal) => client.generateTextWithMetadata(prompt, maxTokens, temperature, signal),
+    { provider: client.type, model: client.modelId, label: `${client.type}:${client.modelId}` },
     onHeartbeat,
+    logger,
   ));
 }
 
@@ -135,10 +160,12 @@ export function boundedGenerateStructured<T>(
   temperature: number,
   elementSchema: ElementSchema,
   onHeartbeat?: InferenceHeartbeat,
+  logger?: Logger,
 ): Promise<StructuredResponse<T>> {
   return spanned(client, 'structured', maxTokens, () => withTimeout(
-    client.generateStructured<T>(prompt, maxTokens, temperature, elementSchema),
-    `${client.type}:${client.modelId}`,
+    (signal) => client.generateStructured<T>(prompt, maxTokens, temperature, elementSchema, signal),
+    { provider: client.type, model: client.modelId, label: `${client.type}:${client.modelId}` },
     onHeartbeat,
+    logger,
   ));
 }

--- a/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
@@ -488,7 +488,21 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     } as never);
 
     await vi.waitFor(() => {
-      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f1', 'boom');
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f1', 'boom', undefined);
+    });
+  });
+
+  it('passes the checkpoint through to failJob (ABANDONED-INFERENCE P2, A3)', async () => {
+    eventBus.get('job:fail').next({
+      resourceId: 'rid-1',
+      jobId: 'job-f2',
+      jobType: 'reference-annotation',
+      error: 'Location stalled',
+      completedUnits: ['Person', 'Date'],
+    } as never);
+
+    await vi.waitFor(() => {
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f2', 'Location stalled', ['Person', 'Date']);
     });
   });
 

--- a/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
@@ -488,7 +488,7 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     } as never);
 
     await vi.waitFor(() => {
-      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f1', 'boom', undefined);
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f1', 'boom', undefined, undefined);
     });
   });
 
@@ -502,7 +502,21 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     } as never);
 
     await vi.waitFor(() => {
-      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f2', 'Location stalled', ['Person', 'Date']);
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f2', 'Location stalled', ['Person', 'Date'], undefined);
+    });
+  });
+
+  it('passes the failure class through to failJob (ABANDONED-INFERENCE P3, A4)', async () => {
+    eventBus.get('job:fail').next({
+      resourceId: 'rid-1',
+      jobId: 'job-f3',
+      jobType: 'reference-annotation',
+      error: 'request exceeds size limits',
+      failureClass: 'deterministic',
+    } as never);
+
+    await vi.waitFor(() => {
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f3', 'request exceeds size limits', undefined, 'deterministic');
     });
   });
 

--- a/packages/make-meaning/src/handlers/job-commands.ts
+++ b/packages/make-meaning/src/handlers/job-commands.ts
@@ -225,7 +225,7 @@ export function registerJobCommandHandlers(
 
   eventBus.get('job:fail').subscribe(async (event) => {
     try {
-      const outcome = await jobQueue.failJob(jobId(event.jobId), event.error, event.completedUnits);
+      const outcome = await jobQueue.failJob(jobId(event.jobId), event.error, event.completedUnits, event.failureClass);
       if (outcome === 'retried') {
         logger.info('Job re-queued for retry', { jobId: event.jobId });
       } else if (outcome === null) {

--- a/packages/make-meaning/src/handlers/job-commands.ts
+++ b/packages/make-meaning/src/handlers/job-commands.ts
@@ -225,7 +225,7 @@ export function registerJobCommandHandlers(
 
   eventBus.get('job:fail').subscribe(async (event) => {
     try {
-      const outcome = await jobQueue.failJob(jobId(event.jobId), event.error);
+      const outcome = await jobQueue.failJob(jobId(event.jobId), event.error, event.completedUnits);
       if (outcome === 'retried') {
         logger.info('Job re-queued for retry', { jobId: event.jobId });
       } else if (outcome === null) {

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -599,6 +599,24 @@ func (e JobDeclinedResultReason) Valid() bool {
 	}
 }
 
+// Defines values for JobFailCommandFailureClass.
+const (
+	Deterministic JobFailCommandFailureClass = "deterministic"
+	Transient     JobFailCommandFailureClass = "transient"
+)
+
+// Valid indicates whether the value is a known member of the JobFailCommandFailureClass enum.
+func (e JobFailCommandFailureClass) Valid() bool {
+	switch e {
+	case Deterministic:
+		return true
+	case Transient:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for JobGenerationResultKind.
 const (
 	Generation JobGenerationResultKind = "generation"
@@ -2911,13 +2929,22 @@ type JobFailCommand struct {
 
 	// AnnotationId Annotation this job is attached to, when applicable. Lets the UI route failure feedback (error toast, revert state) to a specific annotation.
 	AnnotationId *string `json:"annotationId,omitempty"`
-	Error        string  `json:"error"`
-	JobId        string  `json:"jobId"`
+
+	// CompletedUnits Entity-type units whose annotations were fully emitted before this failure (checkpointed resume). The queue records them on the retried job's metadata; a retried claim skips them so completed work is neither redone nor duplicated.
+	CompletedUnits *[]string `json:"completedUnits,omitempty"`
+	Error          string    `json:"error"`
+
+	// FailureClass Worker-side classification of the failure, made where the error is still typed. 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget; absent or 'transient' retries as before. Only KNOWN-deterministic failures carry the class.
+	FailureClass *JobFailCommandFailureClass `json:"failureClass,omitempty"`
+	JobId        string                      `json:"jobId"`
 
 	// JobType Type of background job
 	JobType    JobType `json:"jobType"`
 	ResourceId string  `json:"resourceId"`
 }
+
+// JobFailCommandFailureClass Worker-side classification of the failure, made where the error is still typed. 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget; absent or 'transient' retries as before. Only KNOWN-deterministic failures carry the class.
+type JobFailCommandFailureClass string
 
 // JobFailedPayload Payload for job:failed domain event
 type JobFailedPayload struct {

--- a/specs/src/components/schemas/JobFailCommand.json
+++ b/specs/src/components/schemas/JobFailCommand.json
@@ -21,6 +21,13 @@
     },
     "error": {
       "type": "string"
+    },
+    "completedUnits": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Entity-type units whose annotations were fully emitted before this failure (checkpointed resume). The queue records them on the retried job's metadata; a retried claim skips them so completed work is neither redone nor duplicated."
     }
   },
   "required": [

--- a/specs/src/components/schemas/JobFailCommand.json
+++ b/specs/src/components/schemas/JobFailCommand.json
@@ -28,6 +28,11 @@
         "type": "string"
       },
       "description": "Entity-type units whose annotations were fully emitted before this failure (checkpointed resume). The queue records them on the retried job's metadata; a retried claim skips them so completed work is neither redone nor duplicated."
+    },
+    "failureClass": {
+      "type": "string",
+      "enum": ["transient", "deterministic"],
+      "description": "Worker-side classification of the failure, made where the error is still typed. 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget; absent or 'transient' retries as before. Only KNOWN-deterministic failures carry the class."
     }
   },
   "required": [

--- a/tests/e2e/specs/21-large-doc-assisted-linking.spec.ts
+++ b/tests/e2e/specs/21-large-doc-assisted-linking.spec.ts
@@ -247,19 +247,31 @@ test.describe('large-document assisted linking', () => {
   /**
    * Forces the CHUNK LOOP — the half the 170 KB case cannot reach.
    *
-   * Measured provider input bounds (both read live, not assumed):
-   *   - ollama `gemma4:26b`: context 262,144 (`/api/show`), shared window, so
-   *     the 1:2 split gives ~87K tokens of input per chunk ≈ ~340 KB of text.
-   *   - anthropic sonnet-4-5: 200K context − 64K output − scaffold
-   *     ≈ 135K tokens ≈ ~540 KB.
+   * Per-chunk input bounds under the DURATION bound (ABANDONED-INFERENCE P4;
+   * repointed from the pre-P4 capacity-only sizing, which needed ~750 KB):
+   *   - ollama `gemma4:26b`: unchanged — no published rate, capacity governs:
+   *     context 262,144 (`/api/show`), shared window, 1:2 split →
+   *     ~87K tokens of input per chunk ≈ ~340 KB of text.
+   *   - anthropic sonnet-4-5 (200K context): capacity would allow ~135K
+   *     tokens ≈ ~540 KB, but the duration bound scales it by
+   *     21,333/64,000 (the SDK's 128K-tokens/hour rate × the worker's
+   *     10-minute call bound) → ~45K tokens ≈ ~180 KB.
    *
-   * ~750 KB exceeds BOTH, so chunking is forced regardless of which provider
-   * serves `reference-annotation`. That is what makes the assertion below
-   * legitimate: the plan says never to assert chunk counts *because* chunking
-   * is provider-dependent at e2e-realistic sizes — true at 170 KB, where this
-   * spec's first test correctly asserts outcome only. Sized deliberately past
-   * both bounds, "chunking occurred" stops being provider-dependent, so this
-   * asserts it as a DELIBERATE, reasoned deviation rather than an oversight.
+   * ~400 KB exceeds BOTH, so chunking is forced regardless of which provider
+   * serves `reference-annotation` — on Anthropic via the DURATION bound (the
+   * bound that actually fires in production), on Ollama via capacity. That is
+   * what makes the assertion below legitimate: the plan says never to assert
+   * chunk counts *because* chunking is provider-dependent at e2e-realistic
+   * sizes — true at 170 KB, where this spec's first test correctly asserts
+   * outcome only. Sized deliberately past both bounds, "chunking occurred"
+   * stops being provider-dependent, so this asserts it as a DELIBERATE,
+   * reasoned deviation rather than an oversight.
+   *
+   * Caveat, recorded so a model swap doesn't silently re-inert this test: on
+   * a 1M-context Anthropic model the duration-scaled input bound is ~312K
+   * tokens ≈ ~1.25 MB, and 400 KB would go as one call there. The CHUNKED
+   * log line below prints the fixture size against the live budget — check
+   * it when the fleet's detection model changes.
    *
    * The signal: Phase 3's `onChunk` emits N−1 boundary events, surfaced as
    * interpolated progress strictly between the 20% and 100% milestones. A
@@ -276,8 +288,9 @@ test.describe('large-document assisted linking', () => {
     });
 
     try {
-      // ~750 KB — past both providers' measured per-chunk input bounds.
-      const content = buildLargeDocument(750_000);
+      // ~400 KB — past both providers' per-chunk input bounds (duration-scaled
+      // ~180 KB on anthropic sonnet-4-5/200K, capacity ~340 KB on ollama).
+      const content = buildLargeDocument(400_000);
       // eslint-disable-next-line no-console
       console.log(`CHUNKED: fixture ${content.length} bytes (~${Math.round(content.length / 4)} tokens)`);
 


### PR DESCRIPTION
Detection jobs on large documents died to stalled provider calls, and every layer above made it worse: the 10-minute timeout **abandoned** the call instead of aborting it (zombie requests kept running — one was measured completing 24–34 minutes after its job was gone), a retry restarted from zero and paid for every entity type again, deterministic failures were retried as if transient, and nothing bounded a call's *duration* — capacity budgets happily planned single calls that could not finish inside the timeout. Four phases, one commit each.

## 1. Abort, don't abandon (`@semiont/inference`, `inference-call.ts`)

- Every `InferenceClient` generation method takes a trailing `AbortSignal`; both providers thread it to their transport (the Anthropic SDK checks it between its internal retries too), so the timeout bound now tears the request down at the socket instead of leaving it running and billing.
- The bound names the abort in the log and throws a typed `InferenceTimeoutError`; an in-flight heartbeat reports elapsed-time liveness during long single calls; every provider call gets its own span.

## 2. Checkpointed resume (`packages/jobs`, spec, `job-commands`)

- Reference-annotation persists each entity type's annotations as that unit completes, instead of one batch at the end.
- On failure, the completed units ride `job:fail` (`JobFailCommand.completedUnits`) into job metadata, and the retry skips them — attempt 2 pays only for what attempt 1 didn't finish.

## 3. Failure classification (`failure-class.ts`)

- `classifyFailure` maps errors to `transient` / `deterministic`; `failJob` skips the retry only for **known**-deterministic failures (truncation, unsupported media, non-throttle 4xx) and keeps retrying everything else, timeouts included.
- Deterministic sites throw a typed `DeterministicJobError` at the source; the class rides `JobFailCommand.failureClass`.

## 4. Duration-derived detection budgets (`detection-chunking.ts`)

- `InferenceLimits` gains `outputTokensPerHour` — the provider's own worst-case rate model when it publishes one (Anthropic: 128K/hour, the constant behind the SDK's `calculateNonstreamingTimeout`; Ollama publishes none and gets no bound).
- `deriveDetectionBudget` caps per-call output at what that rate finishes inside the 10-minute bound (~21,333 tokens) and scales input by the same factor — chunk sizing stays derived end to end, no hand-tuned cap, and a call is never *planned* to outlive its own guillotine. Side effect: Anthropic detection calls now sit on the non-streaming path.
- The `@slow` large-doc e2e fixture repoints from 750 KB to 400 KB — chunking is now forced by the duration bound (~180 KB on a 200K-context model), so the loop test got cheaper while finally testing the bound that fires in production.

## Surface deltas (all call sites updated in-tree)

- `JobFailCommand` gains optional `completedUnits` and `failureClass`; `sdk-go` regenerated from the spec.
- `InferenceClient.generate*` gain the trailing `signal` parameter; `failJob(jobId, error, completedUnits?, failureClass?)`.

Also: service README updates (weaver rewritten against its current startup behavior) and inference API docs.

**Verified:** inference 59/59, jobs 440/441 (one pre-existing skip), downstream typechecks clean. Watched live on a local stack (2026-09-02): a stalled call hit the bound → abort logged → `failureClass: "transient"` on the `job:fail` → retry claimed 61 ms later.
