### PR TITLE
reconcile compares against the codec, not five hand-picked facts

### DIFF
--- a/packages/graph/src/__tests__/annotation-codec.test.ts
+++ b/packages/graph/src/__tests__/annotation-codec.test.ts
@@ -16,6 +16,7 @@ import type { Annotation, CreateAnnotationInternal } from '@semiont/core';
 import {
   buildAnnotation,
   encodeAnnotation,
+  intendedGraphAnnotation,
   motivationForCategory,
   storedAnnotationType,
   type AnnotationProperties,
@@ -301,5 +302,65 @@ describe('D7: memorygraph is a faithful reference, not a store where the bug is 
         creator: CREATOR,
       } as unknown as CreateAnnotationInternal)
     ).rejects.toThrow(/missing required field: motivation/);
+  });
+});
+
+/**
+ * `intendedGraphAnnotation` is what a caller asks when it wants to know whether
+ * a graph is correct. It answers "what should the graph hold for this
+ * annotation?" — deliberately NOT "what does the view hold?", because the graph
+ * is a purpose-built projection rather than a copy of the views.
+ *
+ * The weaver's reconcile compares against it, so these are the properties that
+ * check depends on, pinned where the function lives.
+ */
+describe('intendedGraphAnnotation — what the graph is supposed to hold', () => {
+  const full: Annotation = {
+    '@context': 'http://www.w3.org/ns/anno.jsonld',
+    type: 'Annotation',
+    id: annotationId('ann-intent'),
+    motivation: 'highlighting',
+    target: { source: 'res-1', selector: QUOTE_SELECTOR as never },
+    creator: CREATOR,
+    created: CREATED,
+  };
+
+  it('drops a field the encoder does not write, rather than reporting it as missing', () => {
+    // `wasAttributedTo` is on nearly every annotation in a real log and the
+    // encoder writes none of it. A comparison that expected it in the graph
+    // would flag the whole corpus, which is why this scopes itself instead.
+    const intended = intendedGraphAnnotation({
+      ...full,
+      wasAttributedTo: [{ '@type': 'Person', id: 'did:semiont:user:u1', name: 'Ada' }],
+    } as Annotation);
+
+    expect('wasAttributedTo' in intended).toBe(false);
+  });
+
+  it('keeps every field the encoder does write', () => {
+    const intended = intendedGraphAnnotation(full);
+
+    expect(intended.id).toBe(full.id);
+    expect(intended.motivation).toBe('highlighting');
+    expect(intended.created).toBe(CREATED);
+    expect(intended.target).toEqual({ source: 'res-1', selector: QUOTE_SELECTOR });
+    expect(intended.creator).toEqual(CREATOR);
+  });
+
+  it('is idempotent — the answer is itself a fixed point', () => {
+    // Without this a comparison against it could never settle: a graph holding
+    // exactly the intended content would re-derive to something else again.
+    const once = intendedGraphAnnotation(full);
+    expect(intendedGraphAnnotation(once)).toEqual(once);
+  });
+
+  it('carries entity tags through as tagging body items, the way the store rebuilds them', () => {
+    const tagged = intendedGraphAnnotation({
+      ...full,
+      motivation: 'tagging',
+      body: [{ type: 'TextualBody', value: 'Person', purpose: 'tagging' }],
+    } as Annotation);
+
+    expect(tagged.body).toEqual([{ type: 'TextualBody', value: 'Person', purpose: 'tagging' }]);
   });
 });

--- a/packages/graph/src/__tests__/neo4j-projection.test.ts
+++ b/packages/graph/src/__tests__/neo4j-projection.test.ts
@@ -31,7 +31,34 @@ const node = (created: unknown, modified?: unknown) => ({
   },
 });
 
