### PR TITLE
Detection throughput: provider-aware entity-type parallelism + per-call yield telemetry

### DIFF
--- a/packages/inference/src/implementations/anthropic.ts
+++ b/packages/inference/src/implementations/anthropic.ts
@@ -3,7 +3,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { isObject, type Logger } from '@semiont/core';
 import { recordInferenceUsage } from '@semiont/observability';
-import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredReadError, StructuredResponse } from '../interface.js';
+import { ElementSchema, InferenceClient, InferenceLimits, InferenceResponse, StructuredReadError, StructuredResponse, TokenUsage } from '../interface.js';
 
 // The SDK's worst-case output-rate model: client.js's
 // calculateNonstreamingTimeout projects a call's maximum duration as
@@ -286,6 +286,7 @@ export class AnthropicInferenceClient implements InferenceClient {
     return {
       items: parsed as T[],
       stopReason: response.stop_reason || 'unknown',
+      ...usageOf(response),
     };
   }
 
@@ -327,4 +328,15 @@ function requestIdOf(response: unknown): string | undefined {
     return response['_request_id'];
   }
   return undefined;
+}
+
+/**
+ * The provider's own token counts, shaped for `TokenUsage`. Absent when the
+ * SDK reports none — never zero-filled: a zero would read as "this call cost
+ * nothing", which is a different claim from "we do not know".
+ */
+function usageOf(response: { usage?: { input_tokens?: number; output_tokens?: number } }): { usage?: TokenUsage } {
+  const { input_tokens, output_tokens } = response.usage ?? {};
+  if (input_tokens === undefined || output_tokens === undefined) return {};
+  return { usage: { inputTokens: input_tokens, outputTokens: output_tokens } };
 }

