### PR TITLE
orphaned views: reaped at the source, named by the weaver, and the remedy made discoverable

### DIFF
--- a/apps/archivist/README.md
+++ b/apps/archivist/README.md
@@ -27,6 +27,13 @@ Three actors, and they move together on purpose:
 Plus the annotation-assembly and annotation-context handlers, the entity-type bootstrap, and the
 startup view rebuild — this is the one rebuild owner.
 
+**The startup rebuild also reaps.** It replays the log and writes a view for every resource it
+finds, then **deletes the views the log no longer justifies**. Without that step the pass is
+upsert-only, and a log rewrite leaves views behind that nothing ever clears — the weaver's
+catalog is those views, so it spends every boot trying to heal resources that no longer exist.
+A view whose rebuild *threw* is kept rather than reaped: a transient read failure must not read
+as "the log does not justify this." Each reap is logged by resource id, with a count.
+
 **Why these cannot be split.** Stower writes the events and projections Browser reads;
 separating them opens a cross-process read-after-write window over the same state. And git is
 single-writer — the working-tree store shells out to `git add`/`git mv`, so two processes on one
@@ -71,7 +78,9 @@ Librarian, Worker) dial them directly via `archivistContentReads`.
 Mount the KB at `/kb` and the shared state and anchored-text directories at their declared
 paths; the image fixes the container-side paths so the launcher passes no path env. Set
 `SEMIONT_WORKER_SECRET` — it authenticates to the gateway with it and requires it on its own
-surface. `SEMIONT_SKIP_REBUILD=true` skips the startup view rebuild.
+surface. `SEMIONT_SKIP_REBUILD=true` skips the startup view rebuild — and with it the reap, so views
+the log no longer justifies survive until a rebuild runs or `semiont clean --store state`
+clears them.
 
 **The heap ceiling is explicit, and paired.** The image sets
 `NODE_OPTIONS=--max-old-space-size=1536` against a 2 GB container allocation. Without it V8

--- a/apps/launcher/README.md
+++ b/apps/launcher/README.md
@@ -598,7 +598,8 @@ entrypoint refuses to boot unless its `test -w` gate passes, and Apple
 container's virtiofs won't let it chown a mount root.)
 
 `semiont clean` is the one way this state dies: it removes the current
-root's state directory (`--store database|vectors|graph` scopes to one
+root's state directory (`--store database|vectors|graph|anchored-text|state`
+scopes to one
 store; `--dry-run` shows what would go, with sizes; `--root <path|name|key>`
 targets another root — a literal key is how you remove *orphaned* state
 whose KB directory no longer exists). It refuses while a recorded stack is