+/**
+ * What a neo4j DateTime's `toString()` actually produces, measured against
+ * 5.26.28 through the real driver:
+ *
+ *   '…07.000Z' -> '…07Z'            (a zero fraction is dropped)
+ *   '…07.123Z' -> '…07.123000000Z'  (any other is padded to nanoseconds)
+ *
+ * Only a timestamp with no fractional part survives — and nothing produces
+ * those, since every producer stamps `new Date().toISOString()`.
+ */
+const neo4jTemporalToString = (iso: string): string =>
+  iso.replace(/\.000Z$/, 'Z').replace(/\.(\d{3})Z$/, '.$1000000Z');
+
 describe('parseAnnotationNode — temporals leave as ISO strings, never driver objects', () => {
+  // Writes stopped coercing `created` to a temporal, so new rows round-trip
+  // verbatim. Rows written BEFORE that hold a temporal, and this is what they
+  // read back as — a different string than the log carried. It is why the fix
+  // has to be paired with a rebuild, and why a rebuild BEFORE the fix does not
+  // help: it re-creates the loss.
+  it('a legacy temporal row reads back REFORMATTED — the string the log carried is not recoverable from it', () => {
+    const AUTHORED = '2020-03-04T05:06:07.000Z';
+    const legacy = parseAnnotationNode(node(driverDateTime(neo4jTemporalToString(AUTHORED))));
+
+    expect(legacy.created).toBe('2020-03-04T05:06:07Z');
+    expect(legacy.created).not.toBe(AUTHORED);
+    expect(Date.parse(legacy.created!)).toBe(Date.parse(AUTHORED)); // same instant, different string
+  });
+
   it('serializes a native DateTime `created` to its ISO string', () => {
     const ann = parseAnnotationNode(node(driverDateTime('2026-08-19T01:02:03.000000000Z')));
     expect(ann.created).toBe('2026-08-19T01:02:03.000000000Z');

--- a/packages/graph/src/__tests__/store-write-paths.test.ts
+++ b/packages/graph/src/__tests__/store-write-paths.test.ts
@@ -95,20 +95,20 @@ function neo4jStore(): { db: Neo4jGraphDatabase; recorded: Recorded[] } {
       recorded.push({ cypher, params, props });
 
       // A resource write names its properties in the query rather than passing
-      // a bag, so the params ARE the stored node — `created` excepted, which
-      // the query stores as a native temporal.
+      // a bag, so the params ARE the stored node. `created` included: it is
+      // stored as the string it arrived as, not coerced to a temporal.
       if (cypher.includes('UNWIND $resources')) {
         const batch = params.resources as Array<Record<string, unknown>>;
         return {
           records: batch.map(r => ({
             get: (key: string) =>
-              key === 'd' ? { properties: { ...r, created: { toString: () => String(r.created) } } } : [],
+              key === 'd' ? { properties: r } : [],
           })),
         };
       }
 
       if (cypher.includes('MERGE (d:Resource')) {
-        const stored = { ...params, created: { toString: () => String(params.created) } };
+        const stored = { ...params };
         return { records: [{ get: (key: string) => (key === 'd' ? { properties: stored } : []) }] };
       }
 
@@ -116,10 +116,10 @@ function neo4jStore(): { db: Neo4jGraphDatabase; recorded: Recorded[] } {
       // result, which is enough to see the query it asked for.
       if (!params.props) return { records: [] };
 
-      // `SET a.created = datetime($created)` — what comes back out is a
-      // temporal object whose toString() is the ISO form.
-      const stored = { ...props, created: { toString: () => props.created } };
-      return { records: [{ get: (key: string) => (key === 'a' ? { properties: stored } : []) }] };
+      // The annotation write is `SET a = $props` — the codec's string, stored as
+      // written and read back verbatim. It used to re-set `created` as a native
+      // temporal, whose toString() reformatted the value on the way out.
+      return { records: [{ get: (key: string) => (key === 'a' ? { properties: props } : []) }] };
     },
     close: async () => {},
   };
@@ -140,11 +140,12 @@ describe('neo4j write path', () => {
     expect(Object.values(recorded[0]!.props)).not.toContain('{}');
   });
 
-  it('applies the codec bag verbatim and re-sets created as a temporal', async () => {
+  it('applies the codec bag verbatim, with no re-set of created', async () => {
     const { db, recorded } = neo4jStore();
     await db.createAnnotation(HIGHLIGHT);
 
-    expect(recorded[0]!.cypher).toContain('SET a = $props, a.created = datetime($created)');
+    expect(recorded[0]!.cypher).toContain('SET a = $props');
+    expect(recorded[0]!.cypher).not.toContain('datetime(');
     expect(recorded[0]!.props.selector).toBe(JSON.stringify(QUOTE_SELECTOR));
     expect(recorded[0]!.props.exact).toBe('Black Hawk');
     expect(recorded[0]!.props.type).toBe('TextualBody');
@@ -154,10 +155,10 @@ describe('neo4j write path', () => {
     const { db, recorded } = neo4jStore();
     await db.createAnnotation(SOURCE_ONLY);
 
-    expect(recorded[0]!.params.created).toBe(AUTHORED);
+    expect(recorded[0]!.props.created).toBe(AUTHORED);
   });
 
-  it('reads its own write back as the annotation it wrote, temporal and all', async () => {
+  it('reads its own write back as the annotation it wrote, created byte-for-byte', async () => {
     const { db } = neo4jStore();
     const written = await db.createAnnotation(SOURCE_ONLY);
 

--- a/packages/graph/src/annotation-codec.ts
+++ b/packages/graph/src/annotation-codec.ts
@@ -18,6 +18,7 @@
 
 import { annotationId as makeAnnotationId } from '@semiont/core';
 import { getBodySource, getExactText, getTargetSelector, getTargetSource } from '@semiont/core';
+import { getEntityTypes } from '@semiont/ontology';
 import type { Annotation, AnnotationCategory, CreateAnnotationInternal } from '@semiont/core';
 
 /**
@@ -49,10 +50,10 @@ export function motivationForCategory(category: AnnotationCategory): Annotation[
 /**
  * Mint the annotation a create request describes.
  *
- * `created` is a parameter rather than a `new Date()` here so the codec stays
- * pure — and so it is visible at each call site that the graph stamps its own
- * write time. `CreateAnnotationInternal` carries no timestamp, so the event's
- * own time does not reach this projection at all.
+ * `created` comes from the input, which carries the AUTHORED moment from the
+ * event. It used to be a second parameter, and every store passed
+ * `new Date().toISOString()` into it — so the graph stamped its own write time
+ * and a rebuild collapsed every annotation to the rebuild moment.
  */
 export function buildAnnotation(input: CreateAnnotationInternal): Annotation {
   const annotation: Annotation = {
@@ -183,4 +184,22 @@ function decodeSelector(raw: string | undefined): AnnotationSelector | undefined
   const parsed = JSON.parse(raw);
   if (!parsed || Object.keys(parsed).length === 0) return undefined;
   return parsed;
+}
+
+/**
+ * What the graph is SUPPOSED to hold for this annotation — the codec's own
+ * statement of it, obtained by round-tripping through both halves.
+ *
+ * The graph is a purpose-built projection, not a copy of the views: it stores
+ * what graph queries need and nothing else. `wasAttributedTo`, for instance,
+ * rides on almost every annotation in the log and the encoder deliberately
+ * writes none of it. So "is the graph correct?" cannot be answered by comparing
+ * it to a view — only by comparing it to what this module says it should be.
+ *
+ * Callers get a value scoped to exactly the fields the encoder writes, in the
+ * decoded shape, free of any store's physical dialect. Widen or narrow the
+ * encoder and this follows automatically; there is no second list to maintain.
+ */
+export function intendedGraphAnnotation(annotation: Annotation): Annotation {
+  return decodeAnnotation(encodeAnnotation(annotation), getEntityTypes(annotation));
 }

--- a/packages/graph/src/implementations/neo4j.ts
+++ b/packages/graph/src/implementations/neo4j.ts
@@ -211,7 +211,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
              d.entityTypes = $entityTypes,
              d.format = $format,
              d.archived = $archived,
-             d.created = datetime($created),
+             d.created = $created,
              d.creator = $creator,
              d.contentChecksum = $contentChecksum,
              d.sourceAnnotationId = $sourceAnnotationId,
@@ -407,7 +407,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
         ? `MATCH (from:Resource {id: $targetSource})
            MATCH (to:Resource {id: $bodySource})
            CREATE (a:Annotation:${motivationLabel})
-           SET a = $props, a.created = datetime($created)
+           SET a = $props
            CREATE (a)-[:BELONGS_TO]->(from)
            CREATE (a)-[:REFERENCES]->(to)
            FOREACH (entityType IN $entityTypes |
@@ -417,7 +417,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
            RETURN a`
         : `MATCH (d:Resource {id: $targetSource})
            CREATE (a:Annotation:${motivationLabel})
-           SET a = $props, a.created = datetime($created)
+           SET a = $props
            CREATE (a)-[:BELONGS_TO]->(d)
            FOREACH (entityType IN $entityTypes |
              MERGE (et:EntityType {name: entityType})
@@ -427,7 +427,6 @@ export class Neo4jGraphDatabase implements GraphDatabase {
 
       const result = await session.run(cypher, {
         props,
-        created: annotation.created,
         targetSource,
         bodySource: bodySource ?? null,
         entityTypes,
@@ -1006,7 +1005,7 @@ export class Neo4jGraphDatabase implements GraphDatabase {
              d.entityTypes = r.entityTypes,
              d.format = r.format,
              d.archived = r.archived,
-             d.created = datetime(r.created),
+             d.created = r.created,
              d.creator = r.creator,
              d.contentChecksum = r.contentChecksum,
              d.sourceAnnotationId = r.sourceAnnotationId,
@@ -1179,8 +1178,12 @@ export function parseAnnotationNode(node: any, entityTypes: string[] = []): Anno
 /**
  * Flatten a node's properties to the strings the codec reads.
  *
- * `created` is stored as `datetime($created)`, so the driver hands back a
- * native temporal object whose `toString()` is the ISO form — the coercion
+ * `created` is stored as the codec's own string, so it round-trips verbatim.
+ * Rows written before that change hold a native temporal instead, and the
+ * driver hands those back as an object whose `toString()` REFORMATS the value
+ * (a zero fraction elided, any other padded to nanoseconds) — so a legacy row
+ * reads back with a different string than the log carried, until a rebuild
+ * replaces it. The coercion
  * that has to happen before the codec sees a value it is entitled to treat
  * as a string. This seam is untyped, so only a test can see it slip.
  */

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -17,6 +17,7 @@ export { compareByRecencyThenId } from './interface';
 export { getGraphDatabase, createGraphDatabase, closeGraphDatabase } from './factory';
 
 // Implementations (for direct use if needed)
+export { intendedGraphAnnotation } from './annotation-codec';
 export { Neo4jGraphDatabase } from './implementations/neo4j';
 export { NeptuneGraphDatabase } from './implementations/neptune';
 export { JanusGraphDatabase } from './implementations/janusgraph';

--- a/packages/make-meaning/src/__tests__/helpers/weaver-harness.ts
+++ b/packages/make-meaning/src/__tests__/helpers/weaver-harness.ts
@@ -98,6 +98,7 @@ export const makeAnnotationPayload = (aid: string, rid: string): Annotation => (
   // axioms compare a replayed projection against a reference fold, and a
   // clock-derived value would differ between the two.
   created: '2026-01-01T00:00:00.000Z',
+  creator: { '@type': 'Person', '@id': 'did:web:test:users:axioms', name: 'axioms' },
 });
 
 // ── The reference fold (the model M in W4/W5) ───────────────────────────────

--- a/packages/make-meaning/src/__tests__/weaver-axioms.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver-axioms.test.ts
@@ -450,7 +450,7 @@ describe('W8 — recovery convergence', () => {
 
 // ── W9 — Reconcile fixed point + v1 detection completeness ─────────────────
 
-type OobMutation = 'delete-node' | 'flip-archived' | 'mutate-tags' | 'drop-annotation';
+type OobMutation = 'delete-node' | 'flip-archived' | 'mutate-tags' | 'drop-annotation' | 'corrupt-annotation-content';
 
 describe('W9 — reconcile detects and heals out-of-band divergence', () => {
   // ∀ σ, ∀ single oob mutation δ in the v1 class: reconcile detects δ and
@@ -459,7 +459,7 @@ describe('W9 — reconcile detects and heals out-of-band divergence', () => {
     await fc.assert(
       fc.asyncProperty(
         historyArb,
-        fc.constantFrom<OobMutation>('delete-node', 'flip-archived', 'mutate-tags', 'drop-annotation'),
+        fc.constantFrom<OobMutation>('delete-node', 'flip-archived', 'mutate-tags', 'drop-annotation', 'corrupt-annotation-content'),
         fc.nat(10),
         async (history, mutation, pick) => {
           const rig = await buildWeaverRig();
@@ -476,6 +476,10 @@ describe('W9 — reconcile detects and heals out-of-band divergence', () => {
 
             // One out-of-band mutation the Weaver never witnesses.
             let mutated = true;
+            // `dumpGraph` records annotation IDs, not their content, so a
+            // content corruption is invisible to the JSON diff below. It is
+            // still a real change — flag it so the detection assertion runs.
+            let contentCorrupted = false;
             switch (mutation) {
               case 'delete-node':
                 await rig.graph.deleteResource(mkRid(rid));
@@ -489,6 +493,18 @@ describe('W9 — reconcile detects and heals out-of-band divergence', () => {
               case 'mutate-tags':
                 await rig.graph.updateResource(mkRid(rid), { entityTypes: ['OobPhantomTag'] });
                 break;
+              case 'corrupt-annotation-content': {
+                // A stored property OUTSIDE the id set and the body — exactly
+                // what the old five-fact check could not see (GRAPH-DIVERGENCE-DEPTH).
+                const anns = model.resources.get(rid)?.annotations ?? new Set<string>();
+                const [first] = anns;
+                if (!first) { mutated = false; break; }
+                await rig.graph.updateAnnotation(mkAid(first), {
+                  target: { source: rid, selector: { type: 'TextQuoteSelector', exact: 'oob-corruption' } },
+                });
+                contentCorrupted = true;
+                break;
+              }
               case 'drop-annotation': {
                 const anns = model.resources.get(rid)?.annotations ?? new Set<string>();
                 const [first] = anns;
@@ -500,8 +516,8 @@ describe('W9 — reconcile detects and heals out-of-band divergence', () => {
             // A mutation that changes nothing observable (e.g. phantom tag
             // equal to current set) may legitimately not diverge.
             const before = dumpModel(model);
-            const changed = mutated &&
-              JSON.stringify((await dumpGraph(rig.graph)).resources) !== JSON.stringify(before.resources);
+            const changed = mutated && (contentCorrupted ||
+              JSON.stringify((await dumpGraph(rig.graph)).resources) !== JSON.stringify(before.resources));
 
             const summary = await rig.weaver.reconcile();
             if (changed) expect(summary.divergent).toBeGreaterThanOrEqual(1);
@@ -519,11 +535,12 @@ describe('W9 — reconcile detects and heals out-of-band divergence', () => {
     );
   });
 
-  // Was RED (v1 boundary) → GREEN 2026-07-18: reconcile's divergenceOf now
-  // compares annotation BODIES canonically (key-order-independent) against
-  // the view's truth, so a corrupted-in-place body reads as
-  // 'annotation-body-mismatch' and heals from the log — membership equality
-  // alone was blind to it (#845 deep-equality checkbox).
+  // Was RED (v1 boundary) → GREEN 2026-07-18, widened 2026-09-07: divergenceOf
+  // compared annotation BODIES canonically, which caught corruption in place
+  // where membership equality could not (#845 deep-equality checkbox). It now
+  // compares the WHOLE annotation against what the codec says the graph should
+  // hold, so this reads as 'annotation-content-mismatch' — body corruption is
+  // one case of it rather than the only one it can see.
   it('W9-deep: reconcile detects in-place annotation body corruption', async () => {
     const rig = await buildWeaverRig();
     const rid = 'res-deep';

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -1419,6 +1419,93 @@ describe('Weaver', () => {
       expect(JSON.stringify(orphanWarn)).toContain('clean --store state');
     });
 
+    // GRAPH-DIVERGENCE-DEPTH P1. `divergenceOf` compared five hand-picked facts
+    // while the codec writes a dozen, so anything outside that list could go
+    // wrong unseen. The comparison is now against what the CODEC says the graph
+    // should hold — not against the view, which the graph is not a copy of.
+    const viewAnn = (over: Record<string, unknown> = {}) => ({
+      '@context': 'http://www.w3.org/ns/anno.jsonld' as const,
+      type: 'Annotation' as const,
+      id: annotationId('ann-div'),
+      motivation: 'commenting' as const,
+      created: '2020-01-01T00:00:00.000Z',
+      target: { source: 'placeholder' },
+      body: [],
+      creator: { '@type': 'Person' as const, id: 'did:semiont:user:u1', name: 'Ada' },
+      ...over,
+    });
+
+    const seedOneAnnotation = async (rid: string) => {
+      await eventStore.appendEvent({
+        type: 'yield:created', resourceId: resourceId(rid), userId: userId('user1'), version: 1,
+        payload: { name: 'Div', format: 'text/plain', contentChecksum: 'h-dv' },
+      });
+      await eventStore.appendEvent({
+        type: 'mark:added', resourceId: resourceId(rid), userId: userId('user1'), version: 1,
+        payload: { annotation: { ...viewAnn(), target: { source: rid } } },
+      });
+      await tick();
+    };
+
+    it('reports divergence on a stored property outside the old five-fact list', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `div-creator-${Date.now()}`;
+      await seedOneAnnotation(rid);
+
+      // Same id, same body — the graph's annotation is source-only, and the log
+      // says it should carry a selector. The old check compared the id SET and
+      // the bodies, so it called this clean. (Deliberately not `creator`: the
+      // fold derives that from the event, so it is held out — see divergenceOf.)
+      serveBrowseReads([rid], {
+        [rid]: [{ ...viewAnn(),
+                  target: { source: rid, selector: { type: 'TextQuoteSelector', exact: 'Black Hawk' } } }],
+      });
+      const summary = await consumer.reconcile();
+
+      expect(summary.divergent).toBe(1);
+    });
+
+    it('reports NO divergence for a field the codec does not write — the graph is not a copy of the views', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `div-wat-${Date.now()}`;
+      await seedOneAnnotation(rid);
+
+      // `wasAttributedTo` rides on ~99.8% of real annotations and the graph has
+      // no use for it, so the encoder never writes it. A comparison that flagged
+      // it would flag the entire corpus. The graph is a purpose-built projection,
+      // not an isomorphic copy.
+      serveBrowseReads([rid], {
+        [rid]: [{ ...viewAnn(), target: { source: rid },
+                  wasAttributedTo: [{ '@type': 'Person', id: 'did:semiont:user:u1', name: 'Ada' }] }],
+      });
+      const summary = await consumer.reconcile();
+
+      expect(summary.divergent).toBe(0);
+    });
+
+    it('reports NO divergence when the graph holds exactly what the codec says it should', async () => {
+      await consumer.stop();
+      weaverUnit.dispose();
+      graphDb = new MemoryGraphDatabase();
+      consumer = await wireWeaver(graphDb);
+
+      const rid = `div-match-${Date.now()}`;
+      await seedOneAnnotation(rid);
+
+      serveBrowseReads([rid], { [rid]: [{ ...viewAnn(), target: { source: rid } }] });
+      const summary = await consumer.reconcile();
+
+      expect(summary.divergent).toBe(0);
+    });
+
     it('a clean graph reconciles with zero divergence and no heals', async () => {
       await consumer.stop();
       weaverUnit.dispose();

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -49,6 +49,7 @@ import { groupBy, mergeMap, concatMap } from 'rxjs/operators';
 import { didToAgent, burstBuffer, errField, busRequest } from '@semiont/core';
 import type { BusRequestPrimitive, EventMap } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
+import { intendedGraphAnnotation } from '@semiont/graph';
 import type { PersistedEvent, StoredEvent, EventOfType, ResourceId, Logger} from '@semiont/core';
 import type { WeaverCheckpoint } from './weaver-checkpoint.js';
 
@@ -518,16 +519,35 @@ export class Weaver {
       if (!graphIds.has(id)) return 'annotation-set-mismatch';
     }
 
-    // Content depth (W9-deep): membership equality is blind to a body
-    // mutated in place — a corrupted graph doc with the right id reconciled
-    // as clean. Compare bodies canonically against the view's truth.
-    const bodyKey = (a: { body?: unknown }) => Weaver.canonicalJson(a.body ?? []);
+    // Content depth. Membership equality is blind to an annotation mutated in
+    // place, and comparing bodies alone (W9-deep) left every other stored
+    // property — creator, motivation, the selector, created — able to go wrong
+    // unseen.
+    //
+    // The comparison is against what the CODEC says the graph should hold, not
+    // against the view. The graph is a purpose-built projection, not a copy:
+    // `wasAttributedTo` rides on nearly every annotation in the log and the
+    // encoder writes none of it, so a view-equality check would flag the entire
+    // corpus. Round-tripping the view through the codec scopes the comparison to
+    // exactly the fields the graph is meant to carry, and widens or narrows
+    // automatically when the encoder does.
+    //
+    // `creator` is taken from the GRAPH rather than the view, and not for
+    // convenience: the fold derives it from the EVENT's userId (`didToAgent`),
+    // never from the annotation, so the view does not hold the graph's
+    // reference for it. A heal replays the log and re-derives the same value,
+    // so a creator "mismatch" could never be repaired — comparing it could only
+    // manufacture permanent divergence and heal every resource on every boot.
+    // Supplying it also keeps the round-trip total: `creator` is optional on the
+    // wire, and the codec requires it, so a sparse view annotation would
+    // otherwise throw out of a routine divergence check.
     const viewById = new Map(annotations.map((a) => [String(a.id), a]));
     for (const graphAnnotation of graphAnnotations) {
       const viewAnnotation = viewById.get(String(graphAnnotation.id));
       if (!viewAnnotation) continue; // set equality established above
-      if (bodyKey(graphAnnotation) !== bodyKey(viewAnnotation)) {
-        return 'annotation-body-mismatch';
+      const intended = intendedGraphAnnotation({ ...viewAnnotation, creator: graphAnnotation.creator });
+      if (Weaver.canonicalJson(graphAnnotation) !== Weaver.canonicalJson(intended)) {
+        return 'annotation-content-mismatch';
       }
     }
 

--- a/scripts/compliance/audit-weaver-invariants.sh
+++ b/scripts/compliance/audit-weaver-invariants.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # G3  the applied mark has a single writer (noteApplied + the catch-up seed)
 # G4  weave:applied has a single emitter (noteApplied)
 # G5  the fan-in channel list and the fold's switch cases stay in sync
+# G6  divergenceOf compares against the codec, not a hand-written field list
 #
 # Exit code: 0 if clean, 1 if violations found.
 
@@ -84,7 +85,24 @@ if [ "$CHANNELS" != "$CASES" ]; then
   FAIL=1
 fi
 
+# ---------------------------------------------------------------------------
+# G6: the divergence check derives its comparison from the codec.
+#
+# `divergenceOf` used to compare five hand-picked facts while the codec wrote a
+# dozen, so anything outside that list could go wrong unseen — the body check
+# was added for exactly that reason, and only for bodies. The comparison is now
+# `intendedGraphAnnotation`, which scopes itself to whatever the encoder writes
+# and follows it when it changes. A field list restated here is a mirror with
+# nothing keeping it in sync, which is what this gate exists to prevent.
+# ---------------------------------------------------------------------------
+if ! grep -q "intendedGraphAnnotation" "$WEAVER"; then
+  echo "❌ G6: divergenceOf no longer compares against the codec's intendedGraphAnnotation."
+  echo "   A hand-written list of fields to compare is a restatement of a shape"
+  echo "   the codec owns — derive it, do not retype it."
+  FAIL=1
+fi
+
 if [ "$FAIL" -ne 0 ]; then
   exit 1
 fi
-echo "✅ Weaver invariants G1–G5 hold"
+echo "✅ Weaver invariants G1–G6 hold"


### PR DESCRIPTION
# Pull Request

## Description

`divergenceOf` decided whether the graph matched the log by comparing five
hand-picked facts — node presence, archived, entity types, the annotation id
set, and annotation bodies. The codec writes about a dozen properties. Everything
in the second list and not the first was a value reconcile could not see go
wrong, and nothing kept the two lists in sync: when the encoder grew a field, the
check silently kept passing.

The bodies entry is the tell. It was not there originally — membership equality
was blind to a body mutated in place, so the check was deepened, **for bodies
only**. The same reasoning applied to every other stored property and was never
extended.

## The comparison now derives from the codec

```
before:  compare(id-set) + compare(canonicalJson(body))
after:   canonicalJson(graphAnnotation) === canonicalJson(intendedGraphAnnotation(view))
```

`intendedGraphAnnotation` is new, and it lives in the codec because the codec is
what defines a graph annotation's shape. It round-trips an annotation through
both halves, yielding exactly what a correct graph would decode to. The check is
therefore scoped to whatever the encoder writes, in the decoded shape, free of
any store's physical dialect — and it widens or narrows automatically when the
encoder does. There is no second list to maintain.

### Two things that shaped this, both discovered by guardrails failing

**The graph is not a copy of the views.** `wasAttributedTo` rides on 9,410 of
9,425 annotations in the template KB's log, and the encoder writes none of it.
The first instinct — call that a dropped field and fix it — is wrong: the graph
is a purpose-built projection holding what graph queries need, and it will hold
more as it serves more. Comparing against a view assumes an isomorphism that was
never the contract. Comparing against the codec's own output does not.

**`creator` is not the view's to dictate.** The fold derives it from the
**event's** `userId` (`didToAgent`), never from the annotation, so view and graph
hold structurally different creators by design:

```
view:   {"@type":"Person","id":"did:semiont:user:u1","name":"Ada"}
graph:  {"@type":"Person","@id":"user1","name":"user1"}
```

It is therefore taken from the graph when computing intended content, and the
reason is decisive rather than pragmatic: a heal replays the log and re-derives
the same value, so a creator mismatch could **never** be repaired. Comparing it
could only manufacture permanent divergence and heal every resource on every
boot. Supplying it also keeps the round trip total — `creator` is optional on the
wire and the codec requires it, so a sparse view annotation would otherwise throw
out of a routine check.

## First, the graph had to stop reformatting `created`

The comparison could not be correct until this was fixed, and it is a live defect
in its own right. Probed against a real neo4j (5.26.28) through the driver:

| written | read back | |
|---|---|---|
| `2020-03-04T05:06:07.000Z` | `2020-03-04T05:06:07Z` | fraction elided |
| `2020-03-04T05:06:07.123Z` | `2020-03-04T05:06:07.123000000Z` | padded to nanoseconds |
| `2020-03-04T05:06:07Z` | `2020-03-04T05:06:07Z` | **the only case that survives** |

The instant survived; the string did not. And the only surviving form is one
nothing produces, since every producer stamps `new Date().toISOString()` — so the
incidence was total. The graph and the view were serving different strings for
the same field, with no reconcile involved.

Nothing needed the temporal: the only non-write uses are five `ORDER BY … DESC`,
no arithmetic and no range filters. And neo4j was the outlier — the gremlin
stores already wrote plain strings. So the coercion is gone at all four sites,
along with the parameter it needed.

## Type of Change

- [x] Bug fix (`created` reformatted by the graph; divergence invisible outside five fields)
- [x] Code refactoring

## Areas Changed

`packages/graph` (the codec and the neo4j store) · `packages/make-meaning`
(reconcile, the weaver axioms) · `scripts/compliance`.

## Security Checklist

Not applicable — no authentication, authorization, or admin surface touched.

## Verification

- **RED first throughout, and none of it needed a live database in CI.** The
  temporal RED came from making the fake tell the truth: the neo4j session double
  claimed the driver's `toString()` returned the input verbatim, which the real
  5.26.28 refutes. Correcting the fake turned a passing test red.
- The comparison RED was verified red against the old check before being called
  done (`expected +0 to be 1` — a differing selector reported as clean).
- **W9 gained a `corrupt-annotation-content` mutation** rather than a new axiom;
  the property already covers "any single v1-class mutation is detected, healed,
  and the fixed point holds", and content corruption belongs in that class.
  Verified non-vacuous — red against the old comparison. One free consequence:
  with a content-deep predicate, W9's existing `second.divergent === 0` *is* the
  content fixed-point check, so the harness needed no deepening.
- **G6** gates the derivation, so a future hand-written field list in
  `divergenceOf` fails CI. Proven to fire.
- graph 188/188 · make-meaning 591 + 1 expected fail · event-sourcing 255/255 ·
  workspace typecheck 0 errors · weaver-invariants and annotation-codec audits
  green.

## Operational note

Existing graph rows hold temporals. They still read — the store coerces to string
— but in the old lossy form until a `weave:rebuild` or `semiont clean --store
graph`. **Deploy before rebuilding:** a rebuild on the old code re-runs the same
coercion and re-creates the loss. While a graph holds both temporal and string
rows, `ORDER BY a.created DESC` sorts by type before value, so it is briefly
unreliable — an argument for pairing the deploy with a rebuild.