--- a/packages/inference/src/implementations/anthropic.ts
+++ b/packages/inference/src/implementations/anthropic.ts
@@ -46,6 +46,11 @@ interface ModelDiscovery {
 
 export class AnthropicInferenceClient implements InferenceClient {
   readonly type = 'anthropic' as const;
+  // Hosted API: a single detection job uses a sliver of the account rate limit
+  // (measured 2026-09-04: ~1 request / 72 s, zero 429s at 4 concurrent types),
+  // so independent calls genuinely parallelize. Conservative until an 8-way run
+  // measures the next step (DETECTION-QUALITY-THROUGHPUT P6).
+  readonly maxConcurrency = 4;
   readonly modelId: string;
   private client: Anthropic;
   private logger?: Logger;

--- a/packages/inference/src/implementations/mock.ts
+++ b/packages/inference/src/implementations/mock.ts
@@ -12,6 +12,8 @@ const GENEROUS_LIMITS: InferenceLimits = {
 export class MockInferenceClient implements InferenceClient {
   readonly type = 'mock' as const;
   readonly modelId = 'mock-model' as const;
+  // Deterministic default for tests; a test exercising concurrency sets its own.
+  readonly maxConcurrency = 1;
   private responses: string[] = [];
   private responseIndex: number = 0;
   private stopReasons: string[] = [];

--- a/packages/inference/src/implementations/ollama.ts
+++ b/packages/inference/src/implementations/ollama.ts
@@ -118,7 +118,7 @@ export class OllamaInferenceClient implements InferenceClient {
       throw new StructuredReadError(`parsed to ${typeof parsed}, not an array`, response.stopReason);
     }
 
-    return { items: parsed as T[], stopReason: response.stopReason };
+    return { items: parsed as T[], stopReason: response.stopReason, ...(response.usage ? { usage: response.usage } : {}) };
   }
 
   private async generate(
@@ -251,6 +251,9 @@ export class OllamaInferenceClient implements InferenceClient {
     return {
       text: data.response,
       stopReason,
+      ...(data.prompt_eval_count !== undefined && data.eval_count !== undefined
+        ? { usage: { inputTokens: data.prompt_eval_count, outputTokens: data.eval_count } }
+        : {}),
     };
   }
 }

--- a/packages/inference/src/implementations/ollama.ts
+++ b/packages/inference/src/implementations/ollama.ts
@@ -27,6 +27,11 @@ interface OllamaGenerateResponse {
 
 export class OllamaInferenceClient implements InferenceClient {
   readonly type = 'ollama' as const;
+  // Local single model: generation throughput is hardware-bound, so concurrent
+  // requests queue or split one GPU for no aggregate speedup — and each live
+  // context costs KV-cache memory. Detection runs its types sequentially here
+  // (DETECTION-QUALITY-THROUGHPUT P6).
+  readonly maxConcurrency = 1;
   readonly modelId: string;
   private baseURL: string;
   private logger?: Logger;

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -5,7 +5,7 @@ export {
   type InferenceClientType,
 } from './factory';
 
-export { StructuredReadError, type ElementSchema, type InferenceClient, type InferenceLimits, type InferenceResponse, type StructuredResponse } from './interface';
+export { StructuredReadError, type ElementSchema, type InferenceClient, type InferenceLimits, type InferenceResponse, type StructuredResponse, type TokenUsage } from './interface';
 export { AnthropicInferenceClient } from './implementations/anthropic';
 export { OllamaInferenceClient } from './implementations/ollama';
 export { MockInferenceClient } from './implementations/mock';

--- a/packages/inference/src/interface.ts
+++ b/packages/inference/src/interface.ts
@@ -108,6 +108,26 @@ export interface InferenceClient {
   readonly modelId: string;
 
   /**
+   * How many INDEPENDENT inference calls a caller should run concurrently
+   * against this provider for a throughput gain (DETECTION-QUALITY-THROUGHPUT
+   * P6 — detection's per-type fan-out reads this).
+   *
+   * This is a property of the provider's economics, which is why it lives on
+   * the provider and not in the caller. A HOSTED API whose per-account rate
+   * limit sits far above one job's usage has real spare capacity, so >1
+   * genuinely parallelizes. A LOCAL single-model server (Ollama) is 1: its
+   * throughput is hardware-bound, so concurrent requests only queue or split
+   * one GPU — no aggregate speedup, and N live KV-cache contexts is memory
+   * pressure that can OOM. There is no honest default across those two worlds,
+   * so this is required, not optional.
+   *
+   * Hard-coded per implementation for now; the natural seam for future
+   * per-provider or admin tuning (a value that later comes from config changes
+   * only where this is SET, not the callers).
+   */
+  readonly maxConcurrency: number;
+
+  /**
    * The provider's actual context/output ceilings for `modelId`. Discovered
    * lazily on first call and cached for the client's lifetime; a failed
    * discovery is NOT cached — the next call retries. Throws when the ceilings

--- a/packages/inference/src/interface.ts
+++ b/packages/inference/src/interface.ts
@@ -1,8 +1,20 @@
 // Inference client interface - all implementations must follow this contract
 
+/**
+ * What the call actually cost, as the PROVIDER counted it — never estimated
+ * here. Optional because a provider may not report it (and a call that fails
+ * before generating has nothing to report); absent means unknown, and a
+ * consumer must treat it as unknown rather than substituting a guess.
+ */
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
 export interface InferenceResponse {
   text: string;
   stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | string;
+  usage?: TokenUsage;
 }
 
 /**
@@ -37,6 +49,7 @@ export type ElementSchema = Record<string, unknown>;
 export interface StructuredResponse<T> {
   items: T[];
   stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | string;
+  usage?: TokenUsage;
 }
 
 /**

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -57,7 +57,6 @@ vi.mock('../workers/generation/typst-compiler', async (importOriginal) => ({
 
 import { AnnotationDetection } from '../workers/annotation-detection';
 import { extractEntities } from '../workers/detection/entity-extractor';
-import { DETECTION_TYPE_CONCURRENCY } from '../workers/detection/detection-chunking';
 import { generateResourceFromTopic } from '../workers/generation/resource-generation';
 import { compileTypst, MAX_COMPILE_REPAIRS } from '../workers/generation/typst-compiler';
 import type { PdfTextLayer } from '@semiont/content';
@@ -110,9 +109,13 @@ const PDF_LAYER: PdfTextLayer = {
 const pdfBuild = (layer: PdfTextLayer, userId: string = USER_DID): BuildAnnotation =>
   (motivation, match, body) => buildPdfAnnotation(layer, RID, userId, GENERATOR, motivation, match, body);
 
+// The concurrency the fake provider advertises — detection reads it off the
+// client now (a real provider hard-codes its own), so tests set it here.
+const TEST_MAX_CONCURRENCY = 4;
 function makeInferenceClient(): InferenceClient {
   return {
     generateText: vi.fn(),
+    maxConcurrency: TEST_MAX_CONCURRENCY,
   } as unknown as InferenceClient;
 }
 
@@ -321,7 +324,7 @@ describe('processReferenceJob', () => {
     expect(outcome.result.totalEmitted).toBe(3);
   });
 
-  it('never runs more than DETECTION_TYPE_CONCURRENCY types at once', async () => {
+  it('never runs more than the provider maxConcurrency types at once', async () => {
     const content = 'x '.repeat(50);
     let inFlight = 0, maxInFlight = 0;
     vi.mocked(extractEntities).mockImplementation(async () => {
@@ -332,7 +335,7 @@ describe('processReferenceJob', () => {
     });
 
     // More types than the bound, so the cap must actually clamp.
-    const many = Array.from({ length: DETECTION_TYPE_CONCURRENCY + 4 }, (_, i) => entityType(`T${i}`));
+    const many = Array.from({ length: TEST_MAX_CONCURRENCY + 4 }, (_, i) => entityType(`T${i}`));
     await processReferenceJob(
       content, makeInferenceClient(),
       { resourceId: RID, entityTypes: many },
@@ -340,7 +343,30 @@ describe('processReferenceJob', () => {
     );
 
     expect(maxInFlight).toBeGreaterThan(1); // actually concurrent
-    expect(maxInFlight).toBeLessThanOrEqual(DETECTION_TYPE_CONCURRENCY);
+    expect(maxInFlight).toBeLessThanOrEqual(TEST_MAX_CONCURRENCY);
+  });
+
+  it('runs SEQUENTIALLY when the provider advertises maxConcurrency 1 (the Ollama case)', async () => {
+    // A local single-model server gets no aggregate speedup from concurrent
+    // requests and pays KV-cache memory for them, so its client advertises 1 —
+    // and detection must then never overlap calls, exactly as before P6.
+    const content = 'x '.repeat(50);
+    let inFlight = 0, maxInFlight = 0;
+    vi.mocked(extractEntities).mockImplementation(async () => {
+      inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return [];
+    });
+    const ollamaShaped = { generateText: vi.fn(), maxConcurrency: 1 } as unknown as InferenceClient;
+
+    await processReferenceJob(
+      content, ollamaShaped,
+      { resourceId: RID, entityTypes: [entityType('A'), entityType('B'), entityType('C'), entityType('D')] },
+      textBuild(content), vi.fn(), LOGGER, async () => {},
+    );
+
+    expect(maxInFlight).toBe(1);
   });
 
   it('reports each unit once even when types finish OUT OF ORDER', async () => {

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -346,6 +346,42 @@ describe('processReferenceJob', () => {
 describe('processReferenceJob — unit completion gates on the commit (P6)', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  // DETECTION-QUALITY-THROUGHPUT P1. The baseline's headline number — "Person
+  // 935 found / 844 persisted" — had to be reconstructed by reading logs,
+  // because the per-unit result reported only what the model PROPOSED. The gap
+  // is dedupe plus the commit ack, and it is the yield every sizing decision is
+  // judged against, so it belongs on the result rather than in an operator's
+  // head.
+  it('reports found AND persisted per unit — the gap between them is the yield', async () => {
+    // Three proposals, two distinct spans: the duplicate collapses in dedupe,
+    // so found and persisted must differ here or the test proves nothing.
+    vi.mocked(extractEntities).mockResolvedValue([
+      { exact: 'Paris', start: 0, end: 5, entityType: 'Location' } as any,
+      { exact: 'Paris', start: 0, end: 5, entityType: 'Location' } as any,
+      { exact: 'Berlin', start: 10, end: 16, entityType: 'Location' } as any,
+    ]);
+    const onProgress = vi.fn();
+
+    await processReferenceJob(
+      'Paris and Berlin',
+      makeInferenceClient(),
+      { resourceId: RID, entityTypes: [entityType('Location')] },
+      textBuild('Paris and Berlin'),
+      onProgress,
+      LOGGER,
+      vi.fn(async () => {}),
+    );
+
+    const completed = onProgress.mock.calls
+      .map(c => (c[2] as { completedItems?: Array<{ value: string; foundCount: number; persistedCount?: number }> } | undefined)?.completedItems)
+      .filter((items): items is Array<{ value: string; foundCount: number; persistedCount?: number }> => !!items?.length)
+      .at(-1);
+
+    expect(completed).toEqual([
+      { value: 'Location', foundCount: 3, persistedCount: 2 },
+    ]);
+  });
+
   it('a rejecting sink stops the unit counting, and the failure reaches the caller', async () => {
     vi.mocked(extractEntities).mockResolvedValue([
       { exact: 'Paris', start: 0, end: 5, entityType: 'Location' } as any,

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -57,6 +57,7 @@ vi.mock('../workers/generation/typst-compiler', async (importOriginal) => ({
 
 import { AnnotationDetection } from '../workers/annotation-detection';
 import { extractEntities } from '../workers/detection/entity-extractor';
+import { DETECTION_TYPE_CONCURRENCY } from '../workers/detection/detection-chunking';
 import { generateResourceFromTopic } from '../workers/generation/resource-generation';
 import { compileTypst, MAX_COMPILE_REPAIRS } from '../workers/generation/typst-compiler';
 import type { PdfTextLayer } from '@semiont/content';
@@ -285,6 +286,84 @@ describe('processReferenceJob', () => {
       { type: 'TextualBody', value: 'Location', purpose: 'tagging', format: 'text/plain', language: 'en' },
     ]);
     expect(outcome.result).toEqual({ kind: 'reference-annotation', totalFound: 2, totalEmitted: 2, errors: 0 });
+  });
+
+  // ── P6: entity types run concurrently (DETECTION-QUALITY-THROUGHPUT) ──
+  //
+  // The sequential per-type loop was the 9×-sequential grind. These pin that
+  // types now run bounded-concurrent: every type still commits exactly once and
+  // reports its own found/persisted, order-independent, and no more than
+  // DETECTION_TYPE_CONCURRENCY are ever in flight.
+
+  it('runs multiple entity types and commits each exactly once', async () => {
+    // Each type returns its own entity (verbatim in the content so anchoring holds).
+    const content = 'Paris and Ada and Sony are here.';
+    vi.mocked(extractEntities).mockImplementation(async (_c, types) => {
+      const t = String(types[0]);
+      const map: Record<string, any> = {
+        Location: [{ exact: 'Paris', entityType: 'Location' }],
+        Person: [{ exact: 'Ada', entityType: 'Person' }],
+        Organization: [{ exact: 'Sony', entityType: 'Organization' }],
+      };
+      return map[t] ?? [];
+    });
+
+    const units: string[] = [];
+    const outcome = await processReferenceJob(
+      content, makeInferenceClient(),
+      { resourceId: RID, entityTypes: [entityType('Location'), entityType('Person'), entityType('Organization')] },
+      textBuild(content), vi.fn(), LOGGER,
+      async (unit) => { units.push(unit); },
+    );
+
+    expect(units.sort()).toEqual(['Location', 'Organization', 'Person']);
+    expect(outcome.result.totalFound).toBe(3);
+    expect(outcome.result.totalEmitted).toBe(3);
+  });
+
+  it('never runs more than DETECTION_TYPE_CONCURRENCY types at once', async () => {
+    const content = 'x '.repeat(50);
+    let inFlight = 0, maxInFlight = 0;
+    vi.mocked(extractEntities).mockImplementation(async () => {
+      inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return [];
+    });
+
+    // More types than the bound, so the cap must actually clamp.
+    const many = Array.from({ length: DETECTION_TYPE_CONCURRENCY + 4 }, (_, i) => entityType(`T${i}`));
+    await processReferenceJob(
+      content, makeInferenceClient(),
+      { resourceId: RID, entityTypes: many },
+      textBuild(content), vi.fn(), LOGGER, async () => {},
+    );
+
+    expect(maxInFlight).toBeGreaterThan(1); // actually concurrent
+    expect(maxInFlight).toBeLessThanOrEqual(DETECTION_TYPE_CONCURRENCY);
+  });
+
+  it('reports each unit once even when types finish OUT OF ORDER', async () => {
+    const content = 'Paris and Ada are here.';
+    // Location resolves slowly, Person fast — completion order reversed.
+    vi.mocked(extractEntities).mockImplementation(async (_c, types) => {
+      const t = String(types[0]);
+      if (t === 'Location') { await new Promise((r) => setTimeout(r, 20)); return [{ exact: 'Paris', entityType: 'Location' }] as any; }
+      return [{ exact: 'Ada', entityType: 'Person' }] as any;
+    });
+
+    const progress = vi.fn();
+    const outcome = await processReferenceJob(
+      content, makeInferenceClient(),
+      { resourceId: RID, entityTypes: [entityType('Location'), entityType('Person')] },
+      textBuild(content), progress, LOGGER, async () => {},
+    );
+
+    // The terminal frame carries the full completed set; each type appears once.
+    const last = progress.mock.calls.at(-1)![2] as { completedItems?: Array<{ value: string }> };
+    const values = (last.completedItems ?? []).map((i) => i.value).sort();
+    expect(values).toEqual(['Location', 'Person']);
+    expect(outcome.result.totalEmitted).toBe(2);
   });
 
   it('counts errors when reconciliation drops an entity (text not in source)', async () => {

--- a/packages/jobs/src/__tests__/workers/detection/anchor-audit.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/anchor-audit.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Anchor auditing (DETECTION-QUALITY-THROUGHPUT P5).
+ *
+ * The mechanical selector-vs-source check is already a write-time invariant in
+ * both annotation builders, so it cannot fail and auditing it would measure a
+ * constant. The uncertain part is WHICH METHOD anchored a span — and that was
+ * visible only as a log line, which is how 47 degraded anchors went unreviewed
+ * after the 2026-09-03 run.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { recordAnchorOutcomeMock } = vi.hoisted(() => ({ recordAnchorOutcomeMock: vi.fn() }));
+vi.mock('@semiont/observability', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@semiont/observability')>()),
+  recordAnchorOutcome: recordAnchorOutcomeMock,
+}));
+
+import { noteAnchor } from '../../../workers/detection/anchor-audit';
+
+describe('noteAnchor', () => {
+  beforeEach(() => recordAnchorOutcomeMock.mockClear());
+
+  it('counts the CLEAN anchors too — without them the degraded count has no denominator', () => {
+    noteAnchor('reference', 'Paris', 'unique-match');
+    expect(recordAnchorOutcomeMock).toHaveBeenCalledWith('reference', 'unique-match');
+  });
+
+  it('counts a degraded anchor and warns about it', () => {
+    const logger = { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() };
+    noteAnchor('reference', 'Paris', 'first-of-many', logger as never);
+
+    expect(recordAnchorOutcomeMock).toHaveBeenCalledWith('reference', 'first-of-many');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Annotation anchored via degraded method',
+      expect.objectContaining({ label: 'reference', anchorMethod: 'first-of-many' }),
+    );
+  });
+
+  it('treats fuzzy-match as degraded and unique-match as clean — one decider, both callers', () => {
+    const logger = { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() };
+    noteAnchor('comment', 'x', 'fuzzy-match', logger as never);
+    noteAnchor('comment', 'y', 'context-recovered', logger as never);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    // Both were still counted: the rate needs every outcome.
+    expect(recordAnchorOutcomeMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/jobs/src/__tests__/workers/detection/bounded-concurrency.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/bounded-concurrency.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Bounded concurrency (DETECTION-QUALITY-THROUGHPUT P6). The cap is the whole
+ * reason this exists — parallelism without a bound is 429 thrash — so the
+ * central test is that in-flight work never exceeds the limit.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runBounded } from '../../../workers/detection/bounded-concurrency';
+
+/** A worker that records the max number ever in flight at once. */
+function trackingWorker(delayMs = 5) {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const worker = async (n: number): Promise<number> => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((r) => setTimeout(r, delayMs));
+    inFlight--;
+    return n * 2;
+  };
+  return { worker, get maxInFlight() { return maxInFlight; } };
+}
+
+describe('runBounded', () => {
+  it('never exceeds the limit, even with far more items', async () => {
+    const t = trackingWorker();
+    await runBounded([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3, t.worker);
+    expect(t.maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it('actually uses the concurrency — a limit of 3 runs 3 at once', async () => {
+    const t = trackingWorker();
+    await runBounded([1, 2, 3, 4, 5, 6], 3, t.worker);
+    expect(t.maxInFlight).toBe(3);
+  });
+
+  it('returns results in INPUT order regardless of completion order', async () => {
+    // Later items finish sooner — completion order is reversed, input order must survive.
+    const results = await runBounded([1, 2, 3, 4], 4, async (n) => {
+      await new Promise((r) => setTimeout(r, (5 - n) * 5));
+      return n * 10;
+    });
+    expect(results).toEqual([10, 20, 30, 40]);
+  });
+
+  it('processes every item exactly once', async () => {
+    const seen: number[] = [];
+    await runBounded([1, 2, 3, 4, 5], 2, async (n) => { seen.push(n); return n; });
+    expect(seen.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('a limit at or above the item count runs them all together', async () => {
+    const t = trackingWorker();
+    await runBounded([1, 2, 3], 10, t.worker);
+    expect(t.maxInFlight).toBe(3);
+  });
+
+  it('an empty list is a no-op', async () => {
+    const worker = vi.fn(async (n: number) => n);
+    const results = await runBounded([], 4, worker);
+    expect(results).toEqual([]);
+    expect(worker).not.toHaveBeenCalled();
+  });
+
+  it('propagates a worker rejection', async () => {
+    await expect(
+      runBounded([1, 2, 3], 2, async (n) => {
+        if (n === 2) throw new Error('boom');
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/packages/jobs/src/__tests__/workers/detection/chunk-size-controller.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/chunk-size-controller.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Adaptive chunk sizing (DETECTION-QUALITY-THROUGHPUT P2) — controller unit
+ * tests. The plan's RED: grows on sparse output, backs off on dense/truncated,
+ * never leaves [floor, ceiling], tracks a gradient rather than betting the run
+ * on the first sample.
+ *
+ * The controller steers ONE number — output utilization — and leans on
+ * subdivision for the hard bounds, so these are all about that one steer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  nextChunkSize,
+  DEFAULT_CHUNK_SIZING_POLICY,
+  type SizingBounds,
+} from '../../../workers/detection/chunk-size-controller';
+
+// A window with room above the static starting size, so "grow" has somewhere
+// to go — the window-fit ceiling, distinct from the derived starting budget.
+const BOUNDS: SizingBounds = { floor: 96, ceiling: 40_000, outputBudget: 10_666 };
+
+describe('nextChunkSize', () => {
+  it('grows when the last chunk left budget on the table — the calibration case', () => {
+    // The live run: output 4,117 of a 10,666 budget = 39%, under growBelow(0.5).
+    const next = nextChunkSize({ outputTokens: 4_117, truncated: false }, 5_333, BOUNDS);
+    expect(next).toBe(Math.floor(5_333 * DEFAULT_CHUNK_SIZING_POLICY.growFactor)); // 7,999
+  });
+
+  it('eases off when output nears the budget — before it truncates', () => {
+    // 92% of budget: over shrinkAbove(0.8), so ease down rather than wait for
+    // the next stretch to spill over.
+    const next = nextChunkSize({ outputTokens: 9_800, truncated: false }, 6_000, BOUNDS);
+    expect(next).toBe(Math.floor(6_000 * DEFAULT_CHUNK_SIZING_POLICY.shrinkFactor)); // 4,200
+  });
+
+  it('holds inside the band — neither starving nor near the edge', () => {
+    // 65% of budget: between growBelow and shrinkAbove.
+    const next = nextChunkSize({ outputTokens: 6_900, truncated: false }, 6_000, BOUNDS);
+    expect(next).toBe(6_000);
+  });
+
+  it('shrinks on a truncation regardless of the reported count', () => {
+    // Subdivision is already halving-and-retrying THIS chunk; the sizer pulls
+    // the NEXT one down too so the run rides the density change, not one piece.
+    const next = nextChunkSize({ outputTokens: 0, truncated: true }, 8_000, BOUNDS);
+    expect(next).toBe(Math.floor(8_000 * DEFAULT_CHUNK_SIZING_POLICY.shrinkFactor)); // 5,600
+  });
+
+  it('never proposes above the ceiling, however much room a chunk shows', () => {
+    const next = nextChunkSize({ outputTokens: 10, truncated: false }, 30_000, BOUNDS);
+    expect(next).toBeLessThanOrEqual(BOUNDS.ceiling);
+  });
+
+  it('never proposes below the floor, however dense', () => {
+    const next = nextChunkSize({ outputTokens: 10_666, truncated: true }, 120, BOUNDS);
+    expect(next).toBeGreaterThanOrEqual(BOUNDS.floor);
+  });
+
+  it('tracks a gradient: grows through a sparse run, then pulls back as it densifies', () => {
+    // Sparse intro, then a dense index — the case that breaks a size-once
+    // scheme. The sizer must climb on the sparse stretch, then reverse when
+    // utilization crosses the band, not ride a stale first sample into a wall
+    // of truncations.
+    const afterGrow = nextChunkSize({ outputTokens: 3_000, truncated: false }, 5_333, BOUNDS); // 28% → grow
+    const afterDense = nextChunkSize({ outputTokens: 10_100, truncated: false }, afterGrow, BOUNDS); // 95% → shrink
+    expect(afterGrow).toBeGreaterThan(5_333);
+    expect(afterDense).toBeLessThan(afterGrow);
+  });
+
+  it('respects a caller-supplied policy — the future tunable surface', () => {
+    // Aggressive policy: same 39% outcome, but growFactor 3 instead of 1.5.
+    const aggressive = { growBelow: 0.5, shrinkAbove: 0.8, growFactor: 3, shrinkFactor: 0.5 };
+    const next = nextChunkSize({ outputTokens: 4_117, truncated: false }, 5_333, BOUNDS, aggressive);
+    expect(next).toBe(Math.floor(5_333 * 3)); // 15,999 — the policy governed, not the default
+  });
+
+  it('holds on a degenerate (zero) budget rather than dividing by zero', () => {
+    const next = nextChunkSize({ outputTokens: 0, truncated: false }, 6_000, { ...BOUNDS, outputBudget: 0 });
+    expect(next).toBe(6_000);
+  });
+});

--- a/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
@@ -8,7 +8,14 @@
  * the arithmetic.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Observe the telemetry surface without losing the real module.
+const { recordDetectionCallMock } = vi.hoisted(() => ({ recordDetectionCallMock: vi.fn() }));
+vi.mock('@semiont/observability', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@semiont/observability')>()),
+  recordDetectionCall: recordDetectionCallMock,
+}));
 import { deriveDetectionBudget } from '../../../workers/detection/detection-chunking';
 import { INFERENCE_TIMEOUT_MS } from '../../../workers/inference-call';
 
@@ -202,9 +209,9 @@ describe('callChunkSubdividing', () => {
 
   it('passes a successful call through untouched — one invocation, no subdivision', async () => {
     const calls: string[] = [];
-    const result = await callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+    const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
       calls.push(piece);
-      return ['a', 'b'];
+      return { items: ['a', 'b'] };
     });
     expect(result).toEqual(['a', 'b']);
     expect(calls).toEqual([CHUNK]);
@@ -212,10 +219,10 @@ describe('callChunkSubdividing', () => {
 
   it('a timeout on the full chunk retries with smaller pieces and collects their results', async () => {
     const calls: string[] = [];
-    const result = await callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+    const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
       calls.push(piece);
       if (piece.length === CHUNK.length) throw new InferenceTimeoutError('bound');
-      return [`ok:${piece.length}`];
+      return { items: [`ok:${piece.length}`] };
     });
     // First call was the full chunk; the rest are strictly smaller pieces.
     expect(calls[0]).toBe(CHUNK);
@@ -230,9 +237,9 @@ describe('callChunkSubdividing', () => {
       new StructuredReadError('response is not valid JSON', 'max_tokens'),
     ]) {
       let first = true;
-      const result = await callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+      const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
         if (first) { first = false; throw boom; }
-        return [piece.length];
+        return { items: [piece.length] };
       });
       expect(result.length).toBeGreaterThan(0);
     }
@@ -244,7 +251,7 @@ describe('callChunkSubdividing', () => {
       new Error('model exploded'),
     ]) {
       const calls: string[] = [];
-      await expect(callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+      await expect(callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
         calls.push(piece);
         throw boom;
       })).rejects.toBe(boom);
@@ -255,7 +262,7 @@ describe('callChunkSubdividing', () => {
   it('is depth-bounded: a chunk that fails at every size rethrows the ORIGINAL failure', async () => {
     const boom = new InferenceTimeoutError('bound');
     let calls = 0;
-    await expect(callChunkSubdividing(CHUNK, CHUNKING, async () => {
+    await expect(callChunkSubdividing('entity', CHUNK, CHUNKING, async () => {
       calls++;
       throw boom;
     })).rejects.toBe(boom);
@@ -279,10 +286,10 @@ describe('callChunkSubdividing', () => {
     // overlap-derived size floor — only size-based descent can get there.
     const BIG = Array.from({ length: 400 }, (_, i) => `entry ${i} lorem ipsum dolor sit amet `).join('');
     const succeededAt: number[] = [];
-    const result = await callChunkSubdividing(BIG, { chunkSize: 4_000, overlap: 16 }, async (piece) => {
+    const result = await callChunkSubdividing('entity', BIG, { chunkSize: 4_000, overlap: 16 }, async (piece) => {
       if (piece.length > 1_200) throw new StructuredReadError('response is not valid JSON', 'max_tokens');
       succeededAt.push(piece.length);
-      return [piece.length];
+      return { items: [piece.length] };
     });
     expect(result.length).toBeGreaterThan(0);
     for (const len of succeededAt) expect(len).toBeLessThanOrEqual(1_200);
@@ -294,11 +301,11 @@ describe('callChunkSubdividing', () => {
     // re-roll usually escapes; the deterministic rethrow alone would kill
     // a job the same piece passes on the next roll.
     const seen = new Map<string, number>();
-    const result = await callChunkSubdividing(CHUNK, CHUNKING, async (piece) => {
+    const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
       const n = (seen.get(piece) ?? 0) + 1;
       seen.set(piece, n);
       if (n === 1) throw new StructuredReadError('response is not valid JSON', 'max_tokens');
-      return [piece.length];
+      return { items: [piece.length] };
     });
     expect(result.length).toBeGreaterThan(0);
     // Some floor piece was re-rolled — same text, second invocation.
@@ -308,11 +315,92 @@ describe('callChunkSubdividing', () => {
   it('a re-roll that truncates AGAIN rethrows — twice on the same piece is real pathology', async () => {
     const boom = new StructuredReadError('response is not valid JSON', 'max_tokens');
     let calls = 0;
-    await expect(callChunkSubdividing(CHUNK, CHUNKING, async () => {
+    await expect(callChunkSubdividing('entity', CHUNK, CHUNKING, async () => {
       calls++;
       throw boom;
     })).rejects.toBe(boom);
     // Full, first half, first quarter, quarter's one re-roll — then done.
     expect(calls).toBe(4);
+  });
+});
+
+// ── P1: yield telemetry (DETECTION-QUALITY-THROUGHPUT) ──────────────────
+//
+// Every optimization phase after this one is judged by measurement, and the
+// facts that judge it are per-CALL, not per-job: how big the piece was, how
+// long it took, how many items came back, and — the two the adapters cannot
+// know — how deep subdivision had descended and whether this was the floor
+// re-roll. `callChunkSubdividing` is the only place those last two exist, so
+// it is the only place one complete record can be written.
+describe('callChunkSubdividing telemetry', () => {
+  const CHUNKING = { chunkSize: 1_000, overlap: 16 };
+  const CHUNK = Array.from({ length: 200 }, (_, i) => `passage ${i} lorem ipsum dolor sit amet `).join('');
+
+  beforeEach(() => { recordDetectionCallMock.mockClear(); });
+
+  it('records one call at depth 0 on the happy path, carrying the provider usage', async () => {
+    await callChunkSubdividing('highlight', CHUNK, CHUNKING, async () => ({
+      items: ['a', 'b'],
+      usage: { inputTokens: 1200, outputTokens: 340 },
+    }));
+
+    expect(recordDetectionCallMock).toHaveBeenCalledTimes(1);
+    expect(recordDetectionCallMock).toHaveBeenCalledWith(expect.objectContaining({
+      label: 'highlight',
+      pieceChars: CHUNK.length,
+      items: 2,
+      depth: 0,
+      reroll: false,
+      outcome: 'success',
+      inputTokens: 1200,
+      outputTokens: 340,
+    }));
+    // Duration is measured, not passed in — assert it exists and is sane
+    // rather than pinning a number a fast machine would make zero.
+    const { durationMs } = recordDetectionCallMock.mock.calls[0]![0] as { durationMs: number };
+    expect(durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records the FAILED attempt and each smaller retry — the descent is the data', async () => {
+    // A truncation at full size, then success on the sub-pieces. Without a
+    // record for the failure, the cost of a descent is invisible: the calls
+    // that were paid for and thrown away are exactly what P2 must avoid.
+    await callChunkSubdividing<string>('reference', CHUNK, CHUNKING, async (piece) => {
+      if (piece.length === CHUNK.length) throw new DeterministicJobError('truncated (max_tokens)');
+      return { items: ['x'] };
+    });
+
+    const records = recordDetectionCallMock.mock.calls.map(c => c[0] as { depth: number; outcome: string });
+    expect(records.length).toBeGreaterThan(1);
+    expect(records[0]).toMatchObject({ depth: 0, outcome: 'truncated' });
+    expect(records.slice(1).every(r => r.depth === 1 && r.outcome === 'success')).toBe(true);
+  });
+
+  it('marks the floor re-roll, so a degeneration loop is distinguishable from honest overflow', async () => {
+    // At the size floor a truncation is a sampling accident, not size — and
+    // the re-roll is the same piece at the same size. Only the flag tells the
+    // two apart in the history.
+    const small = 'a'.repeat(400);
+    let attempts = 0;
+    await callChunkSubdividing<string>('tag', small, { chunkSize: 8, overlap: 16 }, async () => {
+      if (++attempts === 1) throw new DeterministicJobError('truncated (max_tokens)');
+      return { items: ['ok'] };
+    });
+
+    const records = recordDetectionCallMock.mock.calls.map(c => c[0] as { reroll: boolean; outcome: string });
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({ reroll: false, outcome: 'truncated' });
+    expect(records[1]).toMatchObject({ reroll: true, outcome: 'success' });
+  });
+
+  it('classifies a timeout distinctly from a truncation — they demand opposite responses', async () => {
+    await expect(
+      callChunkSubdividing<string>('comment', CHUNK, CHUNKING, async () => {
+        throw new InferenceTimeoutError('bound');
+      }),
+    ).rejects.toThrow(InferenceTimeoutError);
+
+    const outcomes = recordDetectionCallMock.mock.calls.map(c => (c[0] as { outcome: string }).outcome);
+    expect(new Set(outcomes)).toEqual(new Set(['timeout']));
   });
 });

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -34,7 +34,6 @@ import type {
 } from './types';
 import { noteAnchor } from './workers/detection/anchor-audit';
 import { runBounded } from './workers/detection/bounded-concurrency';
-import { DETECTION_TYPE_CONCURRENCY } from './workers/detection/detection-chunking';
 
 type Agent = components['schemas']['Agent'];
 
@@ -537,7 +536,10 @@ export async function processReferenceJob(
     });
   };
 
-  await runBounded(entityTypeNames, DETECTION_TYPE_CONCURRENCY, async (entityTypeName) => {
+  // Concurrency is the PROVIDER's capability, not a flat constant: a hosted
+  // API parallelizes, a local single-model server does not (P6). Reading it
+  // from the client is what makes the same code correct on both.
+  await runBounded(entityTypeNames, inferenceClient.maxConcurrency, async (entityTypeName) => {
     if (!entityTypeName) return;
     // Cooperative cancellation (JOB-RESTART-SAFETY P4): once aborted, a pending
     // type is skipped when its turn comes; types already in flight finish and

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -33,6 +33,8 @@ import type {
   GenerationResult,
 } from './types';
 import { noteAnchor } from './workers/detection/anchor-audit';
+import { runBounded } from './workers/detection/bounded-concurrency';
+import { DETECTION_TYPE_CONCURRENCY } from './workers/detection/detection-chunking';
 
 type Agent = components['schemas']['Agent'];
 
@@ -508,57 +510,59 @@ export async function processReferenceJob(
 
   const bodyLanguage = params.language ?? 'en';
 
-  for (let i = 0; i < entityTypeNames.length; i++) {
-    // Cooperative cancellation at the unit boundary (JOB-RESTART-SAFETY P4):
-    // a cancel requested mid-run stops the loop cleanly here, between units.
-    // Units already committed stay checkpointed; the in-flight unit is never
-    // started. The caller reads `signal.aborted` to move the job to
-    // cancelled/ rather than complete/.
-    if (signal?.aborted) break;
-    const entityTypeName = entityTypeNames[i];
-    if (!entityTypeName) continue;
-    const pct = 20 + Math.round((i / entityTypeNames.length) * 60);
+  // Entity types run BOUNDED-CONCURRENT (DETECTION-QUALITY-THROUGHPUT P6).
+  // They are independent units — own extraction, own commit, own checkpoint —
+  // and a single sequential job used a sliver of the provider's rate limit, so
+  // the old `for … await` was the 9×-sequential ≈ 2.5 h/document. The bound is
+  // the point: unbounded fan-out just trades sequential waiting for 429 thrash.
+  //
+  // Shared counters and `completedItems` are mutated SYNCHRONOUSLY between
+  // awaits inside the worker — safe under the single-threaded event loop (no
+  // read-modify-write straddles an await), so no locking is needed. Progress is
+  // now "M of N done" rather than "on type i": concurrent types finish out of
+  // order, and `completedItems` already tolerates that.
+  let completed = 0;
+  const total = entityTypeNames.length;
+
+  const emitTypeProgress = (entityTypeName: string): void => {
+    const pct = 20 + Math.round((completed / total) * 60);
     onProgress(pct, { code: 'detecting-entities', entityType: entityTypeName }, {
-      // One vocabulary for "what is in flight" (CLEAN-PROGRESS D2): the entity
-      // type is KB data, `kind` is the code the client localizes around it.
       current: { kind: 'entity-type', value: entityTypeName },
-      processed: i,
-      total: entityTypeNames.length,
+      processed: completed,
+      total,
       entitiesFound: totalFound,
       entitiesEmitted: totalEmitted,
       completedItems: [...completedItems],
       requestParams,
     });
+  };
+
+  await runBounded(entityTypeNames, DETECTION_TYPE_CONCURRENCY, async (entityTypeName) => {
+    if (!entityTypeName) return;
+    // Cooperative cancellation (JOB-RESTART-SAFETY P4): once aborted, a pending
+    // type is skipped when its turn comes; types already in flight finish and
+    // commit, so committed units stay checkpointed. The caller reads
+    // `signal.aborted` to move the job to cancelled/ rather than complete/.
+    if (signal?.aborted) return;
+
+    emitTypeProgress(entityTypeName);
 
     const extractedEntities = await extractEntities(
       content, [entityTypeName], inferenceClient, params.includeDescriptiveReferences ?? false, logger,
       params.sourceLanguage,
-      // Liveness: fires at chunk boundaries AND every ~15 s while a single
-      // inference call is in flight (DETECTION-HEARTBEAT). Progress feeds the
-      // stall watchdog, the janitor, AND the client's inter-emission timeout,
-      // so a long single-chunk call must not be silent. Percentage
-      // interpolates within this entity type's band of the 20–80 range; a
-      // heartbeat repeats the current position rather than inventing an
-      // advance.
-      (completed, total) => {
-        const interpolated = 20 + Math.round(((i + completed / total) / entityTypeNames.length) * 60);
-        onProgress(interpolated, { code: 'detecting-entities', entityType: entityTypeName }, {
-          current: { kind: 'entity-type', value: entityTypeName },
-          processed: i,
-          total: entityTypeNames.length,
-          entitiesFound: totalFound,
-          entitiesEmitted: totalEmitted,
-          completedItems: [...completedItems],
-          requestParams,
-        });
-      },
+      // Liveness heartbeat (DETECTION-HEARTBEAT): fires at chunk boundaries and
+      // every ~15 s while a call is in flight, so a long single-chunk call is
+      // not silent. It repeats the current position rather than inventing an
+      // advance — the stall watchdog, janitor and client timeout need a signal,
+      // not a monotone.
+      () => emitTypeProgress(entityTypeName),
     );
 
     // Unresolved reference body: the entity type as a tagging TextualBody,
     // stamped with the body locale to match the comment/assess/tag pattern.
-    // The bind flow later appends a SpecificResource (purpose: 'linking')
-    // via mark:body-updated to produce the resolved shape. Emitting an
-    // empty body would break the append contract.
+    // The bind flow later appends a SpecificResource (purpose: 'linking') via
+    // mark:body-updated to produce the resolved shape. Emitting an empty body
+    // would break the append contract.
     const unresolvedBody: Annotation['body'] = [
       { type: 'TextualBody' as const, value: entityTypeName, purpose: 'tagging' as const, format: 'text/plain' satisfies SupportedMediaType, language: bodyLanguage },
     ];
@@ -583,9 +587,7 @@ export async function processReferenceJob(
       built.push(ann);
     }
 
-    // De-dupe within the unit — identical spans under the same entity type
-    // collapse; cross-unit duplicates cannot exist, because the body
-    // carries the type name. Then COMMIT: the awaited callback emits the
+    // De-dupe within the unit, then COMMIT: the awaited callback emits the
     // unit's annotations, and only after it resolves does the unit count
     // anywhere — a unit whose commit fails contributes nothing (unit
     // atomicity, A3).
@@ -593,16 +595,17 @@ export async function processReferenceJob(
     await onUnitComplete(entityTypeName, unitAnnotations);
     totalEmitted += unitAnnotations.length;
     totalFound += extractedEntities.length;
-    // Found vs persisted, per unit: the model proposed `extractedEntities`,
-    // the log holds `unitAnnotations` after dedupe and the commit ack. The gap
-    // between them is this flow's yield, and it was previously only
-    // reconstructible by reading logs (DETECTION-QUALITY-THROUGHPUT P1).
+    // Found vs persisted, per unit: the model proposed `extractedEntities`, the
+    // log holds `unitAnnotations` after dedupe and the commit ack. The gap
+    // between them is this flow's yield (DETECTION-QUALITY-THROUGHPUT P1).
     completedItems.push({
       value: entityTypeName,
       foundCount: extractedEntities.length,
       persistedCount: unitAnnotations.length,
     });
-  }
+    completed++;
+    emitTypeProgress(entityTypeName);
+  });
 
   // The terminal frame carries the completed set, and it is the only frame
   // that can: the per-unit entries ride the progress emitted at the START of

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -32,6 +32,7 @@ import type {
   TagDetectionResult,
   GenerationResult,
 } from './types';
+import { noteAnchor } from './workers/detection/anchor-audit';
 
 type Agent = components['schemas']['Agent'];
 
@@ -91,6 +92,10 @@ export type OnProgress = (
 ) => void;
 
 type JobProgress = components['schemas']['JobProgress'];
+/** Derived from the wire, never restated: the per-unit entry's shape is the
+ * spec's, so a field added there reaches these accumulators by regeneration
+ * rather than by someone remembering two places. */
+type CompletedItem = NonNullable<JobProgress['completedItems']>[number];
 type JobProgressMessage = components['schemas']['JobProgressMessage'];
 
 /** The five W3C motivations this system mints — a closed vocabulary, so it is
@@ -494,7 +499,7 @@ export async function processReferenceJob(
 ): Promise<{ result: DetectionResult }> {
   const entityTypeNames = params.entityTypes.map(String);
   const requestParams = [{ label: 'entity-types' as const, value: entityTypeNames.join(', ') }];
-  const completedItems: Array<{ value: string; foundCount: number }> = [];
+  const completedItems: CompletedItem[] = [];
   let totalFound = 0;
   let totalEmitted = 0;
   let errors = 0;
@@ -573,13 +578,7 @@ export async function processReferenceJob(
         errors++;
         continue;
       }
-      if (reconciled.anchorMethod === 'first-of-many' || reconciled.anchorMethod === 'fuzzy-match') {
-        logger.warn('Entity anchored via degraded method', {
-          text: entity.exact,
-          entityType: entity.entityType,
-          anchorMethod: reconciled.anchorMethod,
-        });
-      }
+      noteAnchor('reference', entity.exact, reconciled.anchorMethod, logger);
       const ann = buildAnnotation('linking', toMatch(reconciled), unresolvedBody);
       built.push(ann);
     }
@@ -594,10 +593,25 @@ export async function processReferenceJob(
     await onUnitComplete(entityTypeName, unitAnnotations);
     totalEmitted += unitAnnotations.length;
     totalFound += extractedEntities.length;
-    completedItems.push({ value: entityTypeName, foundCount: extractedEntities.length });
+    // Found vs persisted, per unit: the model proposed `extractedEntities`,
+    // the log holds `unitAnnotations` after dedupe and the commit ack. The gap
+    // between them is this flow's yield, and it was previously only
+    // reconstructible by reading logs (DETECTION-QUALITY-THROUGHPUT P1).
+    completedItems.push({
+      value: entityTypeName,
+      foundCount: extractedEntities.length,
+      persistedCount: unitAnnotations.length,
+    });
   }
 
-  onProgress(100, { code: 'complete-created', count: totalEmitted, kind: 'reference' }, { requestParams });
+  // The terminal frame carries the completed set, and it is the only frame
+  // that can: the per-unit entries ride the progress emitted at the START of
+  // each unit, so the LAST unit's entry — and on a single-type job, every
+  // entry — was never reported anywhere (DETECTION-QUALITY-THROUGHPUT P1).
+  onProgress(100, { code: 'complete-created', count: totalEmitted, kind: 'reference' }, {
+    completedItems: [...completedItems],
+    requestParams,
+  });
 
   return {
     result: { kind: 'reference-annotation', totalFound, totalEmitted, errors },
@@ -615,7 +629,7 @@ export async function processTagJob(
   onProgress(30, { code: 'analyzing-tags' });
 
   const allTags = [];
-  const completedItems: Array<{ value: string; foundCount: number }> = [];
+  const completedItems: CompletedItem[] = [];
   for (let c = 0; c < params.categories.length; c++) {
     const category = params.categories[c]!;
     // The loop always existed; it just never reported itself, so the tag flow

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -67,14 +67,16 @@ async function detectInChunks<T>(
     // response fails the job rather than reading as an empty detection. A
     // size-shaped failure (duration bound, truncation) subdivides in place
     // and retries smaller before it is allowed to fail the job.
-    const items = await callChunkSubdividing<unknown>(chunks[i]!, chunking, async (piece) => {
+    const items = await callChunkSubdividing<unknown>(motivation, chunks[i]!, chunking, async (piece) => {
       const response = await boundedGenerateStructured<unknown>(
         client, buildPrompt(piece), outputBudget, DETECTION_TEMPERATURE, elementSchema,
         // Still alive, same position (a long single call is otherwise silent).
         () => onActivity?.(i, chunks.length),
       );
       assertNotTruncated(response, `${motivation} detection`, i + 1, chunks.length, outputBudget);
-      return response.items;
+      // Usage rides back so the telemetry record carries what the call COST
+      // beside what it yielded — the provider's own counts, not an estimate.
+      return { items: response.items, ...(response.usage ? { usage: response.usage } : {}) };
     });
     collected.push(...parse(items));
     if (i < chunks.length - 1) {

--- a/packages/jobs/src/workers/detection/anchor-audit.ts
+++ b/packages/jobs/src/workers/detection/anchor-audit.ts
@@ -1,0 +1,31 @@
+import type { AnchorMethod, Logger } from '@semiont/core';
+import { recordAnchorOutcome } from '@semiont/observability';
+
+/**
+ * The anchoring methods that picked a plausible occurrence rather than a
+ * certain one: `first-of-many` had several candidates and no usable context,
+ * `fuzzy-match` recovered through case/whitespace/Levenshtein. Neither is an
+ * error — the write-time selector invariant still holds — but both are places
+ * the span could be the wrong instance.
+ *
+ * ONE decider, deliberately. This classification lived in two places (the
+ * reference path's inline warn and the motivation parsers' logger) that
+ * happened to agree; two copies of a risk judgement is one copy too many.
+ */
+const DEGRADED: ReadonlySet<string> = new Set<AnchorMethod>(['first-of-many', 'fuzzy-match']);
+
+/**
+ * Audit one anchoring outcome: counted always, warned only when degraded.
+ *
+ * Counting EVERY outcome is the point (P5). A warning tells an operator that
+ * one anchor was uncertain; only a rate over all anchors says whether the
+ * detection run was precise, and the rate is what the plan asks to put beside
+ * the yield numbers.
+ */
+export function noteAnchor(label: string, exact: string, method: AnchorMethod, logger?: Logger): void {
+  recordAnchorOutcome(label, method);
+  if (!DEGRADED.has(method)) return;
+  const detail = { text: exact, anchorMethod: method };
+  if (logger) logger.warn('Annotation anchored via degraded method', { label, ...detail });
+  else console.warn(`[${label}] anchored via ${method}: "${exact}"`);
+}

--- a/packages/jobs/src/workers/detection/bounded-concurrency.ts
+++ b/packages/jobs/src/workers/detection/bounded-concurrency.ts
@@ -1,0 +1,38 @@
+/**
+ * Run `worker` over `items` with at most `limit` of them in flight at once
+ * (DETECTION-QUALITY-THROUGHPUT P6). Hand-rolled rather than a dependency: the
+ * need is exactly one bounded map, and the BOUND is the whole point — detection
+ * parallelizes independent entity types, but unbounded fan-out just trades
+ * sequential waiting for provider 429 thrash, so the cap is the feature.
+ *
+ * A fixed pool of `min(limit, items.length)` pumps, each pulling the next index
+ * until the work is exhausted — so at most `limit` calls are ever awaiting at
+ * once, whatever the item count. Results are returned in INPUT order (a caller
+ * can zip them back to items); COMPLETION order is not input order — that is the
+ * point of concurrency — so a caller that must act "as each finishes" does so
+ * inside `worker`, not on the returned array.
+ *
+ * Failure matches the sequential loop it replaces: the first `worker` rejection
+ * rejects the whole run. Pumps already awaiting finish (they cannot be
+ * cancelled mid-await), but no new item is pulled once a rejection propagates.
+ */
+export async function runBounded<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+
+  async function pump(): Promise<void> {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i]!, i);
+    }
+  }
+
+  const poolSize = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: poolSize }, () => pump()));
+  return results;
+}

--- a/packages/jobs/src/workers/detection/chunk-size-controller.ts
+++ b/packages/jobs/src/workers/detection/chunk-size-controller.ts
@@ -1,0 +1,123 @@
+/**
+ * Adaptive chunk sizing (DETECTION-QUALITY-THROUGHPUT P2) — DRAFT.
+ *
+ * `deriveDetectionBudget` picks ONE input size for every document from provider
+ * limits alone. It cannot see the document, so it is sized for a worst-case
+ * dense one (input = half the output budget) — and a sparse document then pays
+ * that pessimism as many tiny, overhead-dominated calls. This adjusts the chunk
+ * size AS THE UNIT RUNS, from what each call actually produced, so a document
+ * that turns out sparse grows into bigger chunks and a dense stretch pulls back.
+ *
+ * It steers ONE number: how full of the output budget each chunk came in. That
+ * is the whole model, and it is enough because both hard failures are already
+ * caught downstream by `callChunkSubdividing` — a chunk that truncates is
+ * halved-and-retried, a chunk that outruns the guillotine times out and is
+ * halved-and-retried. So the sizer does not model truncation or duration; it
+ * only keeps chunks in a band that uses the budget well, and the net below it
+ * forgives an overshoot. That safety net is why this is a step rule and not a
+ * control loop (user direction, 2026-09-04: keep it simple).
+ *
+ * "Maximize, don't predict": the only thing that grows a chunk is a MEASURED
+ * under-use of the budget. No document statistic, no a-priori density model
+ * (#1121's ban). Re-evaluated every chunk, so it tracks a gradient (sparse
+ * intro → dense index) rather than betting the run on the first sample.
+ *
+ * Pure and feedback-only — unit-testable in isolation. Wiring into
+ * `detectInChunks` (and the checkpoint interaction a variable boundary implies)
+ * is the GREEN step, deliberately not here.
+ */
+
+/** What one chunk's call produced — the minimum the sizer needs. Duration and
+ * input are NOT here: the guillotine and truncation are the hard bounds, both
+ * backstopped by subdivision, so utilization is the only signal that sizing
+ * acts on. (P1 telemetry records the fuller picture separately.) */
+export interface CallOutcome {
+  /** Provider-reported output tokens for the chunk. */
+  outputTokens: number;
+  /** The chunk hit a size-shaped bound (truncation or the guillotine), even if
+   * subdivision then recovered it. Forces a shrink regardless of the count —
+   * the signal that the last size was too big for this stretch. */
+  truncated: boolean;
+}
+
+/** Provider-DERIVED sizing bounds for one job — not tuning, not policy. From
+ * `deriveDetectionBudget` and the model's window; recomputed per job, never
+ * user-facing. */
+export interface SizingBounds {
+  /** Smallest useful input chunk (tokens) — the overlap-derived floor. */
+  floor: number;
+  /** Largest input chunk (tokens) — the window-fit safety cap; never exceeded. */
+  ceiling: number;
+  /** The output budget one call is given. Utilization is measured against it. */
+  outputBudget: number;
+}
+
+/**
+ * The tuning knobs — the numbers that decide how aggressively chunk size chases
+ * measured output usage. Grouped and named deliberately, because these are
+ * POLICY, not derivation, and the likely future is that they become
+ * user/admin-tunable, perhaps per inference provider (a fast, cheap model
+ * tolerates more aggressive growth than a slow, dear one).
+ *
+ * That future changes where a `ChunkSizingPolicy` comes FROM — provider config,
+ * a settings surface — not the sizing function, which already takes it as a
+ * value, nor the caller's shape. There is exactly ONE today, the default below.
+ * No config system, no env var, no per-provider map yet: just a single named
+ * home, so when the need is real there is one obvious thing to make configurable
+ * and one obvious place to select it (the caller holds the `InferenceClient`,
+ * hence the provider).
+ */
+export interface ChunkSizingPolicy {
+  /** Below this fraction of the output budget, the chunk left room — grow. */
+  growBelow: number;
+  /** Above this fraction, the chunk is near the edge — ease off before it
+   * truncates and costs a subdivision retry. */
+  shrinkAbove: number;
+  /** Geometric step when growing (>1). Geometric so a genuinely sparse document
+   * reaches its ceiling in a few steps and a bad step costs one correction. */
+  growFactor: number;
+  /** Geometric step when easing off (<1). Also the response to a truncation. */
+  shrinkFactor: number;
+}
+
+/** The one policy in effect today. Coarse on purpose — subdivision forgives a
+ * wrong guess — and every value is a candidate for the tunable surface above. */
+export const DEFAULT_CHUNK_SIZING_POLICY: ChunkSizingPolicy = {
+  growBelow: 0.5,
+  shrinkAbove: 0.8,
+  growFactor: 1.5,
+  shrinkFactor: 0.7,
+};
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, value));
+}
+
+/**
+ * Propose the next chunk's input size from what the last chunk produced.
+ *
+ * A truncated chunk, or one whose output filled more than `shrinkAbove` of the
+ * budget, eases the next chunk down; one that used less than `growBelow` grows
+ * it; in between, hold. Always clamped to `[floor, ceiling]`. That is the whole
+ * rule — the hard bounds are subdivision's job, not this function's.
+ */
+export function nextChunkSize(
+  outcome: CallOutcome,
+  current: number,
+  bounds: SizingBounds,
+  policy: ChunkSizingPolicy = DEFAULT_CHUNK_SIZING_POLICY,
+): number {
+  const grow = () => clamp(Math.floor(current * policy.growFactor), bounds.floor, bounds.ceiling);
+  const shrink = () => clamp(Math.floor(current * policy.shrinkFactor), bounds.floor, bounds.ceiling);
+  const hold = () => clamp(current, bounds.floor, bounds.ceiling);
+
+  if (outcome.truncated) return shrink();
+  // A zero/absent budget cannot inform utilization; hold rather than divide by
+  // zero or grow blindly.
+  if (bounds.outputBudget <= 0) return hold();
+
+  const utilization = outcome.outputTokens / bounds.outputBudget;
+  if (utilization < policy.growBelow) return grow();
+  if (utilization > policy.shrinkAbove) return shrink();
+  return hold();
+}

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -25,7 +25,8 @@
  */
 
 import { chunkText, type ChunkingConfig, type Logger } from '@semiont/core';
-import { StructuredReadError, type InferenceLimits } from '@semiont/inference';
+import { StructuredReadError, type InferenceLimits, type TokenUsage } from '@semiont/inference';
+import { recordDetectionCall } from '@semiont/observability';
 import { DeterministicJobError } from '../../failure-class';
 import { INFERENCE_TIMEOUT_MS, InferenceTimeoutError } from '../inference-call';
 
@@ -196,15 +197,55 @@ function truncation(error: unknown): boolean {
  * span-keyed dedupe. On a failure subdivision cannot fix, the ORIGINAL
  * error propagates so classification sees what actually happened.
  */
+export interface ChunkCallResult<T> {
+  items: T[];
+  /** The provider's own token counts, when it reported any. Never estimated. */
+  usage?: TokenUsage;
+}
+
+/** Which shape of failure this was — they demand opposite responses, so the
+ * history must tell them apart: truncation descends by size, a timeout fails
+ * fast, anything else is not size-shaped at all. */
+function outcomeOf(error: unknown): 'truncated' | 'timeout' | 'error' {
+  if (truncation(error)) return 'truncated';
+  if (error instanceof InferenceTimeoutError) return 'timeout';
+  return 'error';
+}
+
 export async function callChunkSubdividing<T>(
+  label: string,
   chunk: string,
   chunking: ChunkingConfig,
-  call: (piece: string) => Promise<T[]>,
+  call: (piece: string) => Promise<ChunkCallResult<T>>,
   logger?: Logger,
 ): Promise<T[]> {
+  // One telemetry record per model call, successes AND failures
+  // (DETECTION-QUALITY-THROUGHPUT P1). This is the only place `depth` and
+  // `reroll` exist, so it is the only place a complete record can be written.
+  async function recorded(piece: string, depth: number, reroll: boolean): Promise<ChunkCallResult<T>> {
+    const start = performance.now();
+    try {
+      const result = await call(piece);
+      recordDetectionCall({
+        label, pieceChars: piece.length, durationMs: performance.now() - start,
+        items: result.items.length, depth, reroll, outcome: 'success',
+        ...(result.usage ? { inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens } : {}),
+      });
+      return result;
+    } catch (error) {
+      // A failed call still cost its input and its wall time — the descent's
+      // price is invisible without it.
+      recordDetectionCall({
+        label, pieceChars: piece.length, durationMs: performance.now() - start,
+        items: 0, depth, reroll, outcome: outcomeOf(error),
+      });
+      throw error;
+    }
+  }
+
   async function attempt(piece: string, chunkSize: number, depth: number): Promise<T[]> {
     try {
-      return await call(piece);
+      return (await recorded(piece, depth, false)).items;
     } catch (error) {
       if (!subdividable(error)) throw error;
       const half = Math.floor(chunkSize / 2);
@@ -226,7 +267,7 @@ export async function callChunkSubdividing<T>(
           pieceChars: piece.length,
           error: error instanceof Error ? error.message : String(error),
         });
-        return await call(piece);
+        return (await recorded(piece, depth, true)).items;
       }
       logger?.warn('Chunk call failed at a size-shaped bound — subdividing and retrying smaller', {
         depth: depth + 1,

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -70,6 +70,23 @@ const OVERLAP_TOKENS = Math.ceil(OVERLAP_CHARS / 4);
  */
 export const DETECTION_TEMPERATURE = 0;
 
+/**
+ * How many entity types one reference-detection job runs at once
+ * (DETECTION-QUALITY-THROUGHPUT P6). The types are independent units, and a
+ * single sequential job uses a sliver of any provider's rate limit (~1 request
+ * / 72 s measured), so concurrency is a near-linear wall-time win up to that
+ * limit — the sequential type loop was the 9×-sequential ≈ 2.5 h/document.
+ *
+ * Deliberately CONSERVATIVE and fixed for the first cut: the plan is start
+ * small, measure the real speedup and any 429s against P1 telemetry, and raise
+ * only on evidence — never fan out unbounded, which trades sequential waiting
+ * for 429 thrash. This is a policy constant, and the natural candidate to
+ * become user/admin-tunable per inference provider (a fast, cheap model
+ * tolerates more) — same status and future as `DETECTION_TEMPERATURE` and the
+ * chunk-sizing policy; homed here so there is one place to make it so.
+ */
+export const DETECTION_TYPE_CONCURRENCY = 4;
+
 export interface DetectionBudget {
   /** Feed to `chunkText` — `chunkSize` is the derived input budget (tokens). */
   chunking: ChunkingConfig;

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -70,23 +70,6 @@ const OVERLAP_TOKENS = Math.ceil(OVERLAP_CHARS / 4);
  */
 export const DETECTION_TEMPERATURE = 0;
 
-/**
- * How many entity types one reference-detection job runs at once
- * (DETECTION-QUALITY-THROUGHPUT P6). The types are independent units, and a
- * single sequential job uses a sliver of any provider's rate limit (~1 request
- * / 72 s measured), so concurrency is a near-linear wall-time win up to that
- * limit — the sequential type loop was the 9×-sequential ≈ 2.5 h/document.
- *
- * Deliberately CONSERVATIVE and fixed for the first cut: the plan is start
- * small, measure the real speedup and any 429s against P1 telemetry, and raise
- * only on evidence — never fan out unbounded, which trades sequential waiting
- * for 429 thrash. This is a policy constant, and the natural candidate to
- * become user/admin-tunable per inference provider (a fast, cheap model
- * tolerates more) — same status and future as `DETECTION_TEMPERATURE` and the
- * chunk-sizing policy; homed here so there is one place to make it so.
- */
-export const DETECTION_TYPE_CONCURRENCY = 4;
-
 export interface DetectionBudget {
   /** Feed to `chunkText` — `chunkSize` is the derived input budget (tokens). */
   chunking: ChunkingConfig;

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -170,7 +170,7 @@ Example output:
     // unreadable model response is a job failure, never a silent []. A
     // size-shaped failure (duration bound, truncation) subdivides in place
     // and retries smaller before it is allowed to fail the job.
-    const items = await callChunkSubdividing<unknown>(chunks[i]!, chunking, async (piece) => {
+    const items = await callChunkSubdividing<unknown>('reference', chunks[i]!, chunking, async (piece) => {
       const response = await boundedGenerateStructured<unknown>(
         client,
         buildPrompt(piece),
@@ -193,7 +193,9 @@ Example output:
       // consuming: a truncated structured response can still carry a valid
       // partial array, so the items themselves cannot signal the loss.
       assertNotTruncated(response, 'Entity extraction', i + 1, chunks.length, outputBudget);
-      return response.items;
+      // Usage rides back so the telemetry record carries what the call COST
+      // beside what it yielded — the provider's own counts, not an estimate.
+      return { items: response.items, ...(response.usage ? { usage: response.usage } : {}) };
     }, logger);
 
     for (const e of items) {

--- a/packages/jobs/src/workers/detection/motivation-parsers.ts
+++ b/packages/jobs/src/workers/detection/motivation-parsers.ts
@@ -11,6 +11,7 @@
 
 import { reconcileSelector, isObject, isString, type AnchorMethod } from '@semiont/core';
 import type { ElementSchema } from '@semiont/inference';
+import { noteAnchor } from './anchor-audit';
 
 // Parsers receive ALREADY-PARSED elements (`unknown[]`) from the structured
 // inference surface — `generateStructured` returns `T[]` or throws, so
@@ -307,14 +308,10 @@ export interface RawTagInput {
 }
 
 /**
- * Single audit log for any anchor-method classification a parser produces.
- * `llm-exact` and `unique-match` are silent (the common path). The risky
- * cases — `first-of-many` (multiple occurrences with no usable context)
- * and `fuzzy-match` (recovered via case/whitespace/Levenshtein) — log
- * `warn` so corpus owners can audit them in worker output.
+ * Audit one anchor-method classification. Forwards to the single decider
+ * shared with the reference path (`anchor-audit.ts`) — which methods count as
+ * risky is one judgement, and this file used to hold a second copy of it.
  */
 function logAnchorMethod(motivation: string, exact: string, anchorMethod: AnchorMethod): void {
-  if (anchorMethod === 'first-of-many' || anchorMethod === 'fuzzy-match') {
-    console.warn(`[MotivationParsers] ${motivation} anchored via ${anchorMethod}: "${exact}"`);
-  }
+  noteAnchor(motivation, exact, anchorMethod);
 }

--- a/packages/make-meaning/src/__tests__/annotation-context.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-context.test.ts
@@ -572,6 +572,7 @@ describe('AnnotationContext', () => {
       const mockInferenceClient = {
         type: 'mock' as const,
         modelId: 'mock-model',
+        maxConcurrency: 1,
         generateText: vi.fn().mockResolvedValue('This passage about a fox relates to the Animals topic in the knowledge base.'),
         generateTextWithMetadata: vi.fn(),
         limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),
@@ -633,6 +634,7 @@ describe('AnnotationContext', () => {
       const mockInferenceClient = {
         type: 'mock' as const,
         modelId: 'mock-model',
+        maxConcurrency: 1,
         generateText: vi.fn().mockRejectedValue(new Error('LLM unavailable')),
         generateTextWithMetadata: vi.fn(),
         limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),

--- a/packages/make-meaning/src/__tests__/gatherer-decoupling.test.ts
+++ b/packages/make-meaning/src/__tests__/gatherer-decoupling.test.ts
@@ -32,6 +32,7 @@ const mockLogger: Logger = {
 const noopInference = {
   type: 'noop',
   modelId: 'noop',
+  maxConcurrency: 1,
   generateText: vi.fn().mockResolvedValue(''),
   generateTextWithMetadata: vi.fn().mockResolvedValue({ text: '', usage: {} }),
 } as unknown as InferenceClient;

--- a/packages/make-meaning/src/__tests__/librarian-decoupling.test.ts
+++ b/packages/make-meaning/src/__tests__/librarian-decoupling.test.ts
@@ -39,6 +39,7 @@ const mockLogger: Logger = {
 const noopInference = {
   type: 'noop',
   modelId: 'noop',
+  maxConcurrency: 1,
   generateText: vi.fn().mockResolvedValue(''),
   generateTextWithMetadata: vi.fn().mockResolvedValue({ text: '', usage: {} }),
 } as unknown as InferenceClient;

--- a/packages/make-meaning/src/__tests__/matcher.test.ts
+++ b/packages/make-meaning/src/__tests__/matcher.test.ts
@@ -129,6 +129,7 @@ const mockLogger: Logger = {
 const noopInference = {
   type: 'noop',
   modelId: 'noop',
+  maxConcurrency: 1,
   generateText: vi.fn().mockResolvedValue(''),
   generateTextWithMetadata: vi.fn().mockResolvedValue({ text: '', usage: {} }),
 } as unknown as InferenceClient;
@@ -633,6 +634,7 @@ describe('Matcher', () => {
       const mockInference = {
         type: 'mock' as const,
         modelId: 'mock-model',
+        maxConcurrency: 1,
         generateText: vi.fn().mockResolvedValue('1. 0.9\n2. 0.2'),
         generateTextWithMetadata: vi.fn(),
         limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),
@@ -681,6 +683,7 @@ describe('Matcher', () => {
       const mockInference = {
         type: 'mock' as const,
         modelId: 'mock-model',
+        maxConcurrency: 1,
         generateText: vi.fn().mockRejectedValue(new Error('LLM unavailable')),
         generateTextWithMetadata: vi.fn(),
         limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),
@@ -745,7 +748,7 @@ describe('Matcher', () => {
     });
 
     describe('inference response parsing edge cases', () => {
-      let mockInference: { type: string; modelId: string; generateText: ReturnType<typeof vi.fn>; generateTextWithMetadata: ReturnType<typeof vi.fn>; limits: ReturnType<typeof vi.fn>; generateStructured: ReturnType<typeof vi.fn> };
+      let mockInference: { type: string; modelId: string; maxConcurrency: number; generateText: ReturnType<typeof vi.fn>; generateTextWithMetadata: ReturnType<typeof vi.fn>; limits: ReturnType<typeof vi.fn>; generateStructured: ReturnType<typeof vi.fn> };
 
       beforeEach(async () => {
         await matcher.stop();
@@ -765,6 +768,7 @@ describe('Matcher', () => {
         mockInference = {
           type: 'mock',
           modelId: 'mock-model',
+          maxConcurrency: 1,
           generateText: vi.fn(),
           generateTextWithMetadata: vi.fn(),
           limits: vi.fn().mockResolvedValue({ contextTokens: 1_000_000, maxOutputTokens: 1_000_000 }),

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -642,6 +642,124 @@ export function recordInferenceUsage(opts: {
   }
 }
 
+let _detectionCallCounter: Counter | undefined;
+let _detectionDurationHistogram: Histogram | undefined;
+let _detectionItemsHistogram: Histogram | undefined;
+let _detectionTokensHistogram: Histogram | undefined;
+
+function detectionCallCounter(): Counter {
+  if (!_detectionCallCounter) {
+    _detectionCallCounter = meter().createCounter('semiont.detection.calls', {
+      description: 'Detection model calls, labeled by motivation, outcome, subdivision depth and whether this was the floor re-roll.',
+    });
+  }
+  return _detectionCallCounter;
+}
+
+function detectionDurationHistogram(): Histogram {
+  if (!_detectionDurationHistogram) {
+    _detectionDurationHistogram = meter().createHistogram('semiont.detection.call.duration', {
+      description: 'Wall time of one detection model call, including the attempts that failed and were retried smaller.',
+      unit: 'ms',
+    });
+  }
+  return _detectionDurationHistogram;
+}
+
+function detectionItemsHistogram(): Histogram {
+  if (!_detectionItemsHistogram) {
+    _detectionItemsHistogram = meter().createHistogram('semiont.detection.call.items', {
+      description: 'Annotations returned by one detection call. Against the input size on the same record, this is yield.',
+    });
+  }
+  return _detectionItemsHistogram;
+}
+
+function detectionTokensHistogram(): Histogram {
+  if (!_detectionTokensHistogram) {
+    _detectionTokensHistogram = meter().createHistogram('semiont.detection.call.tokens', {
+      description: "Provider-reported tokens for one detection call, by direction. Deliberately separate from semiont.inference.tokens: that series is the authoritative total but carries no subdivision depth, and 'what does a depth-2 call cost' is the question every sizing decision asks.",
+    });
+  }
+  return _detectionTokensHistogram;
+}
+
+/**
+ * Record one detection model call (DETECTION-QUALITY-THROUGHPUT P1).
+ *
+ * The adapters already record provider/model/duration/tokens for every
+ * inference call. What they cannot know is the detection shape around it:
+ * which motivation asked, how big the piece was, how many annotations came
+ * back, how deep subdivision had descended, and whether this was the floor
+ * re-roll. Those are the facts that distinguish a healthy call from a
+ * expensive descent, and without them a slow detection run is one
+ * undifferentiated number.
+ *
+ * FAILED attempts are recorded too, and that is the point: the calls paid for
+ * and thrown away during a descent are exactly the cost later phases exist to
+ * avoid, so a record only of successes would hide the thing being optimized.
+ *
+ * Tokens are the PROVIDER's counts, passed through — never estimated. Absent
+ * means the provider did not report them.
+ */
+export function recordDetectionCall(opts: {
+  label: string;
+  pieceChars: number;
+  durationMs: number;
+  items: number;
+  depth: number;
+  reroll: boolean;
+  outcome: 'success' | 'truncated' | 'timeout' | 'error';
+  inputTokens?: number;
+  outputTokens?: number;
+}): void {
+  const attrs = {
+    'detection.label': opts.label,
+    'detection.outcome': opts.outcome,
+    'detection.depth': opts.depth,
+    'detection.reroll': opts.reroll,
+  };
+  detectionCallCounter().add(1, attrs);
+  detectionDurationHistogram().record(opts.durationMs, attrs);
+  detectionItemsHistogram().record(opts.items, attrs);
+  if (opts.inputTokens !== undefined) {
+    detectionTokensHistogram().record(opts.inputTokens, { ...attrs, 'detection.direction': 'input' });
+  }
+  if (opts.outputTokens !== undefined) {
+    detectionTokensHistogram().record(opts.outputTokens, { ...attrs, 'detection.direction': 'output' });
+  }
+}
+
+let _anchorOutcomeCounter: Counter | undefined;
+function anchorOutcomeCounter(): Counter {
+  if (!_anchorOutcomeCounter) {
+    _anchorOutcomeCounter = meter().createCounter('semiont.detection.anchors', {
+      description: 'Every annotation anchoring, labeled by the method that resolved it. EVERY outcome is counted, not just the risky ones, because a bare count of degraded anchors has no denominator — the rate is the precision signal.',
+    });
+  }
+  return _anchorOutcomeCounter;
+}
+
+/**
+ * Record how one annotation got anchored (DETECTION-QUALITY-THROUGHPUT P5).
+ *
+ * The selector-vs-source check is already a WRITE-TIME INVARIANT — both
+ * `buildTextAnnotation` and `buildPdfAnnotation` throw on a selector that does
+ * not match its source — so mechanical correctness is guaranteed rather than
+ * sampled, and auditing it would measure a constant.
+ *
+ * What is genuinely uncertain is which anchoring METHOD got there. An `exact`
+ * the model quoted verbatim and that appears once is certain; one resolved by
+ * `first-of-many` (several occurrences, no usable context) or `fuzzy-match`
+ * picked a plausible occurrence and may have picked wrong. Those were visible
+ * only as log warnings — countable by a human reading worker output, which is
+ * how 47 of them went unreviewed. As a rate they are the precision number that
+ * sits beside the yield numbers.
+ */
+export function recordAnchorOutcome(label: string, method: string): void {
+  anchorOutcomeCounter().add(1, { 'detection.label': label, 'anchor.method': method });
+}
+
 // ── Re-exports from @opentelemetry/api ─────────────────────────────────
 
 export { SpanKind, SpanStatusCode, type Attributes, type Span } from '@opentelemetry/api';

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -3041,6 +3041,9 @@ type JobProgress struct {
 		// FoundCount Annotations found for it.
 		FoundCount int `json:"foundCount"`
 
+		// PersistedCount Annotations actually persisted for it — post-dedupe and post-durability-acknowledgement, so it counts what the event log holds, not what the model proposed. Beside foundCount this is the per-unit yield the sizing work is judged by. Present on flows whose units persist as they complete (reference-annotation); the tagging flow reports the same fact as byCategory on its result, because its annotations are built after the per-category loop.
+		PersistedCount *int `json:"persistedCount,omitempty"`
+
 		// Value The item, shown verbatim.
 		Value string `json:"value"`
 	} `json:"completedItems,omitempty"`

--- a/specs/src/components/schemas/JobProgress.json
+++ b/specs/src/components/schemas/JobProgress.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "description": "Progress report from a running job. The required field is `percentage`; `message` carries the coded phase and the rest are optional job-shape fields. This is the single progress shape for every job type \u2014 annotation workers and generation alike. `stage` and `currentEntityType` were REMOVED (ASSIST-PROGRESS-CONSOLIDATION P5): both were redundant denormalization of `message`. Terminality is signalled on `job:complete` / `job:fail`, not here. The per-flow progress vocabularies (`processedEntityTypes`/`totalEntityTypes` for references, `processedCategories`/`totalCategories`/`currentCategory` for tags) were replaced by one `current`/`processed`/`total` triple (CLEAN-PROGRESS D2): both flows iterate a user-chosen list, so they report the same shape and the client stops guessing which flow it is drawing.",
+  "description": "Progress report from a running job. The required field is `percentage`; `message` carries the coded phase and the rest are optional job-shape fields. This is the single progress shape for every job type — annotation workers and generation alike. `stage` and `currentEntityType` were REMOVED (ASSIST-PROGRESS-CONSOLIDATION P5): both were redundant denormalization of `message`. Terminality is signalled on `job:complete` / `job:fail`, not here. The per-flow progress vocabularies (`processedEntityTypes`/`totalEntityTypes` for references, `processedCategories`/`totalCategories`/`currentCategory` for tags) were replaced by one `current`/`processed`/`total` triple (CLEAN-PROGRESS D2): both flows iterate a user-chosen list, so they report the same shape and the client stops guessing which flow it is drawing.",
   "properties": {
     "percentage": {
       "type": "number",
@@ -16,7 +16,7 @@
     },
     "current": {
       "type": "object",
-      "description": "What the run is working on right now. `kind` is a CODE the client renders a localized name for; `value` is KB data (an entity type, a tag category) shown verbatim \u2014 the same split as `requestParams`. Absent on flows that iterate nothing, such as generation.",
+      "description": "What the run is working on right now. `kind` is a CODE the client renders a localized name for; `value` is KB data (an entity type, a tag category) shown verbatim — the same split as `requestParams`. Absent on flows that iterate nothing, such as generation.",
       "properties": {
         "kind": {
           "type": "string",
@@ -38,7 +38,7 @@
     },
     "processed": {
       "type": "integer",
-      "description": "Items completed so far, zero-based \u2014 the item in `current` is the one after these. Paired with `total`."
+      "description": "Items completed so far, zero-based — the item in `current` is the one after these. Paired with `total`."
     },
     "total": {
       "type": "integer",
@@ -65,6 +65,10 @@
           "foundCount": {
             "type": "integer",
             "description": "Annotations found for it."
+          },
+          "persistedCount": {
+            "type": "integer",
+            "description": "Annotations actually persisted for it — post-dedupe and post-durability-acknowledgement, so it counts what the event log holds, not what the model proposed. Beside foundCount this is the per-unit yield the sizing work is judged by. Present on flows whose units persist as they complete (reference-annotation); the tagging flow reports the same fact as byCategory on its result, because its annotations are built after the per-category loop."
           }
         },
         "required": [
@@ -75,7 +79,7 @@
     },
     "requestParams": {
       "type": "array",
-      "description": "Echoed job parameters for display in the progress UI. `label` is a CODE, not a sentence \u2014 the client owns the wording, same rule as the progress message. `value` is the user's own input (an entity-type list, their instructions) and is deliberately NOT translated: it is their words, not ours.",
+      "description": "Echoed job parameters for display in the progress UI. `label` is a CODE, not a sentence — the client owns the wording, same rule as the progress message. `value` is the user's own input (an entity-type list, their instructions) and is deliberately NOT translated: it is their words, not ours.",
       "items": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
Makes large-document detection **fast and measurable**, driven end-to-end by live data from a real 116-page PDF rather than guesswork.

Two things land in force; two more are scoped explicitly so nobody re-opens them.

## Per-call yield telemetry

Detection was a black box: a job either finished or didn't, and its cost and quality were reconstructable only by reading worker logs. Now every model call emits one record — piece size, duration, items, subdivision depth, floor re-roll, outcome, and the **provider's own token counts** (never estimated: `StructuredResponse`/`InferenceResponse` gained `usage`, and both adapters pass through what they already had). Anchoring is recorded too: every outcome is counted, so the **degraded-anchor rate** — spans resolved by a plausible-but-uncertain method — exists as a number beside the yield rather than as log lines nobody reads. The "which methods are risky" judgement, previously duplicated in two places, is collapsed to one decider.

Reference jobs also now report **found vs persisted per entity type** (`persistedCount` on `JobProgress`), the gap that is this flow's real yield.

Building this found two live bugs, both fixed here:
- the terminal progress frame never carried `completedItems`, so a single-type job reported no per-unit results at all;
- the per-unit accumulator was a hand-written restatement of the wire shape — now derived from the generated type.

## Entity types run concurrently, correctly on every provider

The per-type loop in reference detection ran strictly sequentially — the 9×-sequential grind that made a many-type job take hours. Wall time is output-tokens ÷ generation-rate, and a single job used a *sliver* of a hosted provider's rate limit (~1 request / 72 s measured, zero 429s), so the types — which are independent units — now run **bounded-concurrent** through a small hand-rolled pool (no new dependency).

**Measured on a fresh stack, 4 entity types on the 116-page PDF: ~24 min vs ~68 min sequential — ~2.8×, zero 429s.** Subdivision still catches dense chunks *underneath* the parallelism (3 truncations → 12 halved-and-retried successes), which was the real design risk and it composed cleanly. Concurrent commits are safe: the durable writer serializes appends and the queue unions checkpoints.

Crucially, **concurrency is a provider capability, not a flat constant.** A hosted API with rate headroom parallelizes; a local single-model server (Ollama) does **not** — its throughput is hardware-bound, so concurrent requests only queue or split one GPU for no aggregate speedup while N live KV-cache contexts add memory pressure. So `InferenceClient` gains a required `maxConcurrency` (Anthropic 4, Ollama 1), read at the fan-out. Same code, correct on both; a test pins that a `maxConcurrency: 1` provider runs detection sequentially.

## Scoped out, on purpose

- **Adaptive chunk sizing** is drafted (a pure per-chunk controller that grows/shrinks toward output-budget utilization, with tuning knobs in a named policy object) but **not wired in**. The calibration showed wall time is generation-bound, so chunk sizing barely moves it — its only real win is not over-chunking sparse documents. Low priority; the draft is here for when it's wanted.
- **Multi-type batching** is **dropped**, not deferred: it saves input cost only (output is unchanged), it fights the parallelism above, and asking one prompt for many entity types at once degrades the per-type, closed-vocabulary fidelity detection depends on.

## Verification

`tsc --noEmit` clean and full suites green across inference (59), jobs (513 + 1 skipped), make-meaning (578 + 1 expected fail), observability, and core. New tests are RED-first and proven to bite (stripping a recorder or forcing concurrency to 1 fails the relevant pin). The concurrency and telemetry were additionally validated against a live stack, not just in tests.
