### PR TITLE
Prune mysql2 from the gateway runtime image

### DIFF
--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -121,7 +121,7 @@ COPY --from=installer --chown=semiont:nodejs /home/semiont/.local/share/semiont 
 # with its bundled brace-expansion patched there, so keeping npm is clean for the
 # Trivy gate.
 #
-# We still drop two things pulled transitively but never loaded at runtime:
+# We still drop three things pulled transitively but never loaded at runtime:
 #   - the TypeScript compiler: `typescript` + its native `@typescript/*` Go
 #     binaries (via the qdrant client's dep chain); the native `tsc` carries a
 #     Go-stdlib CVE (CVE-2026-39822).
@@ -132,13 +132,28 @@ COPY --from=installer --chown=semiont:nodejs /home/semiont/.local/share/semiont 
 #     it is Apache-2.0 and prisma's CLI top-level-requires it (removing it breaks
 #     the CLI, and `migrate deploy` still runs at start), while removing only
 #     elkjs leaves the CLI working.
+#   - `mysql2`: prisma pins it at exactly 3.15.3, which carries
+#     GHSA-3f6p-5ww8-9rcr (HIGH: auth-plugin downgrade to mysql_clear_password
+#     leaks credentials). The fix is 3.22.0 and prisma's pin is exact, so no
+#     range bump or lockfile update reaches it — and `ignore-unfixed` does not
+#     suppress it, because a fix exists. Same shape as elkjs: the only import in
+#     the tree is a lazy `import("mysql2/promise")` in the `prisma studio`
+#     command (build/cli.js), and @prisma/studio-core/data/mysql2 is a shim that
+#     never requires mysql2 itself. Our datasource is postgresql via
+#     @prisma/adapter-pg, so no MySQL connection is ever constructed. Retire this
+#     entry at prisma 8 — 8.0.0-rc.13 drops the mysql2 dependency outright.
+#     Matched by -path, NOT -name: a bare `-name mysql2` also hits
+#     @prisma/studio-core/dist/data/mysql2, the adapter shim that cli.js
+#     top-level-requires alongside data/bff and data/node-sqlite. Deleting that
+#     breaks the CLI at load and the container never starts.
 #
 # `find-my-way` used to be dropped here too: @prisma/dev pinned it at exactly
 # 9.6.0, which carried CVE-2026-47219 (HIGH: HTTP/2 DDoS). prisma 7.9.1 now
 # resolves @prisma/dev 0.24.17, which depends on the fixed find-my-way 9.7.0,
 # so there is nothing left to drop.
 RUN find /usr/local/lib/node_modules /home/semiont/.local/share/semiont \
-      -type d \( -name typescript -o -name '@typescript' -o -name elkjs \) \
+      -type d \( -name typescript -o -name '@typescript' -o -name elkjs \
+                 -o -path '*/node_modules/mysql2' \) \
       -prune -exec rm -rf {} +
 
 COPY LICENSE apps/gateway/NOTICE /home/semiont/


### PR DESCRIPTION
Removes `mysql2` from the gateway runtime image. **This is a release blocker, not hygiene** — see below.

## Why it ships at all

`mysql2` is not a dependency anyone declared. It arrives through a chain that is easy to miss:

1. `scripts/ci/publish-npm-apps.mjs` promotes `prisma` from devDependency to a **runtime** dependency of the published gateway (`GATEWAY_RUNTIME_DEVDEPS`), because the container shells out to `npx prisma migrate deploy`.
2. Published `@semiont/gateway` therefore declares `"prisma": "^7.10.0"` — confirmed against the live registry, not just the source manifest.
3. `prisma@7.10.0` pins `mysql2` at **exactly `3.15.3`**.
4. The Dockerfile installs that published package into the runtime prefix.

A side effect worth knowing: Dependabot classifies alerts on prisma transitives as scope `development`, because `prisma` is a devDep in `package-lock.json`. That classification is **wrong for the shipped artifact**, and it applies to every current and future prisma transitive — not just this one.

## Why it blocks the release

`mysql2@3.15.3` carries GHSA-3f6p-5ww8-9rcr (HIGH — auth-plugin downgrade to `mysql_clear_password` leaks plaintext credentials). The gateway image is scanned by `publish-service-images.yml` with:

```yaml
severity: HIGH,CRITICAL
exit-code: '1'
ignore-unfixed: true
vuln-type: os,library
```

Every clause points the same way. It is HIGH, so in scope. `ignore-unfixed` does **not** save us — that suppresses only vulnerabilities with no available fix, and this one has a fix (`3.22.0`). npm libraries are scanned. `exit-code: 1` fails the publish. There is no `.trivyignore` in the repo.

The fix is unreachable by dependency work: prisma's pin is **exact**, so no range bump, lockfile regen, or override moves it. `prisma@8.0.0-rc.13` drops `mysql2` entirely, but taking an RC major to unblock a release inverts the risk.

The advisory was published **2026-09-01**, which is why this has not fired yet — no gateway image has been built since. The next release is the first build that sees it.

## Why pruning is safe

Same rationale as the existing `elkjs` prune directly above it:

- Our datasource is `postgresql` (`apps/gateway/prisma/schema.prisma`) via `@prisma/adapter-pg`. No MySQL connection is ever constructed.
- Zero `mysql2` imports in our own source.
- The **only** import site in the entire prisma tree is a lazy `import("mysql2/promise")` inside the **`prisma studio`** command (`prisma/build/cli.js`). The gateway never runs Studio; its CMD runs `migrate deploy`.
- `@prisma/studio-core/data/mysql2` is a shim whose only import is an internal chunk — it does not require `mysql2` itself.

## `-path`, not `-name` — this part matters

The obvious edit (`-o -name mysql2`) **breaks the container**. It matches two directories:

```
node_modules/mysql2                                 <- the package (intended)
node_modules/@prisma/studio-core/dist/data/mysql2   <- adapter shim (NOT intended)
```

`build/cli.js` top-level-requires that shim alongside its siblings:

```js
var Cfe=require("@prisma/studio-core/data/bff"),
    Iit=require("@prisma/studio-core/data/mysql2"),
    Oit=require("@prisma/studio-core/data/node-sqlite"), ...
```

Deleting it makes the prisma CLI fail at load, so `migrate deploy` dies and the container never starts — the same hazard the existing `elkjs` comment flags ("studio-core itself stays ... removing it breaks the CLI"). Hence `-o -path '*/node_modules/mysql2'`, which matches the package and not the shim.

Verified by a dry run of the exact expression with `-print` substituted for `-exec rm -rf`, against an absolute root: `mysql2` and `elkjs` match, the studio-core shim survives.

## Verification — PR CI does not cover this

`publish-service-images.yml` is `workflow_dispatch`-only, so **no check on this PR builds the gateway image**. A green CI run says nothing about this change. The real verification is a dry-run dispatch on this branch, which builds and runs the Trivy gate without pushing:

```bash
gh workflow run publish-service-images.yml --ref 2026-09-05_prisma_vuln -f version=latest -f dry_run=true
```

What that must show: the Trivy gate passes, and the gateway container starts through `npx prisma migrate deploy`.

## Follow-up

Dependabot alert #145 stays **open** on purpose. It is filed against `package-lock.json`, which this PR does not change, and it is the signal for when this prune becomes retirable. Retire the entry when the gateway reaches prisma 8 and confirm `mysql2` is gone from its dependency set.

## Type of change

- [x] Security fix

## Areas changed

- [x] Gateway (`apps/gateway`) — Dockerfile only, no application code