--- a/apps/launcher/internal/launcher/clean.go
+++ b/apps/launcher/internal/launcher/clean.go
@@ -13,8 +13,11 @@ package launcher
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 )
 
 const cleanUsage = `Usage: semiont clean [options]
@@ -30,8 +33,10 @@ user accounts those tokens name lived in the PostgreSQL data just removed.
 A --store clean keeps the secret.
 
 Options:
-  --store <role>   Remove one store only: database, vectors, graph, or
-                   anchored-text
+  --store <role>   Remove one store only: database, vectors, graph,
+                   anchored-text, or state (views + the gateway's jobs
+                   queue; views rebuild from the event log on next start,
+                   queued jobs are lost)
   --root <value>   Another root: a path, a registered basename, or a state
                    key as listed by status --verbose (how orphaned state,
                    whose KB directory no longer exists, is named)
@@ -72,7 +77,7 @@ func Clean(args []string) int {
 	}
 	if store != "" {
 		if _, ok := stateStores[store]; !ok {
-			u.fail("Unknown store %q (stores with persistent state: anchored-text, database, graph, vectors)", store)
+			u.fail("Unknown store %q (stores with persistent state: %s)", store, strings.Join(slices.Sorted(maps.Keys(stateStores)), ", "))
 			return 1
 		}
 	}

--- a/apps/launcher/internal/launcher/clean_test.go
+++ b/apps/launcher/internal/launcher/clean_test.go
@@ -1,0 +1,24 @@
+package launcher
+
+import (
+	"strings"
+	"testing"
+)
+
+// The --store option list in cleanUsage is hand-written prose (each store
+// carries a tradeoff note), so it cannot be derived from stateStores — this
+// gate fails when the table grows a store the help does not mention. The
+// unknown-store error needs no gate: it joins the table's keys directly.
+func TestCleanUsageNamesEveryStore(t *testing.T) {
+	start := strings.Index(cleanUsage, "Remove one store only:")
+	end := strings.Index(cleanUsage, "--root")
+	if start < 0 || end < start {
+		t.Fatalf("cleanUsage no longer has the --store option list this test anchors on")
+	}
+	list := cleanUsage[start:end]
+	for name := range stateStores {
+		if !strings.Contains(list, name) {
+			t.Errorf("stateStores has %q but cleanUsage's --store list does not mention it", name)
+		}
+	}
+}

--- a/apps/weaver/README.md
+++ b/apps/weaver/README.md
@@ -71,14 +71,19 @@ Two environment variables:
 
 ## Startup catch-up and reconcile
 
-On boot it runs two passes, both fatal on failure — a weaver that cannot catch up is
-projecting a graph of unknown freshness. Both are idempotent, so a restart re-runs them, and
-`/health` reports each one's phase and summary.
+On boot it runs two passes. Both are idempotent, so a restart re-runs them, and `/health`
+reports each one's phase and summary.
 
 **Catch-up** replays what it missed while down, from the checkpoint forward (full replay if
 the checkpoint is gone). **Reconcile** then diffs the projection against what the views serve
 and heals divergence from the log — the backstop for damage the accounting cannot witness: a
 wiped graph volume, an out-of-band mutation.
+
+**A failed pass does not kill the process.** It used to: both rethrew into the catch-all
+around `main()`, and under no restart policy that meant gone until a human noticed — one
+refused bus request was enough. A failed repair pass is a data condition, so the weaver now
+survives it and logs an error. That error is the only operator-visible signal that the
+projection may be stale; nothing else reports it, and `/health` does not fold it in.
 
 So a restart heals missed events and drift. **It does not re-derive events it has already
 applied.** Reconcile compares a fixed set of facts — node presence, archived flag, entity
@@ -86,6 +91,12 @@ types, the annotation id set, and annotation bodies — so a change to what the 
 *stores* outside that set, such as a new denormalized property on a node, is invisible to it.
 After that kind of change, run `weave:rebuild`, and verify the projection actually carries
 what you expect rather than trusting the command's success line.
+
+**An orphaned view is reported, not healed.** A resource in the catalog whose log holds no
+events cannot be rebuilt — replaying nothing writes nothing — so reconcile counts it as
+`orphaned` rather than `healed` and warns with the remedy. It means history was rewritten
+without invalidating the views; the archivist's startup rebuild reaps such views, and
+`semiont clean --store state` clears them outright.
 
 ## Related
 

--- a/docs/system/administration/DATABASE.md
+++ b/docs/system/administration/DATABASE.md
@@ -112,7 +112,7 @@ external PostgreSQL will differ.
 ```bash
 semiont stop
 semiont clean                      # every store
-semiont clean --store database     # PostgreSQL only, leaving graph and vectors
+semiont clean --store database     # PostgreSQL only, leaving every other store
 semiont clean --dry-run            # what would go, and how big
 semiont start
 ```

--- a/docs/system/administration/MAINTENANCE.md
+++ b/docs/system/administration/MAINTENANCE.md
@@ -106,7 +106,8 @@ The verbose report calls out **orphaned** state — state whose KB directory no 
 
 ```bash
 semiont clean --dry-run              # What would go, and how big
