### PR TITLE
Large-document detection: output-demand allocation, duration margin, in-place chunk subdivision, typed truncation

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -38,6 +38,24 @@ The bus (SSE in for `job:queued`, `POST /bus/emit` out for lifecycle), an infere
 and the Archivist's HTTP surface for bytes. It claims jobs atomically, so several workers can
 run against one queue without coordination.
 
+## Nothing wedges, nothing restarts from zero
+
+Layered time bounds, each with one owner: an inference call gets **10 minutes**, and at the
+bound it is **aborted at the socket** (measured: milliseconds to rejection — no zombie
+requests billing against dead jobs) with an in-flight heartbeat every 15 s while it runs; a
+worker whose activity goes quiet for **15 minutes** crashes loudly (stall watchdog) rather
+than wedging; a running job untouched for **30 minutes** is recovered by the queue's janitor.
+
+Detection budgets derive from the provider's published limits — chunk sizes follow the 1:2
+input:output allocation and a duration cap at half the call bound, so no call is planned to
+outlive its own timeout. A chunk that still fails on size (duration, truncation) is
+**subdivided in place and retried smaller** before it is allowed to fail the job.
+
+When a job does fail, the worker classifies it: deterministic failures (an identical retry
+cannot succeed) skip the retry budget; transient ones retry — and the retry **resumes from
+the checkpoint** of entity types the failed attempt already persisted, paying only for what
+is left.
+
 ## Related
 
 - [`@semiont/jobs`](../../packages/jobs/) — the queue, the processors, and this entry point

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -102,8 +102,10 @@ Every generation method takes a trailing optional `AbortSignal`: aborting tears 
 ```typescript
 
 interface InferenceLimits {
-  contextTokens: number;     // context window (Anthropic: max input; Ollama: shared input+output)
-  maxOutputTokens: number;   // max output per generation (Ollama mirrors the shared window here)
+  contextTokens: number;         // context window (Anthropic: max input; Ollama: shared input+output)
+  maxOutputTokens: number;       // max output per generation (Ollama mirrors the shared window here)
+  outputTokensPerHour?: number;  // provider's worst-case output-rate model, when it
+                                 // publishes one (Anthropic: 128_000; absent for Ollama)
 }
 
 interface InferenceResponse {
@@ -129,7 +131,7 @@ Each implementation honors the contract with its provider's mechanism:
 - **Ollama**: grammar-constrained sampling — the request's `format` field carries the caller's element schema wrapped in an array schema.
 - **Anthropic**: response-level structured output — `output_config.format` carries the caller's element schema under an **array root** (accepted on both live-config models; `.plans/spikes/output-config-array-root.md`), so the response text IS the schema-conforming JSON. No tools, no wrapper, no unwrap.
 
-A response that cannot be read as an array — the SDK delivering unparsed tool input as a string, a missing array, an unhonoured grammar — **throws** (`Structured response could not be read: …`). It is never coerced to `[]`: an empty extraction is a legitimate, distinct outcome, and conflating the two silently discards real data (STRUCTURED-INFERENCE).
+A response that cannot be read as an array — the SDK delivering unparsed tool input as a string, a missing array, an unhonoured grammar — **throws a typed `StructuredReadError`** carrying the provider's `stopReason`, because the cause classifies differently downstream: `max_tokens` is truncation (an identical retry truncates identically), anything else is model misbehavior a retry may fix. It is never coerced to `[]`: an empty extraction is a legitimate, distinct outcome, and conflating the two silently discards real data (STRUCTURED-INFERENCE).
 
 Current callers all expect arrays (entity extraction, motivation detection). If an object-emitting caller appears, `generateStructured` grows a sibling, not an option — see the notes in [src/interface.ts](src/interface.ts).
 
@@ -137,8 +139,8 @@ Current callers all expect arrays (entity extraction, motivation detection). If 
 
 `limits()` publishes the provider's **actual** context/output ceilings for the configured model — discovered from the provider itself, never hand-maintained constants:
 
-- **Anthropic**: the Models API (`models.retrieve`) — `max_input_tokens` / `max_tokens`.
-- **Ollama**: `POST /api/show` — the model's context window. Input and output share that window, so it is published as both fields (`maxOutputTokens === contextTokens` signals a shared window).
+- **Anthropic**: the Models API (`models.retrieve`) — `max_input_tokens` / `max_tokens` — plus `outputTokensPerHour: 128_000`, the SDK's own worst-case rate model (the `calculateNonstreamingTimeout` constant): the one duration statement the provider surface makes, which detection's duration-safe budgets derive from.
+- **Ollama**: `POST /api/show` — the model's context window. Input and output share that window, so it is published as both fields (`maxOutputTokens === contextTokens` signals a shared window). No rate is published — local hardware's rate is unknowable, so no duration bound applies.
 
 Discovery is lazy and cached per client; a failed discovery is **not** cached — the next call retries. When ceilings cannot be determined (unknown model, endpoint unreachable), `limits()` **throws**: fail-loud, never a guessed floor.
 

--- a/packages/inference/docs/API.md
+++ b/packages/inference/docs/API.md
@@ -89,8 +89,10 @@ interface InferenceResponse {
 
 ```typescript
 interface InferenceLimits {
-  contextTokens: number;    // context window in tokens
-  maxOutputTokens: number;  // max output tokens per generation
+  contextTokens: number;         // context window in tokens
+  maxOutputTokens: number;       // max output tokens per generation
+  outputTokensPerHour?: number;  // provider's worst-case output-rate model,
+                                 // when it publishes one (Anthropic: 128_000)
 }
 ```
 
@@ -98,6 +100,8 @@ interface InferenceLimits {
 
 - **Anthropic** (separate ceilings): `contextTokens` = maximum *input* tokens, `maxOutputTokens` = the output ceiling — both from the Models API (`models.retrieve`).
 - **Ollama** (shared window): input and output draw from one window, published as both fields — so `maxOutputTokens === contextTokens` signals a shared window to budget-derivation consumers.
+
+`outputTokensPerHour` is the one **duration** statement a provider surface makes: Anthropic's SDK projects a call's maximum duration as `max_tokens / rate` (the `calculateNonstreamingTimeout` constant, 128K/hour) and detection derives its duration-safe output budget from it. Absent for providers whose rates are unknowable (Ollama — local hardware), where no duration bound applies. Note the modeled rate is a ceiling estimate, not a floor: generation measured live at roughly half that rate (2026-09-02), which is why consumers spend only part of their call bound against it.
 
 Discovery is lazy (first call) and cached for the client's lifetime; a failed discovery is **not** cached, so the next call retries. `limits()` **throws** when the ceilings cannot be determined (unknown model, discovery endpoint unreachable) — fail-loud, never a guessed floor.
 
@@ -112,7 +116,7 @@ interface StructuredResponse<T> {
 }
 ```
 
-`generateStructured` returns **parsed elements** — the JSON guarantee lives in the return type, not in a comment. There is no representable value meaning "here is some text I could not read": an implementation that cannot deliver the array **throws** (`Structured response could not be read: …`). Empty (`{ items: [] }`) is a legitimate, distinct outcome and is never conflated with a read failure — the conflation is precisely what silently discarded 202 real entities as a green empty job (STRUCTURED-INFERENCE).
+`generateStructured` returns **parsed elements** — the JSON guarantee lives in the return type, not in a comment. There is no representable value meaning "here is some text I could not read": an implementation that cannot deliver the array **throws a typed `StructuredReadError`** (message `Structured response could not be read: …`, one class across all three implementations) carrying the provider's `stopReason` — because the cause classifies differently downstream: `max_tokens` means the JSON was cut off by the output budget (a retry of the same request truncates the same way — deterministic), anything else is model misbehavior a retry may fix. It is never coerced to `[]`: empty (`{ items: [] }`) is a legitimate, distinct outcome and is never conflated with a read failure — the conflation is precisely what silently discarded 202 real entities as a green empty job (STRUCTURED-INFERENCE).
 
 Provider mechanisms:
 
