### PR TITLE
launcher: store mismatch-clears resolve in preflight, keep the mount root, and restamp — an archivist-prep RemoveAll orphaned the gateway's attached state share

### DIFF
--- a/apps/launcher/internal/fakert/main.go
+++ b/apps/launcher/internal/fakert/main.go
@@ -803,6 +803,28 @@ func pull(image string) {
 	fmt.Printf("Pulled %s\n", image)
 }
 
+// statProbe records whether FAKERT_STAT_PATH exists at the moment a service
+// `run` arrives — one line per run, "present" or "absent", appended to
+// FAKERT_STAT_LOG. This is how a test pins host-side ordering (a store
+// clear) against the boot's container starts: fakert executes at exactly
+// the instant the real runtime would attach the mount.
+func statProbe() {
+	p, out := os.Getenv("FAKERT_STAT_PATH"), os.Getenv("FAKERT_STAT_LOG")
+	if p == "" || out == "" {
+		return
+	}
+	state := "absent"
+	if _, err := os.Stat(p); err == nil {
+		state = "present"
+	}
+	f, err := os.OpenFile(out, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintln(f, state)
+}
+
 // run handles both probe containers (busybox) and detached service starts.
 func run(args []string) {
 	joined := strings.Join(args, " ")
@@ -810,6 +832,7 @@ func run(args []string) {
 		busybox(args, joined)
 		return
 	}
+	statProbe()
 	detached := false
 	var ports []string
 	name := ""

--- a/apps/launcher/internal/launcher/executor.go
+++ b/apps/launcher/internal/launcher/executor.go
@@ -11,9 +11,11 @@ package launcher
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -60,6 +62,7 @@ type executor interface {
 	ensureModels(base string, models []modelNeed)               // pull configured ollama models that are absent
 	stateMounts(role, image, root string) ([]string, bool)      // persistent-state run args; !ok = refuse (data written by another image)
 	stateMountsShared(role, root string) ([]string, bool)       // the same mounts WITHOUT claiming the image stamp (a reader beside the stamp's owner)
+	resolveStoreStamps(fc flowCtx) bool                         // preflight: every store's mismatch refuse/clear, before the first container run (SHARED-STORE-CLEAR-PREFLIGHT)
 	val(live, plan string) string                               // mode-scoped value (kb root, admin password)
 	rtName() string
 
@@ -737,10 +740,70 @@ func (x *liveExec) ensureModels(base string, models []modelNeed) {
 	ensureOllamaModels(x.u, base, models)
 }
 
+// resolveStoreStamp is THE decider for existing store data vs the launching
+// image: refuse for the system of record (database — user rows), clear
+// CONTENTS for projections (rebuildable from the log). Never unlinks the
+// store dir: an attached share survives a contents-clear and is orphaned
+// forever by delete-and-recreate (measured 2026-09-07).
+func (x *liveExec) resolveStoreStamp(role, image, root string) bool {
+	spec := stateStores[role]
+	dir := stateRootDir(root)
+	sd := spec.storeDir(root)
+	meta := loadRootMeta(dir)
+	prev := meta.Stores[role].Image
+	if prev == "" || prev == image {
+		return true
+	}
+	if storeDirNonEmpty(sd) {
+		if !spec.projection {
+			x.u.fail("%s state at %s was written by %s; this config launches %s.", role, sd, prev, image)
+			fmt.Fprintln(os.Stderr, "  That data is not auto-deleted. Remove it first: semiont clean --store "+role)
+			return false
+		}
+		x.u.log("%s state at %s was written by %s; this config launches %s — projections rebuild, so clearing it.",
+			role, sd, prev, image)
+		if err := clearStoreContents(sd); err != nil {
+			x.u.fail("cannot clear %s state %s: %v", role, sd, err)
+			return false
+		}
+	}
+	// Restamp NOW, not at the owner's prep: the old image's output is gone,
+	// and a resolution that leaves the old stamp re-fires at the owner's own
+	// stateMounts — clearing whatever an earlier-booting sharer wrote into
+	// the store in between (the P5 live gate caught exactly this: the
+	// gateway's fresh jobs tree, cleared at archivist prep).
+	meta.Stores[role] = storeMeta{Image: image}
+	saveRootMeta(dir, meta)
+	return true
+}
+
+// resolveStoreStamps runs every store's stamp resolution in PREFLIGHT. The
+// state store is shared — the gateway and librarian attach what the
+// archivist stamps — so a clear at the owner's own prep lands mid-boot,
+// after sharers attached (SHARED-STORE-CLEAR-PREFLIGHT).
+func (x *liveExec) resolveStoreStamps(fc flowCtx) bool {
+	for _, role := range slices.Sorted(maps.Keys(stateStores)) {
+		spec := stateStores[role]
+		var img string
+		if rp, ok := fc.plan.Roles[spec.owner]; ok {
+			if rp.Obligation != obligationProvided {
+				continue // remote or absent: this boot mounts no such store
+			}
+			img = rp.Image
+		} else {
+			img = image(spec.owner, fc.version)
+		}
+		if !x.resolveStoreStamp(role, img, fc.root) {
+			return false
+		}
+	}
+	return true
+}
+
 // stateMounts prepares a role's persistent state dir and returns the run
 // args that mount it (LAUNCHER-STATE.md). The image-mismatch split lives
-// here: database data is user rows — refuse, fix-it names the clean
-// command; projections (vectors/graph) auto-clean and rebuild.
+// in resolveStoreStamp: database data is user rows — refuse, fix-it names
+// the clean command; projections (vectors/graph) auto-clean and rebuild.
 func (x *liveExec) stateMounts(role, image, root string) ([]string, bool) {
 	args := stateMountArgs(role, root)
 	if len(args) == 0 {
@@ -750,21 +813,10 @@ func (x *liveExec) stateMounts(role, image, root string) ([]string, bool) {
 	dir := stateRootDir(root)
 	sd := spec.storeDir(root)
 	meta := loadRootMeta(dir)
-	if prev := meta.Stores[role].Image; prev != "" && prev != image && storeDirNonEmpty(sd) {
-		if spec.projection {
-			// A projection of the event log: staleness is rebuildable, so a
-			// mismatch clears rather than refuses.
-			x.u.log("%s state at %s was written by %s; this config launches %s — projections rebuild, so clearing it.",
-				role, sd, prev, image)
-			if err := os.RemoveAll(sd); err != nil {
-				x.u.fail("cannot clear %s state %s: %v", role, sd, err)
-				return nil, false
-			}
-		} else {
-			x.u.fail("%s state at %s was written by %s; this config launches %s.", role, sd, prev, image)
-			fmt.Fprintln(os.Stderr, "  That data is not auto-deleted. Remove it first: semiont clean --store "+role)
-			return nil, false
-		}
+	// A full start has already resolved the stamp in preflight (this re-check
+	// no-ops on the emptied dir); single-service starts resolve here.
+	if !x.resolveStoreStamp(role, image, root) {
+		return nil, false
 	}
 	for _, m := range spec.mounts {
 		mp := filepath.Join(sd, m.sub)
@@ -1059,6 +1111,11 @@ func (x *planExec) stateMounts(role, _, root string) ([]string, bool) {
 func (x *planExec) stateMountsShared(role, root string) ([]string, bool) {
 	x.c("mount %s state (shared; the stamp stays with its owning service)", role)
 	return stateMountArgs(role, root), true
+}
+
+func (x *planExec) resolveStoreStamps(flowCtx) bool {
+	x.c("resolve persistent-store stamps before any container runs: a database mismatch refuses; a projection mismatch clears the store's contents (the dir itself is kept, so attached shares survive)")
+	return true
 }
 
 func (x *planExec) val(_, plan string) string { return plan }

--- a/apps/launcher/internal/launcher/flows.go
+++ b/apps/launcher/internal/launcher/flows.go
@@ -86,6 +86,13 @@ func flowFullStart(x executor, fc flowCtx) int {
 	x.initStack(fc.root, fc.opts.configName, fc.version, addr, stage)
 	x.recordPorts(checks)
 
+	// Store stamps resolve HERE, before the first container run: the state
+	// store is shared, and a clear at its owner's prep would land after the
+	// gateway attached it (SHARED-STORE-CLEAR-PREFLIGHT).
+	if !x.resolveStoreStamps(fc) {
+		return 1
+	}
+
 	x.banner("Pulling Images")
 	if fc.version == "local" {
 		x.say(sayLog, "Using locally-built %s images (skipping pull)", x.bold(":local"))

--- a/apps/launcher/internal/launcher/resolvestamp_test.go
+++ b/apps/launcher/internal/launcher/resolvestamp_test.go
@@ -1,0 +1,62 @@
+package launcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// SHARED-STORE-CLEAR-PREFLIGHT: resolution must RESTAMP the moment it
+// resolves. The P5 live gate caught the alternative (2026-09-08): preflight
+// cleared but left the old stamp, so the stamp owner's own prep saw
+// mismatch + non-empty again — non-empty because the gateway had already
+// written its jobs tree into the shared store — and cleared a second time,
+// mid-boot, deleting what a sharer had just written.
+func TestResolveStoreStampRestampsOnResolution(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", "")
+	root := t.TempDir()
+	x := &liveExec{u: newUI(true)}
+
+	dir := stateRootDir(root)
+	sd := stateStores["state"].storeDir(root)
+	if err := os.MkdirAll(sd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sd, "stale"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := loadRootMeta(dir)
+	meta.Stores["state"] = storeMeta{Image: "img:old"}
+	saveRootMeta(dir, meta)
+
+	if !x.resolveStoreStamp("state", "img:new", root) {
+		t.Fatal("a projection mismatch must resolve, not refuse")
+	}
+	if _, err := os.Stat(filepath.Join(sd, "stale")); err == nil {
+		t.Error("stale contents survived the clear")
+	}
+	if got := loadRootMeta(dir).Stores["state"].Image; got != "img:new" {
+		t.Errorf("stamp after resolution = %q, want %q — an unstamped resolution re-fires at the owner's prep and clears what sharers wrote in between", got, "img:new")
+	}
+
+	// The refusal path must NOT restamp: the data on disk is still the old
+	// image's, and the stamp is the record of that fact.
+	pgsd := stateStores["database"].storeDir(root)
+	if err := os.MkdirAll(pgsd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pgsd, "PG_VERSION"), []byte("15\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta = loadRootMeta(dir)
+	meta.Stores["database"] = storeMeta{Image: "pg:old"}
+	saveRootMeta(dir, meta)
+
+	if x.resolveStoreStamp("database", "pg:new", root) {
+		t.Fatal("a database mismatch must refuse")
+	}
+	if got := loadRootMeta(dir).Stores["database"].Image; got != "pg:old" {
+		t.Errorf("stamp after a refusal = %q, want %q untouched", got, "pg:old")
+	}
+}

--- a/apps/launcher/internal/launcher/rootstate.go
+++ b/apps/launcher/internal/launcher/rootstate.go
@@ -104,6 +104,10 @@ type stateStoreSpec struct {
 	// auto-cleans and rebuilds instead of refusing. False = system of
 	// record (database): existing data is never auto-deleted.
 	projection bool
+	// owner: the role whose image stamps this store — the writer whose code
+	// the contents reflect. Exactly one service takes the stamped mount path
+	// per store; sharers mount via stateMountsShared.
+	owner string
 }
 
 // stateMount: one -v within a store. sub "" mounts the store dir itself.
@@ -118,12 +122,14 @@ var stateStores = map[string]stateStoreSpec{
 		dir:    "postgres",
 		mounts: []stateMount{{"", "/var/lib/postgresql/data"}},
 		env:    []string{"PGDATA=/var/lib/postgresql/data/pgdata"},
+		owner:  "database",
 	},
 	// Qdrant just writes files; a plain mount works (Phase 0, 7/7).
 	"vectors": {
 		dir:        "qdrant",
 		mounts:     []stateMount{{"", "/qdrant/storage"}},
 		projection: true,
+		owner:      "vectors",
 	},
 	// Neo4j's entrypoint gates on `test -w` of /data and /logs and insists
 	// on chowning an unwritable mount root — refused on virtiofs, and
@@ -134,6 +140,7 @@ var stateStores = map[string]stateStoreSpec{
 		mounts:     []stateMount{{"data", "/data"}, {"logs", "/logs"}},
 		mode:       0o777,
 		projection: true,
+		owner:      "graph",
 	},
 	// The gateway's own derived state: the anchored-text store, one coordinate
 	// map per representation, ~2.9s/page of OCR to rebuild. Unmounted it lives
@@ -153,6 +160,7 @@ var stateStores = map[string]stateStoreSpec{
 		dir:        "anchored-text",
 		mounts:     []stateMount{{"", "/anchored-text"}},
 		projection: true,
+		owner:      "smelter",
 	},
 	// The XDG state tree, shared across the Archivist (projection writer —
 	// owns the stamp), the librarian (reads views), and the gateway (jobs
@@ -161,7 +169,26 @@ var stateStores = map[string]stateStoreSpec{
 		dir:        "state",
 		mounts:     []stateMount{{"", "/semiont-state"}},
 		projection: true,
+		owner:      "archivist",
 	},
+}
+
+// clearStoreContents empties a store dir without unlinking the dir itself.
+// Delete-and-recreate orphans every container share attached to the old
+// directory (Apple container virtiofs, measured 2026-09-07: the attached
+// container sees an empty mount and ENOENT on writes, forever); clearing
+// contents is invisible to attached shares.
+func clearStoreContents(sd string) error {
+	entries, err := os.ReadDir(sd)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(sd, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // storeDir: the store's directory under a root's state dir.

--- a/apps/launcher/launcher_test.go
+++ b/apps/launcher/launcher_test.go
@@ -765,6 +765,90 @@ func TestStateImageMismatchRefuses(t *testing.T) {
 	}
 }
 
+// SHARED-STORE-CLEAR-PREFLIGHT P1: the state store is SHARED — the gateway
+// and librarian attach what the archivist stamps — so its mismatch-clear
+// must resolve before the boot's first service container runs. A clear at
+// the stamp owner's own prep delete-and-recreates a directory earlier
+// services have already attached, orphaning their virtiofs shares (measured
+// 2026-09-07: ls total 0, every write ENOENT, 14 e2e failures).
+func TestSharedStoreClearResolvesBeforeFirstRun(t *testing.T) {
+	s := newScenario(t, "container")
+	dir := stateRootFor(s.home, testKBKey)
+	sentinel := filepath.Join(dir, "state", "stale-view")
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sentinel, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"kbRoot":"` + s.kb + `","stores":{"state":{"image":"ghcr.io/the-ai-alliance/semiont-archivist:0.0.0-old"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	statLog := filepath.Join(s.fakertDir, "stat.log")
+	s.extraEnv = append(s.extraEnv, "FAKERT_STAT_PATH="+sentinel, "FAKERT_STAT_LOG="+statLog)
+	stdout, stderr, code := s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("start with a state-store mismatch must boot: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	b, err := os.ReadFile(statLog)
+	if err != nil {
+		t.Fatalf("stat log (did no service container run?): %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	// "present" at the first service run means the clear had not resolved
+	// yet — it will delete-and-recreate a mount another container already
+	// attached. "absent" throughout also proves the clear happened at all.
+	for i, l := range lines {
+		if l != "absent" {
+			t.Fatalf("state-store sentinel still %s at service run %d of %d — the mismatch-clear resolved mid-boot, after a sharer attached", l, i+1, len(lines))
+		}
+	}
+}
+
+// SHARED-STORE-CLEAR-PREFLIGHT P2: a clear removes a store's CONTENTS and
+// keeps the mount-root directory itself. Delete-and-recreate orphans every
+// share attached to the old directory (Apple container virtiofs, measured
+// 2026-09-07); a contents-clear is invisible to attached shares. The test
+// holds the directory open across the boot — exactly what an attached share
+// does — and checks it was never unlinked: an open handle to a deleted
+// directory has link count zero. (Inode-number comparison cannot pin this:
+// an immediate recreate reuses the freed inode number.)
+func TestStoreClearKeepsMountRootDir(t *testing.T) {
+	s := newScenario(t, "container")
+	dir := stateRootFor(s.home, testKBKey)
+	sd := filepath.Join(dir, "state")
+	if err := os.MkdirAll(sd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sd, "stale-view"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"kbRoot":"` + s.kb + `","stores":{"state":{"image":"ghcr.io/the-ai-alliance/semiont-archivist:0.0.0-old"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	held, err := os.Open(sd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Close()
+	stdout, stderr, code := s.run(t, "start")
+	if code != 0 {
+		t.Fatalf("start with a state-store mismatch must boot: exit %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(sd, "stale-view")); err == nil {
+		t.Error("stale state-store contents survived the mismatch-clear")
+	}
+	fi, err := held.Stat()
+	if err != nil {
+		t.Fatalf("stat of the held state-store handle: %v", err)
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && st.Nlink == 0 {
+		t.Error("the state store dir was unlinked by the clear — every share attached before it is orphaned; clear contents, keep the directory")
+	}
+}
+
 func TestStateProjectionAutoCleans(t *testing.T) {
 	s := newScenario(t, "container")
 	// Graph/vectors are PROJECTIONS of the event log: data written by a

--- a/apps/launcher/testdata/golden/start-dryrun-default.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-default.txt
@@ -85,6 +85,7 @@ podman rm semiont-librarian
 # append [environments.local.archivist] host/port (launcher-staged topology) to worker.toml
 # append [environments.local.archivist] host/port (launcher-staged topology) to smelter.toml
 # append [environments.local.archivist] host/port (launcher-staged topology) to librarian.toml
+# resolve persistent-store stamps before any container runs: a database mismatch refuses; a projection mismatch clears the store's contents (the dir itself is kept, so attached shares survive)
 container image pull ghcr.io/the-ai-alliance/semiont-gateway:latest
 container image pull ghcr.io/the-ai-alliance/semiont-worker:latest
 container image pull ghcr.io/the-ai-alliance/semiont-smelter:latest

--- a/apps/launcher/testdata/golden/start-dryrun-local.txt
+++ b/apps/launcher/testdata/golden/start-dryrun-local.txt
@@ -35,6 +35,7 @@ container rm semiont-librarian
 # append [environments.local.archivist] host/port (launcher-staged topology) to worker.toml
 # append [environments.local.archivist] host/port (launcher-staged topology) to smelter.toml
 # append [environments.local.archivist] host/port (launcher-staged topology) to librarian.toml
+# resolve persistent-store stamps before any container runs: a database mismatch refuses; a projection mismatch clears the store's contents (the dir itself is kept, so attached shares survive)
 # SEMIONT_VERSION=local — using locally-built :local images (no pull)
 container run -d --name semiont-jaeger --memory 1G -p 16686:16686 -p 14318:4318 jaegertracing/all-in-one:1.76.0
 # wait: http://localhost:16686 (30s)


### PR DESCRIPTION
## The failure

A boot against the template KB failed 14 of 40 e2e tests — every job-dispatching test. The gateway's `FsJobQueue.initialize()` reported success, then every `createJob` hit ENOENT for the life of the process. Inside the broken stack, the gateway's `ls /semiont-state` returned `total 0` while the archivist — same store, same host directory — saw the full tree.

## The mechanism (measured, then reproduced)

Not a virtiofs propagation quirk: controlled two-container experiments show host- and container-created files and directories propagate fine into already-attached mounts, in every variant tried.

It is **share orphaning**. Delete-and-recreate the mounted host directory while a container is attached, and that container's share stays bound to the dead inode forever — `ls` returns `total 0`, writes fail ENOENT — while later-attaching containers see the new tree. Reproduced byte-for-byte.

The one delete-and-recreate in the boot path was the projection **mismatch-clear**: `stateMounts` ran `os.RemoveAll` on the store dir when the stamped image differed from the launching one. For the shared `state` store that ran at **archivist prep** (the stamp owner) — after the gateway had already attached the same store as a sharer. The trigger was #1253 moving the `state` stamp's owner from the gateway to the archivist: a root last stamped before the flip mismatched on its first boot after it.

## The fix — three rules, each pinned by a test that failed first

1. **Stamp resolution happens in preflight**, before the boot's first `container run`. `resolveStoreStamps` walks every store (a new `owner` field on `stateStores` says whose image stamps it; remote-bound roles are skipped) and runs the refuse/clear split up front. A side effect: a database image mismatch now refuses before anything boots, instead of behind a half-started stack. Pinned by `TestSharedStoreClearResolvesBeforeFirstRun`, via a new fakert stat-probe (`FAKERT_STAT_PATH`/`FAKERT_STAT_LOG`) that records whether a host path exists at the instant each service `run` arrives.
2. **No boot path unlinks a mount root.** The clear is now `clearStoreContents`: children removed, directory kept — attached shares survive a contents-clear (measured) and are orphaned by delete-and-recreate. Pinned by `TestStoreClearKeepsMountRootDir`, which holds the directory open across the boot (what an attached share is) and asserts it was never unlinked. (Inode-number comparison can't pin this — an immediate recreate reuses the freed inode.)
3. **Resolution restamps immediately.** The first live run caught the gap: preflight cleared but left the old stamp, so by archivist prep the gateway had rebuilt its jobs tree in the shared store and the decider cleared a second time, mid-boot. Once resolved, the old image's output is gone and the stamp says so; the owner's prep re-check no-ops. Refusals never restamp. Pinned by `TestResolveStoreStampRestampsOnResolution`.

`resolveStoreStamp` is now the one decider, still called from `stateMounts` so `--service` starts keep the same protection.

## Verification

- Full launcher suite green; goldens show the preflight resolution step in the dry-run plan (one new line per full-start golden).
- Live, on the failing root with the trigger deliberately re-staged (mismatched stamp, non-empty store): one preflight clear, no re-fire; the gateway's own view holds the full KB tree with all five job-status dirs; a probe write into `jobs/pending` round-tripped gateway→archivist; the stamp was re-written by preflight.
- e2e (the 14 job-dispatching tests) running separately as the final gate.
