### PR TITLE
A projector no longer dies of a retryable error

### DIFF
--- a/packages/core/src/__tests__/retry.test.ts
+++ b/packages/core/src/__tests__/retry.test.ts
@@ -5,7 +5,14 @@
  * and no restart policy, so exit-on-first-failure is permanent death.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY, type RetryAttemptInfo } from '../retry';
+import {
+  retryWithBackoff,
+  isTransientFetchError,
+  isRetryableRequestError,
+  STARTUP_FETCH_RETRY,
+  type RetryAttemptInfo,
+  type HttpStatusError,
+} from '../retry';
 
 const FAST = { attempts: 4, initialDelayMs: 1, maxDelayMs: 4 };
 
@@ -61,19 +68,48 @@ describe('retryWithBackoff', () => {
     expect(calls).toBe(FAST.attempts);
   });
 
-  it('doubles the delay each retry and caps at maxDelayMs, reporting via onRetry', async () => {
+  it('doubles the delay ceiling each retry and caps at maxDelayMs, reporting via onRetry', async () => {
     const seen: RetryAttemptInfo[] = [];
     await expect(
       retryWithBackoff(
         async () => { throw fetchFailed(); },
         isTransientFetchError,
-        { attempts: 5, initialDelayMs: 1, maxDelayMs: 4 },
+        { attempts: 5, initialDelayMs: 8, maxDelayMs: 32 },
         (info) => seen.push(info),
       ),
     ).rejects.toThrow();
-    expect(seen.map((s) => s.delayMs)).toEqual([1, 2, 4, 4]);
+    // Equal jitter (SIDECAR-BOOT-RESILIENCE P2): each wait is in [cap/2, cap),
+    // so the exact sequence is no longer assertable — but the SCHEDULE is: the
+    // ceilings still double and still cap, and the reported delay is the actual
+    // wait rather than the ceiling. Asserting per-attempt bounds keeps both the
+    // doubling and the cap under test without pinning the random draw.
+    const caps = [8, 16, 32, 32];
+    expect(seen).toHaveLength(caps.length);
+    seen.forEach((info, i) => {
+      expect(info.delayMs, `attempt ${i + 1}`).toBeGreaterThanOrEqual(caps[i]! / 2);
+      expect(info.delayMs, `attempt ${i + 1}`).toBeLessThan(caps[i]!);
+    });
     expect(seen.map((s) => s.attempt)).toEqual([1, 2, 3, 4]);
     expect(seen.every((s) => s.attempts === 5)).toBe(true);
+  });
+
+  it('jitters: repeated runs of the same policy do not produce identical delays', async () => {
+    // The property that matters is DIVERGENCE — N peers backing off by an
+    // identical schedule re-converge on the same instant and re-deliver the
+    // burst that caused the failure. A fixed schedule would make every run here
+    // equal; over 12 runs the chance of a false failure is negligible.
+    const firstDelays: number[] = [];
+    for (let run = 0; run < 12; run++) {
+      await expect(
+        retryWithBackoff(
+          async () => { throw fetchFailed(); },
+          isTransientFetchError,
+          { attempts: 2, initialDelayMs: 8, maxDelayMs: 8 },
+          (info) => firstDelays.push(info.delayMs),
+        ),
+      ).rejects.toThrow();
+    }
+    expect(new Set(firstDelays).size).toBeGreaterThan(1);
   });
 
   it('does not call setTimeout on the success path', async () => {
@@ -103,6 +139,63 @@ describe('isTransientFetchError', () => {
     expect(isTransientFetchError(new Error('Authentication failed: 503'))).toBe(false);
     expect(isTransientFetchError(new TypeError("Cannot read properties of undefined (reading 'x')"))).toBe(false);
     expect(isTransientFetchError('fetch failed')).toBe(false);
+  });
+});
+
+describe('isRetryableRequestError (SIDECAR-BOOT-RESILIENCE P1)', () => {
+  /** What a status-carrying transport error looks like to this predicate. The
+   *  real one is http-transport's `APIError`, which already carries `status`. */
+  const withStatus = (status: number): HttpStatusError =>
+    Object.assign(new Error(`/bus/emit ${status}`), { status });
+
+  it('accepts 429 — the gateway is UP and asking us to wait', () => {
+    // The whole reason this predicate exists. `isTransientFetchError` refuses
+    // every HTTP-level failure by design, and its reasoning ("a 401 means the
+    // gateway is up and rejected us") is right for 401 and wrong for 429: a 429
+    // is the server's own instruction to try again.
+    expect(isTransientFetchError(withStatus(429))).toBe(false);
+    expect(isRetryableRequestError(withStatus(429))).toBe(true);
+  });
+
+  it('accepts 503 and 504 — up, but not now', () => {
+    expect(isRetryableRequestError(withStatus(503))).toBe(true);
+    expect(isRetryableRequestError(withStatus(504))).toBe(true);
+  });
+
+  it('rejects auth and validation failures — retrying cannot change their minds', () => {
+    for (const status of [400, 401, 403, 404, 409, 422]) {
+      expect(isRetryableRequestError(withStatus(status)), String(status)).toBe(false);
+    }
+  });
+
+  it('rejects a bare 500 — an unclassified server fault is not a promise to recover', () => {
+    // 503/504 say "come back"; 500 says "something broke". Retrying a 500 in a
+    // boot pass replays the request that broke it.
+    expect(isRetryableRequestError(withStatus(500))).toBe(false);
+  });
+
+  it("accepts AbortSignal.timeout's TimeoutError — a deadline IS 'try again'", () => {
+    // Measured, not assumed: `AbortSignal.timeout()` rejects with a DOMException
+    // named 'TimeoutError', NOT a TypeError — so `isTransientFetchError` cannot
+    // see it, and the bounded `/bus/emit` was unretryable on timeout.
+    const timeout = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    expect(isTransientFetchError(timeout)).toBe(false);
+    expect(isRetryableRequestError(timeout)).toBe(true);
+  });
+
+  it('still accepts everything isTransientFetchError does — the two compose', () => {
+    expect(isRetryableRequestError(fetchFailed())).toBe(true);
+    expect(isRetryableRequestError(Object.assign(new TypeError('terminated'), {
+      cause: Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+    }))).toBe(true);
+  });
+
+  it('rejects errors with no status and no connection failure', () => {
+    expect(isRetryableRequestError(new Error('something else'))).toBe(false);
+    expect(isRetryableRequestError('429')).toBe(false);
+    expect(isRetryableRequestError(undefined)).toBe(false);
+    // A status that is not a number is not a status — never coerce.
+    expect(isRetryableRequestError(Object.assign(new Error('x'), { status: '429' }))).toBe(false);
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -402,8 +402,8 @@ export type { GraphViews } from './knowledge-graph-views';
 
 // Bounded retry with backoff — startup connections from long-running peers
 // (worker, smelter, weaver) to the KS.
-export { retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY } from './retry';
-export type { RetryPolicy, RetryAttemptInfo } from './retry';
+export { retryWithBackoff, isTransientFetchError, isRetryableRequestError, STARTUP_FETCH_RETRY } from './retry';
+export type { HttpStatusError, RetryPolicy, RetryAttemptInfo } from './retry';
 
 export { getShardPath, jumpConsistentHash } from './shard-utils';
 

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -13,10 +13,30 @@
 export interface RetryPolicy {
   /** Total attempts, including the first one. */
   attempts: number;
-  /** Delay before the second attempt; doubles each retry. */
+  /** Ceiling on the delay before the second attempt; doubles each retry. */
   initialDelayMs: number;
   /** Ceiling for the doubled delay. */
   maxDelayMs: number;
+}
+
+/**
+ * Equal jitter: half the computed ceiling, plus a random share of the other
+ * half — delay ∈ [cap/2, cap).
+ *
+ * Unconditional, not an option (SIDECAR-BOOT-RESILIENCE P2). Every caller of
+ * `retryWithBackoff` is a container in a fleet that boots together and retries
+ * against ONE gateway, which is precisely the lockstep this exists to break: N
+ * peers backing off by an identical schedule re-converge on the same instant and
+ * re-deliver the burst that caused the failure. A flag would leave that hazard
+ * reachable by default-choosing, and nobody would ever pass `false`.
+ *
+ * The worst case is unchanged — `delay <= cap` still holds, so the patience
+ * budget a policy advertises stays true; only the expected wait drops. Same
+ * formula the SSE reconnect already uses (`actor-state-unit.ts`, D1a), so the two
+ * backoffs behave alike rather than each inventing a curve.
+ */
+function equalJitter(cap: number): number {
+  return cap / 2 + Math.random() * (cap / 2);
 }
 
 export interface RetryAttemptInfo {
@@ -30,8 +50,10 @@ export interface RetryAttemptInfo {
 }
 
 /**
- * Default policy for startup connections to the gateway: 8 attempts with
- * delays 1s, 2s, 4s, then capped at 8s — ~39s of patience before giving up.
+ * Default policy for startup connections to the gateway: 8 attempts with delay
+ * ceilings 1s, 2s, 4s, then capped at 8s — up to ~39s of patience before giving
+ * up. "Up to", because the backoff is equal-jittered: each wait lands in
+ * [cap/2, cap), so the worst case is that sum and the expected case is ~75% of it.
  */
 export const STARTUP_FETCH_RETRY: RetryPolicy = {
   attempts: 8,
@@ -54,10 +76,66 @@ export function isTransientFetchError(error: unknown): boolean {
 }
 
 /**
- * Run `fn`, retrying on errors `isRetryable` accepts, with exponential
- * backoff per `policy`. `onRetry` fires before each wait — the caller's
- * hook for logging the attempt. The final error (retryable budget
- * exhausted, or the first non-retryable one) is rethrown verbatim.
+ * An error that knows the HTTP status the server answered with.
+ *
+ * Structural rather than a class, because the class already exists:
+ * http-transport's `APIError` carries `status` and cannot be named from here
+ * without inverting the package dependency. This interface is the contract
+ * between the thrower and `isRetryableRequestError`, stated once — a predicate
+ * that recovered the status by parsing it back out of an error MESSAGE would be
+ * a second statement of the same fact, in the fragile direction.
+ */
+export interface HttpStatusError extends Error {
+  readonly status: number;
+}
+
+/**
+ * Statuses that mean *up, but not now* — the server is answering, and its
+ * answer is "try again".
+ *
+ *  - `429` — the gateway's own rate limiter; its body says to retry when one
+ *            settles. Retrying is compliance, not hope.
+ *  - `503` — unavailable, explicitly temporary by RFC 9110.
+ *  - `504` — an upstream deadline, which the next attempt may well beat.
+ *
+ * Everything else is excluded deliberately, including `500`: 503 and 504 are
+ * promises to recover, while an unclassified server fault is not — retrying it
+ * inside a boot pass just replays whatever broke it.
+ */
+const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([429, 503, 504]);
+
+/**
+ * True for failures worth another attempt: the connection never landed
+ * (`isTransientFetchError`), the server answered "not now"
+ * (`RETRYABLE_STATUSES`), or our own deadline expired.
+ *
+ * The timeout case is the one that is easy to get wrong. `AbortSignal.timeout()`
+ * rejects with a **DOMException named `TimeoutError`**, not a `TypeError` —
+ * measured, not assumed — so `isTransientFetchError` cannot see it, and a
+ * request that bounded itself was unretryable precisely when the bound fired.
+ * Matched by `name` rather than `instanceof DOMException` because the constructor
+ * is not guaranteed present in every runtime this package builds for, while the
+ * name is part of the DOM spec.
+ *
+ * Auth and validation failures stay excluded, preserving `isTransientFetchError`'s
+ * reasoning verbatim: a 401 means the gateway is UP and rejected us, and retrying
+ * will not change its mind. A 429 differs — the gateway is up and *asking* us to
+ * wait, so the same "it answered" fact points the other way.
+ */
+export function isRetryableRequestError(error: unknown): boolean {
+  if (isTransientFetchError(error)) return true;
+  if (typeof error !== 'object' || error === null) return false;
+  if ((error as { name?: unknown }).name === 'TimeoutError') return true;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' && RETRYABLE_STATUSES.has(status);
+}
+
+/**
+ * Run `fn`, retrying on errors `isRetryable` accepts, with equal-jitter
+ * exponential backoff per `policy`. `onRetry` fires before each wait — the
+ * caller's hook for logging the attempt, and it reports the actual jittered
+ * delay. The final error (retryable budget exhausted, or the first
+ * non-retryable one) is rethrown verbatim.
  */
 export async function retryWithBackoff<T>(
   fn: () => Promise<T>,
@@ -65,15 +143,18 @@ export async function retryWithBackoff<T>(
   policy: RetryPolicy,
   onRetry?: (info: RetryAttemptInfo) => void,
 ): Promise<T> {
-  let delayMs = policy.initialDelayMs;
+  let cap = policy.initialDelayMs;
   for (let attempt = 1; ; attempt++) {
     try {
       return await fn();
     } catch (error) {
       if (attempt >= policy.attempts || !isRetryable(error)) throw error;
+      // `delayMs` reported to `onRetry` is the ACTUAL wait, not the ceiling —
+      // a log that printed the ceiling would describe a schedule nobody ran.
+      const delayMs = equalJitter(cap);
       onRetry?.({ attempt, attempts: policy.attempts, delayMs, error });
       await new Promise((resolve) => setTimeout(resolve, delayMs));
-      delayMs = Math.min(delayMs * 2, policy.maxDelayMs);
+      cap = Math.min(cap * 2, policy.maxDelayMs);
     }
   }
 }

--- a/packages/http-transport/src/index.ts
+++ b/packages/http-transport/src/index.ts
@@ -22,8 +22,8 @@ export {
   HttpTransport,
   type HttpTransportConfig,
   type TokenRefresher,
-  APIError,
 } from './transport/http-transport';
+export { APIError } from './transport/api-error';
 
 export { HttpContentTransport } from './transport/http-content-transport';
 

--- a/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
+++ b/packages/http-transport/src/transport/__tests__/actor-state-unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { firstValueFrom } from 'rxjs';
-import { createActorStateUnit } from '../actor-state-unit';
+import { createActorStateUnit, EMIT_RETRY } from '../actor-state-unit';
 import { assertStateUnitAxioms } from '@semiont/core/testing/axioms';
 // The SSE/fetch harness lives in helpers/mock-conn.ts (shared with the
 // liveness property suite). Importing it stubs the global fetch.
@@ -132,22 +132,35 @@ describe('createActorStateUnit', () => {
     stateUnit.dispose();
   });
 
-  it('emit rejects (does not hang) when its timeout aborts the POST (P7)', async () => {
+  it('emit retries a timeout, then rejects (does not hang) when the budget runs out (P7)', async () => {
     // When the deadline fires, `AbortSignal.timeout` rejects the fetch with a
     // TimeoutError; the caller must receive that rejection — a job failure the
     // queue classifies transient — rather than an unsettled promise. (The
     // deadline itself is a native timer vitest's fake clock does not drive, so
     // this pins the propagation the deadline produces, and the pin above pins
     // that the deadline is wired.)
-    mockFetch.mockRejectedValueOnce(new DOMException('The operation timed out.', 'TimeoutError'));
+    //
+    // SIDECAR-BOOT-RESILIENCE P2 changed WHEN that rejection arrives: a deadline
+    // is the definition of "try again", so the emit now spends its budget first.
+    // The no-hang guarantee is unchanged and is what this still pins — it is the
+    // budget, not the first failure, that bounds the wait. `mockRejectedValue`
+    // (not `…Once`) so every attempt times out; fake timers drive the retry
+    // sleeps, which are ordinary `setTimeout`s even though the deadline is not.
+    vi.useFakeTimers();
+    mockFetch.mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'));
     const stateUnit = createActorStateUnit({
       baseUrl: 'http://localhost:4000',
       token: 'tok',
       channels: [],
     });
 
-    await expect(stateUnit.emit('mark:added', { annotationId: 'a-1' })).rejects.toThrow(/timed out/i);
+    const rejects = expect(stateUnit.emit('mark:added', { annotationId: 'a-1' }))
+      .rejects.toThrow(/timed out/i);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await rejects;
+    expect(mockFetch).toHaveBeenCalledTimes(EMIT_RETRY.attempts);
 
+    vi.useRealTimers();
     stateUnit.dispose();
   });
 
@@ -463,6 +476,51 @@ describe('createActorStateUnit', () => {
 
     await expect(stateUnit.emit('match:search-requested', { correlationId: 'c-1' }))
       .rejects.toThrow(/400.*Bus emit validation failed/);
+
+    stateUnit.dispose();
+  });
+
+  it('emit RETRIES a 429 and resolves — the gateway is up and asking us to wait', async () => {
+    // SIDECAR-BOOT-RESILIENCE P2. A 429 rejected on the first attempt, and the
+    // sidecars treat a failed boot emit as fatal, so one rate-limit refusal
+    // killed a projector outright (2026-09-07 weaver incident). Retry is
+    // compliance with the gateway's own instruction, not optimism.
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429, statusText: 'Too Many Requests', text: async () => 'retry when one settles' });
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const stateUnit = createActorStateUnit({ baseUrl: 'http://localhost:4000', token: 'tok', channels: [] });
+
+    await expect(stateUnit.emit('mark:added', { annotationId: 'a-1' })).resolves.toBe(-1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    stateUnit.dispose();
+  });
+
+  it('emit does NOT retry a 401 — the gateway is up and rejected us', async () => {
+    // The asymmetry that made a status-blind predicate wrong in both directions:
+    // 429 and 401 both mean "the gateway answered", and only one of them is an
+    // invitation to try again. Retrying auth failures would burn the budget and
+    // delay a real error reaching the caller.
+    mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized', text: async () => 'token expired' });
+
+    const stateUnit = createActorStateUnit({ baseUrl: 'http://localhost:4000', token: 'tok', channels: [] });
+
+    await expect(stateUnit.emit('mark:added', { annotationId: 'a-1' })).rejects.toThrow(/401/);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    stateUnit.dispose();
+  });
+
+  it('emit exposes the status as a FIELD, not only inside the message', async () => {
+    // D1. A predicate that recovered the status by parsing it back out of prose
+    // would be a second statement of the same fact, in the fragile direction —
+    // and `isRetryableRequestError` reads the field.
+    mockFetch.mockResolvedValue({ ok: false, status: 403, statusText: 'Forbidden', text: async () => 'nope' });
+
+    const stateUnit = createActorStateUnit({ baseUrl: 'http://localhost:4000', token: 'tok', channels: [] });
+
+    await expect(stateUnit.emit('mark:added', { annotationId: 'a-1' }))
+      .rejects.toMatchObject({ name: 'APIError', status: 403 });
 
     stateUnit.dispose();
   });

--- a/packages/http-transport/src/transport/__tests__/api-error.test.ts
+++ b/packages/http-transport/src/transport/__tests__/api-error.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { SemiontError, type TransportErrorCode } from '@semiont/core';
 
-import { APIError } from '../http-transport';
+import { APIError } from '../api-error';
 
 describe('APIError', () => {
   describe('classifyApiCode (via constructor)', () => {

--- a/packages/http-transport/src/transport/__tests__/http-content-transport.xhr.test.ts
+++ b/packages/http-transport/src/transport/__tests__/http-content-transport.xhr.test.ts
@@ -18,7 +18,8 @@ vi.mock('ky', () => ({
 }));
 
 import ky from 'ky';
-import { HttpTransport, APIError } from '../http-transport';
+import { HttpTransport } from '../http-transport';
+import { APIError } from '../api-error';
 import { HttpContentTransport } from '../http-content-transport';
 import { BehaviorSubject } from 'rxjs';
 

--- a/packages/http-transport/src/transport/__tests__/http-transport.hooks.test.ts
+++ b/packages/http-transport/src/transport/__tests__/http-transport.hooks.test.ts
@@ -33,7 +33,8 @@ vi.mock('ky', () => {
 });
 
 import ky, { HTTPError } from 'ky';
-import { HttpTransport, APIError } from '../http-transport';
+import { HttpTransport } from '../http-transport';
+import { APIError } from '../api-error';
 
 const testBaseUrl = baseUrl('http://localhost:4000');
 

--- a/packages/http-transport/src/transport/actor-state-unit.ts
+++ b/packages/http-transport/src/transport/actor-state-unit.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { filter, map, share } from 'rxjs/operators';
-import { busLog, busLogEnabled, uuidV4, type components, type ConnectionState, type StateUnit } from '@semiont/core';
+import { busLog, busLogEnabled, uuidV4, retryWithBackoff, isRetryableRequestError, type components, type ConnectionState, type StateUnit, type RetryPolicy } from '@semiont/core';
 import {
   SpanKind,
   extractTraceparent,
@@ -9,6 +9,7 @@ import {
   withTraceparent,
 } from '@semiont/observability';
 import { SseConnectError } from './sse-connect-error';
+import { APIError } from './api-error';
 
 export type { ConnectionState };
 
@@ -87,6 +88,25 @@ const MAX_RECONNECT_MS = 60_000;
  * type — not just the reference-annotation persist P6 bounded.
  */
 export const EMIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Retry budget for ONE `/bus/emit` POST (SIDECAR-BOOT-RESILIENCE D3).
+ *
+ * Per request, deliberately — not per boot pass. "Retry when one settles" is
+ * advice about a single request; re-running a whole catch-up pass to recover
+ * from one refusal re-sends hundreds of already-successful emits, which is the
+ * amplification that wedged the weaver in the first place.
+ *
+ * Small on purpose. `EMIT_TIMEOUT_MS` bounds each attempt, so the worst case
+ * here is 4 attempts plus up to ~7s of jittered waiting, and an emit that a
+ * caller is awaiting must fail while the caller still cares. The patience for a
+ * gateway that is genuinely down belongs to the boot pass above it, not here.
+ */
+export const EMIT_RETRY: RetryPolicy = {
+  attempts: 4,
+  initialDelayMs: 1_000,
+  maxDelayMs: 4_000,
+};
 
 /**
  * How long a superseded connection keeps DRAINING after a make-before-break
@@ -738,28 +758,49 @@ export function createActorStateUnit(options: ActorStateUnitOptions): ActorState
         headers['traceparent'] = trace.traceparent;
         if (trace.tracestate) headers['tracestate'] = trace.tracestate;
       }
-      // Bounded (JOB-RESTART-SAFETY P7): an unresponsive gateway must not hang
-      // the caller's loop forever. AbortSignal.timeout rejects with a
-      // TimeoutError, which propagates like any other emit failure.
-      const res = await fetch(`${baseUrl}/bus/emit`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(EMIT_TIMEOUT_MS),
-      });
-      // A refused emit (validation 400, auth 401…) must REJECT — busRequest's
-      // contract detaches its doomed reply and propagates this to the caller.
-      // Resolving a sentinel here instead leaves that caller waiting for a
-      // reply the gateway will never send.
-      if (!res.ok) {
-        let detail = '';
-        try {
-          detail = (await res.text()).slice(0, 500);
-        } catch {
-          // status alone
+      // Retried per request (SIDECAR-BOOT-RESILIENCE D3): a 429/503/504 or an
+      // expired deadline gets another attempt; a 400/401/403 rejects on the
+      // first, unretried. The predicate is core's, shared with the boot passes
+      // above, so "retryable" means one thing across the fleet.
+      //
+      // The whole attempt — POST, status check, and the error it throws — is
+      // inside the retried unit, because the refusal IS the failure being
+      // classified. Retrying only the fetch would re-run the request and then
+      // hand back the same unexamined response.
+      const res = await retryWithBackoff(async () => {
+        // Bounded (JOB-RESTART-SAFETY P7): an unresponsive gateway must not hang
+        // the caller's loop forever. AbortSignal.timeout rejects with a
+        // DOMException named TimeoutError — which the predicate treats as
+        // retryable, since a deadline is the definition of "try again".
+        const attempt = await fetch(`${baseUrl}/bus/emit`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(EMIT_TIMEOUT_MS),
+        });
+        // A refused emit (validation 400, auth 401…) must REJECT — busRequest's
+        // contract detaches its doomed reply and propagates this to the caller.
+        // Resolving a sentinel here instead leaves that caller waiting for a
+        // reply the gateway will never send.
+        if (!attempt.ok) {
+          let detail = '';
+          try {
+            detail = (await attempt.text()).slice(0, 500);
+          } catch {
+            // status alone
+          }
+          // APIError, not a bare Error: the status rides as a FIELD (D1), which
+          // is what makes it classifiable without parsing it back out of prose.
+          // The message keeps its shape, so callers matching on it are unaffected.
+          throw new APIError(
+            `/bus/emit ${attempt.status}${detail ? `: ${detail}` : ''}`,
+            attempt.status,
+            attempt.statusText,
+            detail || undefined,
+          );
         }
-        throw new Error(`/bus/emit ${res.status}${detail ? `: ${detail}` : ''}`);
-      }
+        return attempt;
+      }, isRetryableRequestError, EMIT_RETRY);
       // `-1` = count unknown (older gateway / unreadable body) — never let a
       // parse failure read as an empty room. Same sentinel as the Go client.
       try {

--- a/packages/http-transport/src/transport/api-error.ts
+++ b/packages/http-transport/src/transport/api-error.ts
@@ -1,0 +1,50 @@
+/**
+ * `APIError` — the transport's HTTP failure, carrying the status it came from.
+ *
+ * Lives in its own module rather than in `http-transport.ts` because
+ * `actor-state-unit.ts` throws it too (SIDECAR-BOOT-RESILIENCE P2) and
+ * `http-transport.ts` imports `actor-state-unit.ts` — so the obvious home is a
+ * cycle. The alternative, a second status-bearing error class beside this one,
+ * is the duplicated shape the house rules forbid: there would then be two
+ * answers to "how does an HTTP failure carry its status", and the retry
+ * predicate could only agree with one of them.
+ */
+
+import { SemiontError, type TransportErrorCode, type HttpStatusError } from '@semiont/core';
+
+function classifyApiCode(status: number): TransportErrorCode {
+  if (status === 400) return 'bad-request';
+  if (status === 401) return 'unauthorized';
+  if (status === 403) return 'forbidden';
+  if (status === 404) return 'not-found';
+  if (status === 409) return 'conflict';
+  if (status >= 500) return 'unavailable';
+  return 'error';
+}
+
+export class APIError extends SemiontError {
+  declare code: TransportErrorCode;
+  readonly status: number;
+  readonly statusText: string;
+
+  constructor(message: string, status: number, statusText: string, body?: unknown) {
+    super(message, classifyApiCode(status), { status, statusText, body });
+    this.name = 'APIError';
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
+/**
+ * The contract between this class and core's `isRetryableRequestError`, asserted
+ * at compile time (SIDECAR-BOOT-RESILIENCE P1/P2).
+ *
+ * Core cannot name `APIError` — http-transport depends on core, not the reverse —
+ * so the predicate reads the `status` field structurally. Without this line that
+ * agreement is a coincidence: rename `status` here and every 429 silently stops
+ * being retryable, with no test failing, because a predicate that finds no status
+ * simply answers `false`. **A silent loss of retry is exactly the failure this
+ * plan exists to prevent**, so it is pinned by the compiler rather than by a test.
+ */
+const _conformsToRetryContract: HttpStatusError = new APIError('', 0, '');
+void _conformsToRetryContract;

--- a/packages/http-transport/src/transport/http-content-transport.ts
+++ b/packages/http-transport/src/transport/http-content-transport.ts
@@ -44,7 +44,7 @@ import type { AccessToken, ResourceId, PutBinaryOptions, components } from '@sem
 import { busLog } from '@semiont/core';
 import { SpanKind, getActiveTraceparent, withSpan } from '@semiont/observability';
 import type { HttpTransport } from './http-transport';
-import { APIError } from './http-transport';
+import { APIError } from './api-error';
 import type { IContentTransport, PutBinaryRequest } from '@semiont/core';
 
 type GetResourceResponse = components['schemas']['GetResourceResponse'];

--- a/packages/http-transport/src/transport/http-transport.ts
+++ b/packages/http-transport/src/transport/http-transport.ts
@@ -31,9 +31,9 @@ import {
   SemiontError,
   busLog,
 } from '@semiont/core';
-import type { TransportErrorCode } from '@semiont/core';
 import { SpanKind, recordBusEmit, withSpan } from '@semiont/observability';
 import { createActorStateUnit, type ActorStateUnit } from './actor-state-unit';
+import { APIError } from './api-error';
 import type {
   ConnectionState,
   IGatewayOperations,
@@ -63,29 +63,6 @@ export const RESOURCE_SCOPED_CHANNELS = [
   ...PERSISTED_EVENT_TYPES.filter((t) => !(BRIDGED_CHANNELS as readonly string[]).includes(t)),
   ...RESOURCE_BROADCAST_TYPES,
 ];
-
-function classifyApiCode(status: number): TransportErrorCode {
-  if (status === 400) return 'bad-request';
-  if (status === 401) return 'unauthorized';
-  if (status === 403) return 'forbidden';
-  if (status === 404) return 'not-found';
-  if (status === 409) return 'conflict';
-  if (status >= 500) return 'unavailable';
-  return 'error';
-}
-
-export class APIError extends SemiontError {
-  declare code: TransportErrorCode;
-  readonly status: number;
-  readonly statusText: string;
-
-  constructor(message: string, status: number, statusText: string, body?: unknown) {
-    super(message, classifyApiCode(status), { status, statusText, body });
-    this.name = 'APIError';
-    this.status = status;
-    this.statusText = statusText;
-  }
-}
 
 export type TokenRefresher = () => Promise<string | null>;
 

--- a/packages/make-meaning/src/__tests__/boot-pass.test.ts
+++ b/packages/make-meaning/src/__tests__/boot-pass.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `runBootPass` — a projector's startup repair must not kill the projector
+ * (SIDECAR-BOOT-RESILIENCE P3).
+ *
+ * The weaver and smelter each run repair passes at boot (catch-up, reconcile) and
+ * each treated any failure as fatal: rethrow into the catch-all around `main()`,
+ * `process.exit(1)`, and — with containers running under no restart policy — gone
+ * until a human notices. A single 429 from the gateway was enough (2026-09-07).
+ *
+ * P1/P2 made the underlying emit retry, which narrows the window but does not
+ * change what happens at the end of it. This is that end.
+ *
+ * Tested here rather than through `weaver-main.ts` because that module calls
+ * `main()` at load, so importing it runs it. Extracting the contract is also what
+ * makes both mains answer the same way structurally, rather than by two sessions
+ * separately remembering to.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runBootPass, type BootPassState } from '../boot-pass';
+
+const fakeLogger = () => ({
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(function (this: unknown) { return this as never; }),
+});
+
+describe('runBootPass (SIDECAR-BOOT-RESILIENCE P3)', () => {
+  it('does NOT rethrow when the pass fails — the process survives', async () => {
+    // The whole phase. A rejected boot pass used to reach `main().catch()`, which
+    // exits. D4: a failed repair pass is a DATA condition, not a reason to die.
+    const logger = fakeLogger();
+    await expect(
+      runBootPass('catch-up', async () => { throw new Error('/bus/emit 429'); }, logger),
+    ).resolves.toBeUndefined();
+  });
+
+  it('records the failure, so the phase outlives the pass', async () => {
+    // Before P3 this state was written and then made unreachable one line later:
+    // the process exited before anything could read what it had just recorded.
+    const states: BootPassState[] = [];
+    await runBootPass('catch-up', async () => { throw new Error('/bus/emit 429'); },
+      fakeLogger(), (s) => states.push(s));
+
+    expect(states.map((s) => s.phase)).toEqual(['running', 'failed']);
+    expect(states[1]).toMatchObject({ phase: 'failed', error: expect.stringContaining('429') });
+  });
+
+  it('logs the failure at error level — the ONLY operator signal left', async () => {
+    // D4 accepts losing the crude staleness alarm that a dead container provided,
+    // and does not replace it: `/health` still reports `status: 'ok'` until D5.
+    // If this log goes quiet, a projector can fall behind with nothing saying so.
+    const logger = fakeLogger();
+    await runBootPass('reconcile', async () => { throw new Error('boom'); }, logger);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error.mock.calls[0]![0]).toMatch(/reconcile/i);
+  });
+
+  it('records running then done with the summary on success', async () => {
+    const states: BootPassState[] = [];
+    await runBootPass('reconcile', async () => ({ healed: 3 }), fakeLogger(), (s) => states.push(s));
+
+    expect(states.map((s) => s.phase)).toEqual(['running', 'done']);
+    expect(states[1]).toMatchObject({ phase: 'done', summary: { healed: 3 } });
+  });
+
+  it('does not log an error on the success path', async () => {
+    const logger = fakeLogger();
+    await runBootPass('catch-up', async () => 'ok', logger);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('works without a state sink — the smelter records its own', async () => {
+    // `Smelter.reconcileState` is set inside `reconcile()` before it throws, so
+    // that main passes no sink and must not need one.
+    const logger = fakeLogger();
+    await expect(
+      runBootPass('reconcile', async () => { throw new Error('boom'); }, logger),
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/make-meaning/src/boot-pass.ts
+++ b/packages/make-meaning/src/boot-pass.ts
@@ -1,0 +1,66 @@
+/**
+ * Running a projector's startup repair pass without letting it kill the
+ * projector (SIDECAR-BOOT-RESILIENCE P3).
+ *
+ * The weaver (catch-up, reconcile) and the smelter (reconcile) each repair a
+ * derived store they OWN — bringing a graph projection or a vector index back in
+ * line with the event log, which is the system of record. That is write-side work,
+ * which is why the librarian has none: it is a reader, owns nothing derived, and
+ * has nothing to bring back.
+ *
+ * Both mains used to rethrow a failed pass into the catch-all around `main()`,
+ * which exits. Under no restart policy that means gone until a human notices, and
+ * one 429 from the gateway was enough (2026-09-07). P1/P2 made the underlying emit
+ * retry, which narrows the window; this decides what happens at the end of it.
+ *
+ * **D4: a failed repair pass is a DATA condition, not a reason to die**, and not a
+ * health verdict either — `/health` means "can I reach what I need, and are my
+ * expected processes running?", under which "did catch-up succeed at boot?" is
+ * neither. Two supports worth keeping: it is a boot-time fact that would be
+ * reported forever as a current state, and the old fatality guarded only the ~30 s
+ * boot window anyway — a subscription that drops silently an hour later leaves the
+ * same stale graph with `/health` still saying `ok`.
+ *
+ * **The cost, accepted deliberately:** a dead container was a crude staleness
+ * alarm and nothing replaces it yet. The `logger.error` here is therefore the only
+ * operator-visible signal that a pass failed, until D5 makes `/health` compute
+ * what it claims. Do not quiet it.
+ *
+ * Shared rather than inlined twice so the two mains cannot drift into two
+ * different answers about what surviving a failed pass means.
+ */
+
+import { errField, type Logger } from '@semiont/core';
+
+export type BootPassState =
+  | { phase: 'pending' }
+  | { phase: 'running' }
+  | { phase: 'done'; summary: unknown }
+  | { phase: 'failed'; error: string };
+
+/**
+ * Run one boot pass. **Never throws.**
+ *
+ * `onState` is optional because the two callers record differently: the weaver
+ * keeps its phases in `main()` locals that `/health` closes over, while the
+ * smelter's `reconcile()` already sets `Smelter.reconcileState` — including the
+ * failed phase — before it throws.
+ */
+export async function runBootPass<T>(
+  pass: string,
+  run: () => Promise<T>,
+  logger: Logger,
+  onState?: (state: BootPassState) => void,
+): Promise<void> {
+  onState?.({ phase: 'running' });
+  try {
+    const summary = await run();
+    onState?.({ phase: 'done', summary });
+  } catch (error) {
+    onState?.({ phase: 'failed', error: error instanceof Error ? error.message : String(error) });
+    logger.error(`Boot pass '${pass}' failed — continuing with a store that may be behind`, {
+      pass,
+      error: errField(error),
+    });
+  }
+}

--- a/packages/make-meaning/src/smelter-main.ts
+++ b/packages/make-meaning/src/smelter-main.ts
@@ -27,6 +27,7 @@ import { Smelter } from './smelter';
 import { SMELTER_REPLY_CHANNELS } from './service-channels';
 import { HttpTransport } from '@semiont/http-transport';
 import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader, retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY } from '@semiont/core';
+import { runBootPass } from './boot-pass';
 import type { AccessToken } from '@semiont/core';
 import { createVectorStore, createEmbeddingProvider } from '@semiont/vectors';
 import type { ChunkingConfig } from '@semiont/core';
@@ -266,10 +267,14 @@ async function main() {
 
   // Catch-up pass: the live subscription is attached, so anything that
   // changed while this worker was down — or a wiped Qdrant volume — is
-  // brought back in sync here. Fatal on failure: a smelter that cannot
-  // reconcile is serving an index of unknown completeness. (A restart
-  // re-runs it from scratch — reconcile is idempotent.)
-  await smelter.reconcile();
+  // brought back in sync here.
+  //
+  // NOT fatal since SIDECAR-BOOT-RESILIENCE P3, for the same reason as the
+  // weaver's: an index of unknown completeness is a data condition, and exiting
+  // does not complete it. No state sink is passed — `Smelter.reconcile()` already
+  // sets `reconcileState` to `{ phase: 'failed' }` before it throws, and that is
+  // what `/health` serves.
+  await runBootPass('reconcile', () => smelter.reconcile(), logger);
 }
 
 main().catch((error) => {

--- a/packages/make-meaning/src/weaver-main.ts
+++ b/packages/make-meaning/src/weaver-main.ts
@@ -25,6 +25,7 @@ import { FileWeaverCheckpoint } from './weaver-checkpoint';
 import { WEAVER_REPLY_CHANNELS } from './service-channels';
 import { HttpTransport } from '@semiont/http-transport';
 import { baseUrl as makeBaseUrl, accessToken as makeAccessToken, createTomlConfigLoader, retryWithBackoff, isTransientFetchError, STARTUP_FETCH_RETRY } from '@semiont/core';
+import { runBootPass, type BootPassState } from './boot-pass';
 import type { AccessToken } from '@semiont/core';
 import { getGraphDatabase } from '@semiont/graph';
 import { createServer } from 'http';
@@ -198,8 +199,8 @@ async function main() {
   actorStateUnit.start();
   logger.info('Subscribed to graph-relevant events and rebuild commands');
 
-  let catchUpState: Record<string, unknown> = { phase: 'pending' };
-  let reconcileState: Record<string, unknown> = { phase: 'pending' };
+  let catchUpState: BootPassState = { phase: 'pending' };
+  let reconcileState: BootPassState = { phase: 'pending' };
 
   const health = createServer((req, res) => {
     if (req.url === '/health') {
@@ -235,30 +236,22 @@ async function main() {
 
   // Catch-up pass: the live subscription is attached, so anything that
   // changed while this weaver was down is brought back in sync here —
-  // checkpointed replay, full replay if the checkpoint is gone. Fatal on
-  // failure: a weaver that cannot catch up is projecting a graph of
-  // unknown freshness. (A restart re-runs it — catch-up is idempotent.)
-  catchUpState = { phase: 'running' };
-  try {
-    const summary = await weaver.catchUp();
-    catchUpState = { phase: 'done', summary };
-  } catch (error) {
-    catchUpState = { phase: 'failed', error: error instanceof Error ? error.message : String(error) };
-    throw error;
-  }
+  // checkpointed replay, full replay if the checkpoint is gone.
+  //
+  // NOT fatal since SIDECAR-BOOT-RESILIENCE P3. It used to be, on the argument
+  // that "a weaver that cannot catch up is projecting a graph of unknown
+  // freshness" — true, but exiting does not make the graph fresher, and the rule
+  // only ever guarded this ~30 s window: a subscription that drops silently an
+  // hour from now leaves exactly the same stale graph. What it did guarantee was
+  // that one 429 removed the weaver entirely (2026-09-07). The failed phase is
+  // recorded and logged; the live subscription keeps running.
+  await runBootPass('catch-up', () => weaver.catchUp(), logger, (s) => { catchUpState = s; });
 
   // Reconcile pass (#845): the state-diff backstop for divergence the
   // accounting cannot witness — out-of-band mutations, wiped/rolled-back
-  // graph volumes, historical damage. Fatal on a thrown reconcile (bus
-  // unreachable); heal failures are reported in the summary, not fatal.
-  reconcileState = { phase: 'running' };
-  try {
-    const summary = await weaver.reconcile();
-    reconcileState = { phase: 'done', summary };
-  } catch (error) {
-    reconcileState = { phase: 'failed', error: error instanceof Error ? error.message : String(error) };
-    throw error;
-  }
+  // graph volumes, historical damage. Also non-fatal (P3); heal failures were
+  // already reported in the summary rather than thrown.
+  await runBootPass('reconcile', () => weaver.reconcile(), logger, (s) => { reconcileState = s; });
 }
 
 main().catch((error) => {


### PR DESCRIPTION
One `429` from the gateway removed the weaver. The boot pass rethrew, the catch-all
around `main()` called `process.exit(1)`, and containers run with no restart policy —
so the projector was gone until a human noticed. The smelter had the same defect
(2026-08-27).

## The retry machinery existed and would not have helped

All the sidecars already import `retryWithBackoff` and use it — once, around
`authenticate()`. Wrapping the boot passes in the same call would still not have
retried that 429, because the predicate excluded it **on purpose**:

> Deliberately false for HTTP-level failures (a 401 means the gateway is UP and
> rejected us; retrying won't change its mind)

That reasoning is right for 401 and wrong for 429. A 429 also means the gateway is
up — and its body says *"retry when one settles."* Same fact, opposite conclusion.
So this was never a missing call site; it was a **missing category**, and two things
underneath it:

- **The error carried no status to branch on.** `/bus/emit` threw a plain `Error`
  whose message was built by interpolation. Any predicate wanting the status had to
  parse it back out of prose.
- **The health surface was written and structurally unreachable.** The weaver set
  `catchUpState = { phase: 'failed' }` and *then* rethrew, so the process exited
  before `/health` could ever be scraped.

## What changed

| | before | after |
|---|---|---|
| retryable | connection failures only | + `429`/`503`/`504`, + `TimeoutError` |
| emit error | `Error` with the status in the message | `APIError` with `status` as a field |
| retry scope | none on emit | per **request** |
| failed boot pass | `process.exit(1)` | recorded, logged, process lives |

**`500` is excluded deliberately.** 503 and 504 are promises to recover; an
unclassified server fault is not, and retrying one inside a boot pass replays
whatever broke it.

**The timeout case was measured, not assumed.** `AbortSignal.timeout()` rejects with
a **DOMException named `TimeoutError`**, not a `TypeError` — so the connection-level
predicate could not see it, and a request that bounded itself was unretryable
precisely when its own bound fired. Against a *refused* connection it surfaces as
`TypeError: fetch failed` instead, which is why a careless check would have appeared
to pass.

## Retry per request, not per pass

"Retry when one settles" is advice about one request. Wrapping a whole boot pass
re-runs hundreds of already-successful emits to recover from a single refusal — and
on a catch-up that is the exact amplification that wedged the weaver in the first
place. The budget is 4 attempts with 1s→4s ceilings, small on purpose: each attempt
is already bounded by the emit deadline, and an emit a caller is awaiting must fail
while the caller still cares.

## Two structural things this turned up

**Throwing `APIError` from the emit site was a cycle.** It lived in
`http-transport.ts`, which imports `actor-state-unit.ts`. It moved to its own leaf
module that both import — no re-export shim, and the package's public surface is
unchanged. The alternative, a second status-bearing error class beside `APIError`,
would give two answers to *how does an HTTP failure carry its status*, and the
predicate could only agree with one — silently, since a predicate that finds no
status just answers `false`. That agreement is now pinned by a one-line compile-time
conformance assertion rather than by coincidence.

**`retryWithBackoff` had no jitter, so it does now — for every caller.** Rather than
add a flag nobody would set to `false`, or write a second retry loop, jitter is
unconditional: delay ∈ [cap/2, cap), the same equal-jitter formula the SSE reconnect
already used, so the two backoffs behave alike instead of each inventing a curve.
**This changes shared behavior for all five existing callers** — every one a
container in a fleet that boots together and retries against one gateway, which is
the lockstep jitter exists to break. The advertised worst case is unchanged
(`delay <= cap` still holds); only the expected wait drops. The exact-delay test
became a bounds test that still pins the doubling and the cap, plus a new test that
repeated runs diverge.

## What this deliberately does not do

**`/health` is untouched, and it is still wrong.** All three sidecars hardcode
`status: 'ok'`. That is left alone because a failed repair pass is a *data*
condition, not a health verdict — `/health` should mean "can I reach what I need,
and are my expected processes running?", under which "did catch-up succeed at boot?"
is neither. It is also a boot-time fact that would otherwise be reported forever as
a current state.

**Reporting `degraded` in the body would have been a no-op.** Measured: for a
sidecar, `semiont status` reads the HTTP **status code** and never parses the body,
and the librarian's Docker healthcheck is likewise `statusCode < 400`. Staying up
while returning `200` with a `degraded` body would have been *strictly worse than
dying* — a live projector serving a graph of unknown freshness that every existing
consumer reports as fine.

**So a crude alarm is lost on purpose.** A dead container was a staleness signal,
and nothing replaces it here. Until `/health` computes what it claims, the
`logger.error` on a failed pass is the only operator-visible trace — which is why
there is a test asserting it fires, protecting a signal rather than a behavior.

Note the old rule guarded less than it appeared to: if catch-up *succeeds* and the
subscription later drops silently, the graph goes stale and `/health` still says
`ok`. It protected one ~30s window at boot and was blind afterwards.

## The librarian is untouched, and that is not an omission

It is a **reader** — no authority to write, no derived store of its own, nothing to
drift, and therefore no repair pass to fail. Catch-up and reconcile are write-side
work: the weaver owns the graph projection, the smelter owns the vector index. The
librarian's boot steps are `authenticate()` (already retried) and two
`initialize()` calls that are pure subscription wiring — no I/O, no emits, nothing a
429 can reach. It still benefits from this change, in steady state: its replies are
emits, and emits now retry.

`runBootPass` is shared rather than inlined twice so the two projectors cannot drift
into two different answers about what surviving a failed pass means.