@@ -121,7 +125,7 @@ Provider mechanisms:
 
 `T` is a **caller assertion, not a runtime guarantee** — nothing verifies the element schema and `T` agree, and the type parameter is erased. Declare the schema and `T` adjacently at the call site, and keep per-element structural guards on the consuming side.
 
-Truncation still surfaces via `stopReason: 'max_tokens'` — a truncated structured response can carry a valid partial array, so consumers gate on the stop reason before consuming `items`.
+Truncation surfaces on two paths, and consumers must handle both: a truncated response that still parses carries a valid partial array with `stopReason: 'max_tokens'` (gate on the stop reason before consuming `items`); one cut off mid-JSON throws `StructuredReadError` with `stopReason: 'max_tokens'`. Either way the stop reason names the cause.
 
 ## AnthropicInferenceClient
 

--- a/packages/inference/src/implementations/anthropic.ts
+++ b/packages/inference/src/implementations/anthropic.ts
@@ -3,7 +3,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { isObject, type Logger } from '@semiont/core';
 import { recordInferenceUsage } from '@semiont/observability';
-import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredResponse } from '../interface.js';
+import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredReadError, StructuredResponse } from '../interface.js';
 
 // The SDK's worst-case output-rate model: client.js's
 // calculateNonstreamingTimeout projects a call's maximum duration as
@@ -255,10 +255,7 @@ export class AnthropicInferenceClient implements InferenceClient {
         textLength: textContent.text.length,
         stopReason: response.stop_reason,
       });
-      throw new Error(
-        `Structured response could not be read: response is not valid JSON (stop_reason: ${response.stop_reason})`,
-        { cause: err },
-      );
+      throw new StructuredReadError('response is not valid JSON', response.stop_reason || 'unknown', { cause: err });
     }
     if (!Array.isArray(parsed)) {
       this.recordError(start, response);
@@ -267,9 +264,7 @@ export class AnthropicInferenceClient implements InferenceClient {
         parsedType: typeof parsed,
         stopReason: response.stop_reason,
       });
-      throw new Error(
-        `Structured response could not be read: parsed to ${typeof parsed}, not an array (stop_reason: ${response.stop_reason})`,
-      );
+      throw new StructuredReadError(`parsed to ${typeof parsed}, not an array`, response.stop_reason || 'unknown');
     }
 
     recordInferenceUsage({

--- a/packages/inference/src/implementations/mock.ts
+++ b/packages/inference/src/implementations/mock.ts
@@ -1,6 +1,6 @@
 // Mock implementation of InferenceClient for testing
 
-import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredResponse } from '../interface.js';
+import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredReadError, StructuredResponse } from '../interface.js';
 
 // Generous defaults so existing consumers never trip chunking or window
 // guards unless a test injects tighter limits deliberately.
@@ -61,15 +61,10 @@ export class MockInferenceClient implements InferenceClient {
     try {
       parsed = JSON.parse(text);
     } catch (err) {
-      throw new Error(
-        `Structured response could not be read: response is not valid JSON (stop_reason: ${stopReason})`,
-        { cause: err },
-      );
+      throw new StructuredReadError('response is not valid JSON', stopReason, { cause: err });
     }
     if (!Array.isArray(parsed)) {
-      throw new Error(
-        `Structured response could not be read: parsed to ${typeof parsed}, not an array (stop_reason: ${stopReason})`,
-      );
+      throw new StructuredReadError(`parsed to ${typeof parsed}, not an array`, stopReason);
     }
     return { items: parsed as T[], stopReason };
   }

--- a/packages/inference/src/implementations/ollama.ts
+++ b/packages/inference/src/implementations/ollama.ts
@@ -4,7 +4,7 @@
 import { estimateTokens, isNumber, isObject } from '@semiont/core';
 import type { Logger } from '@semiont/core';
 import { recordInferenceUsage } from '@semiont/observability';
-import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredResponse } from '../interface.js';
+import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredReadError, StructuredResponse } from '../interface.js';
 
 // Slack added to the chars/4 prompt estimate when sizing `num_ctx`:
 // proportional to the estimate (the heuristic's error grows with prompt size)
@@ -107,10 +107,7 @@ export class OllamaInferenceClient implements InferenceClient {
         textLength: response.text.length,
         stopReason: response.stopReason,
       });
