### PR TITLE
Archivist survivability: supervised restart, fail-fast on unanswerable requests, and the first process-runtime metrics

### DIFF
--- a/apps/archivist/Dockerfile
+++ b/apps/archivist/Dockerfile
@@ -77,6 +77,38 @@ ENV NODE_ENV=production
 # the launcher mounts host dirs AT these targets and passes no path env.
 ENV SEMIONT_ROOT=/kb
 ENV SEMIONT_ANCHORED_TEXT_DIR=/anchored-text
+
+# ── Heap ceiling (ARCHIVIST-STAYS-UP P4) ─────────────────────────────────
+# WHY THIS EXISTS, because a bare number here is unreadable in a year:
+#
+# On 2026-09-03 this process died with "JavaScript heap out of memory" at
+# ~1016 MB while the container was allotted 2048 MB — it never came close to
+# the container's limit. V8 derives its own default old-space ceiling from
+# visible memory and lands well under the cgroup allocation, so roughly half
+# the memory the fleet pays for was unreachable. See
+# .plans/bugs/absent-archivist-wedges-browse.md.
+#
+# 1536 leaves ~512 MB under the container's 2G for everything OUTSIDE the JS
+# heap: RSS overhead, Buffers, the git subprocesses this image shells out to,
+# and neo4j-driver's native allocations. Do not raise this to 2048 — being
+# OOM-KILLED by the cgroup is strictly worse than a V8 heap error, because the
+# process is shot rather than given the chance to throw and log.
+#
+# ⚠️ THIS NUMBER IS PAIRED with the archivist's `mem` in
+# apps/launcher/internal/launcher/service.go. Changing either without the
+# other silently re-opens the gap this closes. That pairing wants a gate —
+# see ARCHIVIST-STAYS-UP P2, which already cross-checks Dockerfile
+# declarations against launcher facts.
+#
+# Applies to EVERY node invocation in the container, which is intended: the
+# CMD is supervise.sh, and the child it spawns is the process that needs the
+# ceiling. The HEALTHCHECK's `node -e` inherits it too and does not care.
+#
+# VERIFY IT TOOK EFFECT: the `semiont.runtime.heap{heap.stat="limit"}` gauge
+# reports V8's actual ceiling at runtime. A cap that was set but not applied
+# shows up there as the old default — assume nothing.
+ENV NODE_OPTIONS=--max-old-space-size=1536
+
 EXPOSE 24103
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \

--- a/apps/archivist/Dockerfile
+++ b/apps/archivist/Dockerfile
@@ -82,4 +82,8 @@ EXPOSE 24103
 HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://localhost:24103/health', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"
 
-CMD ["node", "/usr/local/lib/node_modules/@semiont/make-meaning/dist/archivist-main.js"]
+# The supervisor, not node directly (ARCHIVIST-STAYS-UP P1): restarts a
+# crashed child, probes and kills a hung one, keeps the pre-death log on the
+# state mount. No runtime restart mechanism exists on all three runtimes.
+COPY apps/archivist/supervise.sh /usr/local/bin/supervise.sh
+CMD ["/bin/sh", "/usr/local/bin/supervise.sh"]

--- a/apps/archivist/README.md
+++ b/apps/archivist/README.md
@@ -73,6 +73,15 @@ paths; the image fixes the container-side paths so the launcher passes no path e
 `SEMIONT_WORKER_SECRET` — it authenticates to the gateway with it and requires it on its own
 surface. `SEMIONT_SKIP_REBUILD=true` skips the startup view rebuild.
 
+**The heap ceiling is explicit, and paired.** The image sets
+`NODE_OPTIONS=--max-old-space-size=1536` against a 2 GB container allocation. Without it V8
+picks its own default, which lands well under the cgroup limit — this process once died at
+~1016 MB inside 2048 MB, with half the memory it was allotted unreachable. The 1536/2048 pair
+must move together: raising the cap to the container's full allocation trades a catchable V8
+heap error for an uncatchable cgroup kill. `semiont.runtime.heap{heap.stat="limit"}` reports the
+ceiling actually in force, so a cap that was set but did not apply is visible rather than
+assumed. Rationale in full lives in the Dockerfile beside the `ENV`.
+
 Start it **after the gateway** (it mints an agent token there) and **before the sidecars** (they
 dial it). Its `/health` answers only once the actors and bus pumps are up, which is what makes
 that ordering enforceable.

--- a/apps/archivist/supervise.sh
+++ b/apps/archivist/supervise.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# supervise.sh — the Archivist's in-container supervisor (ARCHIVIST-STAYS-UP P1).
+#
+# Exists because no runtime mechanism can: Apple container has no --restart
+# flag, and plain docker cannot restart-on-unhealthy. One loop gives all
+# three runtimes the same behavior: a crashed child restarts, a hung child is
+# probed and killed, a deterministic boot refusal fails fast instead of
+# looping, and `semiont stop` (TERM) is forwarded and never fought.
+#
+# LOGGING, deliberately minimal: the child writes to STDOUT exactly as
+# before — the container outlives child deaths, so the runtime's own log
+# keeps every life, `container logs`/dumpLogs work natively, and the
+# launcher's preflight snapshot archives it before teardown. Only the
+# supervisor's OWN events (starts, exit codes, kills) also go to a small
+# capped file on the state mount, so the death record survives even a
+# torn-down container.
+
+ENTRY=/usr/local/lib/node_modules/@semiont/make-meaning/dist/archivist-main.js
+EVDIR=/semiont-state/archivist-supervisor
+mkdir -p "$EVDIR" 2>/dev/null || EVDIR=/tmp
+EVENTS="$EVDIR/events.log"
+
+PROBE_URL="http://localhost:24103/health"
+PROBE_EVERY=10      # seconds between probes, once armed
+PROBE_FAILS=3       # consecutive failures before the child is killed
+MAX_RAPID=5         # exits under RAPID_SECS in a row before giving up
+RAPID_SECS=10
+EVENTS_CAP=262144   # ~256KB of one-line events; keep the newest half beyond it
+
+note() {
+  line="[supervise $(date -u +%Y-%m-%dT%H:%M:%SZ)] $1"
+  echo "$line"
+  echo "$line" >> "$EVENTS"
+  if [ "$(wc -c < "$EVENTS")" -gt "$EVENTS_CAP" ]; then
+    tail -c $((EVENTS_CAP / 2)) "$EVENTS" > "$EVENTS.tmp" && mv "$EVENTS.tmp" "$EVENTS"
+  fi
+}
+
+stopping=""
+child=""
+trap 'stopping=1; [ -n "$child" ] && kill -TERM "$child" 2>/dev/null' TERM INT
+
+rapid=0
+while [ -z "$stopping" ]; do
+  started=$(date +%s)
+  note "starting archivist (rapid failures so far: $rapid)"
+  node "$ENTRY" &
+  child=$!
+
+  # Health self-probe: arms after the FIRST success (boot readiness is the
+  # launcher's gate, not ours), then kills a child that stops answering.
+  (
+    armed=""; fails=0
+    while kill -0 "$child" 2>/dev/null; do
+      sleep "$PROBE_EVERY"
+      if wget -q -T 5 -O /dev/null "$PROBE_URL" 2>/dev/null; then
+        armed=1; fails=0
+      elif [ -n "$armed" ]; then
+        fails=$((fails+1))
+        if [ "$fails" -ge "$PROBE_FAILS" ]; then
+          echo "[supervise] health probe failed ${fails}x after arming — killing hung child $child"
+          kill -TERM "$child" 2>/dev/null; sleep 5; kill -KILL "$child" 2>/dev/null
+          break
+        fi
+      fi
+    done
+  ) &
+  prober=$!
+
+  wait "$child"; code=$?
+  kill "$prober" 2>/dev/null; wait "$prober" 2>/dev/null
+  child=""
+  [ -n "$stopping" ] && { note "stopped by TERM (exit $code) — not restarting"; exit 0; }
+
+  lived=$(( $(date +%s) - started ))
+  note "archivist exited code=$code after ${lived}s"
+  if [ "$lived" -lt "$RAPID_SECS" ]; then
+    rapid=$((rapid+1))
+    if [ "$rapid" -ge "$MAX_RAPID" ]; then
+      note "gave up: $rapid rapid failures — a deterministic refusal should be visible, not looped"
+      exit 1
+    fi
+  else
+    rapid=0
+  fi
+  sleep 2
+done

