### PR TITLE
Decoding is not extraction

### DIFF
--- a/docs/development/MEDIA-TYPES.md
+++ b/docs/development/MEDIA-TYPES.md
@@ -19,7 +19,7 @@ interface MediaTypeCapabilities {
   label: string;
   render:      'text' | 'image' | 'pdf' | 'none';
   anchoring:   'text-selector' | 'spatial' | 'none';
-  extractText: 'decode' | 'pdf-text-layer' | 'none';
+  textSource: 'decode' | 'pdf-text-layer' | 'none';
   authorable: boolean;
   uploadable: boolean;
   generatable: boolean;
@@ -31,7 +31,7 @@ the spec enum without a capabilities row — or the reverse — is a compile err
 That drift-lock is the reason this guide can describe behavior by reading one
 table.
 
-| Media type | `render` | `anchoring` | `extractText` |
+| Media type | `render` | `anchoring` | `textSource` |
 |---|---|---|---|
 | `text/markdown`, `text/plain`, `text/html` | `text` | `text-selector` | `decode` |
 | `application/json` | `text` | `text-selector` | `decode` |
@@ -83,18 +83,39 @@ space of possible ones. Time-based media needs a fourth, and video needs a
 [Time-based media](#time-based-media-what-the-model-must-absorb) below before
 extending this axis.
 
-### `extractText` — how meaning is recovered, and what it costs
+### `textSource` — WHERE a type's text comes from
 
-Feeds the Smelter's gate (`textExtractionOf`). On a registry miss, base types
-under `text/*` fall back to `decode` — RFC 2046 guarantees the `text` top-level
-type is textual — and everything else is `none`.
+Read it with `textSourceOf(format)`. On a registry miss, base types under
+`text/*` fall back to `decode` — RFC 2046 guarantees the `text` top-level type is
+textual — and everything else is `none`.
 
 - **`decode`** — charset-aware passthrough. The text *is* the bytes. Free.
 - **`pdf-text-layer`** — parse the content stream, and where a page has no
   glyphs, rasterize and OCR it. Roughly **2.9 seconds per scanned page**.
-- **`none`** — no extractor. No embedding, no vector search, no AI detection.
+- **`none`** — no text to be had. No embedding, no vector search, no AI detection.
 
-`extractText: 'none'` is not a gap to fill. An image is annotatable
+**The two values are not two settings of one operation** (READ-VS-EXTRACT). They
+name genuinely different work, and the field was called `extractText` until that
+was noticed:
+
+| | `decode` | `pdf-text-layer` |
+|---|---|---|
+| cost | microseconds | minutes |
+| determinism | total | none, across engine versions |
+| artifact | none to persist | exactly one, canonical |
+| who may do it | anyone holding bytes | the Smelter alone — it needs the store |
+
+Calling both "extraction" made them interchangeable at every call site, and that
+is what let a worker OCR PDFs for four months. They are now separate surfaces:
+decoding is `decodeRepresentation` in this package; deriving is
+`derivingExtractorFor(mediaType)` in `@semiont/content`, callable only with the
+store that persists its output.
+
+**`yieldsGeometryOf(format)` is derived from this field**, not stored beside it —
+`pdf-text-layer` produces positioned runs, `decode` does not. A second stored
+field could contradict the one it came from.
+
+`textSource: 'none'` is not a gap to fill. An image is annotatable
 (`anchoring: 'spatial'`) and carries no text; that combination is coherent and
 final.
 
@@ -118,7 +139,7 @@ the reading direction only.
 
 When a PDF is generated, the model writes [Typst](https://typst.app/) source
 and a pinned compiler in the worker image renders it. The result is an ordinary
-born-digital PDF: `extractText: 'pdf-text-layer'` reads it exactly as it reads a
+born-digital PDF: `textSource: 'pdf-text-layer'` reads it exactly as it reads a
 PDF someone uploaded, and every rung of the running example below applies
 unchanged. There is no second path and no authored sidecar — the PDF's own text
 layer carries the geometry.
@@ -152,7 +173,7 @@ of the renderer degrading the typography.
 
 ## The running example: a PDF, end to end
 
-A PDF declares `render: 'pdf'`, `anchoring: 'spatial'`, `extractText:
+A PDF declares `render: 'pdf'`, `anchoring: 'spatial'`, `textSource:
 'pdf-text-layer'` — the hardest setting on every axis. Each numbered step below
 exists because of one of those three declarations.
 
@@ -388,7 +409,7 @@ each axis knowingly:
   the type is time-based, read the section above first — the axis needs
   extending before the row can be written honestly, and a row that understates
   its anchoring model is not something later annotations can be migrated off.
-- **`extractText: 'none'` is a valid destination**, not a placeholder. It means
+- **`textSource: 'none'` is a valid destination**, not a placeholder. It means
   no embedding, no search, and no AI detection for that type.
 - **Extraction that costs real time needs an artifact and a key.** Anything
   above passthrough cost should be content-addressed by checksum, written once,

--- a/docs/protocol/flows/MARK.md
+++ b/docs/protocol/flows/MARK.md
@@ -253,25 +253,22 @@ Detection logic lives in the `AnnotationDetection` class from [@semiont/jobs](..
 - **Detection Method**: [AnnotationDetection.detectHighlights()](../../../packages/jobs/src/workers/annotation-detection.ts)
 - **Job processor**: [processHighlightJob](../../../packages/jobs/src/processors.ts)
 - **Task**: Identify important/noteworthy passages
-- **Input**: First 8000 characters + optional user instructions
+- **Input**: The whole document, chunked to the derived budget + optional user instructions
 - **Output**: JSON array with `exact`, `start`, `end`, `prefix`, `suffix`
-- **Model params**: max_tokens=2000, temperature=0.3
 
 **Assessment Detection**:
 - **Detection Method**: [AnnotationDetection.detectAssessments()](../../../packages/jobs/src/workers/annotation-detection.ts)
 - **Job processor**: [processAssessmentJob](../../../packages/jobs/src/processors.ts)
 - **Task**: Assess and evaluate key passages
-- **Input**: First 8000 characters + optional user instructions
+- **Input**: The whole document, chunked to the derived budget + optional user instructions
 - **Output**: JSON array with `exact`, `start`, `end`, `prefix`, `suffix`, `assessment`
-- **Model params**: max_tokens=2000, temperature=0.3
 
 **Comment Detection**:
 - **Detection Method**: [AnnotationDetection.detectComments()](../../../packages/jobs/src/workers/annotation-detection.ts)
 - **Job processor**: [processCommentJob](../../../packages/jobs/src/processors.ts)
 - **Task**: Identify passages needing explanatory comments
-- **Input**: First 8000 characters + optional user instructions + optional tone (scholarly/explanatory/conversational/technical)
+- **Input**: The whole document, chunked to the derived budget + optional user instructions + optional tone (scholarly/explanatory/conversational/technical)
 - **Output**: JSON array with `exact`, `start`, `end`, `prefix`, `suffix`, `comment`
-- **Model params**: max_tokens=3000 (higher to allow for comment generation), temperature=0.4 (higher for creative context)
 - **Guidelines**: Emphasis on selectivity (3-8 comments per 2000 words), value beyond restating text, focus on context/background/clarification
 
 **Tag Detection**:
@@ -280,7 +277,6 @@ Detection logic lives in the `AnnotationDetection` class from [@semiont/jobs](..
 - **Task**: Detect and extract structured tags using ontology schemas
 - **Input**: Full document content + schema ID + category
 - **Output**: JSON array with `exact`, `start`, `end`, `prefix`, `suffix`, `category`
-- **Model params**: max_tokens=2000, temperature=0.3
 
 **Reference/Entity Detection**:
 - **Detection Method**: [AnnotationDetection.extractEntities()](../../../packages/jobs/src/workers/detection/entity-extractor.ts)
@@ -288,7 +284,12 @@ Detection logic lives in the `AnnotationDetection` class from [@semiont/jobs](..
 - **Task**: Identify entity references by type (Person, Location, Concept, etc.)
 - **Input**: Full document content + selected entity types (with optional examples)
 - **Output**: JSON array with `exact`, `entityType`, `startOffset`, `endOffset`, `prefix`, `suffix`
-- **Model params**: max_tokens=4000, temperature=0.3
+- **Concurrency**: entity types are independent, so they run in parallel up to the provider's `maxConcurrency`
+
+**Model parameters are not per-motivation.** All five share `temperature = 0`
+(detection is extraction, not generation) and an output budget **derived from the
+provider's limits** per chunk — there are no hand-set `max_tokens` values left to
+document. See "Long documents are chunked, not truncated" below.
 
 ### Detection Parameters
 
@@ -371,25 +372,39 @@ Controls the target number of annotations per 2000 words:
 
 **Prompt Impact**: When enabled, the AI is instructed to find both explicit names and descriptive references that clearly refer to entities.
 
-### Content Truncation Strategy
+### Long documents are chunked, not truncated
 
-| Detection Type | Content Limit | Rationale |
-|----------------|---------------|-----------|
-| Highlights | 8000 chars (~2000 words) | LLM context, response time, cost |
-| Assessments | 8000 chars (~2000 words) | LLM context, response time, cost |
-| Comments | 8000 chars (~2000 words) | LLM context, response time, cost (higher max_tokens for comment generation) |
-| References | Full document | Entity extraction needs complete context |
+**There is no character cap.** Detection derives its budget from the inference
+provider's *published limits* and chunks the document to fit — no hand-tuned
+constants, and document content never enters the arithmetic.
 
-**Impact**:
+Providers come in two shapes, and the budget follows:
 
-- Highlights/assessments/comments: Only first ~2000 words analyzed, long documents incomplete
-- References: Full document processed, but may hit max_tokens (4000) on very long documents
+- **Shared window** (Ollama publishes `maxOutputTokens === contextTokens`): what
+  remains after the prompt scaffold is split input:output **1:2**. Annotation
+  JSON echoes each span plus a fixed envelope, so output needs the larger share.
+- **Separate ceilings** (Anthropic): output takes its full ceiling, duration-capped;
+  input follows the same 1:2 allocation and is **never** more than half the output
+  budget.
 
-**Future Improvements**:
+Input deliberately does *not* get "the rest of the window." A window-sized chunk of
+entity-dense text demands more output than any budget holds, so the model grinds
+toward `max_tokens` for minutes or collapses to a degenerate empty result.
+**Chunking is the fix for that, not a cost of it.**
 
-- Chunking strategy with sliding window for highlights/assessments/comments
-- User-controlled excerpt selection
-- Multi-pass detection for long documents
+**Truncation is typed, and it is a signal.** A response that hits the output budget
+is caught per chunk by `assertNotTruncated` — never predicted in advance — and a
+chunk that overflows is **subdivided in place** rather than retried at the same
+size. That failure is the useful one: deterministic, and therefore actionable.
+
+**Entity types run in parallel, with a bound.** Independent entity types fan out
+concurrently, capped at the provider's `maxConcurrency` — unbounded fan-out just
+trades sequential waiting for 429 thrash, so the cap is the feature, not a
+limitation.
+
+For the numbers behind any of this, read
+[`detection-chunking.ts`](../../../packages/jobs/src/workers/detection/detection-chunking.ts);
+they move with provider limits and are deliberately not restated here.
 
 ### Response Validation
 
@@ -708,7 +723,7 @@ After detection completes:
 - **Position accuracy**: Annotations render at correct character positions
 - **Fuzzy anchoring**: Finds correct text even when LLM positions are wrong by searching for exact text and using prefix/suffix context for disambiguation
 - **CRLF handling**: Windows line endings normalized correctly ([CODEMIRROR-INTEGRATION.md](../../../packages/react-ui/docs/CODEMIRROR-INTEGRATION.md))
-- **Content limits**: Highlights/assessments/comments process first 8000 chars, references process full document
+- **Chunk coverage**: every motivation processes the whole document — chunk boundaries do not drop spans, and a chunk that overflows its output budget subdivides rather than silently truncating
 - **User instructions**: Influence LLM detection results as expected (highlights/assessments/comments)
 - **Tone selection**: Tone influences writing style as expected
   - Assessment tones: analytical/critical/balanced/constructive
@@ -725,12 +740,14 @@ After detection completes:
 
 ### Known Limitations
 
-1. **Content truncation**: Highlights/assessments/comments only analyze first 8000 characters (long documents incomplete)
-2. **Position approximation**: LLM positions may be ±5 characters off (fuzzy anchoring and validation compensate)
-3. **Single-pass processing**: No iterative refinement or confidence scores
-4. **No batch position validation**: Highlights/assessments/comments don't validate positions before creating annotations (rely on fuzzy anchoring)
-5. **Comment selectivity**: AI may occasionally over-comment or under-comment (target is 3-8 per 2000 words)
-6. **Reference max tokens**: Very long documents may hit 4000 token limit, truncating entity extraction response
+1. **Position approximation**: LLM positions may be ±5 characters off (fuzzy anchoring and validation compensate)
+2. **Single-pass processing**: No iterative refinement or confidence scores
+3. **No batch position validation**: Highlights/assessments/comments don't validate positions before creating annotations (rely on fuzzy anchoring)
+4. **Comment selectivity**: AI may occasionally over-comment or under-comment (target is 3-8 per 2000 words)
+
+*(Content truncation and a fixed token ceiling were listed here until budgets
+became provider-derived and long documents began chunking — see "Long documents
+are chunked, not truncated" above.)*
 
 ---
 

--- a/packages/content/src/__tests__/anchored-text-cache.test.ts
+++ b/packages/content/src/__tests__/anchored-text-cache.test.ts
@@ -53,7 +53,7 @@ vi.mock('../extract-pdf-text-layer', async (importOriginal) => {
   };
 });
 
-const { derivingExtractorFor } = await import('../content-extractor');
+const { derivingExtractorFor } = await import('../text-extractor');
 const { createAnchoredTextStore, encodeLines, decodeLines } = await import('../anchored-text-store');
 const { calculateChecksum } = await import('../checksum');
 const { locate, textUnder, getShardPath } = await import('@semiont/core');

--- a/packages/content/src/__tests__/anchored-text-cache.test.ts
+++ b/packages/content/src/__tests__/anchored-text-cache.test.ts
@@ -53,7 +53,7 @@ vi.mock('../extract-pdf-text-layer', async (importOriginal) => {
   };
 });
 
-const { EXTRACTORS } = await import('../content-extractor');
+const { derivingExtractorFor } = await import('../content-extractor');
 const { createAnchoredTextStore, encodeLines, decodeLines } = await import('../anchored-text-store');
 const { calculateChecksum } = await import('../checksum');
 const { locate, textUnder, getShardPath } = await import('@semiont/core');
@@ -62,7 +62,7 @@ type Item = import('@semiont/core').PdfTextItem;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, 'fixtures');
 const SCAN = fs.readFileSync(path.join(FIXTURES, 'scanned-image.pdf'));
-const pdfExtractor = EXTRACTORS['pdf-text-layer']!;
+const pdfExtractor = derivingExtractorFor('application/pdf')!;
 
 /** Entry files wherever the layout puts them — the pins that manipulate
  *  stored files find them by walking, so the layout can move without the
@@ -282,16 +282,13 @@ describe('anchored-text cache', () => {
     expect(recognizeSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('extracts normally when given no cache at all', { timeout: 60_000 }, async () => {
-    // The cache is optional: every existing caller passes nothing and must be
-    // unaffected. This fixture's raster is a synthetic bitmap font, which the
-    // recognizer correctly reads as nothing — so the unchanged behaviour being
-    // asserted is the clean decline, the same one 22-pdf-scanned-decline
-    // depends on. What matters here is that the engine still ran.
-    const out = await pdfExtractor.extract(SCAN, 'application/pdf');
-    expect(out).toEqual({ kind: 'declined', declined: 'no-text-layer' });
-    expect(recognizeSpy).toHaveBeenCalledTimes(1);
-  });
+  // DELETED by READ-VS-EXTRACT P2: 'extracts normally when given no cache at all'.
+  // Its premise — "the cache is optional: every existing caller passes nothing" —
+  // had already stopped being true (both live callers pass one), and P2 made the
+  // cache required, so the path it covered no longer exists to be tested. Its one
+  // live assertion, that a synthetic-bitmap scan declines cleanly after a full
+  // recognition pass, is covered by the cache-miss cases above, which run the same
+  // engine pass against the same fixture.
 
   // The negative is worth caching precisely because it is expensive: a scan the
   // engine cannot read costs a full recognition pass to discover, and without

--- a/packages/content/src/__tests__/content-extractor.test.ts
+++ b/packages/content/src/__tests__/content-extractor.test.ts
@@ -1,101 +1,138 @@
 /**
- * ContentExtractor registry — Phase 0 (SMELTER-MEDIA-TYPES.md, #743).
+ * Deriving text, and who is allowed to (SMELTER-MEDIA-TYPES #743;
+ * READ-VS-EXTRACT P1/P2).
  *
- * The registry resolves by `TextExtraction` strategy, consuming core's
- * media-type vocabulary directly — no second media-type table. Phase 0
- * fills only the 'decode' slot (passthrough over `decodeRepresentation`,
- * today's exact behavior, now scoped); 'pdf-text-layer' stays null until
- * Phase 1 (#744) fills it.
+ * The strategy-keyed `EXTRACTORS` registry these tests used to cover is gone.
+ * It held one real extractor and a one-line wrapper around core's
+ * `decodeRepresentation` — whose own behavior (UTF-8, charset parameters, the
+ * no-charset default) is tested in `@semiont/core`'s `resource-utils.test.ts`,
+ * so the wrapper's tests were duplicating that through an indirection and left
+ * with it.
+ *
+ * What is covered here is what remains: which media types need deriving, that
+ * deriving cannot be reached without the store that persists it, and that core's
+ * geometry answer matches what actually runs.
  */
 
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
-import { yieldsGeometryOf, type TextExtraction } from '@semiont/core';
-import { EXTRACTORS } from '../content-extractor';
+import { yieldsGeometryOf, decodeRepresentation, type TextExtraction, type ExtractionOutcome } from '@semiont/core';
+import { derivingExtractorFor } from '../content-extractor';
+import type { AnchoredTextStore } from '../anchored-text-store';
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
-describe('EXTRACTORS registry (Phase 0)', () => {
-  it("resolves 'decode' to the passthrough extractor", () => {
-    expect(EXTRACTORS['decode']).not.toBeNull();
+describe('derivingExtractorFor (READ-VS-EXTRACT P2)', () => {
+  it('answers for the one media type whose text must be derived', () => {
+    expect(derivingExtractorFor('application/pdf')).not.toBeNull();
   });
 
-  it("resolves 'pdf-text-layer' to the pdf extractor (Phase 1, #744)", () => {
-    expect(EXTRACTORS['pdf-text-layer']).not.toBeNull();
+  it('answers null for text — decoding is not deriving, and is core\'s job', () => {
+    // The deleted registry returned a passthrough extractor here, making
+    // "decode UTF-8" and "OCR a scan" the same call. Callers now reach
+    // `decodeRepresentation` in @semiont/core directly, as five sites in
+    // @semiont/make-meaning already did.
+    expect(derivingExtractorFor('text/markdown')).toBeNull();
+    expect(derivingExtractorFor('text/plain')).toBeNull();
+    expect(derivingExtractorFor('application/json')).toBeNull();
   });
 
-  it("resolves 'none' to null — nothing to extract", () => {
-    expect(EXTRACTORS['none']).toBeNull();
+  it('answers null where there is no text at all', () => {
+    expect(derivingExtractorFor('image/png')).toBeNull();
+  });
+
+  it('tolerates parameters and case, like the core accessor it reads', () => {
+    expect(derivingExtractorFor('application/pdf; version=1.7')).not.toBeNull();
+    expect(derivingExtractorFor('APPLICATION/PDF')).not.toBeNull();
   });
 });
 
-describe('passthrough extractor', () => {
-  it('decodes UTF-8 bytes verbatim as text-passthrough', async () => {
-    const text = '# Heading\n\nStig Dagerman — swedish prose, naïve façade.';
-    const ex = EXTRACTORS['decode'];
-    expect(ex).not.toBeNull();
-    const out = await ex!.extract(Buffer.from(text, 'utf8'), 'text/markdown');
-    expect(out).toEqual({ kind: 'extracted', text, method: 'text-passthrough' });
+describe('deriving requires the store that persists what it derives (READ-VS-EXTRACT P2)', () => {
+  // The ownership rule, enforced by the type rather than by a convention: an
+  // `ExtractionCache` carries an `AnchoredTextStore`, only the Smelter holds
+  // one, so only the Smelter can call this. A worker cannot derive by accident
+  // because it cannot construct the argument.
+  //
+  // These assertions are the COMPILER's — `@ts-expect-error` fails `tsc` if the
+  // call ever starts type-checking, which is exactly the regression to catch.
+  // Nothing is invoked; a runtime guard would be the fifth thing to remember,
+  // and remembering is what this phase removes.
+  it('does not type-check without a cache', () => {
+    const extractor = derivingExtractorFor('application/pdf')!;
+    const call = () =>
+      // @ts-expect-error - deriving without the store is not reachable (P2)
+      extractor.extract(Buffer.from(''), 'application/pdf');
+    expect(typeof call).toBe('function');
   });
 
-  it('honors the charset parameter via decodeRepresentation', async () => {
-    // 'café' in ISO-8859-1 is a single 0xE9 byte for é — a UTF-8 decode
-    // would mangle it, so this pins the charset-aware path.
-    const latin1 = Buffer.from('café', 'latin1');
-    const ex = EXTRACTORS['decode'];
-    expect(ex).not.toBeNull();
-    const out = await ex!.extract(latin1, 'text/plain; charset=iso-8859-1');
-    if (out.kind === 'declined') throw new Error('unexpected decline');
-    expect(out.text).toBe('café');
-    expect(out.method).toBe('text-passthrough');
+  it('type-checks with one', () => {
+    const extractor = derivingExtractorFor('application/pdf')!;
+    const store = { read: async () => undefined, write: async () => {} } as unknown as AnchoredTextStore;
+    const call = () => extractor.extract(Buffer.from(''), 'application/pdf', { key: 'k', store });
+    expect(typeof call).toBe('function');
   });
 });
 
 /**
- * The census gate for READ-VS-EXTRACT P1.
+ * The census gate for READ-VS-EXTRACT P1, restated against P2's shape.
  *
- * `yieldsGeometry` used to be a boolean declared on each extractor, beside the
- * implementations, in this package — while the strategy that determines it lives
- * in core's media-type registry. Two homes for one fact. P1 deleted the boolean
- * and made core's `yieldsGeometryOf` the single home.
+ * P1 deleted the `yieldsGeometry` boolean each extractor declared and made core's
+ * `yieldsGeometryOf` the single home. That removes the chance of two
+ * *declarations* disagreeing, but not the thing that matters: core can still be
+ * wrong about what the code DOES. So the gate is behavioral — for every strategy,
+ * check that positioned runs appear exactly where core says they will.
  *
- * That removes the possibility of the two *declarations* disagreeing, but not the
- * thing that actually matters: core can still be wrong about what an extractor
- * DOES. So the gate is behavioral — run each strategy's extractor and check that
- * positioned runs appear exactly where core says they will. Asserting core's
- * answer against a second hand-written table would be a mirror; asserting it
- * against the extractor's output cannot be.
+ * Asserting core's answer against a second hand-written table would be a mirror;
+ * asserting it against what actually runs cannot be.
  */
-describe('core\'s geometry answer matches what the extractors produce (READ-VS-EXTRACT P1)', () => {
+describe("core's geometry answer matches what actually runs (READ-VS-EXTRACT P1/P2)", () => {
   // Keyed by strategy, so a strategy added in core fails to compile here until
-  // someone decides which media type exercises it — the same exhaustiveness
-  // `EXTRACTORS: Record<TextExtraction, …>` already gives the registry itself.
-  // `bytes: null` means the strategy runs nothing; core must still answer.
+  // someone decides which media type exercises it.
   const PROBES: Record<TextExtraction, { mediaType: string; bytes: (() => Buffer) | null }> = {
     'decode': { mediaType: 'text/markdown', bytes: () => Buffer.from('# just text\n') },
     'pdf-text-layer': {
       mediaType: 'application/pdf',
       bytes: () => fs.readFileSync(path.join(FIXTURES, 'single-line.pdf')),
     },
+    // Nothing reads this type at all; core must still answer.
     'none': { mediaType: 'image/png', bytes: null },
   };
 
-  for (const [strategy, probe] of Object.entries(PROBES) as [TextExtraction, { mediaType: string; bytes: (() => Buffer) | null }][]) {
+  const memoryStore = (): AnchoredTextStore => {
+    const kept = new Map<string, ExtractionOutcome>();
+    return {
+      read: async (key: string) => kept.get(key),
+      write: async (key: string, outcome: ExtractionOutcome) => { kept.set(key, outcome); },
+    } as unknown as AnchoredTextStore;
+  };
+
+  for (const [strategy, probe] of Object.entries(PROBES) as [TextExtraction, typeof PROBES['decode']][]) {
     it(`'${strategy}': positioned runs appear iff core says the type yields geometry`, async () => {
-      const extractor = EXTRACTORS[strategy];
+      const extractor = derivingExtractorFor(probe.mediaType);
 
       if (!probe.bytes) {
-        // The strategy names a capability nothing provides, so there is no
-        // behavior to compare against — only that both sides agree there is none.
         expect(extractor).toBeNull();
         expect(yieldsGeometryOf(probe.mediaType)).toBe(false);
         return;
       }
 
-      expect(extractor).not.toBeNull();
-      const out = await extractor!.extract(probe.bytes(), probe.mediaType);
+      // Whether a deriving extractor exists at all is itself the geometry
+      // answer — P2 keyed the accessor on `yieldsGeometryOf`, so this pins the
+      // two together before either is run.
+      expect(extractor !== null).toBe(yieldsGeometryOf(probe.mediaType));
+
+      if (!extractor) {
+        // The decode route: core's own function, the same call the Smelter and
+        // the detection worker make. A string, never geometry.
+        const text = decodeRepresentation(probe.bytes(), probe.mediaType);
+        expect(typeof text).toBe('string');
+        expect(yieldsGeometryOf(probe.mediaType)).toBe(false);
+        return;
+      }
+
+      const out = await extractor.extract(probe.bytes(), probe.mediaType, { key: 'probe', store: memoryStore() });
       if (out.kind === 'declined') throw new Error(`probe for '${strategy}' declined: ${out.declined}`);
 
       const carriesGeometry = (out.items?.length ?? 0) > 0;

--- a/packages/content/src/__tests__/content-extractor.test.ts
+++ b/packages/content/src/__tests__/content-extractor.test.ts
@@ -8,8 +8,14 @@
  * Phase 1 (#744) fills it.
  */
 
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
+import { yieldsGeometryOf, type TextExtraction } from '@semiont/core';
 import { EXTRACTORS } from '../content-extractor';
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
 describe('EXTRACTORS registry (Phase 0)', () => {
   it("resolves 'decode' to the passthrough extractor", () => {
@@ -45,4 +51,55 @@ describe('passthrough extractor', () => {
     expect(out.text).toBe('café');
     expect(out.method).toBe('text-passthrough');
   });
+});
+
+/**
+ * The census gate for READ-VS-EXTRACT P1.
+ *
+ * `yieldsGeometry` used to be a boolean declared on each extractor, beside the
+ * implementations, in this package — while the strategy that determines it lives
+ * in core's media-type registry. Two homes for one fact. P1 deleted the boolean
+ * and made core's `yieldsGeometryOf` the single home.
+ *
+ * That removes the possibility of the two *declarations* disagreeing, but not the
+ * thing that actually matters: core can still be wrong about what an extractor
+ * DOES. So the gate is behavioral — run each strategy's extractor and check that
+ * positioned runs appear exactly where core says they will. Asserting core's
+ * answer against a second hand-written table would be a mirror; asserting it
+ * against the extractor's output cannot be.
+ */
+describe('core\'s geometry answer matches what the extractors produce (READ-VS-EXTRACT P1)', () => {
+  // Keyed by strategy, so a strategy added in core fails to compile here until
+  // someone decides which media type exercises it — the same exhaustiveness
+  // `EXTRACTORS: Record<TextExtraction, …>` already gives the registry itself.
+  // `bytes: null` means the strategy runs nothing; core must still answer.
+  const PROBES: Record<TextExtraction, { mediaType: string; bytes: (() => Buffer) | null }> = {
+    'decode': { mediaType: 'text/markdown', bytes: () => Buffer.from('# just text\n') },
+    'pdf-text-layer': {
+      mediaType: 'application/pdf',
+      bytes: () => fs.readFileSync(path.join(FIXTURES, 'single-line.pdf')),
+    },
+    'none': { mediaType: 'image/png', bytes: null },
+  };
+
+  for (const [strategy, probe] of Object.entries(PROBES) as [TextExtraction, { mediaType: string; bytes: (() => Buffer) | null }][]) {
+    it(`'${strategy}': positioned runs appear iff core says the type yields geometry`, async () => {
+      const extractor = EXTRACTORS[strategy];
+
+      if (!probe.bytes) {
+        // The strategy names a capability nothing provides, so there is no
+        // behavior to compare against — only that both sides agree there is none.
+        expect(extractor).toBeNull();
+        expect(yieldsGeometryOf(probe.mediaType)).toBe(false);
+        return;
+      }
+
+      expect(extractor).not.toBeNull();
+      const out = await extractor!.extract(probe.bytes(), probe.mediaType);
+      if (out.kind === 'declined') throw new Error(`probe for '${strategy}' declined: ${out.declined}`);
+
+      const carriesGeometry = (out.items?.length ?? 0) > 0;
+      expect(carriesGeometry).toBe(yieldsGeometryOf(probe.mediaType));
+    });
+  }
 });

--- a/packages/content/src/__tests__/extraction-limits.test.ts
+++ b/packages/content/src/__tests__/extraction-limits.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { derivingExtractorFor } from '../content-extractor';
+import { derivingExtractorFor } from '../text-extractor';
 import type { AnchoredTextStore } from '../anchored-text-store';
 
 const NO_CACHE = { key: 'test', store: { read: async () => undefined, write: async () => {} } as unknown as AnchoredTextStore };

--- a/packages/content/src/__tests__/extraction-limits.test.ts
+++ b/packages/content/src/__tests__/extraction-limits.test.ts
@@ -17,7 +17,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { EXTRACTORS } from '../content-extractor';
+import { derivingExtractorFor } from '../content-extractor';
+import type { AnchoredTextStore } from '../anchored-text-store';
+
+const NO_CACHE = { key: 'test', store: { read: async () => undefined, write: async () => {} } as unknown as AnchoredTextStore };
 import { MAX_PDF_BYTES, withinByteBudget } from '../pdf-extractor';
 import { MAX_IMAGE_PIXELS, PEAK_BYTES_PER_PIXEL, withinPixelBudget, extractPageImages } from '../pdf-page-images';
 
@@ -89,7 +92,7 @@ describe('input size budget', () => {
         const oversized = Buffer.alloc(0);
         Object.defineProperty(oversized, 'length', { value: MAX_PDF_BYTES + 1 });
 
-        const out = await EXTRACTORS['pdf-text-layer']!.extract(oversized, 'application/pdf');
+        const out = await derivingExtractorFor('application/pdf')!.extract(oversized, 'application/pdf', NO_CACHE);
         expect(out).toEqual({ kind: 'declined', declined: 'too-large' });
     });
 });

--- a/packages/content/src/__tests__/pdf-extractor.test.ts
+++ b/packages/content/src/__tests__/pdf-extractor.test.ts
@@ -12,7 +12,12 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { describe, it, expect } from 'vitest';
 import { extractPdfTextLayer } from '../extract-pdf-text-layer';
-import { EXTRACTORS } from '../content-extractor';
+import { derivingExtractorFor } from '../content-extractor';
+import type { AnchoredTextStore } from '../anchored-text-store';
+
+/** Deriving requires the store (READ-VS-EXTRACT P2); these cases are about the
+ *  extraction itself, so the store is a black hole that keeps nothing. */
+const NO_CACHE = { key: 'test', store: { read: async () => undefined, write: async () => {} } as unknown as AnchoredTextStore };
 import { classifyPdfError } from '../pdf-extractor';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -23,13 +28,13 @@ const KNOWN_PHRASE = 'known phrase from fixture';
 
 describe('pdfExtractor (Phase 1 registry slot)', () => {
     it("fills the 'pdf-text-layer' slot", () => {
-        expect(EXTRACTORS['pdf-text-layer']).not.toBeNull();
+        expect(derivingExtractorFor('application/pdf')).not.toBeNull();
     });
 
     it('class A: extracts the text layer with items and pdfClass', async () => {
-        const ex = EXTRACTORS['pdf-text-layer'];
+        const ex = derivingExtractorFor('application/pdf');
         expect(ex).not.toBeNull();
-        const out = await ex!.extract(readFixture('single-line.pdf'), 'application/pdf');
+        const out = await ex!.extract(readFixture('single-line.pdf'), 'application/pdf', NO_CACHE);
         expect(out).not.toHaveProperty('declined');
         if (out.kind === 'declined') throw new Error('unreachable');
         expect(out.text).toContain(KNOWN_PHRASE);
@@ -41,25 +46,25 @@ describe('pdfExtractor (Phase 1 registry slot)', () => {
     });
 
     it("class B: scanned PDF declines 'no-text-layer'", async () => {
-        const ex = EXTRACTORS['pdf-text-layer'];
+        const ex = derivingExtractorFor('application/pdf');
         expect(ex).not.toBeNull();
-        const out = await ex!.extract(readFixture('scanned.pdf'), 'application/pdf');
+        const out = await ex!.extract(readFixture('scanned.pdf'), 'application/pdf', NO_CACHE);
         expect(out).toEqual({ kind: 'declined', declined: 'no-text-layer' });
     });
 
     it("class G: corrupt bytes decline 'corrupt'", async () => {
-        const ex = EXTRACTORS['pdf-text-layer'];
+        const ex = derivingExtractorFor('application/pdf');
         expect(ex).not.toBeNull();
-        const out = await ex!.extract(Buffer.from('not a pdf at all', 'utf8'), 'application/pdf');
+        const out = await ex!.extract(Buffer.from('not a pdf at all', 'utf8'), 'application/pdf', NO_CACHE);
         expect(out).toEqual({ kind: 'declined', declined: 'corrupt' });
     });
 });
 
 describe('class C — hybrid native/scanned routing (Phase 3)', () => {
     const extract = async (fixture: string) => {
-        const ex = EXTRACTORS['pdf-text-layer'];
+        const ex = derivingExtractorFor('application/pdf');
         expect(ex).not.toBeNull();
-        return ex!.extract(readFixture(fixture), 'application/pdf');
+        return ex!.extract(readFixture(fixture), 'application/pdf', NO_CACHE);
     };
 
     it('names the pages it could not read, and labels the document hybrid', async () => {
@@ -90,9 +95,9 @@ describe('class C — hybrid native/scanned routing (Phase 3)', () => {
 
 describe('class D — table structure (Phase 2)', () => {
     const extract = async (fixture: string) => {
-        const ex = EXTRACTORS['pdf-text-layer'];
+        const ex = derivingExtractorFor('application/pdf');
         expect(ex).not.toBeNull();
-        const out = await ex!.extract(readFixture(fixture), 'application/pdf');
+        const out = await ex!.extract(readFixture(fixture), 'application/pdf', NO_CACHE);
         if (out.kind === 'declined') throw new Error(`unexpected decline: ${out.declined}`);
         return out;
     };
@@ -135,9 +140,9 @@ describe('class D — table structure (Phase 2)', () => {
 
 describe('class E — AcroForm field values (Phase 2)', () => {
     const extract = async (fixture: string) => {
-        const ex = EXTRACTORS['pdf-text-layer'];
+        const ex = derivingExtractorFor('application/pdf');
         expect(ex).not.toBeNull();
-        const out = await ex!.extract(readFixture(fixture), 'application/pdf');
+        const out = await ex!.extract(readFixture(fixture), 'application/pdf', NO_CACHE);
         if (out.kind === 'declined') throw new Error(`unexpected decline: ${out.declined}`);
         return out;
     };

--- a/packages/content/src/__tests__/pdf-extractor.test.ts
+++ b/packages/content/src/__tests__/pdf-extractor.test.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { describe, it, expect } from 'vitest';
 import { extractPdfTextLayer } from '../extract-pdf-text-layer';
-import { derivingExtractorFor } from '../content-extractor';
+import { derivingExtractorFor } from '../text-extractor';
 import type { AnchoredTextStore } from '../anchored-text-store';
 
 /** Deriving requires the store (READ-VS-EXTRACT P2); these cases are about the

--- a/packages/content/src/__tests__/pdf-ocr.test.ts
+++ b/packages/content/src/__tests__/pdf-ocr.test.ts
@@ -13,7 +13,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { derivingExtractorFor } from '../content-extractor';
+import { derivingExtractorFor } from '../text-extractor';
 import type { AnchoredTextStore } from '../anchored-text-store';
 
 const NO_CACHE = { key: 'test', store: { read: async () => undefined, write: async () => {} } as unknown as AnchoredTextStore };

--- a/packages/content/src/__tests__/pdf-ocr.test.ts
+++ b/packages/content/src/__tests__/pdf-ocr.test.ts
@@ -13,7 +13,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { EXTRACTORS } from '../content-extractor';
+import { derivingExtractorFor } from '../content-extractor';
+import type { AnchoredTextStore } from '../anchored-text-store';
+
+const NO_CACHE = { key: 'test', store: { read: async () => undefined, write: async () => {} } as unknown as AnchoredTextStore };
 import { recognizeImages, type OcrWord } from '../ocr';
 
 vi.mock('../ocr', () => ({ recognizeImages: vi.fn() }));
@@ -23,7 +26,7 @@ const FIXTURES = path.join(__dirname, 'fixtures');
 const readFixture = (name: string): Buffer => fs.readFileSync(path.join(FIXTURES, name));
 
 const extract = (fixture: string) =>
-    EXTRACTORS['pdf-text-layer']!.extract(readFixture(fixture), 'application/pdf');
+    derivingExtractorFor('application/pdf')!.extract(readFixture(fixture), 'application/pdf', NO_CACHE);
 
 /** Every image recognizes as the same known text, as one word per token. */
 const recognizesAs = (text: string) => {

--- a/packages/content/src/__tests__/text-extractor.test.ts
+++ b/packages/content/src/__tests__/text-extractor.test.ts
@@ -18,8 +18,8 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
-import { yieldsGeometryOf, decodeRepresentation, type TextExtraction, type ExtractionOutcome } from '@semiont/core';
-import { derivingExtractorFor } from '../content-extractor';
+import { yieldsGeometryOf, decodeRepresentation, type TextSource, type ExtractionOutcome } from '@semiont/core';
+import { derivingExtractorFor } from '../text-extractor';
 import type { AnchoredTextStore } from '../anchored-text-store';
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
@@ -90,7 +90,7 @@ describe('deriving requires the store that persists what it derives (READ-VS-EXT
 describe("core's geometry answer matches what actually runs (READ-VS-EXTRACT P1/P2)", () => {
   // Keyed by strategy, so a strategy added in core fails to compile here until
   // someone decides which media type exercises it.
-  const PROBES: Record<TextExtraction, { mediaType: string; bytes: (() => Buffer) | null }> = {
+  const PROBES: Record<TextSource, { mediaType: string; bytes: (() => Buffer) | null }> = {
     'decode': { mediaType: 'text/markdown', bytes: () => Buffer.from('# just text\n') },
     'pdf-text-layer': {
       mediaType: 'application/pdf',
@@ -108,7 +108,7 @@ describe("core's geometry answer matches what actually runs (READ-VS-EXTRACT P1/
     } as unknown as AnchoredTextStore;
   };
 
-  for (const [strategy, probe] of Object.entries(PROBES) as [TextExtraction, typeof PROBES['decode']][]) {
+  for (const [strategy, probe] of Object.entries(PROBES) as [TextSource, typeof PROBES['decode']][]) {
     it(`'${strategy}': positioned runs appear iff core says the type yields geometry`, async () => {
       const extractor = derivingExtractorFor(probe.mediaType);
 

--- a/packages/content/src/content-extractor.ts
+++ b/packages/content/src/content-extractor.ts
@@ -1,20 +1,24 @@
 /**
- * ContentExtractor — strategy-keyed text extraction for embedding.
+ * ContentExtractor — DERIVING text from bytes that carry none of their own.
  *
- * The registry is keyed by `TextExtraction` from `@semiont/core` — the
- * media-type registry's dispatch vocabulary — never by a second media-type
- * list (SMELTER-MEDIA-TYPES.md, Design §1): there is exactly one media-type
- * table in the system, and this registry consumes it. The Smelter resolves
- * `textExtractionOf(contentType)` and looks the extractor up by strategy; a
- * `null` slot means decline (settle skipped, reason 'no-extractor').
+ * Scope note (READ-VS-EXTRACT P2): this file used to hold a strategy-keyed
+ * registry covering both ways a resource yields text — decoding (charset-aware
+ * `Buffer → string`) and deriving (parse a PDF, OCR it when there is no text
+ * layer). Those share a name and almost nothing else: microseconds vs. minutes,
+ * total determinism vs. none across engine versions, no canonical artifact vs.
+ * exactly one, and anyone-with-bytes vs. the Smelter alone. The registry made
+ * them interchangeable at every call site.
  *
- * Extraction is ephemeral: `extract` runs at read time, its output feeds the
- * chunker, and is discarded — no stored derived representation. Annotations
- * anchor to native geometry (`items`), never to extracted-text offsets, so
- * re-extraction can never break an anchor.
+ * Decoding left: it is `decodeRepresentation` in `@semiont/core`, called
+ * directly. What remains here is the deriving half, reached through
+ * `derivingExtractorFor` and callable only with the store that persists its
+ * output.
+ *
+ * Anchoring is unaffected: annotations anchor to native geometry (`items`),
+ * never to extracted-text offsets, so re-derivation can never break an anchor.
  */
 
-import { decodeRepresentation, type TextExtraction, type PdfTextItem } from '@semiont/core';
+import { yieldsGeometryOf, type PdfTextItem } from '@semiont/core';
 import type { AnchoredTextStore } from './anchored-text-store';
 import { pdfExtractor } from './pdf-extractor';
 
@@ -83,12 +87,15 @@ export interface ExtractionDecline {
  * (PERSIST-ANCHORS P1b); readers mirror it (P1c). One SHA-256 over bytes
  * already in memory is noise against the engine pass a hit avoids.
  *
- * Optional throughout: a caller that passes nothing extracts uncached and is
- * unaffected. The seam is `extract()` itself (PERSIST-ANCHORS D1/P2b): a hit
- * returns the FINISHED outcome — classification, geometry, provenance, or a
- * named decline — so neither the native parse nor the engine runs. Every
- * geometry-yielding extraction produces an entry, native documents included;
- * the 'decode' strategy ignores the cache (no geometry, nothing expensive).
+ * REQUIRED, and that is the ownership rule (READ-VS-EXTRACT P2). It carries an
+ * `AnchoredTextStore`, and only the Smelter holds one — so deriving is reachable
+ * exactly to the process that can persist what it derived. The restriction is a
+ * capability the caller must already hold, not a convention it must remember:
+ * a would-be second producer cannot construct the argument, so it cannot compile.
+ *
+ * The seam is `extract()` itself (PERSIST-ANCHORS D1/P2b): a hit returns the
+ * FINISHED outcome — classification, geometry, provenance, or a named decline —
+ * so neither the native parse nor the engine runs.
  */
 export interface ExtractionCache {
   key: string;
@@ -106,28 +113,40 @@ export interface ExtractionCache {
  */
 export interface ContentExtractor {
   /**
-   * Extract embeddable/annotatable text, or decline with the class reason
-   * (scanned-without-OCR, encrypted, corrupt). The caller skips embedding
-   * and settles skipped with that reason.
+   * Derive text WITH geometry from bytes that carry no text of their own, or
+   * decline with the class reason (scanned-without-OCR, encrypted, corrupt).
+   * The caller skips embedding and settles skipped with that reason.
+   *
+   * Expensive, non-deterministic across engine versions, and the sole producer
+   * of a canonical artifact — which is why `cache` is required rather than
+   * optional (see `ExtractionCache`).
    */
-  extract(content: Buffer, mediaType: string, cache?: ExtractionCache): Promise<ExtractedText | ExtractionDecline>;
+  extract(content: Buffer, mediaType: string, cache: ExtractionCache): Promise<ExtractedText | ExtractionDecline>;
 }
 
-/** Charset-aware decode of textual bytes — the pre-registry behavior, now
- *  scoped as the 'decode' strategy's extractor. Never declines: any byte
- *  sequence decodes to *some* string; emptiness is the caller's call. */
-const passthroughExtractor: ContentExtractor = {
-  async extract(content, mediaType) {
-    return { kind: 'extracted', text: decodeRepresentation(content, mediaType), method: 'text-passthrough' };
-  },
-};
-
 /**
- * Strategy → extractor. A `null` slot is a decline: the strategy names a
- * capability nothing currently provides ('none' permanently).
+ * The deriving extractor for a media type, or `null` when its text needs no
+ * deriving.
+ *
+ * **This replaced a `Record<TextExtraction, ContentExtractor | null>` keyed by
+ * strategy (READ-VS-EXTRACT P2), and the deletion is the point.** That map held
+ * one real extractor, a `null`, and — under 'decode' — a one-line wrapper around
+ * core's `decodeRepresentation`, which five sites in `@semiont/make-meaning`
+ * already called directly. Resolving "give me an extractor for this media type"
+ * therefore returned, half the time, a trivial function dressed as the same
+ * capability as OCR: identical at the call site, wildly different in cost,
+ * determinism, and who is allowed to run it. That symmetry is what let a
+ * detection worker OCR scanned PDFs for four months without anyone reading it as
+ * a category error (#739).
+ *
+ * Decoding is now a direct `decodeRepresentation()` call at the two sites that
+ * need it. There is no registry to resolve, so there is no way to reach OCR by
+ * asking a generic question — and a caller that gets a non-null answer here still
+ * cannot run it without an `AnchoredTextStore`.
+ *
+ * Keyed by P1's `yieldsGeometryOf`, so this and the Smelter's publish gate cannot
+ * disagree about which media types have a canonical artifact.
  */
-export const EXTRACTORS: Record<TextExtraction, ContentExtractor | null> = {
-  'decode': passthroughExtractor,
-  'pdf-text-layer': pdfExtractor,
-  'none': null,
-};
+export function derivingExtractorFor(mediaType: string): ContentExtractor | null {
+  return yieldsGeometryOf(mediaType) ? pdfExtractor : null;
+}

--- a/packages/content/src/content-extractor.ts
+++ b/packages/content/src/content-extractor.ts
@@ -95,18 +95,16 @@ export interface ExtractionCache {
   store: AnchoredTextStore;
 }
 
+/**
+ * Whether a strategy's extractions carry positioned runs lives in
+ * `@semiont/core`'s `yieldsGeometryOf`, NOT here (READ-VS-EXTRACT P1). It is a
+ * property of the strategy, and the strategy vocabulary is core's — declaring it
+ * per-implementation made it two facts that could disagree, and forced consumers
+ * asking about a media type to resolve an implementation to find out.
+ * `content-extractor.test.ts` gates core's answer against what these extractors
+ * actually produce.
+ */
 export interface ContentExtractor {
-  /**
-   * Whether this strategy's extractions carry positioned runs (`items`) — the
-   * geometry an anchored-text artifact is made of. Declared, not probed:
-   * the reconcile planner must know "should an artifact exist?" without
-   * running the extractor (PERSIST-ANCHORS P0, the third drift class), and
-   * the declaration keeps the planner's gate and the live fetch's behavior
-   * twins by construction. Text strategies anchor by character offset and
-   * declare false.
-   */
-  yieldsGeometry: boolean;
-
   /**
    * Extract embeddable/annotatable text, or decline with the class reason
    * (scanned-without-OCR, encrypted, corrupt). The caller skips embedding
@@ -119,7 +117,6 @@ export interface ContentExtractor {
  *  scoped as the 'decode' strategy's extractor. Never declines: any byte
  *  sequence decodes to *some* string; emptiness is the caller's call. */
 const passthroughExtractor: ContentExtractor = {
-  yieldsGeometry: false,
   async extract(content, mediaType) {
     return { kind: 'extracted', text: decodeRepresentation(content, mediaType), method: 'text-passthrough' };
   },

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -21,11 +21,11 @@ export {
 // `decodeRepresentation`, called directly).
 export {
   derivingExtractorFor,
-  type ContentExtractor,
+  type TextExtractor,
   type ExtractedText,
   type ExtractionDecline,
   type ExtractionCache,
-} from './content-extractor';
+} from './text-extractor';
 
 // Extraction byte budget (#1124). Also the generation output bound
 // (PDF-GENERATION P5): an artifact we generate must stay within the budget

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -16,9 +16,11 @@ export {
   verifyChecksum
 } from './checksum';
 
-// Strategy-keyed text extraction for embedding (SMELTER-MEDIA-TYPES)
+// Deriving text from bytes that carry none (SMELTER-MEDIA-TYPES; narrowed to
+// the deriving half by READ-VS-EXTRACT P2 — decoding is core's
+// `decodeRepresentation`, called directly).
 export {
-  EXTRACTORS,
+  derivingExtractorFor,
   type ContentExtractor,
   type ExtractedText,
   type ExtractionDecline,

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -225,7 +225,7 @@ export const pdfExtractor: ContentExtractor = {
     // code that did the deriving. Declines are first-class hits: "we read
     // this and there was nothing" costs a full recognition pass to discover,
     // so the negative is precisely the result worth keeping.
-    const hit = await cache?.store.read(cache.key);
+    const hit = await cache.store.read(cache.key);
     if (hit) return hit;
 
     const outcome = await extractPdf(content);
@@ -238,13 +238,11 @@ export const pdfExtractor: ContentExtractor = {
     // is where "best-effort" is chosen, by the seam that wants it. Previously
     // the store swallowed for every caller and this comment described a
     // property it did not own.
-    if (cache) {
-      try {
-        if (outcome.kind === 'declined') await cache.store.write(cache.key, outcome);
-        else if (outcome.items) await cache.store.write(cache.key, { ...outcome, items: outcome.items });
-      } catch {
-        // Cached nothing; the outcome below is still correct.
-      }
+    try {
+      if (outcome.kind === 'declined') await cache.store.write(cache.key, outcome);
+      else if (outcome.items) await cache.store.write(cache.key, { ...outcome, items: outcome.items });
+    } catch {
+      // Cached nothing; the outcome below is still correct.
     }
     return outcome;
   },

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -210,8 +210,9 @@ function shapeTables(layer: PdfTextLayer): ExtractedText | null {
 
 export const pdfExtractor: ContentExtractor = {
   // Every non-declined PDF extraction carries positioned runs — native text
-  // layers and OCR both anchor by page geometry.
-  yieldsGeometry: true,
+  // layers and OCR both anchor by page geometry. That fact is declared in core
+  // ('pdf-text-layer' → true) rather than here; this comment records the
+  // behavior the census gate holds core's answer to.
   async extract(content, _mediaType, cache) {
     // The seam (PERSIST-ANCHORS D1/P2b): consult the store for the FINISHED
     // outcome before anything runs — byte gate, native parse, image decode

--- a/packages/content/src/pdf-extractor.ts
+++ b/packages/content/src/pdf-extractor.ts
@@ -18,7 +18,7 @@
 
 import { isObject, type PdfTextItem } from '@semiont/core';
 import { extractPdfTextLayer } from './extract-pdf-text-layer';
-import type { ContentExtractor, ExtractedText, ExtractionDecline } from './content-extractor';
+import type { TextExtractor, ExtractedText, ExtractionDecline } from './text-extractor';
 import type { PdfTextLayer } from './pdf-text-layer';
 import { detectTable, renderTable } from './pdf-tables';
 import { extractPageImages } from './pdf-page-images';
@@ -208,7 +208,7 @@ function shapeTables(layer: PdfTextLayer): ExtractedText | null {
   return { kind: 'extracted', text, items, method: 'table', pdfClass: 'D' };
 }
 
-export const pdfExtractor: ContentExtractor = {
+export const pdfExtractor: TextExtractor = {
   // Every non-declined PDF extraction carries positioned runs — native text
   // layers and OCR both anchor by page geometry. That fact is declared in core
   // ('pdf-text-layer' → true) rather than here; this comment records the

--- a/packages/content/src/text-extractor.ts
+++ b/packages/content/src/text-extractor.ts
@@ -1,10 +1,10 @@
 /**
- * ContentExtractor — DERIVING text from bytes that carry none of their own.
+ * TextExtractor — DERIVING text from bytes that carry none of their own.
  *
- * Scope note (READ-VS-EXTRACT P2): this file used to hold a strategy-keyed
- * registry covering both ways a resource yields text — decoding (charset-aware
- * `Buffer → string`) and deriving (parse a PDF, OCR it when there is no text
- * layer). Those share a name and almost nothing else: microseconds vs. minutes,
+ * Scope note (READ-VS-EXTRACT P2/P3): this file used to hold a registry covering
+ * both ways a resource yields text — decoding (charset-aware `Buffer → string`)
+ * and deriving (parse a PDF, OCR it when there is no text layer). Those shared a
+ * name and almost nothing else: microseconds vs. minutes,
  * total determinism vs. none across engine versions, no canonical artifact vs.
  * exactly one, and anyone-with-bytes vs. the Smelter alone. The registry made
  * them interchangeable at every call site.
@@ -76,7 +76,7 @@ export interface ExtractionDecline {
 }
 
 /**
- * Where a strategy may reuse an earlier recognition, and under what key.
+ * Where a derivation may reuse an earlier recognition, and under what key.
  *
  * The caller supplies the key, and derives it from the bytes it actually
  * holds — `calculateChecksum` over the same Buffer it passes to `extract()` —
@@ -103,15 +103,22 @@ export interface ExtractionCache {
 }
 
 /**
- * Whether a strategy's extractions carry positioned runs lives in
- * `@semiont/core`'s `yieldsGeometryOf`, NOT here (READ-VS-EXTRACT P1). It is a
- * property of the strategy, and the strategy vocabulary is core's — declaring it
- * per-implementation made it two facts that could disagree, and forced consumers
- * asking about a media type to resolve an implementation to find out.
- * `content-extractor.test.ts` gates core's answer against what these extractors
- * actually produce.
+ * Deriving text from bytes that carry none of their own.
+ *
+ * Named `ContentExtractor` until READ-VS-EXTRACT P3: the `Content` prefix named
+ * the INPUT, when what distinguishes this type is that it produces TEXT — by
+ * deriving, which since P3 is the only thing "extraction" means here. WHERE a
+ * media type's text comes from at all is core's `TextSource`, which spans both
+ * routes and is therefore not called extraction.
+ *
+ * Whether a text source yields positioned runs lives in `@semiont/core`'s
+ * `yieldsGeometryOf`, NOT here (P1). It is a property of the source, and that
+ * vocabulary is core's — declaring it per-implementation made it two facts that
+ * could disagree, and forced consumers asking about a media type to resolve an
+ * implementation to find out. `text-extractor.test.ts` gates core's answer
+ * against what these extractors actually produce.
  */
-export interface ContentExtractor {
+export interface TextExtractor {
   /**
    * Derive text WITH geometry from bytes that carry no text of their own, or
    * decline with the class reason (scanned-without-OCR, encrypted, corrupt).
@@ -128,7 +135,7 @@ export interface ContentExtractor {
  * The deriving extractor for a media type, or `null` when its text needs no
  * deriving.
  *
- * **This replaced a `Record<TextExtraction, ContentExtractor | null>` keyed by
+ * **This replaced a `Record<TextSource, TextExtractor | null>` keyed by
  * strategy (READ-VS-EXTRACT P2), and the deletion is the point.** That map held
  * one real extractor, a `null`, and — under 'decode' — a one-line wrapper around
  * core's `decodeRepresentation`, which five sites in `@semiont/make-meaning`
@@ -147,6 +154,6 @@ export interface ContentExtractor {
  * Keyed by P1's `yieldsGeometryOf`, so this and the Smelter's publish gate cannot
  * disagree about which media types have a canonical artifact.
  */
-export function derivingExtractorFor(mediaType: string): ContentExtractor | null {
+export function derivingExtractorFor(mediaType: string): TextExtractor | null {
   return yieldsGeometryOf(mediaType) ? pdfExtractor : null;
 }

--- a/packages/core/src/__tests__/media-types.test.ts
+++ b/packages/core/src/__tests__/media-types.test.ts
@@ -14,7 +14,7 @@ import {
   capabilitiesOf,
   extensionForMediaType,
   mediaTypeForExtension,
-  textExtractionOf,
+  textSourceOf,
   isAnnotatable,
   yieldsGeometryOf,
   AUTHORABLE_MEDIA_TYPES,
@@ -83,7 +83,7 @@ describe('media-types registry', () => {
     it('extracts text from every text/* row (embed anything that decodes as text)', () => {
       for (const [type, caps] of rows) {
         if (type.startsWith('text/')) {
-          expect(caps.extractText, type).toBe('decode');
+          expect(caps.textSource, type).toBe('decode');
         }
       }
     });
@@ -93,31 +93,31 @@ describe('media-types registry', () => {
     it('pins the seven curated rows', () => {
       expect(MEDIA_TYPES['text/markdown']).toEqual({
         extension: '.md', label: 'Markdown', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: true, uploadable: true, generatable: true,
+        textSource: 'decode', authorable: true, uploadable: true, generatable: true,
       });
       expect(MEDIA_TYPES['text/plain']).toEqual({
         extension: '.txt', label: 'Plain Text', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: true, uploadable: true, generatable: true,
+        textSource: 'decode', authorable: true, uploadable: true, generatable: true,
       });
       expect(MEDIA_TYPES['text/html']).toEqual({
         extension: '.html', label: 'HTML', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: true, uploadable: true, generatable: false,
+        textSource: 'decode', authorable: true, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['application/json']).toEqual({
         extension: '.json', label: 'JSON', render: 'text', anchoring: 'text-selector',
-        extractText: 'decode', authorable: false, uploadable: true, generatable: false,
+        textSource: 'decode', authorable: false, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['image/png']).toEqual({
         extension: '.png', label: 'PNG image', render: 'image', anchoring: 'spatial',
-        extractText: 'none', authorable: false, uploadable: true, generatable: false,
+        textSource: 'none', authorable: false, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['image/jpeg']).toEqual({
         extension: '.jpg', label: 'JPEG image', render: 'image', anchoring: 'spatial',
-        extractText: 'none', authorable: false, uploadable: true, generatable: false,
+        textSource: 'none', authorable: false, uploadable: true, generatable: false,
       });
       expect(MEDIA_TYPES['application/pdf']).toEqual({
         extension: '.pdf', label: 'PDF', render: 'pdf', anchoring: 'spatial',
-        extractText: 'pdf-text-layer', authorable: false, uploadable: true, generatable: true,
+        textSource: 'pdf-text-layer', authorable: false, uploadable: true, generatable: true,
       });
     });
   });
@@ -186,12 +186,12 @@ describe('media-types registry', () => {
       expect(isAnnotatable('application/x-proprietary')).toBe(false);
       expect(isAnnotatable('')).toBe(false);
 
-      // The asymmetry with textExtractionOf is deliberate, not an oversight.
+      // The asymmetry with textSourceOf is deliberate, not an oversight.
       // Extracting the wrong bytes costs one bad vector and refusing to
       // extract costs a resource nobody can find, so extraction guesses. An
       // annotation is a durable write against a coordinate model the system
       // does not have for an unknown type, so it refuses.
-      expect(textExtractionOf('text/x-obscure-notation')).toBe('decode');
+      expect(textSourceOf('text/x-obscure-notation')).toBe('decode');
       expect(isAnnotatable('text/x-obscure-notation')).toBe(false);
     });
   });
@@ -225,21 +225,21 @@ describe('media-types registry', () => {
       expect(EMBEDDABLE_MEDIA_TYPES.filter(yieldsGeometryOf)).toEqual(['application/pdf']);
     });
 
-    it('agrees with textExtractionOf on every registry row — one fact, derived', () => {
+    it('agrees with textSourceOf on every registry row — one fact, derived', () => {
       // The census gate the duplicated pair lacked. Not a mirror: the expectation
       // is COMPUTED from the strategy, so it cannot drift from the thing it
       // derives from. A new strategy makes GEOMETRY_BY_STRATEGY fail to compile
       // in media-types.ts, which is where the fact belongs.
       for (const type of Object.keys(MEDIA_TYPES) as SupportedMediaType[]) {
-        expect(yieldsGeometryOf(type), type).toBe(textExtractionOf(type) === 'pdf-text-layer');
+        expect(yieldsGeometryOf(type), type).toBe(textSourceOf(type) === 'pdf-text-layer');
       }
     });
 
-    it('is lenient like textExtractionOf, not strict like isAnnotatable', () => {
-      // An unregistered text/* type decodes (textExtractionOf's leniency), and
+    it('is lenient like textSourceOf, not strict like isAnnotatable', () => {
+      // An unregistered text/* type decodes (textSourceOf's leniency), and
       // decoding yields no geometry — so the answer is a real false, not a
       // refusal. Nothing here is a durable write, so there is nothing to protect.
-      expect(textExtractionOf('text/x-obscure-notation')).toBe('decode');
+      expect(textSourceOf('text/x-obscure-notation')).toBe('decode');
       expect(yieldsGeometryOf('text/x-obscure-notation')).toBe(false);
       expect(yieldsGeometryOf('application/x-proprietary')).toBe(false);
       expect(yieldsGeometryOf('')).toBe(false);
@@ -438,27 +438,27 @@ describe('media-types registry', () => {
     });
   });
 
-  describe('textExtractionOf (the Smelter gate)', () => {
+  describe('textSourceOf (the Smelter gate)', () => {
     it('answers from registry rows', () => {
-      expect(textExtractionOf('text/markdown')).toBe('decode');
-      expect(textExtractionOf('application/json')).toBe('decode');
-      expect(textExtractionOf('application/pdf')).toBe('pdf-text-layer');
-      expect(textExtractionOf('image/png')).toBe('none');
-      expect(textExtractionOf('application/zip')).toBe('none');
+      expect(textSourceOf('text/markdown')).toBe('decode');
+      expect(textSourceOf('application/json')).toBe('decode');
+      expect(textSourceOf('application/pdf')).toBe('pdf-text-layer');
+      expect(textSourceOf('image/png')).toBe('none');
+      expect(textSourceOf('application/zip')).toBe('none');
     });
 
     it('decodes unregistered text/* (RFC 2046 — imported text subtypes embed)', () => {
-      expect(textExtractionOf('text/x-obscure-notation')).toBe('decode');
-      expect(textExtractionOf('text/x-obscure-notation; charset=iso-8859-1')).toBe('decode');
+      expect(textSourceOf('text/x-obscure-notation')).toBe('decode');
+      expect(textSourceOf('text/x-obscure-notation; charset=iso-8859-1')).toBe('decode');
     });
 
     it('never decodes unregistered non-text types — no mojibake', () => {
-      expect(textExtractionOf('application/x-proprietary')).toBe('none');
-      expect(textExtractionOf('chemical/x-pdb')).toBe('none');
+      expect(textSourceOf('application/x-proprietary')).toBe('none');
+      expect(textSourceOf('chemical/x-pdb')).toBe('none');
     });
 
     it('treats SVG as binary despite its XML body (image/* is not text/*)', () => {
-      expect(textExtractionOf('image/svg+xml')).toBe('none');
+      expect(textSourceOf('image/svg+xml')).toBe('none');
     });
   });
 
@@ -469,7 +469,7 @@ describe('media-types registry', () => {
 
     it('EMBEDDABLE_MEDIA_TYPES is exactly the rows with text extraction', () => {
       for (const type of EMBEDDABLE_MEDIA_TYPES) {
-        expect(MEDIA_TYPES[type].extractText).not.toBe('none');
+        expect(MEDIA_TYPES[type].textSource).not.toBe('none');
       }
       expect(EMBEDDABLE_MEDIA_TYPES).toContain('application/pdf');
       expect(EMBEDDABLE_MEDIA_TYPES).toContain('text/x-python');

--- a/packages/core/src/__tests__/media-types.test.ts
+++ b/packages/core/src/__tests__/media-types.test.ts
@@ -16,6 +16,7 @@ import {
   mediaTypeForExtension,
   textExtractionOf,
   isAnnotatable,
+  yieldsGeometryOf,
   AUTHORABLE_MEDIA_TYPES,
   EMBEDDABLE_MEDIA_TYPES,
   GENERATABLE_MEDIA_TYPES,
@@ -192,6 +193,61 @@ describe('media-types registry', () => {
       // does not have for an unknown type, so it refuses.
       expect(textExtractionOf('text/x-obscure-notation')).toBe('decode');
       expect(isAnnotatable('text/x-obscure-notation')).toBe(false);
+    });
+  });
+
+  describe('yieldsGeometryOf (READ-VS-EXTRACT P1)', () => {
+    // The question is about a MEDIA TYPE, so core answers it. Before P1 it was a
+    // boolean declared on each extractor in @semiont/content — a property of the
+    // strategy, stored beside the implementations, in another package. Two homes
+    // for one fact, gated by nothing.
+    it("is true for the one strategy that derives geometry", () => {
+      expect(yieldsGeometryOf('application/pdf')).toBe(true);
+    });
+
+    it('is false for decoded text — the text itself is the coordinate system', () => {
+      expect(yieldsGeometryOf('text/markdown')).toBe(false);
+      expect(yieldsGeometryOf('text/plain')).toBe(false);
+      expect(yieldsGeometryOf('text/html')).toBe(false);
+      expect(yieldsGeometryOf('application/json')).toBe(false);
+    });
+
+    it("is false where there is no text to extract at all", () => {
+      expect(yieldsGeometryOf('image/png')).toBe(false);
+      expect(yieldsGeometryOf('image/jpeg')).toBe(false);
+    });
+
+    it('answers without resolving an extractor — the reconcile planner\'s need', () => {
+      // PERSIST-ANCHORS P0, the third drift class: the planner asks "should an
+      // anchored-text artifact exist for this resource?" over a whole catalog,
+      // and must not construct or run an extractor to find out. That this file
+      // can answer at all, with no dependency on @semiont/content, IS the test.
+      expect(EMBEDDABLE_MEDIA_TYPES.filter(yieldsGeometryOf)).toEqual(['application/pdf']);
+    });
+
+    it('agrees with textExtractionOf on every registry row — one fact, derived', () => {
+      // The census gate the duplicated pair lacked. Not a mirror: the expectation
+      // is COMPUTED from the strategy, so it cannot drift from the thing it
+      // derives from. A new strategy makes GEOMETRY_BY_STRATEGY fail to compile
+      // in media-types.ts, which is where the fact belongs.
+      for (const type of Object.keys(MEDIA_TYPES) as SupportedMediaType[]) {
+        expect(yieldsGeometryOf(type), type).toBe(textExtractionOf(type) === 'pdf-text-layer');
+      }
+    });
+
+    it('is lenient like textExtractionOf, not strict like isAnnotatable', () => {
+      // An unregistered text/* type decodes (textExtractionOf's leniency), and
+      // decoding yields no geometry — so the answer is a real false, not a
+      // refusal. Nothing here is a durable write, so there is nothing to protect.
+      expect(textExtractionOf('text/x-obscure-notation')).toBe('decode');
+      expect(yieldsGeometryOf('text/x-obscure-notation')).toBe(false);
+      expect(yieldsGeometryOf('application/x-proprietary')).toBe(false);
+      expect(yieldsGeometryOf('')).toBe(false);
+    });
+
+    it('tolerates parameters and case, like every other accessor here', () => {
+      expect(yieldsGeometryOf('application/pdf; version=1.7')).toBe(true);
+      expect(yieldsGeometryOf('APPLICATION/PDF')).toBe(true);
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -307,7 +307,7 @@ export {
   cloneFormat,
   extensionForMediaType,
   mediaTypeForExtension,
-  textExtractionOf,
+  textSourceOf,
   yieldsGeometryOf,
   isAnnotatable,
   AUTHORABLE_MEDIA_TYPES,
@@ -319,7 +319,7 @@ export type {
   MediaTypeCapabilities,
   RenderMode,
   AnchoringModel,
-  TextExtraction,
+  TextSource,
 } from './media-types';
 
 // Resource types

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -308,6 +308,7 @@ export {
   extensionForMediaType,
   mediaTypeForExtension,
   textExtractionOf,
+  yieldsGeometryOf,
   isAnnotatable,
   AUTHORABLE_MEDIA_TYPES,
   EMBEDDABLE_MEDIA_TYPES,

--- a/packages/core/src/media-types.ts
+++ b/packages/core/src/media-types.ts
@@ -264,6 +264,43 @@ export function textExtractionOf(format: string): TextExtraction {
 }
 
 /**
+ * Whether a strategy's extraction carries positioned runs (`items`) — the
+ * geometry an anchored-text artifact is made of.
+ *
+ * Exhaustive over `TextExtraction` on purpose: a new strategy fails to compile
+ * here until someone decides which side it is on, so the next media type cannot
+ * default into the wrong answer. Private — `yieldsGeometryOf` is the surface.
+ */
+const GEOMETRY_BY_STRATEGY: Record<TextExtraction, boolean> = {
+  'decode': false,
+  'pdf-text-layer': true,
+  'none': false,
+};
+
+/**
+ * WHETHER a type's extracted text carries geometry — page-positioned runs
+ * rather than a bare string. Answers "should an anchored-text artifact exist
+ * for this resource?" (PERSIST-ANCHORS P0, the third drift class) and "does
+ * this type anchor spatially or by character offset?".
+ *
+ * Derived from `extractText`, not stored: until READ-VS-EXTRACT P1 this was a
+ * `yieldsGeometry` boolean declared on each `ContentExtractor` in
+ * `@semiont/content` — a property of the STRATEGY, declared per-implementation,
+ * in a different package from the strategy vocabulary. Two facts that must
+ * agree, gated by nothing, and consumers asking about a media type had to
+ * resolve an implementation to get an answer.
+ *
+ * Lenient like `textExtractionOf`, not strict like `isAnnotatable`. An
+ * unregistered `text/*` type decodes, and decoding yields no geometry — so
+ * `false` here is a real answer rather than a refusal. Nothing downstream is a
+ * durable write against a coordinate model, which is what makes `isAnnotatable`
+ * strict.
+ */
+export function yieldsGeometryOf(format: string): boolean {
+  return GEOMETRY_BY_STRATEGY[textExtractionOf(format)];
+}
+
+/**
  * WHETHER a type can carry annotations — `anchoring` remains the authority on
  * HOW. Derived rather than stored: a parallel `annotatable` row field would be
  * two facts that can disagree, with nothing to adjudicate

--- a/packages/core/src/media-types.ts
+++ b/packages/core/src/media-types.ts
@@ -9,8 +9,11 @@
  * - `render`      — which viewer the UI mounts ('none' → metadata + download)
  * - `anchoring`   — which annotation model applies: character-offset text
  *                   selectors vs spatial geometry (PDFs are spatial)
- * - `extractText` — how the Smelter gets embeddable text ('none' → skip
- *                   embedding, never mojibake)
+ * - `textSource`  — WHERE a type's text comes from: decoded from its own bytes,
+ *                   or derived by reading them ('none' → skip embedding, never
+ *                   mojibake). Named `extractText` until READ-VS-EXTRACT P3,
+ *                   which called decoding an extraction — the conflation that
+ *                   let a worker OCR PDFs for four months (#739)
  * - `authorable`  — offered in the compose editor's format dropdown
  * - `uploadable`  — big tent: true for every registry member
  * - `generatable` — the generation worker can produce it as a yield artifact
@@ -36,7 +39,7 @@ export type SupportedMediaType = components['schemas']['SupportedMediaType'];
 
 export type RenderMode = 'text' | 'image' | 'pdf' | 'none';
 export type AnchoringModel = 'text-selector' | 'spatial' | 'none';
-export type TextExtraction = 'decode' | 'pdf-text-layer' | 'none';
+export type TextSource = 'decode' | 'pdf-text-layer' | 'none';
 
 export interface MediaTypeCapabilities {
   /** Canonical file extension, with leading dot. */
@@ -45,7 +48,7 @@ export interface MediaTypeCapabilities {
   label: string;
   render: RenderMode;
   anchoring: AnchoringModel;
-  extractText: TextExtraction;
+  textSource: TextSource;
   authorable: boolean;
   uploadable: boolean;
   /** Whether the generation worker can produce this type as a yield artifact.
@@ -61,7 +64,7 @@ const storedBinary = (extension: `.${string}`, label: string): MediaTypeCapabili
   label,
   render: 'none',
   anchoring: 'none',
-  extractText: 'none',
+  textSource: 'none',
   authorable: false,
   uploadable: true,
   generatable: false,
@@ -70,7 +73,7 @@ const storedBinary = (extension: `.${string}`, label: string): MediaTypeCapabili
 /** Storage tier, text-flavored: embedded (charset-aware decode), not rendered. */
 const storedText = (extension: `.${string}`, label: string): MediaTypeCapabilities => ({
   ...storedBinary(extension, label),
-  extractText: 'decode',
+  textSource: 'decode',
 });
 
 /**
@@ -86,13 +89,13 @@ export const MEDIA_TYPES = {
   // Full-capability tier
   // `generatable: application/pdf` — the Typst renderer (PDF-GENERATION P3):
   // the model writes Typst, the worker's pinned binary compiles it.
-  'text/markdown':    { extension: '.md',   label: 'Markdown',   render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true, generatable: true },
-  'text/plain':       { extension: '.txt',  label: 'Plain Text', render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true, generatable: true },
-  'text/html':        { extension: '.html', label: 'HTML',       render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: true,  uploadable: true, generatable: false },
-  'application/json': { extension: '.json', label: 'JSON',       render: 'text',  anchoring: 'text-selector', extractText: 'decode',         authorable: false, uploadable: true, generatable: false },
-  'image/png':        { extension: '.png',  label: 'PNG image',  render: 'image', anchoring: 'spatial',       extractText: 'none',           authorable: false, uploadable: true, generatable: false },
-  'image/jpeg':       { extension: '.jpg',  label: 'JPEG image', render: 'image', anchoring: 'spatial',       extractText: 'none',           authorable: false, uploadable: true, generatable: false },
-  'application/pdf':  { extension: '.pdf',  label: 'PDF',        render: 'pdf',   anchoring: 'spatial',       extractText: 'pdf-text-layer', authorable: false, uploadable: true, generatable: true },
+  'text/markdown':    { extension: '.md',   label: 'Markdown',   render: 'text',  anchoring: 'text-selector', textSource: 'decode',         authorable: true,  uploadable: true, generatable: true },
+  'text/plain':       { extension: '.txt',  label: 'Plain Text', render: 'text',  anchoring: 'text-selector', textSource: 'decode',         authorable: true,  uploadable: true, generatable: true },
+  'text/html':        { extension: '.html', label: 'HTML',       render: 'text',  anchoring: 'text-selector', textSource: 'decode',         authorable: true,  uploadable: true, generatable: false },
+  'application/json': { extension: '.json', label: 'JSON',       render: 'text',  anchoring: 'text-selector', textSource: 'decode',         authorable: false, uploadable: true, generatable: false },
+  'image/png':        { extension: '.png',  label: 'PNG image',  render: 'image', anchoring: 'spatial',       textSource: 'none',           authorable: false, uploadable: true, generatable: false },
+  'image/jpeg':       { extension: '.jpg',  label: 'JPEG image', render: 'image', anchoring: 'spatial',       textSource: 'none',           authorable: false, uploadable: true, generatable: false },
+  'application/pdf':  { extension: '.pdf',  label: 'PDF',        render: 'pdf',   anchoring: 'spatial',       textSource: 'pdf-text-layer', authorable: false, uploadable: true, generatable: true },
 
   // Storage tier — the big tent. Every row is a deliberate admission,
   // promotable by editing its row. Text-flavored rows embed (decode).
@@ -252,26 +255,33 @@ export function mediaTypeForExtension(ext: string): SupportedMediaType | undefin
 }
 
 /**
- * The Smelter's gate: how to get embeddable text from a format. Registry
- * rows answer directly; on a registry miss, base types under text/* decode
- * (RFC 2046 guarantees the text top-level type is textual — imported
- * unregistered text subtypes embed too), everything else is 'none'.
+ * WHERE a format's text comes from. Registry rows answer directly; on a registry
+ * miss, base types under text/* decode (RFC 2046 guarantees the text top-level
+ * type is textual — imported unregistered text subtypes embed too), everything
+ * else is 'none'.
+ *
+ * The three answers are different operations, not degrees of one: `decode` is a
+ * pure charset-aware `Buffer → string` anyone holding bytes may run;
+ * `pdf-text-layer` parses and, failing that, OCRs — expensive, not deterministic
+ * across engine versions, and runnable only by the process that persists its
+ * output. Calling both "extraction" is what this accessor was named for until
+ * READ-VS-EXTRACT P3.
  */
-export function textExtractionOf(format: string): TextExtraction {
+export function textSourceOf(format: string): TextSource {
   const caps = capabilitiesOf(format);
-  if (caps) return caps.extractText;
+  if (caps) return caps.textSource;
   return baseMediaType(format).startsWith('text/') ? 'decode' : 'none';
 }
 
 /**
- * Whether a strategy's extraction carries positioned runs (`items`) — the
- * geometry an anchored-text artifact is made of.
+ * Whether a text source yields positioned runs (`items`) — the geometry an
+ * anchored-text artifact is made of. Only deriving does.
  *
- * Exhaustive over `TextExtraction` on purpose: a new strategy fails to compile
+ * Exhaustive over `TextSource` on purpose: a new strategy fails to compile
  * here until someone decides which side it is on, so the next media type cannot
  * default into the wrong answer. Private — `yieldsGeometryOf` is the surface.
  */
-const GEOMETRY_BY_STRATEGY: Record<TextExtraction, boolean> = {
+const GEOMETRY_BY_STRATEGY: Record<TextSource, boolean> = {
   'decode': false,
   'pdf-text-layer': true,
   'none': false,
@@ -283,21 +293,21 @@ const GEOMETRY_BY_STRATEGY: Record<TextExtraction, boolean> = {
  * for this resource?" (PERSIST-ANCHORS P0, the third drift class) and "does
  * this type anchor spatially or by character offset?".
  *
- * Derived from `extractText`, not stored: until READ-VS-EXTRACT P1 this was a
- * `yieldsGeometry` boolean declared on each `ContentExtractor` in
+ * Derived from `textSource`, not stored: until READ-VS-EXTRACT P1 this was a
+ * `yieldsGeometry` boolean declared on each `TextExtractor` in
  * `@semiont/content` — a property of the STRATEGY, declared per-implementation,
  * in a different package from the strategy vocabulary. Two facts that must
  * agree, gated by nothing, and consumers asking about a media type had to
  * resolve an implementation to get an answer.
  *
- * Lenient like `textExtractionOf`, not strict like `isAnnotatable`. An
+ * Lenient like `textSourceOf`, not strict like `isAnnotatable`. An
  * unregistered `text/*` type decodes, and decoding yields no geometry — so
  * `false` here is a real answer rather than a refusal. Nothing downstream is a
  * durable write against a coordinate model, which is what makes `isAnnotatable`
  * strict.
  */
 export function yieldsGeometryOf(format: string): boolean {
-  return GEOMETRY_BY_STRATEGY[textExtractionOf(format)];
+  return GEOMETRY_BY_STRATEGY[textSourceOf(format)];
 }
 
 /**
@@ -306,9 +316,9 @@ export function yieldsGeometryOf(format: string): boolean {
  * two facts that can disagree, with nothing to adjudicate
  * `{ annotatable: true, anchoring: 'none' }`.
  *
- * Strict on a registry miss, where `textExtractionOf` above is lenient. The
- * asymmetry is deliberate. Extracting the wrong bytes costs one bad vector,
- * and refusing to extract costs a resource nobody can find, so extraction
+ * Strict on a registry miss, where `textSourceOf` above is lenient. The
+ * asymmetry is deliberate. Reading the wrong bytes costs one bad vector, and
+ * refusing to read costs a resource nobody can find, so the text source
  * guesses; an annotation is a durable write against a coordinate model the
  * system does not have for an unknown type, so it refuses.
  */
@@ -324,10 +334,10 @@ export const AUTHORABLE_MEDIA_TYPES: readonly SupportedMediaType[] = REGISTRY_KE
   (type) => MEDIA_TYPES[type].authorable,
 );
 
-/** Registry rows whose text the Smelter can extract. Rows only — the
- *  text/* fallback in `textExtractionOf` isn't enumerable. */
+/** Registry rows whose text the Smelter can get at, by either route. Rows only —
+ *  the text/* fallback in `textSourceOf` isn't enumerable. */
 export const EMBEDDABLE_MEDIA_TYPES: readonly SupportedMediaType[] = REGISTRY_KEYS.filter(
-  (type) => MEDIA_TYPES[type].extractText !== 'none',
+  (type) => MEDIA_TYPES[type].textSource !== 'none',
 );
 
 /** Types the generation worker can produce as a yield artifact — the

--- a/packages/jobs/src/__tests__/prepare-detection.test.ts
+++ b/packages/jobs/src/__tests__/prepare-detection.test.ts
@@ -21,7 +21,7 @@ vi.mock('@semiont/content', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@semiont/content')>();
   return {
     ...actual,
-    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn(), yieldsGeometry: true } },
+    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn() } },
   };
 });
 // No `@semiont/event-sourcing` mock: annotation ids are content-addressed
@@ -137,7 +137,7 @@ describe('prepareDetection', () => {
     expect(sels.some((s) => s.type === 'TextQuoteSelector')).toBe(true);
   });
 
-  it('a class A PDF takes the consult path too — the rule is yieldsGeometry, not "is it a scan"', async () => {
+  it('a class A PDF takes the consult path too — the rule is yieldsGeometryOf, not "is it a scan"', async () => {
     // A class-A carve-out would reintroduce a second producer for an operation
     // that is merely *probably* deterministic. The consult, not the pdfClass,
     // decides.

--- a/packages/jobs/src/__tests__/prepare-detection.test.ts
+++ b/packages/jobs/src/__tests__/prepare-detection.test.ts
@@ -12,24 +12,23 @@
  * the media type — positioned runs anchor by viewrect, their absence
  * anchors by character offset in that same text.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { resourceId } from '@semiont/core';
 import type { components } from '@semiont/core';
 import type { PdfTextItem } from '@semiont/core';
 
-vi.mock('@semiont/content', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@semiont/content')>();
-  return {
-    ...actual,
-    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn() } },
-  };
-});
+// No `@semiont/content` mock. Since READ-VS-EXTRACT P2 this seam imports nothing
+// from it that runs — deriving is reachable only through `derivingExtractorFor`
+// and callable only with an `AnchoredTextStore`, which this worker does not have.
+// The `pdfExtract` spy that used to prove "the worker did not OCR" had no target
+// left; the `getBinary` assertions below prove the same thing observably, and
+// better: no bytes fetched is no derivation possible.
 // No `@semiont/event-sourcing` mock: annotation ids are content-addressed
 // (JOB-RESTART-SAFETY P3), so the real function is already deterministic. The
 // mock existed only to buy that determinism, and keeping it would hide the
 // identity these builders now compute — which is the thing worth exercising.
 
-import { EXTRACTORS, type ContentReads } from '@semiont/content';
+import type { ContentReads } from '@semiont/content';
 import { prepareDetection } from '../workers/detection/prepare-detection';
 
 type Agent = components['schemas']['Agent'];
@@ -51,9 +50,6 @@ const PDF_ITEMS: PdfTextItem[] = [
   { start: 11, end: 16, page: 1, x: 72,  y: 700, width: 45, height: 12 },
   { start: 17, end: 22, page: 1, x: 125, y: 700, width: 42, height: 12 },
 ];
-
-/** The PDF slot, stubbed — the only extractor these tests fake. */
-const pdfExtract = vi.mocked(EXTRACTORS['pdf-text-layer']!.extract);
 
 /**
  * The byte read, serving `text`. A plain `ContentReads` rather than a
@@ -82,7 +78,6 @@ const selectors = (ann: Record<string, unknown>): Sel[] =>
   (ann.target as { selector: Sel[] }).selector;
 
 describe('prepareDetection', () => {
-  beforeEach(() => { pdfExtract.mockReset(); });
 
   // ── NON-geometry: decode the bytes, no consult ──────────────────────────
 
@@ -127,7 +122,6 @@ describe('prepareDetection', () => {
 
     expect(consult).toHaveBeenCalledWith(RID);
     expect(getBinary).not.toHaveBeenCalled();
-    expect(pdfExtract).not.toHaveBeenCalled();
     expect(source.text).toBe(PDF_TEXT);
 
     const ann = source.buildAnnotation('highlighting', { exact: 'alpha', start: 0, end: 5 }) as Record<string, unknown>;
@@ -159,7 +153,6 @@ describe('prepareDetection', () => {
     // No fallback extraction: a local OCR pass that runs and is discarded still
     // burns the CPU this plan exists to stop duplicating.
     expect(getBinary).not.toHaveBeenCalled();
-    expect(pdfExtract).not.toHaveBeenCalled();
   });
 
   it("a no-map consult answer declines 'no-map' (TERMINAL — drift on a geometry type)", async () => {

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -71,7 +71,6 @@ vi.mock('@semiont/content', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@semiont/content')>();
   return {
     ...actual,
-    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn() } },
     // PDF citation geometry (P4): the worker re-anchors claims through the
     // extracted text layer; tests supply it.
     extractPdfTextLayer: vi.fn(),

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -917,7 +917,7 @@ describe('handleJob orchestration', () => {
   // ── Detection media-type gate (MEDIA-TYPES.md Phase 3c) ──────────────
   // browse.resourceContent() sends Accept: text/plain and TextDecoder-
   // decodes whatever returns, so a detection job on a binary resource
-  // would feed mojibake to the LLM. The gate checks textExtractionOf
+  // would feed mojibake to the LLM. The gate checks textSourceOf
   // on the resource's primary media type before fetching.
 
   describe('detection media-type gate', () => {

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -71,7 +71,7 @@ vi.mock('@semiont/content', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@semiont/content')>();
   return {
     ...actual,
-    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn(), yieldsGeometry: true } },
+    EXTRACTORS: { ...actual.EXTRACTORS, 'pdf-text-layer': { extract: vi.fn() } },
     // PDF citation geometry (P4): the worker re-anchors claims through the
     // extracted text layer; tests supply it.
     extractPdfTextLayer: vi.fn(),

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -377,7 +377,7 @@ async function handleJobInner(
         throw new DeterministicJobError(`Cannot run ${jobType} on resource ${resourceId}: media type '${mediaType ?? 'unknown'}' has no extractable text to analyze`);
       }
       if (source.declined === 'no-map' || source.declined === 'unknown') {
-        // Terminal, and loud: no-map is drift between `yieldsGeometry` and the
+        // Terminal, and loud: no-map is drift between `yieldsGeometryOf` and the
         // Smelter's skip decision (a geometry type it declined to map); unknown
         // is a resource with no content identity. Neither is retryable, and
         // both mean something upstream is wrong — surface it, do not complete

--- a/packages/jobs/src/workers/detection/prepare-detection.ts
+++ b/packages/jobs/src/workers/detection/prepare-detection.ts
@@ -1,5 +1,5 @@
 import type { ResourceId, components, AnchoredTextAnswer } from '@semiont/core';
-import { textExtractionOf, yieldsGeometryOf, decodeRepresentation } from '@semiont/core';
+import { textSourceOf, yieldsGeometryOf, decodeRepresentation } from '@semiont/core';
 import type { ContentReads, ExtractionDecline } from '@semiont/content';
 import { buildTextAnnotation, buildPdfAnnotation, type BuildAnnotation } from '../../processors';
 import { DeterministicJobError } from '../../failure-class';
@@ -46,7 +46,7 @@ export type ConsultAnchoredText = (resourceId: ResourceId) => Promise<AnchoredTe
  * For one detection job, resolve the text the model detects over and the
  * media-appropriate way to turn a detected span into a stored annotation.
  *
- * Both routes are core's, keyed by the media type's `TextExtraction` strategy,
+ * Both routes are core's, keyed by the media type's `TextSource` strategy,
  * so detection and embedding always read a resource identically. A
  * geometry-bearing type (PDF) is CONSULTED for the Smelter's canonical text
  * rather than derived here — the Smelter owns OCR (SMELTER-OWNS-OCR) — and
@@ -71,7 +71,7 @@ export async function prepareDetection(
   generator: Agent,
   consult: ConsultAnchoredText,
 ): Promise<DetectionSource> {
-  if (textExtractionOf(mediaType) === 'none') return { declined: 'no-extractor' };
+  if (textSourceOf(mediaType) === 'none') return { declined: 'no-extractor' };
 
   // The media type decides where the text comes from (SMELTER-OWNS-OCR).
   //

--- a/packages/jobs/src/workers/detection/prepare-detection.ts
+++ b/packages/jobs/src/workers/detection/prepare-detection.ts
@@ -1,6 +1,6 @@
 import type { ResourceId, components, AnchoredTextAnswer } from '@semiont/core';
-import { textExtractionOf, yieldsGeometryOf } from '@semiont/core';
-import { EXTRACTORS, type ContentReads, type ExtractionDecline } from '@semiont/content';
+import { textExtractionOf, yieldsGeometryOf, decodeRepresentation } from '@semiont/core';
+import type { ContentReads, ExtractionDecline } from '@semiont/content';
 import { buildTextAnnotation, buildPdfAnnotation, type BuildAnnotation } from '../../processors';
 import { DeterministicJobError } from '../../failure-class';
 
@@ -46,12 +46,12 @@ export type ConsultAnchoredText = (resourceId: ResourceId) => Promise<AnchoredTe
  * For one detection job, resolve the text the model detects over and the
  * media-appropriate way to turn a detected span into a stored annotation.
  *
- * Extraction goes through the **same registry the Smelter embeds from**
- * (`EXTRACTORS`, keyed by the media-type registry's `TextExtraction`
- * strategy), so detection and embedding always read a resource identically —
- * but a geometry-bearing type (PDF) is CONSULTED for the Smelter's canonical
- * text rather than re-extracted here — the Smelter owns OCR
- * (SMELTER-OWNS-OCR).
+ * Both routes are core's, keyed by the media type's `TextExtraction` strategy,
+ * so detection and embedding always read a resource identically. A
+ * geometry-bearing type (PDF) is CONSULTED for the Smelter's canonical text
+ * rather than derived here — the Smelter owns OCR (SMELTER-OWNS-OCR) — and
+ * since READ-VS-EXTRACT P2 this worker cannot derive even by mistake: deriving
+ * needs the anchored-text store, which it does not have.
  *
  * Bytes come from the injected `ContentReads` for NON-geometry types only;
  * geometry types take the injected `consult` seam instead. Both are narrow
@@ -71,8 +71,7 @@ export async function prepareDetection(
   generator: Agent,
   consult: ConsultAnchoredText,
 ): Promise<DetectionSource> {
-  const extractor = EXTRACTORS[textExtractionOf(mediaType)];
-  if (!extractor) return { declined: 'no-extractor' };
+  if (textExtractionOf(mediaType) === 'none') return { declined: 'no-extractor' };
 
   // The media type decides where the text comes from (SMELTER-OWNS-OCR).
   //
@@ -127,14 +126,18 @@ export async function prepareDetection(
   // consult — the Smelter publishes nothing for them, so there is nothing to
   // diverge from. Decode the bytes directly; the text itself is the
   // coordinate system, anchored by character offset.
+  //
+  // `decodeRepresentation` is core's, and it is the SAME call the Smelter's
+  // embedding path makes for these types — not a second implementation that
+  // happens to agree. It cannot decline: any byte sequence decodes to some
+  // string, so 'empty' below is the only way this route yields nothing.
   const { data } = await content.getBinary(resourceId);
-  const extracted = await extractor.extract(Buffer.from(data), mediaType);
-  if (extracted.kind === 'declined') return extracted;
-  if (!extracted.text.trim()) return { declined: 'empty' };
+  const text = decodeRepresentation(Buffer.from(data), mediaType);
+  if (!text.trim()) return { declined: 'empty' };
 
   return {
-    text: extracted.text,
+    text,
     buildAnnotation: (motivation, match, body) =>
-      buildTextAnnotation(extracted.text, resourceId, userId, generator, motivation, match, body),
+      buildTextAnnotation(text, resourceId, userId, generator, motivation, match, body),
   };
 }

--- a/packages/jobs/src/workers/detection/prepare-detection.ts
+++ b/packages/jobs/src/workers/detection/prepare-detection.ts
@@ -1,5 +1,5 @@
 import type { ResourceId, components, AnchoredTextAnswer } from '@semiont/core';
-import { textExtractionOf } from '@semiont/core';
+import { textExtractionOf, yieldsGeometryOf } from '@semiont/core';
 import { EXTRACTORS, type ContentReads, type ExtractionDecline } from '@semiont/content';
 import { buildTextAnnotation, buildPdfAnnotation, type BuildAnnotation } from '../../processors';
 import { DeterministicJobError } from '../../failure-class';
@@ -32,7 +32,7 @@ export type DetectionDecline = {
     // (SMELTER-OWNS-OCR P2). `not-yet` is transient — the Smelter has not
     // settled this generation yet, and the retry finds the store warm.
     // `no-map` and `unknown` are terminal: the first is drift between
-    // `yieldsGeometry` and the Smelter's skip decision (a geometry type it
+    // `yieldsGeometryOf` and the Smelter's skip decision (a geometry type it
     // declined to map), the second is a resource with no content identity.
     | 'not-yet' | 'no-map' | 'unknown';
 };
@@ -81,10 +81,10 @@ export async function prepareDetection(
   // is the sole producer, and a second derivation here is a second producer
   // whose divergent offsets misanchor every annotation silently. The worker
   // fetches no bytes and runs no OCR: the consult carries the text and its
-  // geometry. `yieldsGeometry` is declared on the extractor and is the same
-  // predicate the Smelter uses to decide whether to publish, so the two
-  // cannot drift about which resources have canonical text.
-  if (extractor.yieldsGeometry) {
+  // geometry. `yieldsGeometryOf` is core's, derived from the same media-type
+  // strategy the Smelter reads to decide whether to publish, so the two cannot
+  // drift about which resources have canonical text (READ-VS-EXTRACT P1).
+  if (yieldsGeometryOf(mediaType)) {
     const answer = await consult(resourceId);
     switch (answer.kind) {
       case 'extracted': {

--- a/packages/make-meaning/docs/job-workers.md
+++ b/packages/make-meaning/docs/job-workers.md
@@ -111,7 +111,14 @@ const adapter = startWorkerProcess({
 });
 ```
 
-Before dispatching a detection job, the worker process fetches the resource descriptor through its session (`session.client.browse.resource(resourceId).fresh()`), then `prepareDetection` fetches the bytes (`session.client.browse.resourceRepresentation(resourceId)`) and extracts text through the **same extractor registry the Smelter embeds from**, cached in the anchored-text store. It never reads KB storage directly.
+Before dispatching a detection job, the worker process fetches the resource descriptor through its session (`session.client.browse.resource(resourceId).fresh()`), then `prepareDetection` fetches the bytes (`session.client.browse.resourceRepresentation(resourceId)`) and gets text from them. It never reads KB storage directly.
+
+**How it gets that text depends on whether the bytes carry any** (READ-VS-EXTRACT). Those are two operations, not one, and they no longer share a registry:
+
+- **Decoding** — a charset-aware `Buffer → string` for text media. Microseconds, deterministic, no artifact to persist, and anyone holding bytes can do it. It is `decodeRepresentation` in `@semiont/core`, called directly.
+- **Deriving** — parsing a PDF, OCR-ing it when there is no text layer. Minutes, non-deterministic across engine versions, and it produces exactly one canonical artifact. Reached through `derivingExtractorFor(mediaType)` in `@semiont/content`, and **callable only with the store that persists its output** — which is why the Smelter owns it.
+
+The type decides which applies: `textSourceOf(format)` returns `'decode' | 'pdf-text-layer' | 'none'`. Derived text is cached in the anchored-text store, so a detection pass reuses what the Smelter already produced rather than re-deriving it.
 
 ## See Also
 

--- a/packages/make-meaning/src/__tests__/handlers/annotation-assembly.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/annotation-assembly.test.ts
@@ -98,7 +98,7 @@ describe('mark:create-request refuses unannotatable targets (MEDIA-CAPABILITY-DI
   });
 
   it('refuses a target the registry has never seen (D2 second population)', async () => {
-    // Import leniency means a KB can hold these, and `textExtractionOf` is
+    // Import leniency means a KB can hold these, and `textSourceOf` is
     // lenient for `text/*` so they embed and turn up in search — a user who
     // found one will reasonably try to annotate it. The refusal has to read
     // sanely for a type the registry cannot make vocabulary claims about.

--- a/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
@@ -25,7 +25,7 @@ import { MemoryVectorStore } from '@semiont/vectors';
 import type { EmbeddingChunk, AnnotationPayload } from '@semiont/vectors';
 import { chunkText } from '@semiont/core';
 import type { ExtractionOutcome, ChunkingConfig } from '@semiont/core';
-import { textExtractionOf } from '@semiont/core';
+import { textSourceOf } from '@semiont/core';
 import { Smelter, type SmelterTiming } from '../smelter';
 import type { SmelterEvent } from '../smelter-actor-state-unit';
 import { partitionByType } from '../batch-utils';
@@ -87,7 +87,7 @@ const textArb = fc.string({ minLength: 1, maxLength: 60 }).filter((s) => s.trim(
 // application/pdf entries never embed here even though the strategy is
 // eligible (P0b): eligibility is an extractor existing, not extraction
 // succeeding (SMELTER-MEDIA-TYPES Phase 1).
-const embeds = (mediaType: string) => textExtractionOf(mediaType) === 'decode';
+const embeds = (mediaType: string) => textSourceOf(mediaType) === 'decode';
 
 /** Eligibility: the type has SOME way to read text (P0b). Wider than `embeds` —
  *  a PDF is eligible and still declines on garbage bytes.
@@ -96,7 +96,7 @@ const embeds = (mediaType: string) => textExtractionOf(mediaType) === 'decode';
  *  `EXTRACTORS[strategy] !== null`, which was true but was a second statement of
  *  `strategy !== 'none'`, answered by resolving an implementation to learn a fact
  *  about a media type. */
-const eligible = (mediaType: string) => textExtractionOf(mediaType) !== 'none';
+const eligible = (mediaType: string) => textSourceOf(mediaType) !== 'none';
 
 // Pools by behavioral outcome: decodable types embed; the rest (binary
 // without an extractor, and pdfs whose garbage bytes decline) are skipped.
@@ -403,7 +403,7 @@ describe('P0 — pure laws', () => {
   it('P0b: eligibility is exactly "an extractor exists for the strategy"', () => {
     fc.assert(
       fc.property(fc.string({ maxLength: 20 }).map((s) => `text/${s}`), (mt) => {
-        expect(textExtractionOf(mt)).toBe('decode');
+        expect(textSourceOf(mt)).toBe('decode');
         expect(eligible(mt)).toBe(true);
       }),
       { numRuns: 500 },
@@ -413,7 +413,7 @@ describe('P0 — pure laws', () => {
     expect(eligible('application/zip')).toBe(false);        // binary stays out — no extractor
     expect(eligible('application/octet-stream')).toBe(false);
     expect(eligible('application/pdf')).toBe(true);         // Phase 1: the pdf-text-layer slot is filled
-    expect(textExtractionOf('application/pdf')).toBe('pdf-text-layer');
+    expect(textSourceOf('application/pdf')).toBe('pdf-text-layer');
   });
 });
 

--- a/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter-axioms.test.ts
@@ -26,7 +26,6 @@ import type { EmbeddingChunk, AnnotationPayload } from '@semiont/vectors';
 import { chunkText } from '@semiont/core';
 import type { ExtractionOutcome, ChunkingConfig } from '@semiont/core';
 import { textExtractionOf } from '@semiont/core';
-import { EXTRACTORS } from '@semiont/content';
 import { Smelter, type SmelterTiming } from '../smelter';
 import type { SmelterEvent } from '../smelter-actor-state-unit';
 import { partitionByType } from '../batch-utils';
@@ -90,9 +89,14 @@ const textArb = fc.string({ minLength: 1, maxLength: 60 }).filter((s) => s.trim(
 // succeeding (SMELTER-MEDIA-TYPES Phase 1).
 const embeds = (mediaType: string) => textExtractionOf(mediaType) === 'decode';
 
-/** Eligibility: an extractor exists for the type's strategy (P0b). Wider than
- *  `embeds` — a PDF is eligible and still declines on garbage bytes. */
-const eligible = (mediaType: string) => EXTRACTORS[textExtractionOf(mediaType)] !== null;
+/** Eligibility: the type has SOME way to read text (P0b). Wider than `embeds` —
+ *  a PDF is eligible and still declines on garbage bytes.
+ *
+ *  Asked of core since READ-VS-EXTRACT P2. It used to be
+ *  `EXTRACTORS[strategy] !== null`, which was true but was a second statement of
+ *  `strategy !== 'none'`, answered by resolving an implementation to learn a fact
+ *  about a media type. */
+const eligible = (mediaType: string) => textExtractionOf(mediaType) !== 'none';
 
 // Pools by behavioral outcome: decodable types embed; the rest (binary
 // without an extractor, and pdfs whose garbage bytes decline) are skipped.
@@ -390,7 +394,7 @@ describe('P0 — pure laws', () => {
     );
   });
 
-  // P0b (FOPL): ∀ m ∈ M: eligible(m) ⇔ EXTRACTORS[extraction(m)] ≠ null,
+  // P0b (FOPL): ∀ m ∈ M: eligible(m) ⇔ extraction(m) ≠ 'none',
   // with ∀ s: extraction("text/" ⧺ s) = decode — the registry gate never
   // narrows the old text/* prefix gate (MEDIA-TYPES.md decision 7), and at
   // Phase 1 (SMELTER-MEDIA-TYPES #744) the pdf tier joins ELIGIBILITY: an

--- a/packages/make-meaning/src/__tests__/smelter.test.ts
+++ b/packages/make-meaning/src/__tests__/smelter.test.ts
@@ -20,18 +20,22 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vite
 import { BehaviorSubject, EMPTY, Observable, Subject } from 'rxjs';
 import type { ExtractionOutcome, EventMap, components } from '@semiont/core';
 import { resourceId as makeResourceId, chunkText } from '@semiont/core';
-import { calculateChecksum, extractPdfTextLayer, EXTRACTORS } from '@semiont/content';
+import { calculateChecksum, extractPdfTextLayer } from '@semiont/content';
+
+/** The real deriving extractor with `extract` spied — one instance, so a
+ *  `mockResolvedValueOnce` set up in a test is the one the Smelter calls.
+ *  Since READ-VS-EXTRACT P2 the seam is the `derivingExtractorFor` accessor
+ *  rather than a strategy-keyed map, so the mock wraps the accessor. */
+const derivedSpy = vi.hoisted(() => ({ extract: vi.fn() }));
 
 vi.mock('@semiont/content', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@semiont/content')>();
+  const real = actual.derivingExtractorFor('application/pdf')!;
+  derivedSpy.extract.mockImplementation(real.extract.bind(real));
   return {
     ...actual,
-    EXTRACTORS: {
-      ...actual.EXTRACTORS,
-      // Spread the real extractor so its declared properties (e.g. geometry
-      // capability) survive the spy — only `extract` is wrapped.
-      'pdf-text-layer': { ...actual.EXTRACTORS['pdf-text-layer']!, extract: vi.fn(actual.EXTRACTORS['pdf-text-layer']!.extract) },
-    },
+    derivingExtractorFor: (mediaType: string) =>
+      actual.derivingExtractorFor(mediaType) === null ? null : derivedSpy,
   };
 });
 import { PDFDocument, StandardFonts } from 'pdf-lib';
@@ -461,7 +465,7 @@ describe('Smelter PDF embedding (Phase 1 — SMELTER-MEDIA-TYPES #744)', () => {
     // attached, and nothing downstream can recompute how the text was
     // obtained. So the projection that carries the text carries the fact.
     const h = await pdfHarness({ 'res-scan': SCANNED_PDF });
-    vi.mocked(EXTRACTORS['pdf-text-layer']!.extract).mockResolvedValueOnce({
+    derivedSpy.extract.mockResolvedValueOnce({
       kind: 'extracted',
       text: 'recovered from a scan',
       items: [],
@@ -484,7 +488,7 @@ describe('Smelter PDF embedding (Phase 1 — SMELTER-MEDIA-TYPES #744)', () => {
     // came from OCR has to say so here too — otherwise half the gather paths
     // lose the provenance the other half carries.
     const h = await pdfHarness({ 'res-scan': SCANNED_PDF });
-    vi.mocked(EXTRACTORS['pdf-text-layer']!.extract).mockResolvedValueOnce({
+    derivedSpy.extract.mockResolvedValueOnce({
       kind: 'extracted', text: 'recovered from a scan', items: [], method: 'ocr', pdfClass: 'B',
     });
     try {

--- a/packages/make-meaning/src/annotation-operations.ts
+++ b/packages/make-meaning/src/annotation-operations.ts
@@ -33,7 +33,7 @@ type UpdateAnnotationBodyRequest = components['schemas']['UpdateAnnotationBodyRe
  *
  * Two populations land here: a registry row that declines (storage tier) and a
  * type the registry has never seen (import leniency keeps those in the KB, and
- * `textExtractionOf` is lenient for `text/*`, so they embed and turn up in
+ * `textSourceOf` is lenient for `text/*`, so they embed and turn up in
  * search). The wording states what cannot be done rather than making a
  * vocabulary claim the registry is not entitled to make about a miss.
  *

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -40,8 +40,8 @@ import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
 import { burstBuffer, errField } from '@semiont/core';
 import type { Logger, Annotation, ResourceId, AnnotationId, ResourceDescriptor, EventMap } from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId } from '@semiont/core';
-import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, getResourceEntityTypes, textExtractionOf, yieldsGeometryOf } from '@semiont/core';
-import { calculateChecksum, EXTRACTORS, type AnchoredTextStore, type ContentReads } from '@semiont/content';
+import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, getResourceEntityTypes, textExtractionOf, yieldsGeometryOf, decodeRepresentation } from '@semiont/core';
+import { calculateChecksum, derivingExtractorFor, type AnchoredTextStore, type ContentReads, type ExtractedText, type ExtractionDecline } from '@semiont/content';
 import type { VectorStore, EmbeddingChunk, AnnotationPayload } from '@semiont/vectors';
 import type { EmbeddingProvider } from '@semiont/vectors';
 import type { ChunkingConfig } from '@semiont/core';
@@ -51,15 +51,15 @@ import { busRequest, type BusRequestPrimitive } from '@semiont/core';
 import { partitionByType } from './batch-utils';
 import type { SmelterEvent } from './smelter-actor-state-unit';
 
-// Media dispatch is the strategy-keyed extractor registry
-// (`.plans/SMELTER-MEDIA-TYPES.md`): both call sites (live fetch and
-// reconcile planning) resolve `EXTRACTORS[textExtractionOf(mediaType)]`,
-// and a null slot declines — settle skipped, reason 'no-extractor' — so
-// binary types never decode to mojibake. 'decode' is the charset-aware
-// passthrough (RFC 2046 text/* fallback included); 'pdf-text-layer'
-// extracts native text layers inline and declines scanned/encrypted/
-// corrupt PDFs with their class reason (Phase 3 turns 'no-text-layer'
-// declines into OCR coverage).
+// Media dispatch is core's, keyed by the media type's `TextExtraction`
+// strategy (`.plans/SMELTER-MEDIA-TYPES.md`, narrowed by READ-VS-EXTRACT P2).
+// 'none' declines — settle skipped, reason 'no-extractor' — so binary types
+// never decode to mojibake. 'decode' is core's charset-aware
+// `decodeRepresentation` (RFC 2046 text/* fallback included), called directly;
+// 'pdf-text-layer' is the one DERIVING strategy, reached through
+// `derivingExtractorFor` and callable only with the anchored-text store, which
+// is why the Smelter is its only caller. It reads native text layers inline and
+// declines scanned/encrypted/corrupt PDFs with their class reason.
 
 export interface ReconcileSummary {
   resourcesEmbedded: number;
@@ -421,8 +421,8 @@ export class Smelter {
     if (!rid) return;
     const { data, contentType } = await this.content.getBinary(makeResourceId(rid));
     const bytes = Buffer.from(data);
-    const extractor = EXTRACTORS[textExtractionOf(contentType)];
-    if (!extractor || !yieldsGeometryOf(contentType)) {
+    const extractor = derivingExtractorFor(contentType);
+    if (!extractor) {
       // Planned from a catalog claim the bytes no longer match — nothing to
       // derive is a decision, not a failure.
       this.logger.info('Re-anchor found no geometry-capable extractor', { resourceId: rid, contentType });
@@ -487,21 +487,26 @@ export class Smelter {
       const { data, contentType } = await this.content.getBinary(makeResourceId(resourceId));
       const bytes = Buffer.from(data);
       const checksum = calculateChecksum(bytes);
-      const extractor = EXTRACTORS[textExtractionOf(contentType)];
-      if (!extractor) {
-        this.logger.debug('Skipping resource with no extractor for its media type', { resourceId, contentType });
+      // The only site that wants text by EITHER route, so it is the only site
+       // that branches (READ-VS-EXTRACT P2). Deriving is expensive, stores a
+       // canonical artifact, and is reachable only here and in `reanchorResource`
+       // because both hold the store; decoding is a pure function over bytes.
+      const extractor = derivingExtractorFor(contentType);
+      if (!extractor && textExtractionOf(contentType) === 'none') {
+        this.logger.debug('Skipping resource with no way to read its media type', { resourceId, contentType });
         return { kind: 'skipped', checksum, reason: 'no-extractor' };
       }
-      // The cache seam (PERSIST-ANCHORS P2c, decision C): extraction consults
+      // The cache seam (PERSIST-ANCHORS P2c, decision C): derivation consults
       // the artifact store for this exact byte content and, on a miss, the
       // seam itself stores whatever it concluded — success with provenance,
       // or the decline. The write moved INTO extract() with D1, which is why
       // there is no publish call in this method anymore: exactly one place
       // writes exactly one artifact, and this is not it.
-      const extracted = await extractor.extract(bytes, contentType, {
-        key: checksum,
-        store: this.anchoredStore,
-      });
+      const extracted: ExtractedText | ExtractionDecline = extractor
+        ? await extractor.extract(bytes, contentType, { key: checksum, store: this.anchoredStore })
+        // Decoding never declines and never yields geometry — any byte sequence
+        // decodes to SOME string, and emptiness is the caller's call below.
+        : { kind: 'extracted', text: decodeRepresentation(bytes, contentType), method: 'text-passthrough' };
       if (extracted.kind === 'declined') {
         this.logger.debug('Extractor declined', { resourceId, contentType, reason: extracted.declined });
         return { kind: 'skipped', checksum, reason: extracted.declined };
@@ -1017,10 +1022,12 @@ export class Smelter {
    * representation's checksum (the bytes the smelter would read), the
    * current entity-type set (the discriminator the stamps must carry), and
    * whether the media type's extractor derives geometry (whether an
-   * anchored-text artifact should exist). Embeddable ⇔ an extractor exists
-   * for the media type's strategy — the same registry the live fetch resolves.
-   * The geometry answer comes from core's `yieldsGeometryOf`, keyed by the same
-   * strategy, so this gate and the live fetch cannot disagree about it.
+   * anchored-text artifact should exist). Both answers are core's, keyed by the
+   * media type's strategy: embeddable ⇔ the type has any text-reading strategy
+   * at all, and geometry ⇔ that strategy derives it. Until READ-VS-EXTRACT P2
+   * embeddability was asked as `EXTRACTORS[strategy] !== null` — true, but a
+   * second statement of `strategy !== 'none'`, answered by resolving an
+   * implementation to learn a fact about a media type.
    * Shared by `reconcile()` and the `smelt:rebuild-anchors` planner.
    */
   private classifyEmbeddable(
@@ -1029,8 +1036,8 @@ export class Smelter {
     const embeddable = new Map<string, { checksum: string | undefined; entityTypes: string[]; yieldsGeometry: boolean }>();
     for (const resource of resources) {
       const mediaType = getPrimaryMediaType(resource);
-      const extractor = mediaType ? EXTRACTORS[textExtractionOf(mediaType)] : null;
-      if (resource['@id'] && mediaType && extractor) {
+      const readable = mediaType !== undefined && textExtractionOf(mediaType) !== 'none';
+      if (resource['@id'] && mediaType && readable) {
         embeddable.set(resource['@id'], {
           checksum: getPrimaryRepresentation(resource)?.checksum,
           entityTypes: getResourceEntityTypes(resource),

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -40,7 +40,7 @@ import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
 import { burstBuffer, errField } from '@semiont/core';
 import type { Logger, Annotation, ResourceId, AnnotationId, ResourceDescriptor, EventMap } from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId } from '@semiont/core';
-import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, getResourceEntityTypes, textExtractionOf, yieldsGeometryOf, decodeRepresentation } from '@semiont/core';
+import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, getResourceEntityTypes, textSourceOf, yieldsGeometryOf, decodeRepresentation } from '@semiont/core';
 import { calculateChecksum, derivingExtractorFor, type AnchoredTextStore, type ContentReads, type ExtractedText, type ExtractionDecline } from '@semiont/content';
 import type { VectorStore, EmbeddingChunk, AnnotationPayload } from '@semiont/vectors';
 import type { EmbeddingProvider } from '@semiont/vectors';
@@ -51,7 +51,7 @@ import { busRequest, type BusRequestPrimitive } from '@semiont/core';
 import { partitionByType } from './batch-utils';
 import type { SmelterEvent } from './smelter-actor-state-unit';
 
-// Media dispatch is core's, keyed by the media type's `TextExtraction`
+// Media dispatch is core's, keyed by the media type's `TextSource`
 // strategy (`.plans/SMELTER-MEDIA-TYPES.md`, narrowed by READ-VS-EXTRACT P2).
 // 'none' declines — settle skipped, reason 'no-extractor' — so binary types
 // never decode to mojibake. 'decode' is core's charset-aware
@@ -492,7 +492,7 @@ export class Smelter {
        // canonical artifact, and is reachable only here and in `reanchorResource`
        // because both hold the store; decoding is a pure function over bytes.
       const extractor = derivingExtractorFor(contentType);
-      if (!extractor && textExtractionOf(contentType) === 'none') {
+      if (!extractor && textSourceOf(contentType) === 'none') {
         this.logger.debug('Skipping resource with no way to read its media type', { resourceId, contentType });
         return { kind: 'skipped', checksum, reason: 'no-extractor' };
       }
@@ -1036,7 +1036,7 @@ export class Smelter {
     const embeddable = new Map<string, { checksum: string | undefined; entityTypes: string[]; yieldsGeometry: boolean }>();
     for (const resource of resources) {
       const mediaType = getPrimaryMediaType(resource);
-      const readable = mediaType !== undefined && textExtractionOf(mediaType) !== 'none';
+      const readable = mediaType !== undefined && textSourceOf(mediaType) !== 'none';
       if (resource['@id'] && mediaType && readable) {
         embeddable.set(resource['@id'], {
           checksum: getPrimaryRepresentation(resource)?.checksum,

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -40,7 +40,7 @@ import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
 import { burstBuffer, errField } from '@semiont/core';
 import type { Logger, Annotation, ResourceId, AnnotationId, ResourceDescriptor, EventMap } from '@semiont/core';
 import { resourceId as makeResourceId, annotationId as makeAnnotationId } from '@semiont/core';
-import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, getResourceEntityTypes, textExtractionOf } from '@semiont/core';
+import { getExactText, getTargetSelector, getPrimaryMediaType, getPrimaryRepresentation, getResourceEntityTypes, textExtractionOf, yieldsGeometryOf } from '@semiont/core';
 import { calculateChecksum, EXTRACTORS, type AnchoredTextStore, type ContentReads } from '@semiont/content';
 import type { VectorStore, EmbeddingChunk, AnnotationPayload } from '@semiont/vectors';
 import type { EmbeddingProvider } from '@semiont/vectors';
@@ -422,7 +422,7 @@ export class Smelter {
     const { data, contentType } = await this.content.getBinary(makeResourceId(rid));
     const bytes = Buffer.from(data);
     const extractor = EXTRACTORS[textExtractionOf(contentType)];
-    if (!extractor?.yieldsGeometry) {
+    if (!extractor || !yieldsGeometryOf(contentType)) {
       // Planned from a catalog claim the bytes no longer match — nothing to
       // derive is a decision, not a failure.
       this.logger.info('Re-anchor found no geometry-capable extractor', { resourceId: rid, contentType });
@@ -1018,9 +1018,9 @@ export class Smelter {
    * current entity-type set (the discriminator the stamps must carry), and
    * whether the media type's extractor derives geometry (whether an
    * anchored-text artifact should exist). Embeddable ⇔ an extractor exists
-   * for the media type's strategy — the same registry the live fetch
-   * resolves, and `yieldsGeometry` is declared on the extractor itself, so
-   * every gate here and the live fetch's behavior are twins by construction.
+   * for the media type's strategy — the same registry the live fetch resolves.
+   * The geometry answer comes from core's `yieldsGeometryOf`, keyed by the same
+   * strategy, so this gate and the live fetch cannot disagree about it.
    * Shared by `reconcile()` and the `smelt:rebuild-anchors` planner.
    */
   private classifyEmbeddable(
@@ -1030,11 +1030,11 @@ export class Smelter {
     for (const resource of resources) {
       const mediaType = getPrimaryMediaType(resource);
       const extractor = mediaType ? EXTRACTORS[textExtractionOf(mediaType)] : null;
-      if (resource['@id'] && extractor) {
+      if (resource['@id'] && mediaType && extractor) {
         embeddable.set(resource['@id'], {
           checksum: getPrimaryRepresentation(resource)?.checksum,
           entityTypes: getResourceEntityTypes(resource),
-          yieldsGeometry: extractor.yieldsGeometry,
+          yieldsGeometry: yieldsGeometryOf(mediaType),
         });
       }
     }

--- a/packages/react-ui/src/features/resource-viewer/state/__tests__/resource-viewer-page-state-unit.test.ts
+++ b/packages/react-ui/src/features/resource-viewer/state/__tests__/resource-viewer-page-state-unit.test.ts
@@ -152,7 +152,7 @@ describe('createResourceViewerPageStateUnit', () => {
     stateUnit.dispose();
   });
 
-  // isBinaryType keys off textExtractionOf(...) !== 'decode', not render mode:
+  // isBinaryType keys off textSourceOf(...) !== 'decode', not render mode:
   // storage-tier binary (ZIP, gif/webp) must be fetched as bytes, never
   // decoded as text — the client-side twin of the Phase 3a serving-side fix.
   it('fetches storage-tier binary (ZIP) as bytes, never the text-decode path', async () => {

--- a/packages/react-ui/src/features/resource-viewer/state/resource-viewer-page-state-unit.ts
+++ b/packages/react-ui/src/features/resource-viewer/state/resource-viewer-page-state-unit.ts
@@ -10,7 +10,7 @@ import { createGatherStateUnit, type GatherStateUnit } from '@semiont/sdk';
 import { createMatchStateUnit } from '@semiont/sdk';
 import { createYieldStateUnit, type YieldStateUnit } from '@semiont/sdk';
 import type { SemiontSession } from '@semiont/sdk';
-import { decodeWithCharset, textExtractionOf, uuidV4 } from '@semiont/core';
+import { decodeWithCharset, textSourceOf, uuidV4 } from '@semiont/core';
 import { groupAnnotations } from '../../../lib/annotation-groups';
 import type { ReferencedByEntry } from '@semiont/sdk';
 
@@ -109,7 +109,7 @@ export function createResourceViewerPageStateUnit(
   // type does not decode to text. Storage-tier images (gif/webp) are
   // render:'none' but still binary, and a ZIP must avoid the text path; a
   // mechanical render-mode check would mis-route both into mojibake.
-  const isBinaryType = textExtractionOf(mediaType) !== 'decode';
+  const isBinaryType = textSourceOf(mediaType) !== 'decode';
 
   if (!isBinaryType && mediaType) {
     contentLoading$.next(true);


### PR DESCRIPTION
One `extract()` covered two operations that share a name and almost nothing else.

|  | decoding | deriving |
|---|---|---|
| example | charset-aware `Buffer → string` | parse a PDF, OCR it when there is no text layer |
| determinism | total | **not guaranteed** across engine versions |
| cost | microseconds | minutes on a 116-page scan |
| output | text | text **+ positioned runs** |
| who may run it | anyone holding bytes | **the Smelter alone** |
| canonical artifact? | no, by design | yes — the anchored-text store |

The last two rows are the point, and the type said nothing about them. A registry
lookup returned either one, identically, at every call site. That symmetry is why a
detection worker OCR-ing scanned PDFs read as a worker using a capability it had —
for four months, through review, with the cost noted (`one scanned document gets
OCR'd five times`) and the divergence hazard missed entirely.

The previous PR fixed the instance. This fixes the shape that permitted it.

## The registry is gone

`EXTRACTORS` held one real extractor, a `null`, and — under `'decode'` — a one-line
wrapper around `decodeRepresentation`, which lives in `@semiont/core` and which
**five sites already called directly**. So "split the registry" was the wrong frame:
there was only ever one extractor.

What replaced it is `derivingExtractorFor(mediaType)`, non-null only for
geometry-bearing types, and **`ExtractionCache` is now required** rather than
optional. Decoding left the package entirely.

**The ownership rule is enforced by a capability, not a name.** `ExtractionCache`
carries an `AnchoredTextStore`; only the Smelter holds one. A second producer cannot
construct the argument, so it cannot compile — *you may derive only if you can
persist what you derived*, which is the actual invariant, now stated at the
signature rather than in a comment.

**Proved by inversion:** making the cache optional again fails `tsc` with
`TS2578: Unused '@ts-expect-error' directive`. The compiler asserts the rule; there
is no runtime guard to remember.

## One home for "does this derive geometry?"

`yieldsGeometry` was a boolean declared on each extractor in `@semiont/content` —
a property of the media-type *strategy*, stored beside the *implementations*, in a
different package from the strategy vocabulary. Two facts that had to agree, gated
by nothing, and consumers asking about a media type had to resolve an implementation
to get an answer.

It is now `yieldsGeometryOf` in core, derived from an exhaustive
`Record<TextSource, boolean>` — so a new source fails to compile until someone
decides which side it is on. This applies a rule the target file already stated in
its own header: *questions answerable from those rows get a helper, never a row of
their own.*

**The census gate that replaced the deleted declaration is behavioral.** Removing
the field removes the chance of two *declarations* disagreeing, but not the risk
that core is wrong about what the code does — so the test runs each source and
checks that positioned runs appear exactly where core says. Flipping
`'pdf-text-layer'` to `false` fails it. A second hand-written table would have been
a mirror; the extractor's own output cannot be.

## Naming

The defect was in **core**, not in the extractors: `TextExtraction` /
`textExtractionOf` / the `extractText` row field name a value spanning decoding
**and** deriving — the one place the codebase actually called decoding an
extraction. Now `TextSource` / `textSourceOf` / `textSource`. `ContentExtractor`
became `TextExtractor`: the `Content` prefix named the input, when what
distinguishes the type is that it produces text.

**`.extract()`, `ExtractionOutcome`, `ExtractedText`, `ExtractionDecline` and
`ExtractionCache` deliberately did not move.** Once *extraction* means *deriving*,
each is already exactly right — and since `extract()` returns `ExtractedText`,
renaming the verb alone would have re-split the vocabulary this was meant to unify.

An earlier proposal (`TextReader` / `.read()` / `TEXT_READERS`) was dropped: `read`
is load-bearing here in the opposite sense. A dozen `*Reads` seam interfaces plus
`readAnchoredText`, `anchoredText.read()` and `archivistContentReads` all use it to
mean *fetch a stored thing through a narrow seam*, not *derive from bytes in hand*.

Zero occurrences in `specs/` or `sdk-go/client_gen.go`, so nothing regenerates and
no wire consumer can break.

## What fell out

**A planned rename cancelled itself.** The wire types were queued for a rename
sized at ~20 files plus a Go drift-gate cycle. Once the decode path returns a
`string`, `ExtractionOutcome` and its members describe exactly one thing — the
derived stored artifact — and conflate nothing. No spec change, no regeneration.

**The same duplication, one layer down.** `EXTRACTORS[strategy] !== null` ⇔
`strategy !== 'none'`, which core already knew. Two places asked it the long way:
`classifyEmbeddable` and the smelter axioms' P0b. Both now ask core; the FOPL axiom
survives verbatim in meaning.

**Three test deletions, each because its subject stopped existing** — not because it
became inconvenient. A test asserting the cache is optional (its premise had already
gone false). A spy proving the worker did not OCR (the mock target is gone; the
`getBinary` assertions beside it prove the same thing observably, and better: no
bytes fetched is no derivation possible). And the passthrough extractor's own tests,
which exercised `decodeRepresentation` through a wrapper — core's own suite covers
it directly, checked before deleting rather than assumed.

## Scope note

Structure and vocabulary behind an unchanged contract. No new tests for the rename:
its correctness is the compiler's, and a test asserting a name would be a mirror
with no source of truth.

`packages/react-ui` is in the diff for one mechanical rename — the resource viewer's
page state unit reads the accessor.