-      throw new Error(
-        `Structured response could not be read: response is not valid JSON (stop_reason: ${response.stopReason})`,
-        { cause: err },
-      );
+      throw new StructuredReadError('response is not valid JSON', response.stopReason, { cause: err });
     }
     if (!Array.isArray(parsed)) {
       this.logger?.error('Structured response could not be read', {
@@ -118,9 +115,7 @@ export class OllamaInferenceClient implements InferenceClient {
         parsedType: typeof parsed,
         stopReason: response.stopReason,
       });
-      throw new Error(
-        `Structured response could not be read: parsed to ${typeof parsed}, not an array (stop_reason: ${response.stopReason})`,
-      );
+      throw new StructuredReadError(`parsed to ${typeof parsed}, not an array`, response.stopReason);
     }
 
     return { items: parsed as T[], stopReason: response.stopReason };

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -5,7 +5,7 @@ export {
   type InferenceClientType,
 } from './factory';
 
-export { type ElementSchema, type InferenceClient, type InferenceLimits, type InferenceResponse, type StructuredResponse } from './interface';
+export { StructuredReadError, type ElementSchema, type InferenceClient, type InferenceLimits, type InferenceResponse, type StructuredResponse } from './interface';
 export { AnthropicInferenceClient } from './implementations/anthropic';
 export { OllamaInferenceClient } from './implementations/ollama';
 export { MockInferenceClient } from './implementations/mock';

--- a/packages/inference/src/interface.ts
+++ b/packages/inference/src/interface.ts
@@ -68,6 +68,25 @@ export interface InferenceLimits {
   outputTokensPerHour?: number;
 }
 
+/**
+ * Thrown when a structured generation's response cannot be read as the
+ * requested array — never coerced to `[]` (empty is a legitimate, distinct
+ * outcome). One class for every implementation, because the message shape
+ * and the classification contract must not diverge between providers.
+ *
+ * Carries the provider's stop reason because the cause classifies
+ * differently downstream: `max_tokens` means the JSON was cut off by the
+ * output budget — the same input truncates the same way, so a retry is
+ * guaranteed waste — while any other reason is model misbehavior a retry
+ * may legitimately fix.
+ */
+export class StructuredReadError extends Error {
+  override readonly name = 'StructuredReadError';
+  constructor(detail: string, readonly stopReason: string, options?: ErrorOptions) {
+    super(`Structured response could not be read: ${detail} (stop_reason: ${stopReason})`, options);
+  }
+}
+
 export interface InferenceClient {
   /** Provider type identifier (e.g. 'anthropic', 'ollama') */
   readonly type: string;

--- a/packages/jobs/README.md
+++ b/packages/jobs/README.md
@@ -98,10 +98,12 @@ interface JobMetadata {
   created: string;
   retryCount: number;
   maxRetries: number;
+  completedUnits?: string[];  // Checkpoint: work units (entity types) already
+                              // persisted by a failed attempt — the retry skips them
 }
 ```
 
-The `userName`, `userEmail`, and `userDomain` fields are an audit-only snapshot of the requesting user, persisted in the on-disk job file. Workers derive annotation `creator` attribution from `userId` via `didToAgent()`.
+The `userName`, `userEmail`, and `userDomain` fields are an audit-only snapshot of the requesting user, persisted in the on-disk job file. Workers derive annotation `creator` attribution from `userId` via `didToAgent()`. `completedUnits` is written only by `failJob`, unioned across attempts, and carried on the `job:fail` event — see Failure discipline below.
 
 ## Annotation Workers
 
@@ -118,7 +120,17 @@ The worker process (`worker-main.ts` → `startWorkerProcess` in `worker-process
 
 Detection logic lives in the `AnnotationDetection` class (`src/workers/annotation-detection.ts`); generation synthesis in `generateResourceFromTopic()` (`src/workers/generation/resource-generation.ts`). Processors never fetch content themselves — the worker process fetches it via `session.client.browse.resourceContent(resourceId)` and passes it in.
 
-Workers emit bus events via `session.client.transport.emit('mark:create' | 'job:start' | 'job:report-progress' | 'job:complete' | 'job:fail', payload)` — the Stower actor in @semiont/make-meaning handles persistence to the event log, and the job command handlers mirror the same events into the queue files (completion, retry-on-failure with `maxRetries`, progress-as-heartbeat).
+Workers emit bus events via `session.client.transport.emit('mark:create' | 'job:start' | 'job:report-progress' | 'job:complete' | 'job:fail', payload)` — the Stower actor in @semiont/make-meaning handles persistence to the event log, and the job command handlers mirror the same events into the queue files (completion, retry-on-failure with `maxRetries`, progress-as-heartbeat). `job:fail` carries two optional fields the worker computes: `completedUnits` (the checkpoint) and `failureClass` (the retry decision) — see Failure discipline.
+
+## Failure discipline
+
+Long inference work fails in bounded, classified, resumable ways — every piece below was built against a measured production failure, not a hypothetical:
+
+- **Every inference call is bounded and truly cancelled.** A call gets 10 minutes (`INFERENCE_TIMEOUT_MS`); at the bound the worker aborts it at the transport (`AbortSignal` through the provider SDK to the socket — milliseconds to rejection, no zombie billing on) and fails the job with a typed `InferenceTimeoutError`. An in-flight heartbeat reports elapsed-time liveness every 15 s during long calls.
+- **Budgets are derived, never tuned** (`workers/detection/detection-chunking.ts`). Input:output allocation is 1:2 per entity type asked for (`input ≤ outputBudget / (2 × typesPerCall)`), and when the provider publishes a worst-case output rate, per-call output is capped at what that rate finishes in HALF the bound — so the slowest legitimate call still clears the guillotine with margin.
+- **Size-shaped failures subdivide in place** (`callChunkSubdividing`). A chunk call that hits the duration bound or truncates is split in half and retried smaller (then quartered, then fail-fast with the original error). The attempt is not burned; sub-piece overlap duplicates fall to the existing span-keyed dedupe.
+- **Failures are classified at the worker, where errors are still typed** (`failure-class.ts`). Only KNOWN-deterministic failures — truncation at the subdivision floor, unsupported media, non-throttle 4xx — skip the retry budget; everything unrecognized stays retryable. The class rides `job:fail` as `failureClass`.
+- **Retries resume from the checkpoint.** Reference-annotation persists each entity type's annotations as that unit completes; completed units ride `job:fail` into `metadata.completedUnits`, and the retry processes only what's left.
 
 ## Adding a Job Type
 

--- a/packages/jobs/docs/API.md
+++ b/packages/jobs/docs/API.md
@@ -88,12 +88,12 @@ Moves a running job to `complete` with the result and `completedAt`. Returns `fa
 const moved = await queue.completeJob(jobId('job-abc123'), { totalFound: 3, totalEmitted: 3, errors: 0 });
 ```
 
-### `failJob(jobId: JobId, error): Promise<'retried' | 'failed' | null>`
+### `failJob(jobId: JobId, error, completedUnits?, failureClass?): Promise<'retried' | 'failed' | null>`
 
-Retry-or-fail a running job. While `retryCount < maxRetries` the job moves back to `pending` with the count bumped (and is re-announced for another worker to claim); after that it moves to `failed` with the error. Returns `null` if the job isn't running.
+Retry-or-fail a running job. While `retryCount < maxRetries` **and the failure is not classified `'deterministic'`**, the job moves back to `pending` with the count bumped (and is re-announced for another worker to claim); a deterministic failure — one the worker knows cannot succeed on an identical second attempt — moves straight to `failed` without spending the budget. `completedUnits` (work units the failed attempt already persisted) is unioned into `metadata.completedUnits`, surviving the retry rebuild so the next attempt resumes rather than restarts. Returns `null` if the job isn't running.
 
 ```typescript
-const outcome = await queue.failJob(jobId('job-abc123'), 'inference timeout');
+const outcome = await queue.failJob(jobId('job-abc123'), 'inference timeout', ['Person'], 'transient');
 // 'retried' | 'failed' | null
 ```
 

--- a/packages/jobs/docs/JobQueue.md
+++ b/packages/jobs/docs/JobQueue.md
@@ -218,9 +218,9 @@ The queue exposes transition methods that the gateway's bus handlers (in `@semio
 
 `job:complete` → moves `running/` → `complete/` with the result and `completedAt`. Returns `false` if the job isn't running (duplicate events are harmless).
 
-### `failJob(jobId, error): Promise<'retried' | 'failed' | null>`
+### `failJob(jobId, error, completedUnits?, failureClass?): Promise<'retried' | 'failed' | null>`
 
-`job:fail` → retry-or-fail. While `metadata.retryCount < metadata.maxRetries`, the job moves back to `pending/` with the count bumped and is re-announced for another worker. After that it moves to `failed/` with the error.
+`job:fail` → retry-or-fail. While `metadata.retryCount < metadata.maxRetries` and the failure is not classified `'deterministic'`, the job moves back to `pending/` with the count bumped and is re-announced for another worker; a deterministic failure lands in `failed/` immediately (an identical retry is guaranteed waste). `completedUnits` from the event is unioned into the job's checkpoint, so the retry resumes where the failed attempt left off. After the budget it moves to `failed/` with the error.
 
 ### `recordProgress(jobId, progress): Promise<void>`
 

--- a/packages/jobs/docs/JobTypes.md
+++ b/packages/jobs/docs/JobTypes.md
@@ -31,6 +31,9 @@ interface JobMetadata {
   created: string;        // ISO 8601
   retryCount: number;
   maxRetries: number;
+  completedUnits?: string[];  // Checkpoint: units a failed attempt persisted
+                              // (entity types, for reference-annotation);
+                              // written only by failJob, the retry skips them
 }
 ```
 

--- a/packages/jobs/docs/Workers.md
+++ b/packages/jobs/docs/Workers.md
@@ -228,7 +228,7 @@ emit job:fail  →  adapter.failJob(jobId, message)
 
 The subscription in `startWorkerProcess` wraps `handleJob` in a `.catch` that emits `job:fail` and calls `adapter.failJob`, so any throw from your processor surfaces as a clean failure. `handleJob` also records an OpenTelemetry span (`job:<type>`) and a job-outcome metric around each run — you get that for free by living inside `handleJobInner`.
 
-On the gateway, `job:fail` feeds a retry-or-fail path: the job is re-queued (and re-announced) while `retryCount < maxRetries`, then lands in `failed/`. Your `onProgress` calls double as a heartbeat — a running job that reports nothing for 30 minutes is presumed orphaned and recovered the same way, so call `onProgress` at meaningful stages rather than never.
+On the gateway, `job:fail` feeds a retry-or-fail path: the job is re-queued (and re-announced) while `retryCount < maxRetries` — unless the worker classified the failure `deterministic` (truncation at the subdivision floor, unsupported media, non-throttle 4xx), in which case it lands in `failed/` immediately rather than paying for a retry that cannot succeed. The event's `completedUnits` checkpoint is unioned into job metadata so the retry resumes. Your `onProgress` calls double as a heartbeat — a running job that reports nothing for 30 minutes is presumed orphaned and recovered the same way, so call `onProgress` at meaningful stages rather than never.
 
 ## Reporting Progress
 

--- a/packages/jobs/src/__tests__/failure-class.test.ts
+++ b/packages/jobs/src/__tests__/failure-class.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { StructuredReadError } from '@semiont/inference';
 import { classifyFailure, DeterministicJobError } from '../failure-class';
 import { InferenceTimeoutError } from '../workers/inference-call';
 
@@ -36,6 +37,19 @@ describe('classifyFailure (A4)', () => {
     for (const status of [400, 401, 403, 413, 422]) {
       expect(classifyFailure(Object.assign(new Error(`http ${status}`), { status }))).toBe('deterministic');
     }
+  });
+
+  it('an unreadable structured response CUT OFF by max_tokens is deterministic — same input truncates the same way', () => {
+    // Measured live 2026-09-02 (repro-real.log run 3): the truncated JSON of
+    // an over-demanded answer surfaces as StructuredReadError from the
+    // adapter BEFORE the caller's assertNotTruncated can see the stop
+    // reason — without this rule it classified retryable and burned the
+    // budget re-issuing a guaranteed truncation.
+    expect(classifyFailure(new StructuredReadError('response is not valid JSON', 'max_tokens'))).toBe('deterministic');
+  });
+
+  it('an unreadable structured response with any other stop reason stays retryable — sampling may fix it', () => {
+    expect(classifyFailure(new StructuredReadError('parsed to object, not an array', 'end_turn'))).toBeUndefined();
   });
 
   it('everything unrecognized is unclassified — retryable by default (HD2 gates only KNOWN-deterministic)', () => {

--- a/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
@@ -19,6 +19,7 @@ describe('deriveDetectionBudget', () => {
     const { chunking, outputBudget } = deriveDetectionBudget(
       { contextTokens: 8192, maxOutputTokens: 8192 },
       500,
+      1,
     );
 
     const available = 8192 - 500;
@@ -28,15 +29,21 @@ describe('deriveDetectionBudget', () => {
     expect(outputBudget).toBeGreaterThan(chunking.chunkSize);
   });
 
-  it('gives output its full ceiling and input the rest on separate-ceilings providers', () => {
-    // Anthropic shape: 200K context, 64K output ceiling.
+  it('gives output its full ceiling on separate-ceilings providers, and input at most HALF of it', () => {
+    // Anthropic shape: 200K context, 64K output ceiling. Input is NOT "the
+    // rest of the window": the 1:2 allocation policy applies to every shape.
+    // Measured 2026-09-02 (repro-real.log): a ~40K-token entity-dense chunk
+    // demanded MORE than the whole output budget — the model ground toward
+    // truncation for minutes or collapsed to []. Capacity-sized input plans
+    // calls whose honest answers cannot fit.
     const { chunking, outputBudget } = deriveDetectionBudget(
       { contextTokens: 200_000, maxOutputTokens: 64_000 },
       500,
+      1,
     );
 
     expect(outputBudget).toBe(64_000);
-    expect(chunking.chunkSize).toBe(200_000 - 64_000 - 500);
+    expect(chunking.chunkSize).toBe(32_000);
   });
 
   it('falls back to the shared split when the output ceiling nearly fills the window', () => {
@@ -45,6 +52,7 @@ describe('deriveDetectionBudget', () => {
     const { chunking, outputBudget } = deriveDetectionBudget(
       { contextTokens: 10_000, maxOutputTokens: 9_900 },
       500,
+      1,
     );
 
     const available = 10_000 - 500;
@@ -56,6 +64,7 @@ describe('deriveDetectionBudget', () => {
     const { chunking } = deriveDetectionBudget(
       { contextTokens: 8192, maxOutputTokens: 8192 },
       500,
+      1,
     );
     // 64-char prefix + 64-char suffix + 2×64 span allowance ≈ 256 chars ≈ 64
     // tokens at the ~4 chars/token heuristic.
@@ -64,7 +73,7 @@ describe('deriveDetectionBudget', () => {
 
   it('throws (fail-loud) when the window cannot hold the scaffold plus a useful chunk', () => {
     expect(() =>
-      deriveDetectionBudget({ contextTokens: 300, maxOutputTokens: 300 }, 250),
+      deriveDetectionBudget({ contextTokens: 300, maxOutputTokens: 300 }, 250, 1),
     ).toThrow(/window too small/i);
   });
 });
@@ -83,14 +92,14 @@ describe('deriveDetectionBudget — duration bound (A5)', () => {
   const anthropic1MNoRate = { contextTokens: 1_000_000, maxOutputTokens: 64_000 };
 
   it('caps per-call output at the provider rate × the inference bound', () => {
-    const budget = deriveDetectionBudget(anthropic1M, 1_000);
+    const budget = deriveDetectionBudget(anthropic1M, 1_000, 1);
 
     expect(budget.outputBudget).toBe(Math.floor(128_000 * (INFERENCE_TIMEOUT_MS / 3_600_000)));
   });
 
   it('scales input by the same factor — ratio preserved, so a capacity-sized document now splits (A5)', () => {
-    const uncapped = deriveDetectionBudget(anthropic1MNoRate, 1_000);
-    const capped = deriveDetectionBudget(anthropic1M, 1_000);
+    const uncapped = deriveDetectionBudget(anthropic1MNoRate, 1_000, 1);
+    const capped = deriveDetectionBudget(anthropic1M, 1_000, 1);
 
     const factor = capped.outputBudget / uncapped.outputBudget;
     expect(capped.chunking.chunkSize).toBe(Math.floor(uncapped.chunking.chunkSize * factor));
@@ -102,17 +111,72 @@ describe('deriveDetectionBudget — duration bound (A5)', () => {
   it('is a floor on chunk count, never a raise — no-op when capacity is already tighter', () => {
     const tinyOutput = { contextTokens: 200_000, maxOutputTokens: 8_000 };
 
-    expect(deriveDetectionBudget({ ...tinyOutput, outputTokensPerHour: 128_000 }, 1_000))
-      .toEqual(deriveDetectionBudget(tinyOutput, 1_000));
+    expect(deriveDetectionBudget({ ...tinyOutput, outputTokensPerHour: 128_000 }, 1_000, 1))
+      .toEqual(deriveDetectionBudget(tinyOutput, 1_000, 1));
   });
 
   it('providers publishing no rate are byte-identical to today — Ollama stays capacity-governed', () => {
     const shared = { contextTokens: 32_768, maxOutputTokens: 32_768 };
 
-    const budget = deriveDetectionBudget(shared, 500);
+    const budget = deriveDetectionBudget(shared, 500, 1);
     const available = 32_768 - 500;
     const inputBudget = Math.floor(available / 3);
     expect(budget.chunking.chunkSize).toBe(inputBudget);
     expect(budget.outputBudget).toBe(available - inputBudget);
+  });
+});
+
+// ── Output-demand allocation (2026-09-02 live diagnosis) ──────────────
+// The separate-ceilings branch used to hand input the whole remaining
+// window on the assumption that detection output stays far below its
+// ceiling. Measured false: on a 1M-context model both DoD documents were
+// single-chunk (~40K tokens in), and the honest answer for entity-dense
+// prose EXCEEDED the entire duration-safe output budget — calls ground
+// silently toward max_tokens for 4-10+ minutes (killed by the 10-minute
+// bound as "stalls") or collapsed to the degenerate []. The shared-window
+// branch always encoded the truth: annotation JSON echoes each span plus
+// an envelope, so output needs the LARGER share. One policy, every shape.
+
+describe('deriveDetectionBudget — input never exceeds half the output budget', () => {
+  it('clamps duration-scaled separate-ceilings input to outputBudget/2', () => {
+    const anthropic1M = { contextTokens: 1_000_000, maxOutputTokens: 64_000, outputTokensPerHour: 128_000 };
+    const { chunking, outputBudget } = deriveDetectionBudget(anthropic1M, 1_000, 1);
+
+    expect(outputBudget).toBe(Math.floor(128_000 * (INFERENCE_TIMEOUT_MS / 3_600_000)));
+    expect(chunking.chunkSize).toBe(Math.floor(outputBudget / 2));
+  });
+
+  it('is a no-op for the shared-window split, which is the policy it generalizes', () => {
+    const { chunking, outputBudget } = deriveDetectionBudget(
+      { contextTokens: 8192, maxOutputTokens: 8192 },
+      500,
+      1,
+    );
+    // 1:2 split already satisfies input ≤ output/2 exactly.
+    expect(chunking.chunkSize).toBe(Math.floor(outputBudget / 2));
+  });
+
+  it('holds on tiny separate ceilings too — input follows the output budget down', () => {
+    const { chunking, outputBudget } = deriveDetectionBudget(
+      { contextTokens: 200_000, maxOutputTokens: 8_000 },
+      1_000,
+      1,
+    );
+    expect(outputBudget).toBe(8_000);
+    expect(chunking.chunkSize).toBe(4_000);
+  });
+
+  it('scales input down by the number of entity types one call asks for — output demand is per type', () => {
+    // A call listing K types demands roughly K types' worth of annotation
+    // JSON from the same input, so the allocation divides by K. K=1 is the
+    // production shape today (the per-type loop); the formula stops
+    // silently assuming it.
+    const anthropic1M = { contextTokens: 1_000_000, maxOutputTokens: 64_000, outputTokensPerHour: 128_000 };
+    const one = deriveDetectionBudget(anthropic1M, 1_000, 1);
+    const three = deriveDetectionBudget(anthropic1M, 1_000, 3);
+
+    expect(three.outputBudget).toBe(one.outputBudget);
+    expect(three.chunking.chunkSize).toBe(Math.floor(one.outputBudget / (2 * 3)));
+    expect(one.chunking.chunkSize).toBe(Math.floor(one.outputBudget / 2));
   });
 });

--- a/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
@@ -94,7 +94,7 @@ describe('deriveDetectionBudget — duration bound (A5)', () => {
   it('caps per-call output at the provider rate × the inference bound', () => {
     const budget = deriveDetectionBudget(anthropic1M, 1_000, 1);
 
-    expect(budget.outputBudget).toBe(Math.floor(128_000 * (INFERENCE_TIMEOUT_MS / 3_600_000)));
+    expect(budget.outputBudget).toBe(Math.floor(128_000 * (INFERENCE_TIMEOUT_MS / 2) / 3_600_000));
   });
 
   it('scales input by the same factor — ratio preserved, so a capacity-sized document now splits (A5)', () => {
@@ -142,7 +142,7 @@ describe('deriveDetectionBudget — input never exceeds half the output budget',
     const anthropic1M = { contextTokens: 1_000_000, maxOutputTokens: 64_000, outputTokensPerHour: 128_000 };
     const { chunking, outputBudget } = deriveDetectionBudget(anthropic1M, 1_000, 1);
 
-    expect(outputBudget).toBe(Math.floor(128_000 * (INFERENCE_TIMEOUT_MS / 3_600_000)));
+    expect(outputBudget).toBe(Math.floor(128_000 * (INFERENCE_TIMEOUT_MS / 2) / 3_600_000));
     expect(chunking.chunkSize).toBe(Math.floor(outputBudget / 2));
   });
 
@@ -178,5 +178,93 @@ describe('deriveDetectionBudget — input never exceeds half the output budget',
     expect(three.outputBudget).toBe(one.outputBudget);
     expect(three.chunking.chunkSize).toBe(Math.floor(one.outputBudget / (2 * 3)));
     expect(one.chunking.chunkSize).toBe(Math.floor(one.outputBudget / 2));
+  });
+});
+
+// ── Duration margin + subdivision (user direction, 2026-09-02 night) ──
+// DoD attempt #4 measured the zero-margin residual firing: the output cap
+// equalled rate × the FULL bound, so a chunk that goes exhaustive at the
+// provider's own worst-case rate collides with the guillotine by
+// construction (chunk 3 died at exactly 600 s, twice). The cap now spends
+// HALF the bound — the slowest legitimate full-cap generation finishes at
+// ~300 s, and the guillotine only fires on calls at least 2× slower than
+// the provider's own worst-case model, i.e. genuinely wedged. And when a
+// chunk call still hits a size-shaped failure, it subdivides in place
+// instead of burning the attempt.
+
+import { callChunkSubdividing } from '../../../workers/detection/detection-chunking';
+import { InferenceTimeoutError } from '../../../workers/inference-call';
+import { DeterministicJobError } from '../../../failure-class';
+import { StructuredReadError } from '@semiont/inference';
+
+describe('callChunkSubdividing', () => {
+  const CHUNKING = { chunkSize: 1_000, overlap: 16 };
+  // ~8K chars ≈ 2K tokens: splits into multiple sub-pieces at half size.
+  const CHUNK = 'lorem ipsum dolor sit amet consectetur '.repeat(200);
+
+  it('passes a successful call through untouched — one invocation, no subdivision', async () => {
+    const calls: string[] = [];
+    const result = await callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+      calls.push(piece);
+      return ['a', 'b'];
+    });
+    expect(result).toEqual(['a', 'b']);
+    expect(calls).toEqual([CHUNK]);
+  });
+
+  it('a timeout on the full chunk retries with smaller pieces and collects their results', async () => {
+    const calls: string[] = [];
+    const result = await callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+      calls.push(piece);
+      if (piece.length === CHUNK.length) throw new InferenceTimeoutError('bound');
+      return [`ok:${piece.length}`];
+    });
+    // First call was the full chunk; the rest are strictly smaller pieces.
+    expect(calls[0]).toBe(CHUNK);
+    expect(calls.length).toBeGreaterThan(1);
+    for (const c of calls.slice(1)) expect(c.length).toBeLessThan(CHUNK.length);
+    expect(result.length).toBe(calls.length - 1);
+  });
+
+  it('truncation-shaped failures subdivide too: DeterministicJobError and StructuredReadError(max_tokens)', async () => {
+    for (const boom of [
+      new DeterministicJobError('truncated despite budget'),
+      new StructuredReadError('response is not valid JSON', 'max_tokens'),
+    ]) {
+      let first = true;
+      const result = await callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+        if (first) { first = false; throw boom; }
+        return [piece.length];
+      });
+      expect(result.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('does NOT subdivide on failures size cannot fix — unreadable end_turn, plain errors', async () => {
+    for (const boom of [
+      new StructuredReadError('parsed to object, not an array', 'end_turn'),
+      new Error('model exploded'),
+    ]) {
+      const calls: string[] = [];
+      await expect(callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+        calls.push(piece);
+        throw boom;
+      })).rejects.toBe(boom);
+      expect(calls).toEqual([CHUNK]);
+    }
+  });
+
+  it('is depth-bounded: a chunk that fails at every size rethrows the ORIGINAL failure', async () => {
+    const boom = new InferenceTimeoutError('bound');
+    let calls = 0;
+    await expect(callChunkSubdividing(CHUNK, CHUNKING, async () => {
+      calls++;
+      throw boom;
+    })).rejects.toBe(boom);
+    // Fail-fast: full chunk, first half-piece, first quarter-piece — then
+    // the original error propagates without trying siblings. A quarter-size
+    // piece still failing is not a size problem, and exhaustively probing
+    // every sibling would multiply a wedged provider's cost.
+    expect(calls).toBe(3);
   });
 });

--- a/packages/jobs/src/__tests__/workers/inference-call.test.ts
+++ b/packages/jobs/src/__tests__/workers/inference-call.test.ts
@@ -32,6 +32,7 @@ import {
   INFERENCE_TIMEOUT_MS,
 } from '../../workers/inference-call';
 import { AnnotationDetection } from '../../workers/annotation-detection';
+import { MAX_SUBDIVISION_DEPTH } from '../../workers/detection/detection-chunking';
 
 const never = () => new Promise<never>(() => {});
 
@@ -322,14 +323,26 @@ describe('bounded inference calls', () => {
     });
   });
 
-  it('detection call sites route through the bound (never-resolving model → timeout, not a wedged worker)', async () => {
+  it('detection call sites route through the bound (never-resolving model → bounded ladder, not a wedged worker)', async () => {
     vi.useFakeTimers();
-    const client = clientWith({ generateStructured: vi.fn(never) });
+    const generateStructured = vi.fn(never);
+    const client = clientWith({ generateStructured });
 
     const pending = AnnotationDetection.detectHighlights('some content', client);
     const assertion = expect(pending).rejects.toThrow(/timed out/);
-    await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS + 1);
+    // The bound is per CALL, and a bound that fires is size-shaped, so
+    // `callChunkSubdividing` retries smaller — the detection promise settles
+    // only once the whole ladder is spent. Content this small is one piece at
+    // every depth, so that is exactly one call per level: the first plus one
+    // retry per subdivision depth. Derived from the policy constant, not
+    // restated — the ladder growing must move this number with it.
+    const attempts = MAX_SUBDIVISION_DEPTH + 1;
+    await vi.advanceTimersByTimeAsync(INFERENCE_TIMEOUT_MS * attempts + 1);
     await assertion;
+    // The point of the test: the ladder TERMINATES. Without this, a
+    // subdivision that never stopped retrying would still satisfy the
+    // rejection above once the clock ran far enough.
+    expect(generateStructured).toHaveBeenCalledTimes(attempts);
   });
 });
 

--- a/packages/jobs/src/failure-class.ts
+++ b/packages/jobs/src/failure-class.ts
@@ -15,6 +15,7 @@
  */
 
 import { isNumber, isObject, isString } from '@semiont/core';
+import { StructuredReadError } from '@semiont/inference';
 import { InferenceTimeoutError } from './workers/inference-call';
 
 export type FailureClass = 'transient' | 'deterministic';
@@ -43,13 +44,17 @@ export class DeterministicJobError extends Error {
  * - Ollama surfaces plain `Error`s (no status) and network failures as
  *   `TypeError: fetch failed`; the SDK's `MessageStream terminated` is a
  *   dropped connection. All land `undefined` → retryable, the safe default.
- * - `@semiont/inference` throws plain `Error`s for its own validation paths
- *   today, so those stay unclassified; if it ever grows typed errors, they
- *   belong in this mapping.
+ * - `@semiont/inference`'s `StructuredReadError` carries the stop reason
+ *   because the cause classifies differently: `max_tokens` is truncation of
+ *   an over-demanded answer — the adapter throws before the caller's
+ *   `assertNotTruncated` can see the stop reason, so the classification
+ *   must happen on the typed error itself (measured live 2026-09-02) —
+ *   while any other reason is model misbehavior a retry may fix.
  */
 export function classifyFailure(error: unknown): FailureClass | undefined {
   if (error instanceof DeterministicJobError) return 'deterministic';
   if (error instanceof InferenceTimeoutError) return 'transient';
+  if (error instanceof StructuredReadError && error.stopReason === 'max_tokens') return 'deterministic';
   if (!isObject(error)) return undefined;
 
   const name = isString(error.name) ? error.name : '';

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -57,7 +57,9 @@ async function detectInChunks<T>(
 ): Promise<T[]> {
   const limits = await client.limits();
   const scaffoldTokens = estimateTokens(buildPrompt(''));
-  const { chunking, outputBudget } = deriveDetectionBudget(limits, scaffoldTokens);
+  // One motivation's spans per call — the single span family this prompt
+  // asks for, the motivation-path analogue of one entity type.
+  const { chunking, outputBudget } = deriveDetectionBudget(limits, scaffoldTokens, 1);
   const chunks = chunkText(content, chunking);
 
   const collected: T[] = [];

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -13,7 +13,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
 import { chunkText, estimateTokens } from '@semiont/core';
 import { boundedGenerateStructured } from './inference-call';
-import { assertNotTruncated, deriveDetectionBudget } from './detection/detection-chunking';
+import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget } from './detection/detection-chunking';
 import { MotivationPrompts } from './detection/motivation-prompts';
 import {
   MotivationParsers,
@@ -65,14 +65,19 @@ async function detectInChunks<T>(
   const collected: T[] = [];
   for (let i = 0; i < chunks.length; i++) {
     // Structured surface: parsed elements or a throw — an unreadable model
-    // response fails the job rather than reading as an empty detection.
-    const response = await boundedGenerateStructured<unknown>(
-      client, buildPrompt(chunks[i]!), outputBudget, temperature, elementSchema,
-      // Still alive, same position (a long single call is otherwise silent).
-      () => onActivity?.(i, chunks.length),
-    );
-    assertNotTruncated(response, `${motivation} detection`, i + 1, chunks.length, outputBudget);
-    collected.push(...parse(response.items));
+    // response fails the job rather than reading as an empty detection. A
+    // size-shaped failure (duration bound, truncation) subdivides in place
+    // and retries smaller before it is allowed to fail the job.
+    const items = await callChunkSubdividing<unknown>(chunks[i]!, chunking, async (piece) => {
+      const response = await boundedGenerateStructured<unknown>(
+        client, buildPrompt(piece), outputBudget, temperature, elementSchema,
+        // Still alive, same position (a long single call is otherwise silent).
+        () => onActivity?.(i, chunks.length),
+      );
+      assertNotTruncated(response, `${motivation} detection`, i + 1, chunks.length, outputBudget);
+      return response.items;
+    });
+    collected.push(...parse(items));
     if (i < chunks.length - 1) {
       onActivity?.(i + 1, chunks.length);
     }

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -167,7 +167,7 @@ export function deriveDetectionBudget(
  * quarter-sized chunk is not a size problem, and the ORIGINAL failure must
  * reach the job-level machinery (classification, retry budget) untouched.
  */
-const MAX_SUBDIVISION_DEPTH = 2;
+export const MAX_SUBDIVISION_DEPTH = 2;
 
 /** The failures a smaller chunk can plausibly fix: our duration bound
  * (generation outran the guillotine), and truncation in either of its two

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -24,10 +24,10 @@
  *   not a cost.
  */
 
-import type { ChunkingConfig } from '@semiont/core';
-import type { InferenceLimits } from '@semiont/inference';
+import { chunkText, type ChunkingConfig, type Logger } from '@semiont/core';
+import { StructuredReadError, type InferenceLimits } from '@semiont/inference';
 import { DeterministicJobError } from '../../failure-class';
-import { INFERENCE_TIMEOUT_MS } from '../inference-call';
+import { INFERENCE_TIMEOUT_MS, InferenceTimeoutError } from '../inference-call';
 
 /**
  * A `max_tokens` stop reason means the model's JSON was cut off mid-stream.
@@ -122,7 +122,15 @@ export function deriveDetectionBudget(
   // detection call at or under the SDK's non-streaming threshold — off the
   // MessageStream path the original `terminated` failure arrived on.
   if (limits.outputTokensPerHour !== undefined) {
-    const durationSafeOutput = Math.floor(limits.outputTokensPerHour * (INFERENCE_TIMEOUT_MS / 3_600_000));
+    // HALF the bound, not all of it: the cap's job is to keep every
+    // legitimate call clearly inside the guillotine, and a cap equal to
+    // rate × the FULL bound put the slowest legitimate call exactly ON it
+    // — measured firing on DoD attempt #4 (2026-09-02: chunk 3 died at
+    // 600.0 s, twice). At half, a full-cap generation at the provider's
+    // own worst-case rate finishes at ~300 s, so the guillotine fires only
+    // on calls at least 2× slower than the provider's worst-case model —
+    // genuinely wedged, not working.
+    const durationSafeOutput = Math.floor(limits.outputTokensPerHour * (INFERENCE_TIMEOUT_MS / 2) / 3_600_000);
     if (outputBudget > durationSafeOutput) {
       inputBudget = Math.floor(inputBudget * (durationSafeOutput / outputBudget));
       outputBudget = durationSafeOutput;
@@ -150,4 +158,66 @@ export function deriveDetectionBudget(
     chunking: { chunkSize: inputBudget, overlap: OVERLAP_TOKENS },
     outputBudget,
   };
+}
+
+/**
+ * Subdivision depth: halve, then quarter, then stop. A policy constant
+ * (user direction, 2026-09-02): "at least one retry with a smaller chunk"
+ * after a size-shaped failure, bounded — a call still failing on a
+ * quarter-sized chunk is not a size problem, and the ORIGINAL failure must
+ * reach the job-level machinery (classification, retry budget) untouched.
+ */
+const MAX_SUBDIVISION_DEPTH = 2;
+
+/** The failures a smaller chunk can plausibly fix: our duration bound
+ * (generation outran the guillotine), and truncation in either of its two
+ * surfaces — caught by `assertNotTruncated` after a parseable response
+ * (`DeterministicJobError`), or thrown by the adapter when the cut-off JSON
+ * would not parse (`StructuredReadError` with `max_tokens`). An unreadable
+ * response that STOPPED NATURALLY is model misbehavior, not size. */
+function subdividable(error: unknown): boolean {
+  return (
+    error instanceof InferenceTimeoutError ||
+    error instanceof DeterministicJobError ||
+    (error instanceof StructuredReadError && error.stopReason === 'max_tokens')
+  );
+}
+
+/**
+ * Run one chunk's inference call, subdividing IN PLACE when it fails in a
+ * way a smaller chunk can fix — instead of burning the whole attempt to
+ * come back at the same size (DoD attempt #4: the same chunk killed both
+ * attempts identically). Sub-pieces re-use the caller's overlap, so spans
+ * straddling a split are caught twice and fall to the downstream span-keyed
+ * dedupe, same as ordinary adjacent chunks. On a failure subdivision cannot
+ * fix — wrong shape, or still failing at the depth floor — the ORIGINAL
+ * error propagates so classification sees what actually happened.
+ */
+export async function callChunkSubdividing<T>(
+  chunk: string,
+  chunking: ChunkingConfig,
+  call: (piece: string) => Promise<T[]>,
+  logger?: Logger,
+): Promise<T[]> {
+  async function attempt(piece: string, chunkSize: number, depth: number): Promise<T[]> {
+    try {
+      return await call(piece);
+    } catch (error) {
+      if (depth >= MAX_SUBDIVISION_DEPTH || !subdividable(error)) throw error;
+      const half = Math.floor(chunkSize / 2);
+      logger?.warn('Chunk call failed at a size-shaped bound — subdividing and retrying smaller', {
+        depth: depth + 1,
+        pieceChars: piece.length,
+        nextChunkSizeTokens: half,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      const pieces = chunkText(piece, { chunkSize: half, overlap: chunking.overlap });
+      const collected: T[] = [];
+      for (const p of pieces) {
+        collected.push(...(await attempt(p, half, depth + 1)));
+      }
+      return collected;
+    }
+  }
+  return attempt(chunk, chunking.chunkSize, 0);
 }

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -14,9 +14,14 @@
  *   key/context envelope, so output needs the larger share). The 1:2 ratio
  *   is the plan's one allocation policy — doc-independent, tuned only on
  *   live evidence.
- * - Separate ceilings (Anthropic): output takes its full ceiling and input
- *   gets the rest of the window. For realistic documents the input bound is
- *   enormous and no chunking occurs.
+ * - Separate ceilings (Anthropic): output takes its full ceiling (duration-
+ *   capped below), and input follows the same 1:2 allocation — never more
+ *   than half the output budget. Input does NOT get "the rest of the
+ *   window": measured 2026-09-02, a window-sized chunk of entity-dense text
+ *   demands more output than any budget holds, so the model grinds toward
+ *   max_tokens for minutes (killed at the call bound as a "stall") or
+ *   collapses to the degenerate []. Large documents chunk; that is the fix,
+ *   not a cost.
  */
 
 import type { ChunkingConfig } from '@semiont/core';
@@ -70,12 +75,17 @@ export interface DetectionBudget {
  * @param limits - the provider's published ceilings (`client.limits()`)
  * @param scaffoldTokens - tokens of the prompt template around the content,
  *   measured from the actually-built template (e.g. `estimateTokens(build(''))`)
+ * @param typesPerCall - how many entity types (or equivalent span families)
+ *   ONE call asks for: output demand scales with it, so the allocation
+ *   divides by it. The per-type loop passes 1; a future multi-type batch
+ *   passes its batch size.
  * @throws when the window is too small to hold the scaffold plus a useful
  *   chunk — fail-loud, same family as the truncation and window guards.
  */
 export function deriveDetectionBudget(
   limits: InferenceLimits,
   scaffoldTokens: number,
+  typesPerCall: number,
 ): DetectionBudget {
   const { contextTokens, maxOutputTokens } = limits;
   const available = contextTokens - scaffoldTokens;
@@ -118,6 +128,17 @@ export function deriveDetectionBudget(
       outputBudget = durationSafeOutput;
     }
   }
+
+  // The 1:2 allocation policy, applied to every provider shape (the shared
+  // split satisfies it by construction; separate ceilings did not). Output
+  // must hold an annotation echo of every span in the chunk plus its
+  // key/context envelope, so a chunk larger than half the output budget is
+  // a call whose honest answer cannot fit — the failure measured live on
+  // 2026-09-02 (silent multi-minute grinds to max_tokens, degenerate []).
+  // The demand is PER TYPE ASKED FOR, so a K-type call divides the input
+  // share by K. Still no density modeling: same one policy, content never
+  // enters.
+  inputBudget = Math.min(inputBudget, Math.floor(outputBudget / (2 * typesPerCall)));
 
   if (inputBudget <= OVERLAP_TOKENS) {
     throw new Error(

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -152,7 +152,9 @@ Example output:
   // before.
   const limits = await client.limits();
   const scaffoldTokens = estimateTokens(buildPrompt(''));
-  const { chunking, outputBudget } = deriveDetectionBudget(limits, scaffoldTokens);
+  // One call asks for every type in `entityTypes` — the processor's per-type
+  // loop passes one, so this is 1 in production today.
+  const { chunking, outputBudget } = deriveDetectionBudget(limits, scaffoldTokens, entityTypes.length);
   const chunks = chunkText(exact, chunking);
 
   logger.debug('Sending entity extraction request', {

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -1,7 +1,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
 import { chunkText, estimateTokens, getLocaleEnglishName, isObject, isString, type Logger } from '@semiont/core';
 import { boundedGenerateStructured } from '../inference-call';
-import { assertNotTruncated, deriveDetectionBudget } from './detection-chunking';
+import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget } from './detection-chunking';
 
 /**
  * Entity reference extracted from text — pre-reconciliation.
@@ -167,32 +167,36 @@ Example output:
   const collected: ExtractedEntity[] = [];
   for (let i = 0; i < chunks.length; i++) {
     // The structured surface returns parsed elements or THROWS — an
-    // unreadable model response is a job failure, never a silent []. The
-    // old JSON.parse + isArray blocks are unreachable by construction now:
-    // the type says T[].
-    const response = await boundedGenerateStructured<unknown>(
-      client,
-      buildPrompt(chunks[i]!),
-      outputBudget,
-      0.3, // Lower temperature for more consistent extraction
-      ENTITY_ELEMENT_SCHEMA,
-      // Still alive, same position: a long single call would otherwise emit
-      // nothing at all between start and finish.
-      () => onActivity?.(i, chunks.length),
-      logger,
-    );
-    logger.debug('Got entity extraction response', {
-      chunk: i + 1,
-      chunks: chunks.length,
-      items: response.items.length,
-    });
+    // unreadable model response is a job failure, never a silent []. A
+    // size-shaped failure (duration bound, truncation) subdivides in place
+    // and retries smaller before it is allowed to fail the job.
+    const items = await callChunkSubdividing<unknown>(chunks[i]!, chunking, async (piece) => {
+      const response = await boundedGenerateStructured<unknown>(
+        client,
+        buildPrompt(piece),
+        outputBudget,
+        0.3, // Lower temperature for more consistent extraction
+        ENTITY_ELEMENT_SCHEMA,
+        // Still alive, same position: a long single call would otherwise emit
+        // nothing at all between start and finish.
+        () => onActivity?.(i, chunks.length),
+        logger,
+      );
+      logger.debug('Got entity extraction response', {
+        chunk: i + 1,
+        chunks: chunks.length,
+        pieceChars: piece.length,
+        items: response.items.length,
+      });
 
-    // Truncation is data loss, not "no entities" — check it BEFORE consuming:
-    // a truncated structured response can still carry a valid partial array,
-    // so the items themselves cannot signal the loss.
-    assertNotTruncated(response, 'Entity extraction', i + 1, chunks.length, outputBudget);
+      // Truncation is data loss, not "no entities" — check it BEFORE
+      // consuming: a truncated structured response can still carry a valid
+      // partial array, so the items themselves cannot signal the loss.
+      assertNotTruncated(response, 'Entity extraction', i + 1, chunks.length, outputBudget);
+      return response.items;
+    }, logger);
 
-    for (const e of response.items) {
+    for (const e of items) {
       // No dedupe here: overlap duplicates from adjacent chunks pass through
       // to the processor's span-keyed dedupeAnnotations — the single dedupe
       // point.

--- a/tests/e2e/specs/21-large-doc-assisted-linking.spec.ts
+++ b/tests/e2e/specs/21-large-doc-assisted-linking.spec.ts
@@ -40,7 +40,10 @@ import { GATEWAY_URL, E2E_EMAIL, E2E_PASSWORD } from '../playwright.config';
  *     pre-fix `truncated (max_tokens) — increase max_tokens…`, post-fix
  *     completes. Also proves the fail-loud guard at the pathological tail
  *     (`truncated … on chunk 1/1 despite the derived output budget of 64000`).
- *     Does NOT prove chunking: at 170 KB it runs as chunk 1/1.
+ *     Under the output-demand allocation (input ≤ outputBudget/2, landed
+ *     2026-09-02 after the live diagnosis) this path chunks at ~42 KB, so
+ *     at 170 KB it ALSO exercises the chunk loop on Anthropic — but this
+ *     test still asserts outcome only, because on Ollama it does not.
  *
  *   ollama (gemma4:26b): context_length 262,144 (read live from POST
  *     /api/show — NOT the ~8K the plan's worked example assumes), shared
@@ -252,10 +255,11 @@ test.describe('large-document assisted linking', () => {
    *   - ollama `gemma4:26b`: unchanged — no published rate, capacity governs:
    *     context 262,144 (`/api/show`), shared window, 1:2 split →
    *     ~87K tokens of input per chunk ≈ ~340 KB of text.
-   *   - anthropic sonnet-4-5 (200K context): capacity would allow ~135K
-   *     tokens ≈ ~540 KB, but the duration bound scales it by
-   *     21,333/64,000 (the SDK's 128K-tokens/hour rate × the worker's
-   *     10-minute call bound) → ~45K tokens ≈ ~180 KB.
+   *   - anthropic sonnet-4-5: the duration bound caps output at 21,333
+   *     tokens (the SDK's 128K-tokens/hour rate × the worker's 10-minute
+   *     call bound), and the output-demand allocation (2026-09-02) caps
+   *     input at HALF that → ~10.6K tokens ≈ ~42 KB per chunk, regardless
+   *     of context size (200K and 1M models alike).
    *
    * ~400 KB exceeds BOTH, so chunking is forced regardless of which provider
    * serves `reference-annotation` — on Anthropic via the DURATION bound (the
@@ -267,11 +271,13 @@ test.describe('large-document assisted linking', () => {
    * stops being provider-dependent, so this asserts it as a DELIBERATE,
    * reasoned deviation rather than an oversight.
    *
-   * Caveat, recorded so a model swap doesn't silently re-inert this test: on
-   * a 1M-context Anthropic model the duration-scaled input bound is ~312K
-   * tokens ≈ ~1.25 MB, and 400 KB would go as one call there. The CHUNKED
-   * log line below prints the fixture size against the live budget — check
-   * it when the fleet's detection model changes.
+   * The output-demand allocation (input ≤ outputBudget/2, 2026-09-02) made
+   * the Anthropic chunk size context-independent (~42 KB on 200K and 1M
+   * models alike), so the earlier caveat about a 1M-context model re-inerting
+   * this test no longer applies. The CHUNKED log line below still prints the
+   * fixture size against the live budget — check it when the fleet's
+   * detection model or provider changes (Ollama's ~340 KB capacity bound is
+   * the binding one now).
    *
    * The signal: Phase 3's `onChunk` emits N−1 boundary events, surfaced as
    * interpolated progress strictly between the 20% and 100% milestones. A


### PR DESCRIPTION
Live runs against a real 100-page PDF (36 MB, ~142 K chars of entity-dense text) showed large-document detection could not complete — and the diagnosis, reproduced out-of-band with usage receipts, was not the suspected transport stall. On a 1M-context model the whole document went to the model as **one chunk per entity type**, and the honest answer for that much dense text **exceeds the entire per-call output budget**: calls ground silently toward `max_tokens` for 4–10+ minutes (killed at the worker's 10-minute bound as "stalls"), collapsed to a degenerate `[]`, or truncated mid-JSON. Measured generation ran at ~18.7 tok/s — half the SDK's own worst-case rate model — so even duration-derived budgets sat on the boundary. This PR makes detection budget for its *output demand*, not just its input capacity.

## Output-demand allocation (`deriveDetectionBudget`)

- The shared-window branch's 1:2 input:output allocation now applies to **every** provider shape: `input ≤ outputBudget / (2 × typesPerCall)`. Input no longer gets "the rest of the window" on separate-ceilings providers — a chunk larger than half the output budget is a call whose honest answer cannot fit.
- `typesPerCall` is a new required parameter: output demand scales with how many entity types one call asks for. The per-type loop passes 1 (today's production shape); a future multi-type batch passes its size.
- Anthropic chunks land at ~10.6 K tokens (~42 KB), context-independent — the same on 200 K and 1 M models. Still no density modeling: document content never enters the arithmetic.

## Duration margin

The duration-safe output cap now spends **half** the 10-minute call bound (`rate × INFERENCE_TIMEOUT_MS/2` → 10,666 tokens): previously it equalled rate × the *full* bound, which put the slowest legitimate full-budget generation exactly on the guillotine — observed losing that race by milliseconds (a chunk completed naturally at 599.9 s in forensics after dying at 600.0 s in production, twice).

## In-place chunk subdivision (`callChunkSubdividing`)

A chunk call that fails in a way a smaller chunk can fix — the duration bound, or truncation on either surface — is **split in half and retried in place** (then quartered, then fail-fast with the original error), instead of burning the whole attempt to come back at the same size. One shared driver wired into both detection loops; sub-piece overlap duplicates fall to the existing span-keyed dedupe; failures size cannot fix (unreadable `end_turn`, plain errors) propagate immediately.

## Typed truncation (`StructuredReadError`)

Truncated JSON that fails to parse used to throw a plain adapter `Error` — classified retryable, burning the retry budget on a guaranteed-repeat failure. All three `InferenceClient` implementations now throw one typed `StructuredReadError` carrying the provider's `stopReason` (six duplicated message constructions collapsed to one class), and the worker's `classifyFailure` maps `stopReason === 'max_tokens'` → deterministic. Any other stop reason stays retryable.

## Verification

Every change RED-first: 11 new/rewritten pins watched fail, then green — jobs 448 passing (1 pre-existing skip), inference suite green, make-meaning/gateway/e2e typechecks clean. Live on a local stack the same night: the previously-fatal document's chunks now answer in seconds (55/85 items per chunk where every prior attempt died), with the subdivision path armed for the slow tail. The `@slow` chunk-forcing e2e spec's sizing prose is updated to the new bounds (Anthropic ~42 KB per chunk; Ollama's ~340 KB capacity bound now the binding one for the fixture).

Known residual, deliberate: run-to-run enumeration variance means a dense chunk can still answer implausibly small (`items: 2` where forensics measured ~96) — a completed, schema-valid response the machinery correctly does not treat as failure. That is a detection-quality concern, tracked separately from this PR's completability fixes.