-semiont clean --store vectors        # One store: database, graph, or vectors
+semiont clean --store vectors        # One store: database, graph, vectors,
+                                     #   anchored-text, or state
 semiont clean --root <path|name|key> # Another root, including an orphan
 ```
 

--- a/packages/event-sourcing/src/__tests__/views/view-materializer.test.ts
+++ b/packages/event-sourcing/src/__tests__/views/view-materializer.test.ts
@@ -1319,5 +1319,90 @@ describe('ViewMaterializer', () => {
       const source = fakeEventSource({});
       await expect(materializer.rebuildAll(source)).resolves.toBeUndefined();
     });
+
+    /**
+     * The reap. `rebuildAll` was upsert-only, so a log rewrite left views the
+     * log no longer justifies behind forever — and the weaver's catalog IS the
+     * views, so it healed ghosts on every boot.
+     */
+    describe('reaping views the log no longer justifies', () => {
+      function seedView(rid: any, name: string) {
+        return viewStorage.save(rid, {
+          resource: {
+            '@context': 'https://schema.org/',
+            '@id': rid,
+            name,
+            representations: [],
+            archived: false,
+            entityTypes: [],
+          },
+          annotations: { resourceId: rid, annotations: [], version: 0, updatedAt: '' },
+        });
+      }
+
+      it('deletes a view whose resource is absent from the log', async () => {
+        const kept = resourceId('doc1');
+        const orphan = resourceId('doc-pruned');
+        await seedView(kept, 'Doc One');
+        await seedView(orphan, 'Ghost');
+
+        await materializer.rebuildAll(
+          fakeEventSource({ [kept as string]: [createdEvent(kept, 'Doc One', 1)] })
+        );
+
+        expect(await viewStorage.exists(orphan)).toBe(false);
+        expect(await viewStorage.exists(kept)).toBe(true);
+      });
+
+      it('deletes a view whose log stream is empty', async () => {
+        const orphan = resourceId('doc-emptied');
+        await seedView(orphan, 'Ghost');
+
+        // The id survives in the log index but its events are gone — the shape
+        // a prune leaves behind, and the one rebuildAll used to skip silently.
+        await materializer.rebuildAll(fakeEventSource({ [orphan as string]: [] }));
+
+        expect(await viewStorage.exists(orphan)).toBe(false);
+      });
+
+      it('keeps every view the log still justifies', async () => {
+        const r1 = resourceId('doc1');
+        const r2 = resourceId('doc2');
+        await seedView(r1, 'Stale One');
+        await seedView(r2, 'Stale Two');
+
+        await materializer.rebuildAll(
+          fakeEventSource({
+            __system__: [entityTypeAddedEvent('Person', 1)],
+            [r1 as string]: [createdEvent(r1, 'Doc One', 1)],
+            [r2 as string]: [createdEvent(r2, 'Doc Two', 1)],
+          })
+        );
+
+        expect((await viewStorage.get(r1))?.resource.name).toBe('Doc One');
+        expect((await viewStorage.get(r2))?.resource.name).toBe('Doc Two');
+      });
+
+      it('keeps a view whose rebuild failed rather than reaping it', async () => {
+        const broken = resourceId('doc-unreadable');
+        await seedView(broken, 'Still Here');
+
+        const source = {
+          async getEvents(rid: any) {
+            if ((rid as string) === (broken as string)) throw new Error('log read failed');
+            return [];
+          },
+          async getAllResourceIds() {
+            return [broken] as any[];
+          },
+        };
+
+        await materializer.rebuildAll(source);
+
+        // A transient read error must never be read as "the log does not
+        // justify this view" — that would turn a retryable fault into deletion.
+        expect(await viewStorage.exists(broken)).toBe(true);
+      });
+    });
   });
 });

--- a/packages/event-sourcing/src/views/view-materializer.ts
+++ b/packages/event-sourcing/src/views/view-materializer.ts
@@ -483,6 +483,8 @@ export class ViewMaterializer {
     );
     this.logger?.info('[ViewMaterializer] Rebuilding resource views', { count: resourceIds.length });
     let skipped = 0;
+    const materialized = new Set<string>();
+    const failed = new Set<string>();
     for (const rid of resourceIds) {
       try {
         const events = await eventLog.getEvents(rid);
@@ -490,12 +492,14 @@ export class ViewMaterializer {
 
         const view = this.materializeFromEvents(events, rid);
         await this.viewStorage.save(rid, view);
+        materialized.add(rid as unknown as string);
 
         for (const event of events) {
           await this.materializeStorageUriIndex(rid, event);
         }
       } catch (error) {
         skipped++;
+        failed.add(rid as unknown as string);
         this.logger?.error('[ViewMaterializer] Failed to rebuild resource view', {
           resourceId: String(rid),
           error: error instanceof Error ? error.message : String(error),
@@ -503,11 +507,41 @@ export class ViewMaterializer {
       }
     }
 
+    const reaped = await this.reapOrphanedViews(materialized, failed);
+
     this.logger?.info('[ViewMaterializer] Rebuild complete', {
       systemEvents: systemEvents.length,
       resources: resourceIds.length,
       skipped,
+      reaped,
     });
+  }
+
+  /**
+   * Delete views the log no longer justifies. Without this the pass is
+   * upsert-only, and a log rewrite leaves ghosts that the weaver's catalog —
+   * which is these views — heals on every boot.
+   *
+   * A resource whose rebuild threw is kept: a transient read failure must not
+   * read as "the log does not justify this view".
+   */
+  private async reapOrphanedViews(materialized: Set<string>, failed: Set<string>): Promise<number> {
+    let reaped = 0;
+
+    for (const view of await this.viewStorage.getAll()) {
+      const id = view.resource['@id'];
+      if (!id || id === '__system__') continue;
+      if (materialized.has(id) || failed.has(id)) continue;
+
+      await this.viewStorage.delete(id as unknown as ResourceId);
+      reaped++;
+      this.logger?.warn('[ViewMaterializer] Reaped view unjustified by the log', { resourceId: id });
+    }
+
+    if (reaped > 0) {
+      this.logger?.warn('[ViewMaterializer] Views reaped', { count: reaped });
+    }
+    return reaped;
   }
 
   /**

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -1378,7 +1378,45 @@ describe('Weaver', () => {
 
       expect(summary.divergent).toBe(1);
       expect(summary.healed).toBe(1);
+      // The guardrail for the orphan branch below: a resource that HAS events
+      // is a real heal, never an orphan. This is also the post-clean shape —
+      // `semiont clean` empties the graph, so every resource reports
+      // `missing-node` and heals from the log. An orphan check keyed on
+      // `missing-node` rather than on zero events would swallow all of it.
+      expect(summary.orphaned).toBe(0);
       expect((await graphDb.getResource(resourceId(rid)))?.name).toBe('Healed');
+    });
+
+    // VIEW-LOG-RECONCILIATION P1. A catalogued resource whose log holds nothing
+    // is an ORPHANED VIEW — someone rewrote history and the views projection
+    // was never invalidated. Healing it replays zero events and writes nothing,
+    // so the same divergence returns on the next boot, forever. Reporting that
+    // as a heal is what let the condition run unnoticed on the template KB for
+    // an unknown number of boots (bugs/weaver-fatal-429-and-phantom-view-heal-wave).
+    it('reports a catalogued resource with no events as an orphan, not a heal', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      // In the catalog, absent from the log — no events are appended for it.
+      const rid = `rec-orphan-${Date.now()}`;
+      serveBrowseReads([rid]);
+      vi.mocked(mockLogger.warn).mockClear();
+      const summary = await consumer.reconcile();
+
+      expect(summary.divergent).toBe(1);
+      expect(summary.orphaned).toBe(1);
+      expect(summary.healed).toBe(0);
+      expect(summary.healFailures).toBe(0);
+
+      // The operator is the mechanism now — `clean --store state` is the
+      // repair, and the breadcrumb has to say so or nobody knows to run it.
+      const orphanWarn = vi.mocked(mockLogger.warn).mock.calls.find(
+        ([msg]) => typeof msg === 'string' && msg.includes('orphaned view'),
+      );
+      expect(orphanWarn, 'reconcile must warn about the orphaned view').toBeDefined();
+      expect(JSON.stringify(orphanWarn)).toContain('clean --store state');
     });
 
     it('a clean graph reconciles with zero divergence and no heals', async () => {

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -429,11 +429,12 @@ export class Weaver {
    * benign. Run after `catchUp()`, mirroring the Smelter's
    * subscribe → catch-up → reconcile startup order.
    */
-  async reconcile(): Promise<{ resourcesChecked: number; divergent: number; healed: number; healFailures: number }> {
+  async reconcile(): Promise<{ resourcesChecked: number; divergent: number; healed: number; healFailures: number; orphaned: number }> {
     const resources = await this.fetchAllResources();
     let divergent = 0;
     let healed = 0;
     let healFailures = 0;
+    let orphaned = 0;
 
     for (const resource of resources) {
       const rid = resource['@id'];
@@ -445,12 +446,29 @@ export class Weaver {
       divergent++;
       this.logger.warn('Reconcile divergence — healing from the log', { resourceId: String(rid), reason });
       const result = await this.rebuildResource(makeResourceId(String(rid)));
-      if (result.eventsFailed === 0) healed++;
+      // Zero events for a CATALOGUED resource is not a heal — it is an
+      // orphaned view. The log is the system of record, the catalog comes from
+      // the views, and a view the log cannot justify means history was
+      // rewritten without invalidating the projection. Replaying nothing
+      // writes nothing, so counting it as healed reports success for a
+      // divergence that returns identically on the next boot, forever.
+      //
+      // Keyed on the event count, never on the divergence reason: after
+      // `semiont clean` every resource legitimately reports `missing-node` and
+      // heals from the log, and an orphan check keyed on that would swallow
+      // the whole rebuild.
+      if (result.eventCount === 0) {
+        orphaned++;
+        this.logger.warn(
+          'Reconcile found an orphaned view — the log has no events for this resource, so healing wrote nothing',
+          { resourceId: String(rid), reason, remedy: 'semiont stop && semiont clean --store state && semiont start' },
+        );
+      } else if (result.eventsFailed === 0) healed++;
       else healFailures++;
     }
 
-    const summary = { resourcesChecked: resources.length, divergent, healed, healFailures };
-    if (divergent > 0 || healFailures > 0) {
+    const summary = { resourcesChecked: resources.length, divergent, healed, healFailures, orphaned };
+    if (divergent > 0 || healFailures > 0 || orphaned > 0) {
       this.logger.warn('Weaver reconcile found divergence', summary);
     } else {
       this.logger.info('Weaver reconcile complete — projection matches the catalog', summary);
@@ -911,7 +929,7 @@ export class Weaver {
    * Rebuild entire resource from events.
    * Bypasses the live pipeline — reads directly from event store.
    */
-  async rebuildResource(resourceId: ResourceId): Promise<{ eventsApplied: number; eventsFailed: number }> {
+  async rebuildResource(resourceId: ResourceId): Promise<{ eventCount: number; eventsApplied: number; eventsFailed: number }> {
     const graphDb = this.ensureInitialized();
     this.logger.info('Rebuilding resource from events', { resourceId });
 
@@ -941,7 +959,7 @@ export class Weaver {
     }
 
     this.logger.info('Resource rebuild complete', { resourceId, eventCount: events.length, eventsFailed });
-    return { eventsApplied: events.length - eventsFailed, eventsFailed };
+    return { eventCount: events.length, eventsApplied: events.length - eventsFailed, eventsFailed };
   }
 
   /**


### PR DESCRIPTION
# Pull Request

## Description

The weaver's `reconcile` takes its catalog from the **views** — a projection —
and heals the graph toward it. That is fine until the two disagree with the event
log, which is the actual system of record.

On the template KB the log had been pruned on purpose (40 event files deleted)
while the views projection kept all 138 resources. Reconcile faithfully declared
~162 resources `missing-node` and "healed" every one of them from a log that held
nothing for them. Each heal replayed **zero events, wrote nothing, and logged
`Resource rebuild complete`** — so the next boot found the identical divergence
and did it all again. Forever, and silently.

It surfaced only by accident: the wave was large enough to trip an unrelated
gateway bug and kill the weaver, which is what made anyone look.

Three changes, at the three places this went wrong — the projection that let the
ghosts persist, the projector that reported them as successes, and the tool whose
help never mentioned the fix.

## 1. The view rebuild stops being upsert-only

`ViewMaterializer.rebuildAll` replayed the log and wrote a view for every resource
it found, but **never deleted a view the log no longer justified**. That is what
left the ghosts behind, and it runs at every archivist boot — so it was also the
natural place to clear them.

It now reaps them, and the care is in what it *keeps*: a resource whose rebuild
**threw** is kept rather than reaped, because a transient read failure must not
read as "the log does not justify this view." `__system__` is skipped. Each reap
warns by resource id, with a count, and `rebuildAll` reports `reaped`.

Four specs, two of them guardrails against over-reaching: a view absent from the
log goes, a view with an empty stream goes, **every view the log still justifies
stays**, and **a view whose rebuild failed stays**.

## 2. The weaver names the condition instead of reporting success

`rebuildResource` now returns `eventCount` explicitly rather than leaving callers
to infer "no events" from arithmetic on applied-vs-failed. `reconcile` branches on
it: zero events for a *catalogued* resource is an **orphaned view**, not a heal.
It gets its own counter in the summary, and a warn that **names the remedy**:

```
Reconcile found an orphaned view — the log has no events for this resource,
so healing wrote nothing
  { resourceId, reason, remedy: 'semiont stop && semiont clean --store state && semiont start' }