--- a/apps/gateway/src/__tests__/routes/bus.test.ts
+++ b/apps/gateway/src/__tests__/routes/bus.test.ts
@@ -976,6 +976,13 @@ describe('bus routes', () => {
     // (LIVENESS-AXIOMS L2: evicting a claim turns its future reply into a
     // silent drop, and the requester burns its whole timeout).
     it('refuses a claim beyond the per-client cap with 429 rather than evicting', async () => {
+      // A handler must be PRESENT but silent. Capacity tracks UNANSWERED
+      // requests (a settled claim releases its slot), and since
+      // ARCHIVIST-STAYS-UP P3 a request reaching zero subscribers is answered
+      // instantly with a synthesized failure — so shouting into a void no
+      // longer accumulates anything. A client at capacity is one with many
+      // requests genuinely in flight, which is what this now models.
+      eventBus.get(REQ).subscribe(() => {});
       for (let i = 0; i < 256; i++) {
         const res = await emit({
           channel: REQ,
@@ -1204,6 +1211,120 @@ describe('bus routes', () => {
       expect(warn.mock.calls.some((c) => String(c[0]).includes('CLAIM-EVICTED'))).toBe(true);
       registry.dispose();
       bus.destroy();
+    });
+  });
+
+  // ── ARCHIVIST-STAYS-UP P3 — an unanswerable request fails fast ────────
+  //
+  // An absent Archivist wedges every browse:* read silently: the gateway sees
+  // nothing subscribed, logs it, and returns 202 anyway, so the caller burns
+  // its full 30 s timeout. busRequest has no retry, so that timeout is
+  // terminal either way — the difference is milliseconds and a name instead
+  // of thirty seconds and a hang.
+  describe('unanswerable request fails fast (ARCHIVIST-STAYS-UP P3)', () => {
+    const REQ = 'gather:resource-requested';
+    const FAILED = 'gather:resource-failed';
+    const OPTS = { depth: 1, maxResources: 1, includeContent: false, includeSummary: false };
+
+    const emit = (body: unknown) =>
+      app.request('/bus/emit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+    it('synthesizes the mapped *-failed when a request reaches zero subscribers', async () => {
+      const failures: unknown[] = [];
+      eventBus.get(FAILED).subscribe((v) => failures.push(v));
+
+      const res = await emit({
+        channel: REQ,
+        clientId: 'client-a',
+        payload: { correlationId: 'c-nobody', resourceId: 'r-1', options: OPTS },
+      });
+
+      expect(res.status).toBe(202);
+      expect(failures).toHaveLength(1);
+      expect(failures[0]).toMatchObject({ correlationId: 'c-nobody' });
+      expect(String((failures[0] as { message?: string }).message)).toMatch(/subscrib/i);
+    });
+
+    // Without the cid the frame is dropped by the delivery filter as a
+    // REPLY-SHAPE violation — the failure would be synthesized and then
+    // silently discarded, in exactly the outage this phase exists for.
+    it('carries the request correlationId, so owner-routing can deliver it', async () => {
+      const failures: Record<string, unknown>[] = [];
+      eventBus.get(FAILED).subscribe((v) => failures.push(v as Record<string, unknown>));
+
+      await emit({
+        channel: REQ,
+        clientId: 'client-b',
+        payload: { correlationId: 'c-routed-fail', resourceId: 'r-2', options: OPTS },
+      });
+
+      expect(failures[0]?.correlationId).toBe('c-routed-fail');
+      // Identifying fields the failure's own contract requires ride along:
+      // `gather:resource-failed` is `{ correlationId; resourceId } & CommandError`.
+      expect(failures[0]?.resourceId).toBe('r-2');
+    });
+
+    it('reaches the emitting client and nobody else', async () => {
+      const owner = await subscribe(app, { clientId: 'client-owner', global: [FAILED] });
+      const other = await subscribe(app, { clientId: 'client-other', global: [FAILED, 'test:event'] });
+      await new Promise((r) => setTimeout(r, 20));
+
+      setTimeout(() => {
+        void emit({
+          channel: REQ,
+          clientId: 'client-owner',
+          payload: { correlationId: 'c-only-mine', resourceId: 'r-3', options: OPTS },
+        });
+        eventBus.get('test:event' as never).next({ marker: 'alive' } as never);
+      }, 10);
+
+      expect(await readSSE(owner, (b) => b.includes('c-only-mine'))).toContain('c-only-mine');
+      const otherBody = await readSSE(other, (b) => b.includes('alive'));
+      expect(otherBody).not.toContain('c-only-mine');
+    });
+
+    // A broadcast reaching nobody is NORMAL — `job:started` with no UI
+    // attached is the common case. The distinction is membership in
+    // BUS_OPERATIONS, never a name pattern.
+    it('stays silent for a broadcast that reaches nobody', async () => {
+      const seen: unknown[] = [];
+      for (const ch of ['gather:resource-failed', 'test:event']) {
+        eventBus.get(ch as never).subscribe((v) => seen.push(v));
+      }
+      const before = seen.length;
+
+      const res = await emit({ channel: 'beckon:focus', payload: { annotationId: 'ann-1' } });
+
+      expect(res.status).toBe(202);
+      await expect(res.json()).resolves.toEqual({ subscribers: 0 });
+      expect(seen.length).toBe(before); // nothing synthesized
+    });
+
+    it('stays silent when a request DID reach a subscriber', async () => {
+      eventBus.get(REQ).subscribe(() => {}); // a handler is present
+      const failures: unknown[] = [];
+      eventBus.get(FAILED).subscribe((v) => failures.push(v));
+
+      await emit({
+        channel: REQ,
+        clientId: 'client-c',
+        payload: { correlationId: 'c-answered', resourceId: 'r-4', options: OPTS },
+      });
+
+      expect(failures).toHaveLength(0);
+    });
+
+    // A request without a correlationId has no reply to fail: synthesizing one
+    // would produce a frame the filter drops and nobody awaits.
+    it('stays silent for a request emit with no correlationId', async () => {
+      const failures: unknown[] = [];
+      eventBus.get(FAILED).subscribe((v) => failures.push(v));
+      await emit({ channel: REQ, payload: { resourceId: 'r-5', options: OPTS } });
+      expect(failures).toHaveLength(0);
     });
   });
 

--- a/apps/gateway/src/__tests__/routes/bus.test.ts
+++ b/apps/gateway/src/__tests__/routes/bus.test.ts
@@ -11,10 +11,18 @@ import type {
   EventMetadata,
   components,
 } from '@semiont/core';
-const observed = vi.hoisted(() => ({ replySuppressed: vi.fn() }));
+const observed = vi.hoisted(() => ({
+  replySuppressed: vi.fn(),
+  resumeGap: vi.fn(),
+  unanswerable: vi.fn(),
+  registryProvider: vi.fn(),
+}));
 vi.mock('@semiont/observability', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@semiont/observability')>()),
   recordReplySuppressed: (...args: unknown[]) => observed.replySuppressed(...args),
+  recordResumeGap: (...args: unknown[]) => observed.resumeGap(...args),
+  recordUnanswerableRequest: (...args: unknown[]) => observed.unanswerable(...args),
+  registerCorrelationRegistryProvider: (p: unknown) => observed.registryProvider(p),
 }));
 
 import { createBusRouter, createCorrelationRegistry } from '../../routes/bus';
@@ -1325,6 +1333,81 @@ describe('bus routes', () => {
       eventBus.get(FAILED).subscribe((v) => failures.push(v));
       await emit({ channel: REQ, payload: { resourceId: 'r-5', options: OPTS } });
       expect(failures).toHaveLength(0);
+    });
+  });
+
+  // ── Gateway telemetry ─────────────────────────────────────────────────
+  //
+  // A counter that is wired but never incremented is the defect these pins
+  // exist to prevent — nothing else in the stack would notice. Spans are not
+  // pinned here: the repo tests no spans anywhere, and inventing a harness for
+  // these four would be a precedent, not a pin.
+  describe('telemetry', () => {
+    const REQ = 'gather:resource-requested';
+    const OPTS = { depth: 1, maxResources: 1, includeContent: false, includeSummary: false };
+
+    it('counts an unanswerable request, labelled by channel', async () => {
+      observed.unanswerable.mockClear();
+      await app.request('/bus/emit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          channel: REQ,
+          clientId: 'client-t',
+          payload: { correlationId: 'c-unans', resourceId: 'r-1', options: OPTS },
+        }),
+      });
+      expect(observed.unanswerable).toHaveBeenCalledWith(REQ);
+    });
+
+    it('does not count a broadcast that reaches nobody', async () => {
+      observed.unanswerable.mockClear();
+      await app.request('/bus/emit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'beckon:focus', payload: { annotationId: 'ann-1' } }),
+      });
+      expect(observed.unanswerable).not.toHaveBeenCalled();
+    });
+
+    it('counts a resume gap, labelled by its reason', async () => {
+      observed.resumeGap.mockClear();
+      const res = await subscribe(app, {
+        clientId: 'client-gap',
+        global: ['test:event'],
+        scoped: [{ scope: 'res-1', channels: ['test:event'], lastEventId: 'not-a-valid-id' }],
+      });
+      await readSSE(res, (b) => b.includes('resume-gap'));
+      expect(observed.resumeGap).toHaveBeenCalled();
+      // The label is a closed set, never a scope or an id — cardinality.
+      expect(typeof observed.resumeGap.mock.calls[0]?.[0]).toBe('string');
+      expect(observed.resumeGap.mock.calls[0]?.[0]).toMatch(/last-event-id|scope|replay/);
+    });
+
+    it('registers a registry-occupancy provider that reports claims and retained replies', async () => {
+      observed.registryProvider.mockClear();
+      await subscribe(app, { clientId: 'client-occ', global: ['gather:resource-complete'] });
+      expect(observed.registryProvider).toHaveBeenCalled();
+
+      const provider = observed.registryProvider.mock.calls[0]?.[0] as () => {
+        claims: number; retainedReplies: number;
+      };
+      expect(provider()).toEqual({ claims: 0, retainedReplies: 0 });
+
+      await app.request('/bus/emit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          channel: REQ,
+          clientId: 'client-occ',
+          payload: { correlationId: 'c-occ', resourceId: 'r-1', options: OPTS },
+        }),
+      });
+      // The claim exists; its reply arrived via the synthesized failure, so
+      // both dimensions move — which is what makes them separate series.
+      const after = provider();
+      expect(after.claims).toBeGreaterThan(0);
+      expect(after.retainedReplies).toBeGreaterThan(0);
     });
   });
 

--- a/apps/gateway/src/lib/archivist.ts
+++ b/apps/gateway/src/lib/archivist.ts
@@ -17,7 +17,24 @@
 import { HTTPException } from 'hono/http-exception';
 import type { StoredResource } from '@semiont/content';
 import { archivistEndpoint, type ArchivistAddressConfig } from '@semiont/core/node';
+import { SpanKind, withSpan } from '@semiont/observability';
 import { getLogger } from '../logger';