```

The closing summary line drops to warn when any orphan was seen, so a run that
healed nothing real no longer reports clean.

This is not made redundant by the reap. The reap clears orphans at archivist boot;
the breadcrumb still catches any that appear afterward, and says what to do about
them.

## 3. `clean` admits that `--store state` exists

It was a real store, it worked, and it was absent from both places a user would
look — the `--store` option list and the unknown-store error. That is the store
whose removal repairs this exact condition.

The option list now names it with its tradeoff (views rebuild from the log on next
start; queued jobs are lost), and the **error message is now derived from the
`stateStores` table** rather than restating it, so it cannot drift again. The
option list is hand-written prose — each store carries a different tradeoff note —
so it gets a census gate instead: a test that fails when the table grows a store
the help does not mention.

## The trap this had to avoid

**Key on the event count, never on the divergence reason.** A full-catalog
`missing-node` wave is also the *designed* rebuild: `semiont clean` empties the
graph and every resource legitimately reports `missing-node`, then heals from the
log. That is the largest such wave the system ever runs, and it is correct.

|  | designed (post-clean) | pathological (orphan) |
|---|---|---|
| reconcile sees | `missing-node` | `missing-node` |
| the heal applies | real events | **zero events** |
| next boot | resolved | identical divergence |

An orphan check keyed on `missing-node` would suppress the whole rebuild. The
guardrail is pinned on the pre-existing heal test rather than duplicated: a
resource *with* events still counts as healed and reports `orphaned: 0`. That test
is the post-clean shape, so it is what stops a future refactor from getting this
backwards.

## Type of Change

- [x] Bug fix (orphaned views persisting; a heal that wrote nothing reported as success)
- [x] Documentation (the `--store state` remedy was undiscoverable)

## Areas Changed

`packages/event-sourcing` (the view rebuild) · `packages/make-meaning` (the
weaver's reconcile) · `apps/launcher` (Go — `clean`'s help and its census gate).

## Security Checklist

Not applicable — no authentication, authorization, or admin surface touched.

## Verification

- **RED first on the weaver specs**: `summary.orphaned` came back `undefined` on
  the orphan case, and the guardrail assertion on the existing heal test failed
  the same way.
- make-meaning 588 passed + 1 expected fail (51 files); workspace typecheck 0
  errors; `build:packages` clean.

## Notes

The operational repair still works and is now discoverable: `semiont clean
--store state` rebuilds the views from the log and drops the orphans with them.
Scope it — an unscoped `clean` also removes the PostgreSQL data (user accounts,
password hashes), which no rebuild restores.

One worklist item was judged inapplicable rather than silently skipped: an orphan
is reported, not excluded from a later pass. `reconcile()` makes exactly one pass
per boot, so there is no later pass to exclude it from — and the heal is not
harmful anyway, since `rebuildResource` deletes then replays nothing, which leaves
the graph agreeing with the log.