+
+/**
+ * Every call here crosses to the Archivist, so every call is a CLIENT span.
+ *
+ * The documented model (OBSERVABILITY.md) pairs a `content.*` client span with
+ * a `content.*.server` span and stops — it was written when the gateway WAS the
+ * content store. SINGLE-KB-MOUNT added this third hop underneath the server
+ * span, so `content.put.server`'s duration has since included a full Archivist
+ * round-trip while attributing none of it: a slow Archivist rendered as a slow
+ * gateway. These spans put the time where it is spent.
+ */
+const archivistSpan = <T>(op: string, run: () => Promise<T>): Promise<T> =>
+  withSpan(`archivist.${op}`, run, {
+    kind: SpanKind.CLIENT,
+    attrs: { 'peer.service': 'archivist' },
+  });
 
 /**
  * The KB working tree's current branch, for `/api/status` (SINGLE-KB-MOUNT
@@ -33,7 +50,7 @@ import { getLogger } from '../logger';
 export async function kbBranch(config: ArchivistAddressConfig): Promise<string | undefined> {
   try {
     const { base, headers } = archivistEndpoint(config);
-    const res = await fetch(`${base}/kb/branch`, { headers });
+    const res = await archivistSpan('kb.branch', () => fetch(`${base}/kb/branch`, { headers }));
     if (!res.ok) return undefined;
     const { branch } = await res.json() as { branch?: string | null };
     return branch ?? undefined;
@@ -79,7 +96,7 @@ export async function putContent(
 
   let res: Response;
   try {
-    res = await fetch(url, { method: 'PUT', headers, body });
+    res = await archivistSpan('content.put', () => fetch(url, { method: 'PUT', headers, body }));
   } catch (error) {
     getLogger().error('Archivist content write unreachable', {
       component: 'archivist-client',
@@ -125,7 +142,7 @@ export async function getContent(
 
   let res: Response;
   try {
-    res = await fetch(url, { headers });
+    res = await archivistSpan('content.get', () => fetch(url, { headers }));
   } catch (error) {
     getLogger().error('Archivist content read unreachable', {
       component: 'archivist-client',

--- a/apps/gateway/src/routes/bus.ts
+++ b/apps/gateway/src/routes/bus.ts
@@ -991,6 +991,47 @@ export function createBusRouter(authMiddleware: AuthMiddleware) {
               scope,
               hint: 'Nothing on this gateway subscribes to that channel. For a UI signal meant to cross to a participant, check that the channel is in BRIDGED_BROADCASTS and that a client subscribed to it.',
             });
+
+            // ── An unanswerable request fails fast (ARCHIVIST-STAYS-UP P3) ──
+            //
+            // A request whose handler is absent can never be answered, and
+            // `busRequest` has no retry — so the caller's only other outcome is
+            // a 30 s timeout. Synthesizing the operation's own mapped failure
+            // turns "the app is hung" into "the Archivist is down", in
+            // milliseconds, for every cause of absence.
+            //
+            // Gated on membership in BUS_OPERATIONS, never a name pattern: a
+            // BROADCAST reaching nobody is normal (`job:started` with no UI
+            // attached is the common case) and must stay silent.
+            //
+            // Since 536dbed0 narrowed each service to its own inbound roster,
+            // zero subscribers on a request channel means the one service that
+            // answers it is absent — a far sharper signal than when every
+            // client subscribed everything.
+            const operation = BUS_OPERATIONS[channel as keyof typeof BUS_OPERATIONS];
+            const failureCid = correlationIdOf(payload);
+            if (operation?.failure && failureCid) {
+              // The request payload is echoed because a failure's own contract
+              // is `{ correlationId, <the request's identifying fields> } &
+              // CommandError` — `gather:resource-failed` needs `resourceId`,
+              // `match:search-failed` needs `referenceId`. Echoing the request
+              // derives those; a per-operation table would restate 36 shapes.
+              // `_userId` is dropped: the gateway injected it inbound and it is
+              // not part of any reply contract.
+              const { _userId: _injected, ...echo } = payload as Record<string, unknown>;
+              const failure = {
+                ...echo,
+                message: `No subscriber for ${channel}: the service that answers it is not connected`,
+              };
+              getBusLogger().warn('[bus UNANSWERABLE] synthesizing failure for an unsubscribed request', {
+                channel,
+                failureChannel: operation.failure,
+                correlationId: failureCid,
+              });
+              // Unscoped, like every other reply: retention and the delivery
+              // filter both watch the unscoped subject.
+              eventBus.get(operation.failure as keyof EventMap).next(failure as never);
+            }
           }
         },
         {

--- a/apps/gateway/src/routes/bus.ts
+++ b/apps/gateway/src/routes/bus.ts
@@ -11,6 +11,9 @@ import {
   injectTraceparent,
   recordBusEmit,
   recordReplySuppressed,
+  recordResumeGap,
+  recordUnanswerableRequest,
+  registerCorrelationRegistryProvider,
   recordSubscriberConnect,
   recordSubscriberDisconnect,
   withSpan,
@@ -49,9 +52,16 @@ async function fetchArchivistReplay(
   fromSequence: number,
 ): Promise<StoredEvent[]> {
   const { base, headers } = archivistEndpoint(config);
-  const res = await fetch(
-    `${base}/events/${encodeURIComponent(resourceId)}?fromSequence=${fromSequence}`,
-    { headers },
+  // A CLIENT span for the same reason lib/archivist.ts wraps its three calls:
+  // this crosses to another service, and without it a slow replay is
+  // indistinguishable from a slow gateway.
+  const res = await withSpan(
+    'archivist.events.replay',
+    () => fetch(
+      `${base}/events/${encodeURIComponent(resourceId)}?fromSequence=${fromSequence}`,
+      { headers },
+    ),
+    { kind: SpanKind.CLIENT, attrs: { 'peer.service': 'archivist' } },
   );
   if (!res.ok) {
     throw new Error(`Archivist replay read failed: ${res.status} ${res.statusText}`);
@@ -231,6 +241,8 @@ export function createCorrelationRegistry(
   owner(cid: string): { clientId: string; principalDid: string | undefined } | undefined;
   lookupReply(cid: string, clientId: string, principalDid: string | undefined): RetainedReply | undefined;
   size(): number;
+  /** Live claims and how many of them still hold a reply payload. */
+  occupancy(): { claims: number; retainedReplies: number };
   dispose(): void;
 } {
   const ttlMs = opts.ttlMs ?? REPLY_RETENTION_TTL_MS;
@@ -362,6 +374,11 @@ export function createCorrelationRegistry(
     size() {
       return claims.size;
     },
+    occupancy() {
+      let retainedReplies = 0;
+      for (const claim of claims.values()) if (claim.reply) retainedReplies++;
+      return { claims: claims.size, retainedReplies };
+    },
     dispose() {
       for (const sub of subs) sub.unsubscribe();
       claims.clear();
@@ -454,6 +471,10 @@ export function createBusRouter(authMiddleware: AuthMiddleware) {
     if (!registry) {
       registry = createCorrelationRegistry(eventBus);
       registryByBus.set(eventBus, registry);
+      // Occupancy is the closest observable to the heap question two OOM
+      // investigations keep asking: a retained browse result is 1-2 MB and up
+      // to REPLY_RETENTION_MAX of them are held at once.
+      registerCorrelationRegistryProvider(() => registry!.occupancy());
     }
     const correlations = registry;
 
@@ -642,6 +663,10 @@ export function createBusRouter(authMiddleware: AuthMiddleware) {
       };
 
       const emitResumeGap = async (reason: string, gapScope?: string, lastSeenId?: string) => {
+        // Counted at the ONE funnel every gap path goes through. `reason` is a
+        // closed set (scope-mismatch, unparseable-last-event-id, replay
+        // failure), so the label stays low-cardinality.
+        recordResumeGap(reason);
         const payload: { scope?: string; lastSeenId?: string; reason: string } = { reason };
         if (gapScope !== undefined) payload.scope = gapScope;
         if (lastSeenId !== undefined) payload.lastSeenId = lastSeenId;
@@ -1023,6 +1048,7 @@ export function createBusRouter(authMiddleware: AuthMiddleware) {
                 ...echo,
                 message: `No subscriber for ${channel}: the service that answers it is not connected`,
               };
+              recordUnanswerableRequest(channel);
               getBusLogger().warn('[bus UNANSWERABLE] synthesizing failure for an unsubscribed request', {
                 channel,
                 failureChannel: operation.failure,

--- a/apps/launcher/internal/launcher/imagepaths_test.go
+++ b/apps/launcher/internal/launcher/imagepaths_test.go
@@ -1,8 +1,10 @@
 package launcher
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -117,5 +119,85 @@ func TestExactlyOneContainerMountsTheKB(t *testing.T) {
 
 	if len(mounters) != 1 || mounters[0] != "archivist" {
 		t.Fatalf("containers mounting %s = %v, want exactly [archivist] — the tree has one owner", mount, mounters)
+	}
+}
+
+// ARCHIVIST-STAYS-UP P1: the archivist's image runs under the supervisor —
+// the only restart mechanism that can be true on all three runtimes (Apple
+// container has no --restart at all; probed 2026-09-04). Asserted against
+// the files, never by running anything.
+func TestArchivistRunsUnderTheSupervisor(t *testing.T) {
+	df, err := os.ReadFile(filepath.Join("..", "..", "..", "archivist", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("reading the archivist Dockerfile: %v", err)
+	}
+	if !strings.Contains(string(df), "supervise.sh") {
+		t.Fatal("the archivist Dockerfile does not run supervise.sh — a crashed or hung Archivist stays down, and its absence looks like a frontend hang")
+	}
+	sup, err := os.ReadFile(filepath.Join("..", "..", "..", "archivist", "supervise.sh"))
+	if err != nil {
+		t.Fatalf("reading supervise.sh: %v", err)
+	}
+	s := string(sup)
+	for what, want := range map[string]string{
+		"the archivist entry point":            "dist/archivist-main.js",
+		"a durable log on the state mount":     "/semiont-state/",
+		"a TERM trap (semiont stop wins)":      "trap",
+		"a rapid-failure cap (fail-fast boot)": "MAX_RAPID",
+		"the health self-probe":                "/health",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("supervise.sh is missing %s (expected to find %q)", what, want)
+		}
+	}
+}
+
+// Each service's health port is hand-written in four homes (TS main const,
+// Dockerfile EXPOSE, Dockerfile HEALTHCHECK, launcher portNeed) — five for the
+// archivist, whose supervisor probes it too. They can't be derived across
+// three languages, so this gate keeps them agreeing.
+func TestServiceHealthPortsAgreeAcrossAllHomes(t *testing.T) {
+	mains := map[string]string{
+		"worker":    filepath.Join("..", "..", "..", "..", "packages", "jobs", "src", "worker-main.ts"),
+		"smelter":   filepath.Join("..", "..", "..", "..", "packages", "make-meaning", "src", "smelter-main.ts"),
+		"weaver":    filepath.Join("..", "..", "..", "..", "packages", "make-meaning", "src", "weaver-main.ts"),
+		"archivist": filepath.Join("..", "..", "..", "..", "packages", "make-meaning", "src", "archivist-main.ts"),
+		"librarian": filepath.Join("..", "..", "..", "..", "packages", "make-meaning", "src", "librarian-main.ts"),
+	}
+	tsPort := regexp.MustCompile(`const healthPort = (\d+)`)
+	exposePort := regexp.MustCompile(`(?m)^EXPOSE (\d+)`)
+	healthURL := regexp.MustCompile(`localhost:(\d+)/health`)
+	for svc, mainPath := range mains {
+		want := roles[svc].ports[0].port
+
+		ts, err := os.ReadFile(mainPath)
+		if err != nil {
+			t.Fatalf("%s: reading %s: %v", svc, mainPath, err)
+		}
+		m := tsPort.FindSubmatch(ts)
+		if m == nil {
+			t.Errorf("%s: no `const healthPort = N` in its main — the gate cannot see its port", svc)
+		} else if got := string(m[1]); got != fmt.Sprint(want) {
+			t.Errorf("%s: TS healthPort %s != launcher portNeed %d", svc, got, want)
+		}
+
+		df, err := os.ReadFile(filepath.Join("..", "..", "..", svc, "Dockerfile"))
+		if err != nil {
+			t.Fatalf("%s: reading Dockerfile: %v", svc, err)
+		}
+		if m := exposePort.FindSubmatch(df); m == nil || string(m[1]) != fmt.Sprint(want) {
+			t.Errorf("%s: Dockerfile EXPOSE disagrees with launcher portNeed %d", svc, want)
+		}
+		if m := healthURL.FindSubmatch(df); m == nil || string(m[1]) != fmt.Sprint(want) {
+			t.Errorf("%s: Dockerfile HEALTHCHECK URL disagrees with launcher portNeed %d", svc, want)
+		}
+	}
+	// The archivist's fifth home: the supervisor's own probe.
+	sup, err := os.ReadFile(filepath.Join("..", "..", "..", "archivist", "supervise.sh"))
+	if err != nil {
+		t.Fatalf("reading supervise.sh: %v", err)
+	}
+	if m := healthURL.FindSubmatch(sup); m == nil || string(m[1]) != fmt.Sprint(roles["archivist"].ports[0].port) {
+		t.Errorf("supervise.sh probes a port that is not the archivist's %d", roles["archivist"].ports[0].port)
 	}
 }

--- a/docs/system/administration/OBSERVABILITY.md
+++ b/docs/system/administration/OBSERVABILITY.md
@@ -33,7 +33,14 @@ headers and SSE `_trace` payload fields.
 | `actor.<name>:<channel>` | In-process subscriber (Stower / Gatherer / Matcher / Browser / Smelter) | consumer |
 | `content.{put,get}`    | `HttpContentTransport.*` / `LocalContentTransport.*` | client / internal |
 | `content.{put,get}.server` | Gateway `/resources*` routes          | server   |
+| `archivist.{content.put,content.get,kb.branch,events.replay}` | Gateway → Archivist HTTP | client |
 | `job:<type>`           | Worker `handleJob`                        | consumer |
+
+The `archivist.*` row is the third hop. The two `content.*` rows describe a
+client/server pair that once covered the whole byte path, because the gateway
+was the content store; SINGLE-KB-MOUNT moved the tree to the Archivist and put
+a network call *inside* `content.put.server`. Without its own span that call is
+invisible, and a slow Archivist reads as a slow gateway.
 
 A typical "open resource" trace, parented by the SPA's transport call:
 
@@ -213,6 +220,10 @@ through the same OTLP endpoint. No extra config required — the
 | `semiont.inference.duration` | histogram        | `inference.provider`, `inference.model`, `inference.outcome` | Anthropic + Ollama clients               |
 | `semiont.sse.subscribers`    | up-down counter  | (none)                                                  | `/bus/subscribe` connect/disconnect           |
 | `semiont.job.queue.size`     | observable gauge | `job.status` (`pending`/`running`/`complete`/`failed`/`cancelled`) | Gateway `FsJobQueue.getStats()` |
+| `semiont.bus.reply.suppressed` | counter        | `bus.channel`                                           | Gateway SSE: a correlated reply withheld from a non-owner |
+| `semiont.bus.resume_gap`     | counter          | `bus.resume_gap.reason`                                 | Gateway SSE: a resume that degraded to a gap  |
+| `semiont.bus.unanswerable`   | counter          | `bus.channel`                                           | Gateway `/bus/emit`: a request that reached zero subscribers |
+| `semiont.bus.correlation.size` | observable gauge | `correlation.kind` (`claims`/`retained_replies`)      | Gateway correlation registry occupancy        |
 
 Additional vars:
 

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@semiont/core": "*",
+    "@semiont/observability": "*",
     "@tesseract.js-data/eng": "^1.0.0",
     "pdfjs-dist": "^6.2.108",
     "tesseract.js": "^7.0.0"

--- a/packages/content/src/working-tree-store.ts
+++ b/packages/content/src/working-tree-store.ts
@@ -30,6 +30,22 @@ import { pipeline } from 'stream/promises';
 import path from 'path';
 import type { SemiontProject } from '@semiont/core/node';
 import type { Logger } from '@semiont/core';
+import { recordGitCommand } from '@semiont/observability';
+
+/**
+ * Every git call here is SYNCHRONOUS and therefore blocks the event loop —
+ * one runs per appended event. The duration is not merely latency, it is time
+ * this process could serve nothing else, which is why it is measured rather
+ * than assumed (ARCHIVIST-STAYS-UP P7).
+ */
+function git(args: string[], cwd: string): void {
+  const started = performance.now();
+  try {
+    execFileSync('git', args, { cwd });
+  } finally {
+    recordGitCommand(args[0] ?? 'git', performance.now() - started);
+  }
+}
 
 /**
  * Result of store() or register()
@@ -136,7 +152,7 @@ export class WorkingTreeStore {
       await fs.rename(tempPath, filePath);
 
       if (this.shouldRunGit(options?.noGit)) {
-        execFileSync('git', ['add', filePath], { cwd: this.projectRoot });
+        git(['add', filePath], this.projectRoot);
       }
 
       this.logger?.info('Resource stored', { storageUri, checksum, byteSize });
@@ -189,7 +205,7 @@ export class WorkingTreeStore {
     }
 
     if (this.shouldRunGit(options?.noGit)) {
-      execFileSync('git', ['add', filePath], { cwd: this.projectRoot });
+      git(['add', filePath], this.projectRoot);
     }
 
     const byteSize = tap.byteSize;
@@ -257,7 +273,7 @@ export class WorkingTreeStore {
 
     if (this.shouldRunGit(options?.noGit)) {
       // git mv handles both the filesystem rename and the index update
-      execFileSync('git', ['mv', fromPath, toPath], { cwd: this.projectRoot });
+      git(['mv', fromPath, toPath], this.projectRoot);
     } else {
       await fs.rename(fromPath, toPath);
     }
@@ -291,7 +307,7 @@ export class WorkingTreeStore {
       const gitArgs = keepFile
         ? ['rm', '--cached', filePath]
         : ['rm', filePath];
-      execFileSync('git', gitArgs, { cwd: this.projectRoot });
+      git(gitArgs, this.projectRoot);
       this.logger?.info('Resource removed', { storageUri, keepFile, git: true });
       return;
     }

--- a/packages/event-sourcing/package.json
+++ b/packages/event-sourcing/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@semiont/core": "*",
     "@semiont/http-transport": "*",
+    "@semiont/observability": "*",
     "nanoid": "^6.0.0",
     "uuid": "^14.0.2"
   }

--- a/packages/event-sourcing/src/__tests__/append-telemetry.test.ts
+++ b/packages/event-sourcing/src/__tests__/append-telemetry.test.ts
@@ -83,4 +83,47 @@ describe('append telemetry', () => {
 
     expect(recordAppendStage.mock.calls.map((c) => c[0])).toContain('persist');
   });
+
+  // Enrich is the one conditional stage: it runs only when an enricher is
+  // registered (make-meaning's event-enrichment does this) AND the event is
+  // resource-scoped. Both halves of that condition are pinned here, because a
+  // stage that silently stops being timed looks identical to one that is fast.
+  it('times the enrich stage when an enricher is registered', async () => {
+    store.setEnrichEvent(async (event) => event);
+
+    await store.appendEvent({
+      type: 'yield:created',
+      resourceId: makeResourceId('res-enriched'),
+      userId: userId('did:web:example:users:alice'),
+      version: 1,
+      payload: { name: 'N', format: 'text/plain', contentChecksum: 'h' },
+    } as never);
+
+    expect(recordAppendStage.mock.calls.map((c) => c[0])).toContain('enrich');
+  });
+
+  it('does not time enrich for a system append — the enricher is resource-scoped', async () => {
+    store.setEnrichEvent(async (event) => event);
+
+    await store.appendEvent({
+      type: 'frame:entity-type-added',
+      userId: userId('did:web:example:users:alice'),
+      version: 1,
+      payload: { entityType: 'Person' },
+    } as never);
+
+    expect(recordAppendStage.mock.calls.map((c) => c[0])).not.toContain('enrich');
+  });
+
+  it('leaves enrich untimed when no enricher is registered', async () => {
+    await store.appendEvent({
+      type: 'yield:created',
+      resourceId: makeResourceId('res-unenriched'),
+      userId: userId('did:web:example:users:alice'),
+      version: 1,
+      payload: { name: 'N', format: 'text/plain', contentChecksum: 'h' },
+    } as never);
+
+    expect(recordAppendStage.mock.calls.map((c) => c[0])).not.toContain('enrich');
+  });
 });

--- a/packages/event-sourcing/src/__tests__/append-telemetry.test.ts
+++ b/packages/event-sourcing/src/__tests__/append-telemetry.test.ts
@@ -1,0 +1,86 @@
+/**
+ * ARCHIVIST-STAYS-UP P7 — the append path reports what it spends.
+ *
+ * `appendEvent` is the Archivist's core operation and the one thing only it
+ * can do, and until this it emitted no span and no metric. Reads were covered
+ * (`recordHandlerDuration` via `withActorSpan`) and the bus was covered; the
+ * WRITE path was dark, which is why "reads serialize behind the detection
+ * job's annotation writes" is a symptom recorded in
+ * `bugs/absent-archivist-wedges-browse.md` with no mechanism attached.
+ *
+ * Four stages, timed separately, because the useful question is not "was the
+ * append slow" but WHICH PART was slow — persisting the record, materializing
+ * the view whose size grows with annotation count, enriching, or publishing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const recordAppendStage = vi.fn();
+vi.mock('@semiont/observability', () => ({
+  recordAppendStage: (...args: unknown[]) => recordAppendStage(...args),
+  recordGitCommand: vi.fn(),
+}));
+
+import { EventBus, resourceId as makeResourceId, userId } from '@semiont/core';
+import { SemiontProject } from '@semiont/core/node';
+import { EventStore } from '../event-store';
+import { FilesystemViewStorage } from '../storage/view-storage';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+describe('append telemetry', () => {
+  let testDir: string;
+  let project: SemiontProject;
+  let bus: EventBus;
+  let store: EventStore;
+
+  beforeEach(async () => {
+    recordAppendStage.mockClear();
+    testDir = join(tmpdir(), `semiont-append-tel-${uuidv4()}`);
+    await fs.mkdir(testDir, { recursive: true });
+    project = new SemiontProject(testDir, { anchoredTextDir: `${testDir}/anchored-text` });
+    bus = new EventBus();
+    store = new EventStore(project, testDir, new FilesystemViewStorage(project), bus);
+  });
+
+  afterEach(async () => {
+    bus.destroy();
+    await project.destroy();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('times every stage of a resource append', async () => {
+    await store.appendEvent({
+      type: 'yield:created',
+      resourceId: makeResourceId('res-telemetry'),
+      userId: userId('did:web:example:users:alice'),
+      version: 1,
+      payload: { name: 'N', format: 'text/plain', contentChecksum: 'h' },
+    } as never);
+
+    const stages = recordAppendStage.mock.calls.map((c) => c[0]);
+    expect(stages).toContain('persist');
+    expect(stages).toContain('materialize');
+    expect(stages).toContain('publish');
+
+    // Every call carries a non-negative duration — a stage that reports no
+    // number is the same as a stage that reports nothing.
+    for (const call of recordAppendStage.mock.calls) {
+      expect(typeof call[1]).toBe('number');
+      expect(call[1] as number).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('times a system append too — `__system__` is not a special case', async () => {
+    await store.appendEvent({
+      type: 'frame:entity-type-added',
+      userId: userId('did:web:example:users:alice'),
+      version: 1,
+      payload: { entityType: 'Person' },
+    } as never);
+
+    expect(recordAppendStage.mock.calls.map((c) => c[0])).toContain('persist');
+  });
+});

--- a/packages/event-sourcing/src/__tests__/storage/git-telemetry.test.ts
+++ b/packages/event-sourcing/src/__tests__/storage/git-telemetry.test.ts
@@ -1,0 +1,140 @@
+/**
+ * ARCHIVIST-STAYS-UP P7 — the synchronous git calls on the append path report
+ * what they cost.
+ *
+ * When `gitSync` is on, every appended event runs `git add` through
+ * `execFileSync`, which blocks the event loop. That duration is not latency ON
+ * the append — it is time this process can serve nothing else, and the
+ * Archivist is the sole subscriber to every `browse:*` channel while it is
+ * blocked. Measuring it is the whole point of the wrapper, so these tests pin
+ * that every call site is measured, including one that throws: a git failure
+ * still consumed the loop, so it still has a duration worth reporting.
+ *
+ * Why this file exists separately: `gitSync` is FALSE in every other suite,
+ * because it is read from `[git] sync = true` in `.semiont/config` and the
+ * temp-dir projects those suites build have no such file. The wrapper was
+ * therefore unexecuted by the whole package until this file enabled it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const recordGitCommand = vi.fn();
+const execFileSyncMock = vi.fn();
+
+vi.mock('@semiont/observability', () => ({
+  recordGitCommand: (...args: unknown[]) => recordGitCommand(...args),
+  recordAppendStage: vi.fn(),
+}));
+
+// Mocked so the suite needs no real repository and can drive the failure
+// path. The wrapper is what is under test here, not git.
+vi.mock('child_process', () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+import { EventStorage } from '../../storage/event-storage';
+import { resourceId, userId } from '@semiont/core';
+import { SemiontProject } from '@semiont/core/node';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+/** `.semiont/config` must exist before the project is constructed — gitSync is read there. */
+async function makeProject(testDir: string, gitSync: boolean): Promise<SemiontProject> {
+  await fs.mkdir(join(testDir, '.semiont'), { recursive: true });
+  await fs.writeFile(
+    join(testDir, '.semiont', 'config'),
+    `[git]\nsync = ${gitSync}\n`,
+    'utf-8',
+  );
+  return new SemiontProject(testDir, { anchoredTextDir: join(testDir, 'anchored-text') });
+}
+
+function appendOne(storage: EventStorage, rid: string) {
+  return storage.appendEvent(
+    {
+      type: 'yield:created',
+      resourceId: resourceId(rid),
+      userId: userId('did:web:example:users:alice'),
+      version: 1,
+      payload: { name: 'N', format: 'text/plain', contentChecksum: 'h' },
+    } as never,
+    resourceId(rid),
+  );
+}
+
+describe('git telemetry', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    recordGitCommand.mockClear();
+    execFileSyncMock.mockReset();
+    testDir = join(tmpdir(), `semiont-git-tel-${uuidv4()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('with gitSync on', () => {
+    it('measures both staging calls a first append makes', async () => {
+      const project = await makeProject(testDir, true);
+      expect(project.gitSync).toBe(true);
+      const storage = new EventStorage(project, { numShards: 256 });
+
+      await appendOne(storage, 'doc-git-1');
+
+      // Two distinct call sites: the event-stream directory (created by
+      // initializeResourceStream) and the JSONL file (written by writeEvent).
+      expect(recordGitCommand).toHaveBeenCalledTimes(2);
+      expect(recordGitCommand.mock.calls.every((c) => c[0] === 'add')).toBe(true);
+
+      const stagedPaths = execFileSyncMock.mock.calls.map((c) => (c[1] as string[])[1]);
+      const docPath = storage.getResourcePath(resourceId('doc-git-1'));
+      expect(stagedPaths).toContain(docPath);
+      expect(stagedPaths).toContain(join(docPath, 'events-000001.jsonl'));
+    });
+
+    it('reports a non-negative duration for every call', async () => {
+      const project = await makeProject(testDir, true);
+      const storage = new EventStorage(project, { numShards: 256 });
+
+      await appendOne(storage, 'doc-git-2');
+
+      for (const call of recordGitCommand.mock.calls) {
+        expect(typeof call[1]).toBe('number');
+        expect(call[1] as number).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('measures a FAILING git call too — the loop was blocked either way', async () => {
+      const project = await makeProject(testDir, true);
+      const storage = new EventStorage(project, { numShards: 256 });
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error('fatal: not a git repository');
+      });
+
+      // The failure propagates — this test pins the measurement, not a swallow.
+      await expect(appendOne(storage, 'doc-git-3')).rejects.toThrow(/not a git repository/);
+
+      expect(recordGitCommand).toHaveBeenCalledTimes(1);
+      expect(recordGitCommand.mock.calls[0]![0]).toBe('add');
+      expect(typeof recordGitCommand.mock.calls[0]![1]).toBe('number');
+    });
+  });
+
+  describe('with gitSync off', () => {
+    it('runs no git command and records nothing', async () => {
+      const project = await makeProject(testDir, false);
+      expect(project.gitSync).toBe(false);
+      const storage = new EventStorage(project, { numShards: 256 });
+
+      await appendOne(storage, 'doc-git-4');
+
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      expect(recordGitCommand).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/event-sourcing/src/event-store.ts
+++ b/packages/event-sourcing/src/event-store.ts
@@ -19,6 +19,7 @@ import type {
   ResourceId,
   Logger,
 } from '@semiont/core';
+import { recordAppendStage } from '@semiont/observability';
 import { EventBus as CoreEventBus } from '@semiont/core';
 import type { SemiontProject } from '@semiont/core/node';
 import type { ViewStorage } from './storage/view-storage';
@@ -68,36 +69,54 @@ export class EventStore {
   ): Promise<StoredEvent> {
     const resourceId: ResourceId | '__system__' = event.resourceId || '__system__';
 
+    // Each stage is timed separately (ARCHIVIST-STAYS-UP P7). The useful
+    // question is never "was the append slow" but WHICH stage: `persist`
+    // includes a SYNCHRONOUS git add that blocks the event loop, and
+    // `materialize` does work proportional to the resource's annotation
+    // count — so one degrades with concurrency and the other with history.
+    const timed = async <T>(stage: 'persist' | 'materialize' | 'enrich' | 'publish', run: () => Promise<T> | T): Promise<T> => {
+      const started = performance.now();
+      try {
+        return await run();
+      } finally {
+        recordAppendStage(stage, performance.now() - started);
+      }
+    };
+
     // 1. Persist event to log
-    const storedEvent = await this.log.append(event, resourceId as any, options);
+    const storedEvent = await timed('persist', () => this.log.append(event, resourceId as any, options));
 
     // 2. Update views
-    if (resourceId === '__system__') {
-      await this.views.materializeSystem(
-        storedEvent.type,
-        storedEvent.payload
-      );
-    } else {
-      await this.views.materializeResource(
-        resourceId as ResourceId,
-        storedEvent,
-        () => this.log.getEvents(resourceId as ResourceId)
-      );
-    }
+    await timed('materialize', async () => {
+      if (resourceId === '__system__') {
+        await this.views.materializeSystem(
+          storedEvent.type,
+          storedEvent.payload
+        );
+      } else {
+        await this.views.materializeResource(
+          resourceId as ResourceId,
+          storedEvent,
+          () => this.log.getEvents(resourceId as ResourceId)
+        );
+      }
+    });
 
     // 3. Enrich (attach post-materialization data like annotations)
     let publishEvent = storedEvent;
     if (this.enrichEvent && resourceId !== '__system__') {
-      publishEvent = await this.enrichEvent(storedEvent, resourceId as ResourceId);
+      publishEvent = await timed('enrich', () => this.enrichEvent!(storedEvent, resourceId as ResourceId));
     }
 
     // 4. Publish to Core EventBus typed channels
-    this.coreEventBus.getDomainEvent(publishEvent.type).next(publishEvent);
+    await timed('publish', () => {
+      this.coreEventBus.getDomainEvent(publishEvent.type).next(publishEvent);
 
-    if (resourceId !== '__system__') {
-      const scopedBus = this.coreEventBus.scope(resourceId as string);
-      scopedBus.getDomainEvent(publishEvent.type).next(publishEvent);
-    }
+      if (resourceId !== '__system__') {
+        const scopedBus = this.coreEventBus.scope(resourceId as string);
+        scopedBus.getDomainEvent(publishEvent.type).next(publishEvent);
+      }
+    });
 
     return storedEvent;
   }

--- a/packages/event-sourcing/src/storage/event-storage.ts
+++ b/packages/event-sourcing/src/storage/event-storage.ts
@@ -20,6 +20,22 @@ import type { StoredEvent, PersistedEvent, EventMetadata, EventInput, ResourceId
 import { resourceId as makeResourceId } from '@semiont/core';
 import type { SemiontProject } from '@semiont/core/node';
 import { jumpConsistentHash } from '@semiont/core';
+import { recordGitCommand } from '@semiont/observability';
+
+/**
+ * Every git call here is SYNCHRONOUS and therefore blocks the event loop —
+ * one runs per appended event. The duration is not merely latency, it is time
+ * this process could serve nothing else, which is why it is measured rather
+ * than assumed (ARCHIVIST-STAYS-UP P7).
+ */
+function git(args: string[], cwd: string): void {
+  const started = performance.now();
+  try {
+    execFileSync('git', args, { cwd });
+  } finally {
+    recordGitCommand(args[0] ?? 'git', performance.now() - started);
+  }
+}
 
 export interface EventStorageConfig {
   maxEventsPerFile?: number;     // File rotation threshold (default: 10000)
@@ -129,7 +145,7 @@ export class EventStorage {
 
       // Stage the new event stream directory in git
       if (this.project.gitSync) {
-        execFileSync('git', ['add', docPath], { cwd: this.project.root });
+        git(['add', docPath], this.project.root);
       }
 
       // Initialize sequence number
@@ -239,7 +255,7 @@ export class EventStorage {
 
     // Stage the event log file in git index if configured
     if (this.project.gitSync) {
-      execFileSync('git', ['add', targetPath], { cwd: this.project.root });
+      git(['add', targetPath], this.project.root);
     }
   }
 

--- a/packages/event-sourcing/src/storage/event-storage.ts
+++ b/packages/event-sourcing/src/storage/event-storage.ts
@@ -28,12 +28,12 @@ import { recordGitCommand } from '@semiont/observability';
  * this process could serve nothing else, which is why it is measured rather
  * than assumed (ARCHIVIST-STAYS-UP P7).
  */
-function git(args: string[], cwd: string): void {
+function git(args: [string, ...string[]], cwd: string): void {
   const started = performance.now();
   try {
     execFileSync('git', args, { cwd });
   } finally {
-    recordGitCommand(args[0] ?? 'git', performance.now() - started);
+    recordGitCommand(args[0], performance.now() - started);
   }
 }
 

--- a/packages/make-meaning/src/__tests__/fact-pump.test.ts
+++ b/packages/make-meaning/src/__tests__/fact-pump.test.ts
@@ -1,0 +1,160 @@
+/**
+ * ARCHIVIST-STAYS-UP P5 — the fact pump.
+ *
+ * The Archivist republishes every persisted event onto the gateway bus so
+ * projectors see it live. That pump is the leading hypothesis for the
+ * load-correlated heap growth in `bugs/absent-archivist-wedges-browse.md`:
+ * it fills at Stower's append rate and drains at HTTP round trips, with no
+ * bound and no number saying how far behind it is.
+ *
+ * These tests pin two properties it did not have:
+ *
+ *   - the two emits for one event are CONCURRENT, not sequential — they are
+ *     independent, and serialising them doubles drain time for nothing;
+ *   - the backlog is OBSERVABLE, so "how far behind is the pump" is a number
+ *     rather than an inference from RSS.
+ *
+ * What is deliberately NOT here: a bounded queue with a drop policy. The
+ * plan's step 1 is to remove the need before designing for it — dropping
+ * costs a projection that stays stale until its projector next restarts
+ * (catch-up is a startup pass, verified in both `smelter-main` and
+ * `weaver-main`). Measure first; the gauge below is what makes that possible.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Subject } from 'rxjs';
+import type { Logger, StoredEvent } from '@semiont/core';
+import { resourceId as makeResourceId, userId } from '@semiont/core';
+import { createFactPump } from '../fact-pump';
+
+const mockLogger: Logger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+const settle = () => new Promise((r) => setImmediate(r));
+
+function fact(seq: number, rid?: string): StoredEvent {
+  return {
+    id: `evt-${seq}`,
+    type: 'mark:added',
+    timestamp: new Date().toISOString(),
+    userId: userId('did:web:example:users:alice'),
+    version: 1,
+    ...(rid ? { resourceId: makeResourceId(rid) } : {}),
+    payload: {},
+    metadata: { sequenceNumber: seq },
+  } as unknown as StoredEvent;
+}
+
+describe('fact pump', () => {
+  it('publishes an unscoped fact once', async () => {
+    const emit = vi.fn(async () => 1);
+    const facts$ = new Subject<StoredEvent>();
+    const pump = createFactPump(facts$, { emit, logger: mockLogger });
+
+    facts$.next(fact(1));
+    await settle();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    pump.unsubscribe();
+  });
+
+  it('publishes a resource-scoped fact globally AND to its scope', async () => {
+    const emit = vi.fn(async () => 1);
+    const facts$ = new Subject<StoredEvent>();
+    const pump = createFactPump(facts$, { emit, logger: mockLogger });
+
+    facts$.next(fact(1, 'res-a'));
+    await settle();
+
+    expect(emit).toHaveBeenCalledTimes(2);
+    const scopes = emit.mock.calls.map((c) => (c as unknown[])[2]);
+    expect(scopes).toContain(undefined);
+    expect(scopes).toContain('res-a');
+    pump.unsubscribe();
+  });
+
+  it('issues the two emits CONCURRENTLY, not one after the other', async () => {
+    // The defect: `await emit(global); await emit(scoped)` doubles the drain
+    // time per event for no reason — the two are independent.
+    let inFlight = 0;
+    let peak = 0;
+    const emit = vi.fn(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await settle();
+      inFlight -= 1;
+      return 1;
+    });
+    const facts$ = new Subject<StoredEvent>();
+    const pump = createFactPump(facts$, { emit, logger: mockLogger });
+
+    facts$.next(fact(1, 'res-a'));
+    await settle();
+    await settle();
+
+    expect(peak).toBe(2);
+    pump.unsubscribe();
+  });
+
+  it('reports its backlog — how far behind the pump is, as a number', async () => {
+    // Without this the only symptom of a pump falling behind is RSS, which is
+    // why the growth in the bug report is still a hypothesis.
+    let release: (() => void) | undefined;
+    const emit = vi.fn(() => new Promise<number>((res) => { release = () => res(1); }));
+    const facts$ = new Subject<StoredEvent>();
+    const pump = createFactPump(facts$, { emit, logger: mockLogger });
+
+    expect(pump.depth()).toBe(0);
+    facts$.next(fact(1));
+    facts$.next(fact(2));
+    facts$.next(fact(3));
+    await settle();
+
+    expect(pump.depth()).toBe(3);
+
+    release?.();
+    await settle();
+    expect(pump.depth()).toBeLessThan(3);
+    pump.unsubscribe();
+  });
+
+  it('keeps events in order — a later fact never overtakes an earlier one', async () => {
+    // Guard on the concurrency change: parallelising the two emits of ONE
+    // event must not parallelise events against each other.
+    const seen: number[] = [];
+    const emit = vi.fn(async (_c: unknown, payload: unknown) => {
+      seen.push((payload as StoredEvent).metadata.sequenceNumber as number);
+      await settle();
+      return 1;
+    });
+    const facts$ = new Subject<StoredEvent>();
+    const pump = createFactPump(facts$, { emit, logger: mockLogger });
+
+    facts$.next(fact(1));
+    facts$.next(fact(2));
+    facts$.next(fact(3));
+    for (let i = 0; i < 12; i++) await settle();
+
+    expect(seen).toEqual([1, 2, 3]);
+    pump.unsubscribe();
+  });
+
+  it('a failed publish is logged and the pump survives it', async () => {
+    const emit = vi.fn()
+      .mockRejectedValueOnce(new Error('gateway down'))
+      .mockResolvedValue(1);
+    const facts$ = new Subject<StoredEvent>();
+    const pump = createFactPump(facts$, { emit, logger: mockLogger });
+
+    facts$.next(fact(1));
+    await settle();
+    facts$.next(fact(2));
+    await settle();
+
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledTimes(2);
+    pump.unsubscribe();
+  });
+});

--- a/packages/make-meaning/src/archivist-main.ts
+++ b/packages/make-meaning/src/archivist-main.ts
@@ -34,8 +34,7 @@
  *   SEMIONT_SKIP_REBUILD      — 'true' skips the startup view rebuild.
  */
 
-import { BehaviorSubject, Subscription, merge, from } from 'rxjs';
-import { concatMap } from 'rxjs/operators';
+import { BehaviorSubject, Subscription, merge } from 'rxjs';
 import { HttpTransport } from '@semiont/http-transport';
 import {
   EventBus,
@@ -47,8 +46,6 @@ import {
   STARTUP_FETCH_RETRY,
   errField,
   type AccessToken,
-  type EventMap,
-  type StoredEvent,
 } from '@semiont/core';
 import { SemiontProject, loadEnvironmentConfig } from '@semiont/core/node';
 import { createEventStore } from '@semiont/event-sourcing';
@@ -63,6 +60,7 @@ import { createSmeltProgress } from './smelt-progress';
 import { createLimitsDiscovery } from './limits-discovery';
 import { makeMeaningConfigFrom } from './config';
 import { createArchivistServer } from './archivist-read-path';
+import { createFactPump } from './fact-pump';
 import { registerAnnotationAssemblyHandler } from './handlers/annotation-assembly';
 import { registerAnnotationContextHandler } from './handlers/annotation-lookups';
 import { workingTreeContentReads } from './knowledge-base';
@@ -115,6 +113,7 @@ const skipRebuild = process.env.SEMIONT_SKIP_REBUILD === 'true';
 /** Claimed as a portNeed in the launcher (P2b): worker 24100, smelter 24101, weaver 24102. */
 const healthPort = 24103;
 
+import { registerFactPumpDepthProvider } from '@semiont/observability';
 import { createProcessLogger } from '@semiont/observability/process-logger';
 const logger = createProcessLogger('archivist');
 
@@ -304,38 +303,30 @@ async function main() {
 
   // ── The fact pump (P3, D5): persisted events ride the bus ──────────
   // Every append publishes an (enriched) StoredEvent on this process's bus;
-  // this pump emits each one to the gateway via the ordinary /bus/emit —
+  // the pump emits each one to the gateway via the ordinary /bus/emit —
   // persisted channels are registered there (validate: null), and channel
   // authz is deferred wholesale (CHANNEL-AUTHZ.md). Emitted twice, exactly
   // as in-process appendEvent published: once global (the Smelter's and
   // Weaver's unscoped subscriptions), once resource-scoped (clients'
   // per-resource feeds, whose SSE frames carry the resumable p-<scope>-<seq>
-  // ids). Serialized with concatMap: projections downstream assume
-  // per-resource ORDER, and parallel emits would reorder. A fact that fails
-  // after the transport's retries is logged loudly and NOT retried further —
-  // the D1 replay path and the projectors' catch-up/reconcile passes exist
-  // for exactly that gap.
-  const publishFact = async (event: StoredEvent): Promise<void> => {
-    try {
-      const type = event.type as keyof EventMap;
-      await httpTransport.emit(type, event as never);
-      if (event.resourceId) {
-        await httpTransport.emit(type, event as never, event.resourceId);
-      }
-    } catch (error) {
-      logger.error('Fact publish failed — projectors will heal on their next catch-up', {
-        type: event.type,
-        resourceId: event.resourceId,
-        sequenceNumber: event.metadata?.sequenceNumber,
-        error: errField(error),
-      });
-    }
-  };
-  pumps.push(
-    merge(...PERSISTED_EVENT_TYPES.map((type) => localBus.getDomainEvent(type)))
-      .pipe(concatMap((event) => from(publishFact(event))))
-      .subscribe(),
+  // ids). A fact that fails after the transport's retries is logged loudly
+  // and NOT retried further — the D1 replay path and the projectors'
+  // catch-up/reconcile passes exist for exactly that gap.
+  //
+  // EXTRACTED to `fact-pump.ts` by ARCHIVIST-STAYS-UP P5, so the component
+  // whose backlog is the leading suspect for load-correlated heap growth can
+  // be tested and measured at all. Two things changed there, and the
+  // distinction matters: events still drain ONE AT A TIME IN ORDER (projections
+  // assume per-resource order), but the two emits WITHIN one event now run
+  // together — they address different scopes and have no ordering relation,
+  // so serialising them only doubled the drain time. `depth()` is published as
+  // a gauge: an unbounded backlog with no number is how this went undiagnosed.
+  const factPump = createFactPump(
+    merge(...PERSISTED_EVENT_TYPES.map((type) => localBus.getDomainEvent(type))),
+    { emit: (channel, payload, scope) => httpTransport.emit(channel, payload, scope), logger },
   );
+  pumps.push({ unsubscribe: () => factPump.unsubscribe() } as Subscription);
+  registerFactPumpDepthProvider(() => factPump.depth());
 
   logger.info('Bus pumps attached', { inbound: ARCHIVIST_INBOUND_CHANNELS.length, outbound: outbound.length, facts: PERSISTED_EVENT_TYPES.length });
 

--- a/packages/make-meaning/src/fact-pump.ts
+++ b/packages/make-meaning/src/fact-pump.ts
@@ -1,0 +1,89 @@
+/**
+ * The fact pump: every persisted event the Archivist appends is republished
+ * onto the gateway bus so projectors see it live (EXTRACT-ARCHIVIST D5).
+ *
+ * Extracted from `archivist-main`'s composition root by ARCHIVIST-STAYS-UP P5.
+ * It was three inline statements there, which meant the one component whose
+ * backlog is the leading suspect for load-correlated heap growth
+ * (`bugs/absent-archivist-wedges-browse.md`) could not be tested or measured
+ * at all.
+ *
+ * **Ordering is load-bearing and preserved.** Events drain one at a time, in
+ * arrival order, because a projector applying `mark:added` before the
+ * `yield:created` it belongs to would materialize a view from an event whose
+ * subject does not exist yet. Only the two emits WITHIN one event run
+ * together — they are independent by construction, and serialising them
+ * doubled the drain time per event for nothing.
+ *
+ * **The backlog is deliberately unbounded, for now.** Bounding it means
+ * choosing what to discard on overflow, and a discarded fact leaves that
+ * projector stale until its NEXT RESTART — catch-up is a startup pass in both
+ * `smelter-main` (`reconcile()`) and `weaver-main`, not a continuous repair.
+ * A projection silently days out of date is the same class of defect as the
+ * silent 202 this plan exists to remove. So: measure first. `depth()` is what
+ * makes that possible; the policy follows the number, not the other way round.
+ */
+
+import { from, concatMap, tap, type Observable, type Subscription } from 'rxjs';
+import type { EventMap, Logger, ResourceId, StoredEvent } from '@semiont/core';
+import { errField } from '@semiont/core';
+
+export interface FactPumpDeps {
+  /** The wire. Narrowed to the one call the pump makes — never the transport. */
+  emit: <K extends keyof EventMap>(
+    channel: K,
+    payload: EventMap[K],
+    resourceScope?: ResourceId,
+  ) => Promise<unknown>;
+  logger: Logger;
+}
+
+export interface FactPump {
+  /**
+   * Facts accepted from the local bus but not yet published — how far behind
+   * the wire the pump is running. Zero at rest; a number that climbs and does
+   * not return is the pump outrunning its transport.
+   */
+  depth(): number;
+  unsubscribe(): void;
+}
+
+export function createFactPump(facts$: Observable<StoredEvent>, deps: FactPumpDeps): FactPump {
+  let depth = 0;
+
+  const publish = async (event: StoredEvent): Promise<void> => {
+    try {
+      const type = event.type as keyof EventMap;
+      // Concurrent: the global and scoped emits are independent, and the
+      // event is the same object in both. Ordering between EVENTS is the
+      // concatMap below; this parallelism does not touch it.
+      await Promise.all([
+        deps.emit(type, event as never),
+        ...(event.resourceId ? [deps.emit(type, event as never, event.resourceId)] : []),
+      ]);
+    } catch (error) {
+      // Never rethrow: one unreachable gateway must not tear down the pump
+      // for every future fact. The projector heals on its next catch-up —
+      // true, but that is a STARTUP pass, so this line is a real degradation
+      // and not merely noise.
+      deps.logger.error('Fact publish failed — projectors will heal on their next catch-up', {
+        type: event.type,
+        resourceId: event.resourceId,
+        sequenceNumber: event.metadata?.sequenceNumber,
+        error: errField(error),
+      });
+    }
+  };
+
+  const subscription: Subscription = facts$
+    .pipe(
+      tap(() => { depth += 1; }),
+      concatMap((event) => from(publish(event).finally(() => { depth -= 1; }))),
+    )
+    .subscribe();
+
+  return {
+    depth: () => depth,
+    unsubscribe: () => subscription.unsubscribe(),
+  };
+}

--- a/packages/observability/src/__tests__/runtime-stats.test.ts
+++ b/packages/observability/src/__tests__/runtime-stats.test.ts
@@ -1,0 +1,46 @@
+/**
+ * ARCHIVIST-STAYS-UP P4 — the process reports its own ceiling.
+ *
+ * The Archivist died at ~1016 MB inside a 2048 MB container
+ * (`bugs/absent-archivist-wedges-browse.md`) because Node was sitting under
+ * its OWN default old-space ceiling, not the container's. Nothing in the
+ * fleet reported either number, so "half the memory is unreachable" was a
+ * discovery made after the fact rather than a value on a dashboard.
+ *
+ * `heapLimit` is the one that matters most and is the least obvious: it is
+ * what the process will actually die at, and it is also how you verify a
+ * configured `--max-old-space-size` took effect at all.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { heapStats } from '../runtime-stats';
+
+describe('heapStats', () => {
+  it('reports used, total, limit and rss as positive numbers', () => {
+    const s = heapStats();
+
+    for (const key of ['heapUsed', 'heapTotal', 'heapLimit', 'rss'] as const) {
+      expect(typeof s[key]).toBe('number');
+      expect(s[key]).toBeGreaterThan(0);
+    }
+  });
+
+  it('reports a limit that used is measured against — the number the process dies at', () => {
+    const s = heapStats();
+
+    expect(s.heapUsed).toBeLessThanOrEqual(s.heapLimit);
+    // The pair is the point: `used` alone cannot say how close to death the
+    // process is, and `limit` is what a configured cap changes.
+    expect(s.heapTotal).toBeLessThanOrEqual(s.heapLimit);
+  });
+
+  it('is a fresh reading each call, not a cached snapshot', () => {
+    const a = heapStats();
+    const churn: unknown[] = [];
+    for (let i = 0; i < 20000; i++) churn.push({ i, pad: 'x'.repeat(20) });
+    const b = heapStats();
+
+    expect(churn.length).toBe(20000);
+    expect(b.heapUsed).not.toBe(a.heapUsed);
+  });
+});

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -247,6 +247,8 @@ let _sseSubscribers: UpDownCounter | undefined;
 let _jobQueueGauge: ObservableGauge | undefined;
 let _jobQueueProvider: (() => Promise<JobQueueSnapshot> | JobQueueSnapshot) | undefined;
 let _vectorIndexSizeGauge: ObservableGauge | undefined;
+let _factPumpDepthGauge: ObservableGauge | undefined;
+let _factPumpDepthProvider: (() => number) | undefined;
 let _vectorIndexSizeProvider: (() => Promise<number> | number) | undefined;
 
 /** Snapshot of job-queue contents by status. Match `JobQueue.getStats()`. */
@@ -510,6 +512,29 @@ export function registerJobQueueProvider(
  * (point count). Async to allow remote queries (Qdrant). Polled at
  * the metric-collection interval.
  */
+/**
+ * Register the Archivist's fact-pump backlog — facts appended to the record
+ * but not yet republished onto the bus.
+ *
+ * At rest this is zero. A value that climbs and does not come back means the
+ * pump is outrunning its transport, which is the leading hypothesis for the
+ * load-correlated heap growth in `bugs/absent-archivist-wedges-browse.md`
+ * (ARCHIVIST-STAYS-UP P5). The backlog is deliberately unbounded today, so
+ * this number is the only thing standing between "the pump is behind" and an
+ * OOM whose cause is inferred from RSS after the fact.
+ */
+export function registerFactPumpDepthProvider(provider: () => number): void {
+  _factPumpDepthProvider = provider;
+  if (!_factPumpDepthGauge) {
+    _factPumpDepthGauge = meter().createObservableGauge('semiont.archivist.fact_pump.depth', {
+      description: 'Facts appended to the record but not yet published to the bus. Zero at rest; a rising floor means the pump is behind its transport.',
+    });
+    _factPumpDepthGauge.addCallback((observer) => {
+      if (_factPumpDepthProvider) observer.observe(_factPumpDepthProvider());
+    });
+  }
+}
+
 export function registerVectorIndexSizeProvider(
   provider: () => Promise<number> | number,
 ): void {

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -232,6 +232,10 @@ const meter = () => metrics.getMeter(METER_NAME);
 
 let _busEmitCounter: Counter | undefined;
 let _replySuppressedCounter: Counter | undefined;
+let _resumeGapCounter: Counter | undefined;
+let _unanswerableCounter: Counter | undefined;
+let _correlationRegistryGauge: ObservableGauge | undefined;
+let _correlationRegistryProvider: (() => CorrelationRegistrySnapshot) | undefined;
 let _handlerDurationHistogram: Histogram | undefined;
 let _jobOutcomeCounter: Counter | undefined;
 let _jobDurationHistogram: Histogram | undefined;
@@ -349,6 +353,76 @@ function replySuppressedCounter(): Counter {
  */
 export function recordReplySuppressed(channel: string): void {
   replySuppressedCounter().add(1, { 'bus.channel': channel });
+}
+
+function resumeGapCounter(): Counter {
+  if (!_resumeGapCounter) {
+    _resumeGapCounter = meter().createCounter('semiont.bus.resume_gap', {
+      description: 'SSE resumes that degraded to a gap because replay was unavailable',
+    });
+  }
+  return _resumeGapCounter;
+}
+
+/**
+ * An SSE resume could not be served and the client was told to fall back to
+ * cache. This degradation is CORRECT by design and therefore silent — which is
+ * exactly why it needs a number. A rising rate means clients are losing
+ * history, and nothing else in the stack says so.
+ */
+export function recordResumeGap(reason: string): void {
+  resumeGapCounter().add(1, { 'bus.resume_gap.reason': reason });
+}
+
+function unanswerableCounter(): Counter {
+  if (!_unanswerableCounter) {
+    _unanswerableCounter = meter().createCounter('semiont.bus.unanswerable', {
+      description: 'Request emits that reached zero subscribers and were failed at the gateway',
+    });
+  }
+  return _unanswerableCounter;
+}
+
+/**
+ * A request-shaped emit reached no subscriber, so the gateway synthesized its
+ * mapped failure (ARCHIVIST-STAYS-UP P3). By channel, this is the absence rate
+ * of the service that answers it — the difference between "it went down once"
+ * and "it is flapping."
+ */
+export function recordUnanswerableRequest(channel: string): void {
+  unanswerableCounter().add(1, { 'bus.channel': channel });
+}
+
+/** Claims held and reply payloads retained by a gateway's correlation registry. */
+export interface CorrelationRegistrySnapshot {
+  claims: number;
+  retainedReplies: number;
+}
+
+/**
+ * Register a callback returning the gateway's correlation-registry occupancy.
+ *
+ * COUNTS, not bytes: retention is count-budgeted today (byte-budgeting is a
+ * known limit in CORRELATED-REPLY-ROUTING), so `retainedReplies` is a proxy for
+ * heap, not a measure of it. It is still the closest observable to the question
+ * two OOM investigations keep asking — a browse result can be 1-2 MB, and up to
+ * REPLY_RETENTION_MAX of them are held at once.
+ */
+export function registerCorrelationRegistryProvider(
+  provider: () => CorrelationRegistrySnapshot,
+): void {
+  _correlationRegistryProvider = provider;
+  if (!_correlationRegistryGauge) {
+    _correlationRegistryGauge = meter().createObservableGauge('semiont.bus.correlation.size', {
+      description: 'Correlation registry occupancy: live claims and retained reply payloads',
+    });
+    _correlationRegistryGauge.addCallback((observer) => {
+      if (!_correlationRegistryProvider) return;
+      const snap = _correlationRegistryProvider();
+      observer.observe(snap.claims, { 'correlation.kind': 'claims' });
+      observer.observe(snap.retainedReplies, { 'correlation.kind': 'retained_replies' });
+    });
+  }
 }
 
 /** Increment the bus-emit counter. Called at every transport `emit` site. */

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -449,6 +449,60 @@ export function recordJobOutcome(jobType: string, outcome: 'completed' | 'failed
   jobDurationHistogram().record(durationMs, { 'job.type': jobType, 'job.outcome': outcome });
 }
 
+let _appendStageHistogram: Histogram | undefined;
+function appendStageHistogram(): Histogram {
+  if (!_appendStageHistogram) {
+    _appendStageHistogram = meter().createHistogram('semiont.record.append.duration', {
+      description: 'Time spent in one stage of appending an event to the record, labeled by stage: persist (JSONL write + git), materialize (view rebuild), enrich, publish. The Archivist\'s core write path.',
+      unit: 'ms',
+    });
+  }
+  return _appendStageHistogram;
+}
+
+/**
+ * Record one stage of `EventStore.appendEvent` (ARCHIVIST-STAYS-UP P7).
+ *
+ * The append path is the one operation only the Archivist can perform, and it
+ * was entirely dark: reads had `recordHandlerDuration` and the bus had its own
+ * counters, while writes had nothing. Stage-labeled because the useful
+ * question is never "was the append slow" but WHICH PART — and `materialize`
+ * in particular does work proportional to a resource's annotation count, so it
+ * degrades with history rather than with load.
+ */
+export function recordAppendStage(
+  stage: 'persist' | 'materialize' | 'enrich' | 'publish',
+  durationMs: number,
+): void {
+  appendStageHistogram().record(durationMs, { 'record.stage': stage });
+}
+
+let _gitCommandHistogram: Histogram | undefined;
+function gitCommandHistogram(): Histogram {
+  if (!_gitCommandHistogram) {
+    _gitCommandHistogram = meter().createHistogram('semiont.git.duration', {
+      description: 'Time spent in a synchronous git subprocess. These run on the event loop, so this duration is also time no other request could be served.',
+      unit: 'ms',
+    });
+  }
+  return _gitCommandHistogram;
+}
+
+/**
+ * Record a synchronous git invocation (ARCHIVIST-STAYS-UP P7).
+ *
+ * These are `execFileSync`, so **the duration is event-loop blockage, not just
+ * latency** — every concurrent `browse:*` read waits behind it. One `git add`
+ * runs per appended event, so a detection job writing hundreds of annotations
+ * spawns hundreds of blocking subprocesses. That is the suspected mechanism
+ * behind "reads serializing behind the detection job's annotation writes" in
+ * `bugs/absent-archivist-wedges-browse.md`, which recorded the symptom without
+ * a cause. This number is what turns that from a hypothesis into a reading.
+ */
+export function recordGitCommand(command: string, durationMs: number): void {
+  gitCommandHistogram().record(durationMs, { 'git.command': command });
+}
+
 function gatherDegradeCounter(): Counter {
   if (!_gatherDegradeCounter) {
     _gatherDegradeCounter = meter().createCounter('semiont.gather.degraded', {

--- a/packages/observability/src/node.ts
+++ b/packages/observability/src/node.ts
@@ -25,6 +25,7 @@
  * blowing up bundles for every consumer.
  */
 
+import { monitorEventLoopDelay } from 'node:perf_hooks';
 import { context, metrics, propagation, trace } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
@@ -147,6 +148,29 @@ export function initObservabilityNode(config: NodeObservabilityConfig): boolean 
     ],
   });
   metrics.setGlobalMeterProvider(meterProviderInstance);
+
+  // Event-loop lag (ARCHIVIST-STAYS-UP P7). The cause-AGNOSTIC detector for a
+  // blocked process: it rises whether the cause is a synchronous git
+  // subprocess, a large JSON parse, or GC. Cheap — libuv keeps the histogram;
+  // we read percentiles and reset once per export interval.
+  //
+  // It earns its place because the Archivist runs `execFileSync('git', …)` on
+  // this loop once per appended event: while that blocks, every concurrent
+  // `browse:*` read waits, and nothing else in the stack says so.
+  const loopDelay = monitorEventLoopDelay({ resolution: 10 });
+  loopDelay.enable();
+  const loopMeter = meterProviderInstance.getMeter('semiont-runtime');
+  loopMeter
+    .createObservableGauge('semiont.runtime.event_loop.lag', {
+      description: 'Event-loop delay percentiles over the last export interval. Time the process could not serve anything.',
+      unit: 'ms',
+    })
+    .addCallback((observer) => {
+      observer.observe(loopDelay.mean / 1e6, { 'lag.stat': 'mean' });
+      observer.observe(loopDelay.percentile(99) / 1e6, { 'lag.stat': 'p99' });
+      observer.observe(loopDelay.max / 1e6, { 'lag.stat': 'max' });
+      loopDelay.reset();
+    });
 
   // Flush traces + metrics on shutdown so nothing is lost on SIGTERM/SIGINT.
   const shutdown = () => {

--- a/packages/observability/src/node.ts
+++ b/packages/observability/src/node.ts
@@ -26,6 +26,7 @@
  */
 
 import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { heapStats } from './runtime-stats';
 import { context, metrics, propagation, trace } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
@@ -159,8 +160,8 @@ export function initObservabilityNode(config: NodeObservabilityConfig): boolean 
   // `browse:*` read waits, and nothing else in the stack says so.
   const loopDelay = monitorEventLoopDelay({ resolution: 10 });
   loopDelay.enable();
-  const loopMeter = meterProviderInstance.getMeter('semiont-runtime');
-  loopMeter
+  const runtimeMeter = meterProviderInstance.getMeter('semiont-runtime');
+  runtimeMeter
     .createObservableGauge('semiont.runtime.event_loop.lag', {
       description: 'Event-loop delay percentiles over the last export interval. Time the process could not serve anything.',
       unit: 'ms',
@@ -170,6 +171,28 @@ export function initObservabilityNode(config: NodeObservabilityConfig): boolean 
       observer.observe(loopDelay.percentile(99) / 1e6, { 'lag.stat': 'p99' });
       observer.observe(loopDelay.max / 1e6, { 'lag.stat': 'max' });
       loopDelay.reset();
+    });
+
+  // Heap (ARCHIVIST-STAYS-UP P4), on the SAME registration as lag rather than
+  // a second mechanism — they are read together when diagnosing a process
+  // that stopped answering, and splitting them would mean two things to wire.
+  //
+  // `limit` is the field that repays the effort: the Archivist died at
+  // ~1016 MB inside a 2048 MB container because V8's own default ceiling sits
+  // well under the container's. `used` alone cannot say how close to death a
+  // process is, and `limit` is what a configured --max-old-space-size changes
+  // — so this is also how that setting is VERIFIED rather than assumed.
+  runtimeMeter
+    .createObservableGauge('semiont.runtime.heap', {
+      description: "Process memory by kind. `limit` is V8's own ceiling, which is what the process dies at — not the container's allocation.",
+      unit: 'By',
+    })
+    .addCallback((observer) => {
+      const s = heapStats();
+      observer.observe(s.heapUsed, { 'heap.stat': 'used' });
+      observer.observe(s.heapTotal, { 'heap.stat': 'total' });
+      observer.observe(s.heapLimit, { 'heap.stat': 'limit' });
+      observer.observe(s.rss, { 'heap.stat': 'rss' });
     });
 
   // Flush traces + metrics on shutdown so nothing is lost on SIGTERM/SIGINT.

--- a/packages/observability/src/runtime-stats.ts
+++ b/packages/observability/src/runtime-stats.ts
@@ -1,0 +1,39 @@
+/**
+ * Process-runtime readings (ARCHIVIST-STAYS-UP P4).
+ *
+ * Node-only, and deliberately a plain function rather than a gauge callback:
+ * the numbers are the thing worth testing, and a callback registered inside
+ * an SDK is awkward to assert against.
+ *
+ * **Why `heapLimit` is the field that matters.** The Archivist died at
+ * ~1016 MB inside a 2048 MB container (`bugs/absent-archivist-wedges-browse.md`)
+ * — not because it exhausted the container, but because it hit V8's OWN
+ * default old-space ceiling, which is derived from visible memory and lands
+ * well under it. `heapUsed` alone cannot express "how close to death is
+ * this"; only the pair can. It is also how a configured
+ * `--max-old-space-size` is verified to have taken effect, rather than
+ * assumed from the fact that someone set an env var.
+ */
+
+import { getHeapStatistics } from 'node:v8';
+
+export interface HeapStats {
+  /** Live heap in use. */
+  heapUsed: number;
+  /** Heap V8 has currently reserved. */
+  heapTotal: number;
+  /** The ceiling V8 will die at — NOT the container's limit. */
+  heapLimit: number;
+  /** Resident set: everything, including buffers outside the JS heap. */
+  rss: number;
+}
+
+export function heapStats(): HeapStats {
+  const mem = process.memoryUsage();
+  return {
+    heapUsed: mem.heapUsed,
+    heapTotal: mem.heapTotal,
+    heapLimit: getHeapStatistics().heap_size_limit,
+    rss: mem.rss,
+  };
+}


### PR DESCRIPTION
On 2026-09-03 the Archivist died with `JavaScript heap out of memory` at ~1016 MB — inside a container allotted 2048 MB, so it never came near the limit it was given. Every `browse:*` read in the app then hung for 30 s and timed out, and the app rendered its loading state forever. Three separate failures stacked to produce that: the process **stayed** dead, its absence was **silent**, and nothing in the stack could **explain** the memory. This PR addresses all three. It does not fix the memory itself — see *What remains*.

The design principle: the Archivist cannot be made highly available by running two of it. Stower is the only `appendEvent` caller by construction, git is single-writer, and it is the sole mount of the knowledge base. So "must not take the KB down with it" has to mean *restarts in seconds, degrades visibly while gone, and reports enough to be diagnosed* — not *runs redundantly*.

## The phases

- **P1 — It comes back.** The original plan was a runtime restart policy; that died on a measurement. Apple `container` 0.11.0 has no `--restart` flag and no health-action flags, and plain docker cannot restart-on-unhealthy either. The mechanism is therefore an in-container supervisor (`apps/archivist/supervise.sh`, now the image CMD): restarts the child on death with backoff, self-probes `/health` and kills a hung child, keeps a capped death record on the state mount, and preserves fail-fast at boot via a rapid-failure cap plus a TERM trap that forwards and exits without restarting, so `semiont stop` is never fought. **Named tradeoff:** "container running" no longer implies "process healthy" for this service — status stays honest because its probe hits `/health`, not container state.

- **P2 — The port gets one home.** `TestServiceHealthPortsAgreeAcrossAllHomes` cross-checks all five internal services across four hand-written homes each (TS `healthPort` const, Dockerfile `EXPOSE`, Dockerfile `HEALTHCHECK` URL, launcher `portNeed`) plus the supervisor's probe URL as the archivist's fifth. Motivated by a live 9093/24103 skew during the 241xx renumber, which left the healthcheck probing a port nothing listened on.

- **P3 — An unanswerable request fails fast.** The gateway already *knew* at emit time that nothing was subscribed — it logged exactly that — and returned 202 anyway, leaving every caller to discover the truth by timing out. `POST /bus/emit` now synthesizes the mapped `*-failed` from the `BUS_OPERATIONS` request→failure mapping when a request-shaped emit reaches zero subscribers. **Request-shaped only:** a broadcast with no listener is normal (`job:started` with no UI attached), so the distinction is gated on registry membership, never on a name pattern. This is the change that pays off for *every* cause of absence, including a deliberate stop during testing.

- **P4 — Reclaim the ceiling, and make memory observable.** `ENV NODE_OPTIONS=--max-old-space-size=1536` against the 2 GB allocation: V8 derives its own default old-space ceiling from visible memory and lands well under the cgroup limit, which is why the process died at ~1016 MB with half its allocation unreachable. Not 2048 — an uncatchable cgroup kill is worse than a catchable V8 heap error. Plus the fleet's **first process-runtime metrics**: `semiont.runtime.heap` (used/total/**limit**/rss) and `semiont.runtime.event_loop.lag` (mean/p99/max). `limit` is how a configured cap is *verified* rather than assumed.

- **P5 — The fact pump, extracted and measured.** The pump that republishes every persisted event onto the bus was three inline statements in the composition root — untestable and unmeasurable, while being the leading suspect for load-correlated growth. Now `packages/make-meaning/src/fact-pump.ts`, with the two emits for one event issued **concurrently** (they address different scopes and have no ordering relation; serialising them doubled drain time for nothing) and a `semiont.archivist.fact_pump.depth` gauge. Event-to-event ordering is unchanged and pinned by a test, because projections assume per-resource order.

- **P7 — The write path reports what it spends.** `appendEvent` emitted no span and no metric: reads were covered and the bus was covered, but the one operation only the Archivist can perform was dark. Added `semiont.record.append.duration` labeled by stage (persist / materialize / enrich / publish) — the useful question is never "was the append slow" but which part, since `persist` contains a synchronous subprocess and `materialize` does work proportional to a resource's annotation count. Plus `semiont.git.duration` over the six `execFileSync('git', …)` sites, now behind one instrumented helper per package.

`@semiont/event-sourcing` and `@semiont/content` gain `@semiont/observability` as a dependency — the direct fix; injecting a timing callback instead would have been dependency injection to avoid a workspace dep that four other packages already take.

## Two findings surfaced while instrumenting

**Every appended event runs a synchronous `git add` on the event loop.** `execFileSync` blocks the thread, so that duration is not latency on the append — it is time the process can serve *nothing else*, and one runs per event. The Archivist is the sole subscriber to every `browse:*` channel and sits on the path for every content read, so this stalls the entire read surface. It is the likely mechanism behind "reads serializing behind the detection job's annotation writes", a symptom recorded during the incident with no explanation attached. **This PR measures it and does not fix it:** git's index is single-writer, so swapping in `execFile` trades a blocked loop for `index.lock` failures under exactly the write bursts that motivate the change. The fix needs a queue, and is scoped separately.

**The fact pump's backlog is unbounded.** P5 makes it observable but deliberately does *not* bound it. Bounding means choosing what to discard, and a discarded fact leaves that projector stale until its **next restart** — catch-up is a startup pass in both the Smelter (`reconcile()`) and the Weaver, not continuous repair. A projection silently days out of date is the same class of defect as the silent 202 this PR removes. The gauge decides the policy; the policy does not precede the gauge.

## Verification

Per-package `tsc --noEmit` + `vitest` green across observability, event-sourcing, content, make-meaning and gateway (make-meaning 578, gateway 381, event-sourcing 248, content 164, observability 57); `go vet`/`go test` for the launcher lane. New suites are RED-first: `fact-pump.test.ts`, `append-telemetry.test.ts` and `runtime-stats.test.ts` each failed against a missing module or an uninstrumented path before implementation. Launcher assertions are made against files, never by running a mutating path.

## What remains (not in this PR)

**The OOM is not fixed, and a restart policy is exactly the kind of change that can make an unfixed one look solved.** The cause is undiagnosed — one observation, and no leak at idle (a sawtooth reclaiming 117→192→120 MB). What this PR delivers is a service that *survives* it, *reports* it, and can now be *measured* under load, which is not the same thing. The distinguishing reading is whether `git.duration`, `event_loop.lag`, `fact_pump.depth` and `heap{used}` rise together during a detection job; if they do, the cause is the chain in *Two findings* rather than a leak.

Also outstanding: the live gates, each needing a rebuilt fleet — kill the node process and watch it return; confirm the configured heap cap took effect via the `limit` gauge; and the load-matched memory measurement itself.

Design and rationale for every phase are in `.plans/ARCHIVIST-STAYS-UP.md`.
