### PR TITLE
PDF detection: subscribe the anchored-text consult, and gate every awaited-operations census at build time

### DIFF
--- a/packages/jobs/src/__tests__/worker-runtime.test.ts
+++ b/packages/jobs/src/__tests__/worker-runtime.test.ts
@@ -416,6 +416,11 @@ describe('worker-runtime — stall watchdog (WORKER-LIVENESS.md P3)', () => {
 describe('worker-runtime — narrowed SSE subscription (worker OOM, 2026-09-03)', () => {
   it('WORKER_CHANNELS carries exactly the reply channels of the operations the worker awaits', () => {
     expect([...WORKER_CHANNELS].sort()).toEqual([
+      // Canonical-geometry consult replies (SMELTER-OWNS-OCR P2) — the pair
+      // whose absence killed every PDF detection job
+      // (.plans/WORKER-ANCHORED-TEXT-CHANNEL.md).
+      'browse:anchored-text-failed',
+      'browse:anchored-text-result',
       'browse:resource-failed',
       'browse:resource-result',
       'job:claim-failed',

--- a/packages/jobs/src/job-claim-adapter.ts
+++ b/packages/jobs/src/job-claim-adapter.ts
@@ -25,6 +25,13 @@ import { busRequest, isArray, isNumber, isString } from '@semiont/core';
 import type { WorkerBus } from '@semiont/sdk';
 import { workerBusAsPrimitive } from './worker-bus-primitive.js';
 
+/**
+ * The bus operation the claim path AWAITS (census declaration — see
+ * `WORKER_AWAITED_OPERATIONS` in worker-runtime.ts). The `satisfies` at the
+ * call site keeps this alias and the actual operation from drifting.
+ */
+export type JobClaimAwaits = 'job:claim';
+
 
 export interface JobAssignment {
   jobId: string;
@@ -157,7 +164,7 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
       // reply's `response` (the claimed job).
       // `job:claimed`'s response is an untyped `Record<string, unknown>`, so narrow
       // it to the claimed-job shape the worker reads.
-      const job = (await busRequest(requestBus, 'job:claim', { jobId: assignment.jobId }, 10_000)) as {
+      const job = (await busRequest(requestBus, 'job:claim' satisfies JobClaimAwaits, { jobId: assignment.jobId }, 10_000)) as {
         params?: Record<string, unknown>;
         metadata?: { userId?: string; completedUnits?: unknown; retryCount?: unknown; maxRetries?: unknown };
       };

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -113,6 +113,17 @@ export interface WorkerProcessConfig {
  * on whether the event is a cross-subscriber broadcast.
  */
 /**
+ * Census declarations (`WORKER_AWAITED_OPERATIONS`, worker-runtime.ts) for the
+ * two operations THIS module awaits. `MarkCommitAwaits` is tied to its call by
+ * a `satisfies`; the descriptor read has no operation literal to tie to — it
+ * awaits through the SDK (`session.client.browse.resource(...).fresh()`), so
+ * its declaration is by convention until SDK bus-backed methods carry their
+ * operation in their own type (the census's recorded endgame).
+ */
+export type MarkCommitAwaits = 'mark:commit';
+export type DescriptorReadAwaits = 'browse:resource-requested';
+
+/**
  * How long a unit's commit may take before the worker treats the sink as down.
  *
  * Generous relative to an append — the batch is one unit's annotations and the
@@ -143,7 +154,7 @@ async function commitAnnotations(
   if (annotations.length === 0) return;
   await busRequest(
     workerBusAsPrimitive((session.client.transport as HttpTransport).actor),
-    'mark:commit',
+    'mark:commit' satisfies MarkCommitAwaits,
     { resourceId, annotations },
     MARK_COMMIT_TIMEOUT_MS,
   );

--- a/packages/jobs/src/worker-runtime.ts
+++ b/packages/jobs/src/worker-runtime.ts
@@ -14,7 +14,9 @@
  */
 
 import { startWorkerProcess } from './worker-process';
-import type { WorkerVitals } from './job-claim-adapter';
+import type { MarkCommitAwaits, DescriptorReadAwaits } from './worker-process';
+import type { WorkerVitals, JobClaimAwaits } from './job-claim-adapter';
+import type { ConsultAnchoredTextAwaits } from './workers/detection/prepare-detection';
 import type { InferenceClient } from '@semiont/inference';
 import { hostname } from 'os';
 import {
@@ -192,15 +194,24 @@ export function startStallWatchdog(opts: StallWatchdogOptions): { dispose(): voi
  * worker subscribes exactly its own operations' reply channels instead.
  *
  * This list restates a fact the code owns (which operations worker code
- * paths call `busRequest` on); its gate is `busRequest`'s `isSubscribed`
- * probe — an operation missing here fails IMMEDIATELY with
- * `bus.unsubscribed` naming the channel, never a silent 30 s timeout.
+ * paths call `busRequest` on); its gate is the build-time census below
+ * (`workerAwaitCensus`): every awaiting site declares its operation next to
+ * the call, and an operation awaited but missing here fails COMPILATION with
+ * the operation named. `busRequest`'s `isSubscribed` probe remains the
+ * runtime backstop for an await nobody declared — a loud `bus.unsubscribed`
+ * at first use, never a silent 30 s timeout.
  * (`job:queued` is not here: it is a broadcast, added by the claim
  * adapter via `addChannels`.)
  */
 export const WORKER_AWAITED_OPERATIONS = [
   'job:claim',
   'browse:resource-requested',
+  // Canonical geometry for a geometry-bearing detection: the consult behind
+  // `ConsultAnchoredText` (SMELTER-OWNS-OCR P2). Its omission broke every
+  // PDF detection job at the transport probe
+  // (.plans/WORKER-ANCHORED-TEXT-CHANNEL.md); the census below now fails the
+  // BUILD when this list and the declared awaits drift.
+  'browse:anchored-text-requested',
   // Durability acknowledgement for a unit's annotations (JOB-RESTART-SAFETY
   // P6). The worker AWAITS this one — a unit may not advance until its
   // annotations are in the event log — so its replies must be in the narrow
@@ -210,6 +221,34 @@ export const WORKER_AWAITED_OPERATIONS = [
 
 /** The derived global SSE channel set for a worker's transport. */
 export const WORKER_CHANNELS: readonly string[] = replyChannelsFor(WORKER_AWAITED_OPERATIONS);
+
+/**
+ * The build-time census gate (WORKER-ANCHORED-TEXT-CHANNEL F2).
+ *
+ * `WORKER_AWAITED_OPERATIONS` restates a fact the code owns — which
+ * operations worker paths call `busRequest` on — and one of those calls
+ * hides behind an injected seam (`ConsultAnchoredText` → the SDK), where no
+ * grep and no runtime probe-before-shipping can see it. So every awaiting
+ * site DECLARES its operation next to the call (the `*Awaits` aliases), the
+ * declarations are assembled here, and this constant compiles ONLY when the
+ * list and the declarations agree in BOTH directions. Drift fails the build
+ * with the drifted operation named in the type error — at build time, not at
+ * the first live job. `busRequest`'s `bus.unsubscribed` probe remains the
+ * runtime backstop for an await nobody declared.
+ */
+type DeclaredWorkerAwaits =
+  | JobClaimAwaits             // job-claim-adapter.ts — claiming an announced job
+  | DescriptorReadAwaits       // worker-process.ts — the resource descriptor read
+  | MarkCommitAwaits           // worker-process.ts — the durability ack (JOB-RESTART-SAFETY P6)
+  | ConsultAnchoredTextAwaits; // prepare-detection.ts — canonical geometry (SMELTER-OWNS-OCR P2)
+
+type WorkerAwaitCensusDrift =
+  | Exclude<DeclaredWorkerAwaits, (typeof WORKER_AWAITED_OPERATIONS)[number]>
+  | Exclude<(typeof WORKER_AWAITED_OPERATIONS)[number], DeclaredWorkerAwaits>;
+
+export const workerAwaitCensus: [WorkerAwaitCensusDrift] extends [never]
+  ? 'in-census'
+  : WorkerAwaitCensusDrift = 'in-census';
 
 export function parseGatewayUrl(url: string): { protocol: 'http' | 'https'; host: string; port: number } {
   const parsed = new URL(url);
@@ -353,10 +392,10 @@ export async function startAgentWorker(
     jobTypes: group.jobTypes,
     inferenceClient: group.client,
     generator,
-    // The extraction seam's cache, consulted over the bus and never written
-    // (ANCHORED-TEXT-TO-SMELTER D2): the Smelter owns this store, the
-    // Archivist answers the checksum-addressed read, and a worker that
-    // misses extracts locally and discards.
+    // Byte reads for decode-path media only. A geometry-bearing type's text
+    // never comes from bytes here — it is CONSULTED from the Smelter's
+    // canonical anchored text over the bus (SMELTER-OWNS-OCR P2), and this
+    // worker cannot derive even by mistake (READ-VS-EXTRACT P2).
     contentReads,
     logger,
   });

--- a/packages/jobs/src/workers/detection/prepare-detection.ts
+++ b/packages/jobs/src/workers/detection/prepare-detection.ts
@@ -43,6 +43,18 @@ export type DetectionDecline = {
 export type ConsultAnchoredText = (resourceId: ResourceId) => Promise<AnchoredTextAnswer>;
 
 /**
+ * The bus operation the consult AWAITS — declared WITH the seam, because the
+ * call itself lives behind the SDK (`browse.resourceAnchoredText`), where
+ * neither a grep for `busRequest(` nor the transport's types can see it. The
+ * worker's subscription census (`WORKER_AWAITED_OPERATIONS`,
+ * worker-runtime.ts) must carry this operation, and fails to COMPILE with
+ * this operation named in the error when it does not — every PDF detection
+ * job died on exactly that omission
+ * (.plans/WORKER-ANCHORED-TEXT-CHANNEL.md).
+ */
+export type ConsultAnchoredTextAwaits = 'browse:anchored-text-requested';
+
+/**
  * For one detection job, resolve the text the model detects over and the
  * media-appropriate way to turn a detected span into a stored annotation.
  *

--- a/packages/make-meaning/src/service-channels.ts
+++ b/packages/make-meaning/src/service-channels.ts
@@ -20,9 +20,14 @@
  *     exactly their inbound request/signal rosters.
  *
  * Each awaited-operations list restates a fact the code owns (which
- * operations that service calls `busRequest` on); its gate is `busRequest`'s
- * `isSubscribed` probe — an operation missing here fails IMMEDIATELY with
- * `bus.unsubscribed` naming the channel, never a silent 30 s timeout.
+ * operations that service calls `busRequest` on); its gate is the build-time
+ * census beside each list: every awaiting site declares its operation next to
+ * the call (a `*Awaits` alias, `satisfies`-tied to the literal), and a drift
+ * between a list and its declarations fails COMPILATION with the operation
+ * named (the worker-runtime pattern — .plans/WORKER-ANCHORED-TEXT-CHANNEL.md,
+ * whose subject was exactly such an omission killing every PDF detection
+ * job). `busRequest`'s `isSubscribed` probe remains the runtime backstop for
+ * an await nobody declared.
  */
 
 import { replyChannelsFor, type BusOperationKey, type EventMap } from '@semiont/core';
@@ -31,6 +36,16 @@ import { GATHERER_CHANNELS } from './gatherer';
 import { STOWER_CHANNELS } from './stower';
 import { BROWSER_CHANNELS } from './browser';
 import { CLONE_TOKEN_CHANNELS } from './clone-token-manager';
+import type {
+  SmelterResourceReadAwaits,
+  SmelterAnnotationsReadAwaits,
+  SmelterCatalogPageAwaits,
+} from './smelter';
+import type {
+  WeaverCatalogPageAwaits,
+  WeaverEventsReadAwaits,
+  WeaverAnnotationsReadAwaits,
+} from './weaver';
 
 // ── Smelter ──────────────────────────────────────────────────────────
 
@@ -45,6 +60,18 @@ export const SMELTER_AWAITED_OPERATIONS = [
 export const SMELTER_REPLY_CHANNELS: readonly (keyof EventMap)[] =
   replyChannelsFor(SMELTER_AWAITED_OPERATIONS);
 
+type DeclaredSmelterAwaits =
+  | SmelterResourceReadAwaits
+  | SmelterAnnotationsReadAwaits
+  | SmelterCatalogPageAwaits;
+type SmelterAwaitCensusDrift =
+  | Exclude<DeclaredSmelterAwaits, (typeof SMELTER_AWAITED_OPERATIONS)[number]>
+  | Exclude<(typeof SMELTER_AWAITED_OPERATIONS)[number], DeclaredSmelterAwaits>;
+/** The build-time census gate — see the header. Drift names the operation. */
+export const smelterAwaitCensus: [SmelterAwaitCensusDrift] extends [never]
+  ? 'in-census'
+  : SmelterAwaitCensusDrift = 'in-census';
+
 // ── Weaver ───────────────────────────────────────────────────────────
 
 /** The operations the Weaver awaits replies to (catch-up + reconcile reads). */
@@ -57,6 +84,18 @@ export const WEAVER_AWAITED_OPERATIONS = [
 /** The Weaver transport's global SSE channel set. */
 export const WEAVER_REPLY_CHANNELS: readonly (keyof EventMap)[] =
   replyChannelsFor(WEAVER_AWAITED_OPERATIONS);
+
+type DeclaredWeaverAwaits =
+  | WeaverCatalogPageAwaits
+  | WeaverEventsReadAwaits
+  | WeaverAnnotationsReadAwaits;
+type WeaverAwaitCensusDrift =
+  | Exclude<DeclaredWeaverAwaits, (typeof WEAVER_AWAITED_OPERATIONS)[number]>
+  | Exclude<(typeof WEAVER_AWAITED_OPERATIONS)[number], DeclaredWeaverAwaits>;
+/** The build-time census gate — see the header. Drift names the operation. */
+export const weaverAwaitCensus: [WeaverAwaitCensusDrift] extends [never]
+  ? 'in-census'
+  : WeaverAwaitCensusDrift = 'in-census';
 
 // ── Librarian ────────────────────────────────────────────────────────
 

--- a/packages/make-meaning/src/smelter.ts
+++ b/packages/make-meaning/src/smelter.ts
@@ -51,6 +51,18 @@ import { busRequest, type BusRequestPrimitive } from '@semiont/core';
 import { partitionByType } from './batch-utils';
 import type { SmelterEvent } from './smelter-actor-state-unit';
 
+/**
+ * Census declarations (`SMELTER_AWAITED_OPERATIONS`, service-channels.ts) for
+ * the operations this module awaits over the wire. The `satisfies` at each
+ * call site keeps a declaration and its operation from drifting; the census
+ * beside the list fails COMPILATION naming the operation when the list and
+ * these declarations disagree (the worker-runtime pattern —
+ * .plans/WORKER-ANCHORED-TEXT-CHANNEL.md P3).
+ */
+export type SmelterResourceReadAwaits = 'browse:resource-requested';
+export type SmelterAnnotationsReadAwaits = 'browse:annotations-requested';
+export type SmelterCatalogPageAwaits = 'browse:resources-requested';
+
 // Media dispatch is core's, keyed by the media type's `TextSource`
 // strategy (`.plans/SMELTER-MEDIA-TYPES.md`, narrowed by READ-VS-EXTRACT P2).
 // 'none' declines — settle skipped, reason 'no-extractor' — so binary types
@@ -571,7 +583,7 @@ export class Smelter {
   private async resolveEntityTypes(resourceId: string): Promise<string[]> {
     const { resource } = await busRequest(
       this.bus,
-      'browse:resource-requested',
+      'browse:resource-requested' satisfies SmelterResourceReadAwaits,
       { resourceId },
     );
     return getResourceEntityTypes(resource);
@@ -636,7 +648,7 @@ export class Smelter {
 
     const { annotations } = await busRequest(
       this.bus,
-      'browse:annotations-requested',
+      'browse:annotations-requested' satisfies SmelterAnnotationsReadAwaits,
       { resourceId: rid },
     );
     for (const annotation of annotations) {
@@ -885,7 +897,7 @@ export class Smelter {
         if (!rid) continue;
         const { annotations } = await busRequest(
           this.bus,
-          'browse:annotations-requested',
+          'browse:annotations-requested' satisfies SmelterAnnotationsReadAwaits,
           { resourceId: rid },
         );
         for (const annotation of annotations) {
@@ -1054,7 +1066,7 @@ export class Smelter {
     for (;;) {
       const page = await busRequest(
         this.bus,
-        'browse:resources-requested',
+        'browse:resources-requested' satisfies SmelterCatalogPageAwaits,
         { archived: false, offset: all.length, limit: Smelter.RECONCILE_PAGE_SIZE },
       );
       all.push(...page.resources);

--- a/packages/make-meaning/src/weaver.ts
+++ b/packages/make-meaning/src/weaver.ts
@@ -79,6 +79,15 @@ import { partitionByType } from './batch-utils.js';
 import type { Annotation, CreateAnnotationInternal } from '@semiont/core';
 import type { ResourceDescriptor } from '@semiont/core';
 
+/**
+ * Census declarations (`WEAVER_AWAITED_OPERATIONS`, service-channels.ts) for
+ * the operations this module awaits over the wire — see the note on
+ * `SmelterResourceReadAwaits` for the mechanism.
+ */
+export type WeaverCatalogPageAwaits = 'browse:resources-requested';
+export type WeaverEventsReadAwaits = 'browse:events-requested';
+export type WeaverAnnotationsReadAwaits = 'browse:annotations-requested';
+
 export class Weaver {
   // Catch-up paging (not timing — page size is a payload concern)
   private static readonly CATCHUP_PAGE_SIZE = 200;
@@ -293,7 +302,7 @@ export class Weaver {
   private async fetchAllResources(): Promise<ResourceDescriptor[]> {
     const resources: ResourceDescriptor[] = [];
     for (;;) {
-      const page = await busRequest(this.bus, 'browse:resources-requested', {
+      const page = await busRequest(this.bus, 'browse:resources-requested' satisfies WeaverCatalogPageAwaits, {
         offset: resources.length,
         limit: Weaver.CATCHUP_PAGE_SIZE,
       });
@@ -305,7 +314,7 @@ export class Weaver {
 
   /** A resource's full event history over the bus, sorted by sequence. */
   private async fetchResourceEvents(resourceId: string): Promise<StoredEvent[]> {
-    const reply = await busRequest(this.bus, 'browse:events-requested', { resourceId });
+    const reply = await busRequest(this.bus, 'browse:events-requested' satisfies WeaverEventsReadAwaits, { resourceId });
     return [...(reply.events as StoredEvent[])]
       .sort((a, b) => a.metadata.sequenceNumber - b.metadata.sequenceNumber);
   }
@@ -510,7 +519,7 @@ export class Weaver {
       return 'entity-types-mismatch';
     }
 
-    const { annotations } = await busRequest(this.bus, 'browse:annotations-requested', { resourceId: rid });
+    const { annotations } = await busRequest(this.bus, 'browse:annotations-requested' satisfies WeaverAnnotationsReadAwaits, { resourceId: rid });
     const graphAnnotations = await graphDb.getResourceAnnotations(makeResourceId(rid));
     const viewIds = new Set(annotations.map((a) => String(a.id)));
     const graphIds = new Set(graphAnnotations.map((a) => String(a.id)));

--- a/scripts/ci/local-build.sh
+++ b/scripts/ci/local-build.sh
@@ -199,6 +199,195 @@ for img in $IMAGES; do
   fi
 done
 
+# --- Drift gates (FIRST: they are the most common failure, and they need only
+# the repo plus a container — failing here costs seconds, not the ten minutes
+# of package and image builds that used to run before them) ---
+
+if [[ "$IMAGES_ONLY" != true ]]; then
+
+# --- bus registry drift gate ---
+#
+# specs/src/bus/registry.json is the AUTHORITY for the event bus: channels,
+# payload shapes, and the request/reply operations. BOTH languages are
+# generated from it — packages/core/src/bus-protocol.ts + bus-operations.ts
+# (TypeScript) and packages/sdk-go/bus/*_gen.go — so an edit to one language's
+# generated file, or a registry change without regeneration, is drift that
+# would let the two sides disagree at runtime. Each generator's --check diffs
+# without writing.
+
+banner "BUS REGISTRY DRIFT GATE"
+
+step "Checking generated bus files against specs/src/bus/registry.json..."
+if $RT run --rm -v "$REPO_ROOT":/workspace -w /workspace node:24-alpine \
+  sh -c 'node scripts/bus/generate-ts.mjs --check && node scripts/bus/generate-go.mjs --check'; then
+  ok "bus registry and both generated languages agree"
+else
+  fail "Generated bus files are STALE (or were hand-edited) — they must match specs/src/bus/registry.json."
+  echo ""
+  echo -e "  Regenerate both languages and commit:"
+  echo ""
+  echo -e "    ${BOLD}node scripts/bus/generate-ts.mjs${RESET}   (packages/core/src/bus-protocol.ts, bus-operations.ts)"
+  echo -e "    ${BOLD}node scripts/bus/generate-go.mjs${RESET}   (packages/sdk-go/bus/*_gen.go)"
+  echo ""
+  echo -e "  Channels and operations are edited in ${BOLD}specs/src/bus/registry.json${RESET}, never in the generated files."
+  echo ""
+  exit 1
+fi
+
+# --- sdk-go drift gate ---
+#
+# packages/sdk-go/client_gen.go is GENERATED from specs/openapi.json and
+# COMMITTED (see packages/sdk-go/README.md). Nothing regenerates it
+# automatically, so a spec change can leave it stale. This gate regenerates
+# to a scratch path inside the container (never the working tree — builds
+# don't mutate source) and diffs: byte-identical or fail. Deterministic
+# because the generator version is pinned.
+
+banner "SDK-GO DRIFT GATE"
+
+# specs/openapi.json is a BUILD ARTIFACT bundled from specs/src/. With the
+# gates running before the package builds, the copy a prior build left may be
+# stale or absent — bundle fresh first. Version pinned to the repo's
+# devDependency, same as CI.
+step "Bundling specs/src into specs/openapi.json..."
+mkdir -p /tmp/semiont-npmcache
+if ! $RT run --rm -v "$REPO_ROOT":/workspace -v /tmp/semiont-npmcache:/root/.npm -w /workspace node:24-alpine \
+  npx --yes @redocly/cli@2.34.0 bundle specs/src/openapi.json -o specs/openapi.json >/dev/null; then
+  fail "Could not bundle the OpenAPI spec (redocly; output above)."
+  exit 1
+fi
+
+step "Checking packages/sdk-go/client_gen.go against specs/openapi.json..."
+GOCACHE_DIR=/tmp/semiont-gocache
+# The MODULE cache is persisted too, not just the build cache. Without it every
+# run re-downloads the whole oapi-codegen tree (~100 MB, 21 modules), which is
+# why a DNS blip could take this gate down. (/tmp, not $TMPDIR: Apple Container
+# cannot sustain mounts from /var/folders. Go writes the module cache
+# read-only, so `chmod -R u+w` before removing it by hand.)
+GOMODCACHE_DIR=/tmp/semiont-gomodcache
+mkdir -p "$GOCACHE_DIR" "$GOMODCACHE_DIR"
+# Caching alone is not enough: `go run <pkg>@<version>` resolves the version
+# against the proxy on EVERY run — including a deprecation lookup — so a
+# populated cache still needed the network. Pointing GOPROXY at the cache's own
+# download dir (a valid module proxy) serves the pinned generator locally and
+# falls through to the network only on a miss. Measured both ways: warm cache
+# succeeds with the network proxies removed entirely; a cold cache still
+# populates through the fallback.
+GOPROXY_CACHED='file:///go/pkg/mod/cache/download,https://proxy.golang.org,direct'
+
+# Generation and comparison report SEPARATELY. Collapsing them into one `&&`
+# made every generator failure — a DNS blip fetching oapi-codegen, an
+# unreadable spec, a container that never started — print "the OpenAPI spec
+# changed without regenerating the Go client": a specific cause the gate had
+# not established, and one that sends the reader to regenerate a file that was
+# never stale. Ignorance is not a finding.
+DRIFT_RC=0
+# Output is tee'd, not just streamed: the exit-3 handler below reads it to tell a
+# CORRUPT MODULE CACHE from a network failure, and the two have opposite remedies.
+# `set -o pipefail` (line 2) is what makes `$?` the container's code rather than
+# tee's — without it this silently reports success on every failure.
+DRIFT_LOG=$(mktemp "${TMPDIR:-/tmp}/semiont-drift.XXXXXX")
+$RT run --rm \
+  -v "$REPO_ROOT":/workspace \
+  -v "$GOCACHE_DIR":/root/.cache/go-build \
+  -v "$GOMODCACHE_DIR":/go/pkg/mod \
+  -e GOPROXY="$GOPROXY_CACHED" \
+  -w /workspace \
+  golang:1.25 \
+  sh -c 'go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0 \
+           -generate types,client,skip-prune -package semiont \
+           -o /tmp/client_gen.check.go specs/openapi.json || exit 3
+         diff -q /tmp/client_gen.check.go packages/sdk-go/client_gen.go >/dev/null || exit 4' \
+  2>&1 | tee "$DRIFT_LOG" \
+  || DRIFT_RC=$?
+
+case "$DRIFT_RC" in
+  0)
+    ok "packages/sdk-go matches the spec"
+    rm -f "$DRIFT_LOG"
+    ;;
+  4)
+    fail "packages/sdk-go/client_gen.go is STALE — the OpenAPI spec changed without regenerating the Go client."
+    echo ""
+    echo -e "  Regenerate and commit it:"
+    echo ""
+    echo -e "    ${BOLD}cd packages/sdk-go && go generate ./...${RESET}"
+    echo -e "    ${BOLD}git add packages/sdk-go/client_gen.go${RESET}   (then commit)"
+    echo ""
+    exit 1
+    ;;
+  *)
+    fail "The sdk-go drift gate could not RUN (the generator exited $DRIFT_RC; its output is above)."
+    echo ""
+    echo -e "  This says nothing about whether the Go client is stale — the check never got"
+    echo -e "  far enough to compare."
+    echo ""
+    # Two causes, opposite remedies. Telling someone to wait for the network when
+    # the module cache is corrupt makes them wait for a network that is already
+    # working, and the next run fails identically.
+    #
+    # The cache holds `cache/download` (module ZIPs — a valid proxy, and what
+    # GOPROXY_CACHED points at) beside the EXTRACTED trees. A run killed
+    # mid-extraction leaves a partial tree that no amount of network fixes; Go
+    # re-extracts from the downloads offline once the bad tree is gone.
+    # `cannot embed` / `no embeddable files` is the shape a TRUNCATED extraction
+    # produces, and it was missing here until it cost a diagnosis (2026-08-24).
+    # Go has two embed failures and they read nothing alike: a pattern matching
+    # nothing says "no matching files found", while a directory that survived
+    # with its subdirectories but none of its files says "cannot embed directory
+    # X: contains no embeddable files". The second is precisely the corrupt-cache
+    # signature — the tree is THERE, so Go trusts it and never re-extracts, and
+    # every retry fails identically. Matching only the first sent the reader to
+    # the network branch below to wait out a network that was already working.
+    if grep -qiE 'no such file or directory|no matching files found|cannot embed|no embeddable files|pattern .*: .*matching|cannot find package' "$DRIFT_LOG"; then
+      echo -e "  ${BOLD}Cause: a corrupt Go module cache, not the network.${RESET} A previous run was"
+      echo -e "  interrupted mid-extraction and left a partial module tree."
+      echo ""
+      echo -e "  Purge the EXTRACTED trees and keep the downloads (no re-fetch, works offline):"
+      echo ""
+      echo -e "    ${BOLD}chmod -R u+w $GOMODCACHE_DIR${RESET}"
+      echo -e "    ${BOLD}find $GOMODCACHE_DIR -mindepth 1 -maxdepth 1 ! -name cache -exec rm -rf {} +${RESET}"
+      echo ""
+      # Everything else in this repo runs in a container, so the reflex is to run
+      # this there too. It fails: rm returns "Permission denied" on the virtiofs
+      # mount even as root, and the tree survives looking untouched.
+      echo -e "  ${DIM}Run those on the HOST, not in a container — rm fails with Permission${RESET}"
+      echo -e "  ${DIM}denied through the mount, even as root, and leaves the cache corrupt.${RESET}"
+      echo ""
+      echo -e "  ${DIM}Do NOT use \`go clean -modcache\` — it deletes cache/download too, costing a${RESET}"
+      echo -e "  ${DIM}~100 MB re-fetch of the 21-module oapi-codegen tree and reintroducing the${RESET}"
+      echo -e "  ${DIM}network dependency GOPROXY_CACHED exists to remove.${RESET}"
+      echo ""
+      # GOPROXY_CACHED is itself a file:// proxy, so a COLD cache with the network
+      # also down produces this same wording. The purge is safe either way (Go
+      # re-extracts from the downloads), but it will not help that case.
+      echo -e "  ${DIM}If the purge changes nothing, the cache was cold rather than corrupt —${RESET}"
+      echo -e "  ${DIM}the file:// proxy reports the same error for a missing module. Treat it${RESET}"
+      echo -e "  ${DIM}as the network case below.${RESET}"
+    else
+      echo -e "  A failed module fetch (${BOLD}proxy.golang.org${RESET}) is the usual cause; retry once the"
+      echo -e "  network is back, and the pinned generator will be cached in"
+      echo -e "  ${BOLD}${GOMODCACHE_DIR}${RESET} for subsequent offline runs."
+    fi
+    echo ""
+    echo -e "  ${DIM}Generator output kept at: $DRIFT_LOG${RESET}"
+    echo ""
+    exit 1
+    ;;
+esac
+
+step "Checking the generated Go client covers every schema..."
+if ! $RT run --rm -v "$REPO_ROOT":/workspace -w /workspace node:24-alpine \
+  node scripts/ci/check-go-schema-coverage.mjs; then
+  fail "The generated Go client is missing schemas (see above)."
+  echo ""
+  echo -e "    ${BOLD}cd packages/sdk-go && go generate ./...${RESET}"
+  echo ""
+  exit 1
+fi
+
+fi
+
 # --- Start fresh Verdaccio ---
 
 banner "LOCAL REGISTRY"
@@ -683,175 +872,6 @@ if [[ "$IMAGES_ONLY" == true ]]; then
   exit 0
 fi
 
-
-# --- bus registry drift gate ---
-#
-# specs/src/bus/registry.json is the AUTHORITY for the event bus: channels,
-# payload shapes, and the request/reply operations. BOTH languages are
-# generated from it — packages/core/src/bus-protocol.ts + bus-operations.ts
-# (TypeScript) and packages/sdk-go/bus/*_gen.go — so an edit to one language's
-# generated file, or a registry change without regeneration, is drift that
-# would let the two sides disagree at runtime. Each generator's --check diffs
-# without writing.
-
-banner "BUS REGISTRY DRIFT GATE"
-
-step "Checking generated bus files against specs/src/bus/registry.json..."
-if $RT run --rm -v "$REPO_ROOT":/workspace -w /workspace node:24-alpine \
-  sh -c 'node scripts/bus/generate-ts.mjs --check && node scripts/bus/generate-go.mjs --check'; then
-  ok "bus registry and both generated languages agree"
-else
-  fail "Generated bus files are STALE (or were hand-edited) — they must match specs/src/bus/registry.json."
-  echo ""
-  echo -e "  Regenerate both languages and commit:"
-  echo ""
-  echo -e "    ${BOLD}node scripts/bus/generate-ts.mjs${RESET}   (packages/core/src/bus-protocol.ts, bus-operations.ts)"
-  echo -e "    ${BOLD}node scripts/bus/generate-go.mjs${RESET}   (packages/sdk-go/bus/*_gen.go)"
-  echo ""
-  echo -e "  Channels and operations are edited in ${BOLD}specs/src/bus/registry.json${RESET}, never in the generated files."
-  echo ""
-  exit 1
-fi
-
-# --- sdk-go drift gate ---
-#
-# packages/sdk-go/client_gen.go is GENERATED from specs/openapi.json and
-# COMMITTED (see packages/sdk-go/README.md). Nothing regenerates it
-# automatically, so a spec change can leave it stale. This gate regenerates
-# to a scratch path inside the container (never the working tree — builds
-# don't mutate source) and diffs: byte-identical or fail. Deterministic
-# because the generator version is pinned.
-
-banner "SDK-GO DRIFT GATE"
-
-step "Checking packages/sdk-go/client_gen.go against specs/openapi.json..."
-GOCACHE_DIR=/tmp/semiont-gocache
-# The MODULE cache is persisted too, not just the build cache. Without it every
-# run re-downloads the whole oapi-codegen tree (~100 MB, 21 modules), which is
-# why a DNS blip could take this gate down. (/tmp, not $TMPDIR: Apple Container
-# cannot sustain mounts from /var/folders. Go writes the module cache
-# read-only, so `chmod -R u+w` before removing it by hand.)
-GOMODCACHE_DIR=/tmp/semiont-gomodcache
-mkdir -p "$GOCACHE_DIR" "$GOMODCACHE_DIR"
-# Caching alone is not enough: `go run <pkg>@<version>` resolves the version
-# against the proxy on EVERY run — including a deprecation lookup — so a
-# populated cache still needed the network. Pointing GOPROXY at the cache's own
-# download dir (a valid module proxy) serves the pinned generator locally and
-# falls through to the network only on a miss. Measured both ways: warm cache
-# succeeds with the network proxies removed entirely; a cold cache still
-# populates through the fallback.
-GOPROXY_CACHED='file:///go/pkg/mod/cache/download,https://proxy.golang.org,direct'
-
-# Generation and comparison report SEPARATELY. Collapsing them into one `&&`
-# made every generator failure — a DNS blip fetching oapi-codegen, an
-# unreadable spec, a container that never started — print "the OpenAPI spec
-# changed without regenerating the Go client": a specific cause the gate had
-# not established, and one that sends the reader to regenerate a file that was
-# never stale. Ignorance is not a finding.
-DRIFT_RC=0
-# Output is tee'd, not just streamed: the exit-3 handler below reads it to tell a
-# CORRUPT MODULE CACHE from a network failure, and the two have opposite remedies.
-# `set -o pipefail` (line 2) is what makes `$?` the container's code rather than
-# tee's — without it this silently reports success on every failure.
-DRIFT_LOG=$(mktemp "${TMPDIR:-/tmp}/semiont-drift.XXXXXX")
-$RT run --rm \
-  -v "$REPO_ROOT":/workspace \
-  -v "$GOCACHE_DIR":/root/.cache/go-build \
-  -v "$GOMODCACHE_DIR":/go/pkg/mod \
-  -e GOPROXY="$GOPROXY_CACHED" \
-  -w /workspace \
-  golang:1.25 \
-  sh -c 'go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0 \
-           -generate types,client,skip-prune -package semiont \
-           -o /tmp/client_gen.check.go specs/openapi.json || exit 3
-         diff -q /tmp/client_gen.check.go packages/sdk-go/client_gen.go >/dev/null || exit 4' \
-  2>&1 | tee "$DRIFT_LOG" \
-  || DRIFT_RC=$?
-
-case "$DRIFT_RC" in
-  0)
-    ok "packages/sdk-go matches the spec"
-    rm -f "$DRIFT_LOG"
-    ;;
-  4)
-    fail "packages/sdk-go/client_gen.go is STALE — the OpenAPI spec changed without regenerating the Go client."
-    echo ""
-    echo -e "  Regenerate and commit it:"
-    echo ""
-    echo -e "    ${BOLD}cd packages/sdk-go && go generate ./...${RESET}"
-    echo -e "    ${BOLD}git add packages/sdk-go/client_gen.go${RESET}   (then commit)"
-    echo ""
-    exit 1
-    ;;
-  *)
-    fail "The sdk-go drift gate could not RUN (the generator exited $DRIFT_RC; its output is above)."
-    echo ""
-    echo -e "  This says nothing about whether the Go client is stale — the check never got"
-    echo -e "  far enough to compare."
-    echo ""
-    # Two causes, opposite remedies. Telling someone to wait for the network when
-    # the module cache is corrupt makes them wait for a network that is already
-    # working, and the next run fails identically.
-    #
-    # The cache holds `cache/download` (module ZIPs — a valid proxy, and what
-    # GOPROXY_CACHED points at) beside the EXTRACTED trees. A run killed
-    # mid-extraction leaves a partial tree that no amount of network fixes; Go
-    # re-extracts from the downloads offline once the bad tree is gone.
-    # `cannot embed` / `no embeddable files` is the shape a TRUNCATED extraction
-    # produces, and it was missing here until it cost a diagnosis (2026-08-24).
-    # Go has two embed failures and they read nothing alike: a pattern matching
-    # nothing says "no matching files found", while a directory that survived
-    # with its subdirectories but none of its files says "cannot embed directory
-    # X: contains no embeddable files". The second is precisely the corrupt-cache
-    # signature — the tree is THERE, so Go trusts it and never re-extracts, and
-    # every retry fails identically. Matching only the first sent the reader to
-    # the network branch below to wait out a network that was already working.
-    if grep -qiE 'no such file or directory|no matching files found|cannot embed|no embeddable files|pattern .*: .*matching|cannot find package' "$DRIFT_LOG"; then
-      echo -e "  ${BOLD}Cause: a corrupt Go module cache, not the network.${RESET} A previous run was"
-      echo -e "  interrupted mid-extraction and left a partial module tree."
-      echo ""
-      echo -e "  Purge the EXTRACTED trees and keep the downloads (no re-fetch, works offline):"
-      echo ""
-      echo -e "    ${BOLD}chmod -R u+w $GOMODCACHE_DIR${RESET}"
-      echo -e "    ${BOLD}find $GOMODCACHE_DIR -mindepth 1 -maxdepth 1 ! -name cache -exec rm -rf {} +${RESET}"
-      echo ""
-      # Everything else in this repo runs in a container, so the reflex is to run
-      # this there too. It fails: rm returns "Permission denied" on the virtiofs
-      # mount even as root, and the tree survives looking untouched.
-      echo -e "  ${DIM}Run those on the HOST, not in a container — rm fails with Permission${RESET}"
-      echo -e "  ${DIM}denied through the mount, even as root, and leaves the cache corrupt.${RESET}"
-      echo ""
-      echo -e "  ${DIM}Do NOT use \`go clean -modcache\` — it deletes cache/download too, costing a${RESET}"
-      echo -e "  ${DIM}~100 MB re-fetch of the 21-module oapi-codegen tree and reintroducing the${RESET}"
-      echo -e "  ${DIM}network dependency GOPROXY_CACHED exists to remove.${RESET}"
-      echo ""
-      # GOPROXY_CACHED is itself a file:// proxy, so a COLD cache with the network
-      # also down produces this same wording. The purge is safe either way (Go
-      # re-extracts from the downloads), but it will not help that case.
-      echo -e "  ${DIM}If the purge changes nothing, the cache was cold rather than corrupt —${RESET}"
-      echo -e "  ${DIM}the file:// proxy reports the same error for a missing module. Treat it${RESET}"
-      echo -e "  ${DIM}as the network case below.${RESET}"
-    else
-      echo -e "  A failed module fetch (${BOLD}proxy.golang.org${RESET}) is the usual cause; retry once the"
-      echo -e "  network is back, and the pinned generator will be cached in"
-      echo -e "  ${BOLD}${GOMODCACHE_DIR}${RESET} for subsequent offline runs."
-    fi
-    echo ""
-    echo -e "  ${DIM}Generator output kept at: $DRIFT_LOG${RESET}"
-    echo ""
-    exit 1
-    ;;
-esac
-
-step "Checking the generated Go client covers every schema..."
-if ! $RT run --rm -v "$REPO_ROOT":/workspace -w /workspace node:24-alpine \
-  node scripts/ci/check-go-schema-coverage.mjs; then
-  fail "The generated Go client is missing schemas (see above)."
-  echo ""
-  echo -e "    ${BOLD}cd packages/sdk-go && go generate ./...${RESET}"
-  echo ""
-  exit 1
-fi
 
 # --- Build the launcher (host binary) ---
 #

--- a/scripts/ci/local-build.sh
+++ b/scripts/ci/local-build.sh
@@ -258,14 +258,32 @@ if ! $RT run --rm -v "$REPO_ROOT":/workspace -v /tmp/semiont-npmcache:/root/.npm
 fi
 
 step "Checking packages/sdk-go/client_gen.go against specs/openapi.json..."
-GOCACHE_DIR=/tmp/semiont-gocache
+# Both Go caches are PER-CONSUMER (-build suffix), not shared with other
+# container consumers (agent sessions, the pre-commit hook). The old shared
+# /tmp/semiont-gomodcache was corrupted three times by concurrent container
+# VMs extracting into it — Go's cache locking is flock, which does not hold
+# across VM boundaries over virtiofs — and a truncated extraction is trusted
+# forever ("cannot embed directory ... contains no embeddable files").
+# This script cannot run concurrently with itself (port 4873), so a private
+# cache is effectively serial, and the class is gone rather than patched.
+GOCACHE_DIR=/tmp/semiont-gocache-build
 # The MODULE cache is persisted too, not just the build cache. Without it every
 # run re-downloads the whole oapi-codegen tree (~100 MB, 21 modules), which is
 # why a DNS blip could take this gate down. (/tmp, not $TMPDIR: Apple Container
 # cannot sustain mounts from /var/folders. Go writes the module cache
 # read-only, so `chmod -R u+w` before removing it by hand.)
-GOMODCACHE_DIR=/tmp/semiont-gomodcache
+GOMODCACHE_DIR=/tmp/semiont-gomodcache-build
 mkdir -p "$GOCACHE_DIR" "$GOMODCACHE_DIR"
+# One-time seed from the legacy shared cache's download dir (a pure
+# content-addressed store — safe to copy, never to share live), so the first
+# -build run costs a local copy instead of a 100 MB re-fetch. The legacy dir
+# is frozen: nothing writes it any more, and it can be deleted once every
+# consumer has seeded.
+if [[ ! -d "$GOMODCACHE_DIR/cache/download" && -d /tmp/semiont-gomodcache/cache/download ]]; then
+  step "Seeding the module cache from the legacy shared downloads (one-time local copy)..."
+  mkdir -p "$GOMODCACHE_DIR/cache"
+  cp -R /tmp/semiont-gomodcache/cache/download "$GOMODCACHE_DIR/cache/download"
+fi
 # Caching alone is not enough: `go run <pkg>@<version>` resolves the version
 # against the proxy on EVERY run — including a deprecation lookup — so a
 # populated cache still needed the network. Pointing GOPROXY at the cache's own
@@ -879,8 +897,8 @@ fi
 # the :local images (SEMIONT_VERSION=local semiont start). Built inside
 # golang:1.25 targeting the host platform — no Go toolchain on the host, the
 # same philosophy as the npm builds above. The Go build cache persists under
-# /tmp/semiont-gocache (/tmp, not $TMPDIR — Apple Container cannot sustain
-# mounts from /var/folders).
+# /tmp/semiont-gocache-build (/tmp, not $TMPDIR — Apple Container cannot
+# sustain mounts from /var/folders).
 
 banner "LAUNCHER"
 


### PR DESCRIPTION
Every PDF detection job in the current build died before reading a single coordinate. The worker's SSE subscription was deliberately narrowed after the 2026-09-03 OOM (~85 multi-MB reply frames/min parsed and dropped) to exactly the reply channels of the operations it awaits — and #1297 (the Smelter owns OCR) then added a new await, the anchored-text consult, without the list moving in the same commit. Every geometry-bearing detection hit the transport's fail-fast probe:

```
Transport is not subscribed to reply channel browse:anchored-text-result —
a reply to browse:anchored-text-requested can never arrive.
```

Measured impact from the release-gate e2e run: both PDF assisted-detection motivations produced **0 annotations**, and the scanned-PDF decline — a designed, asserted "no" — crashed as `job:fail` instead of completing. The browser-side spec passed, localizing the fault to the worker→gateway leg alone.

## Why nothing caught it

The awaited-operations list restates a fact the code owns: which operations worker paths call `busRequest` on. Its claimed gate was the runtime probe — which converts a silent 30 s timeout into a loud crash, but fires when a job reaches the path, **after shipping**, never when the source grows. The test that looked like a gate pinned the same hand-written list against its own derivation: two mirrors agreeing with each other, neither agreeing with the code. And the new await was invisible to any grep — it lives behind an injected seam (`ConsultAnchoredText`) that calls through the SDK.

## The fix: one line, plus the gate that makes the class unshippable

**The gate came first and was observed failing on the unmodified list**, with the missing operation named in the error:

```
worker-runtime.ts(240,14): error TS2322: Type '"in-census"' is not assignable to type '"browse:anchored-text-requested"'.
```

Mechanism: every awaiting site declares its operation **next to the call** — `satisfies`-tied to the literal where one exists (`job:claim`, `mark:commit`), declared on the seam type where the SDK hides it (`ConsultAnchoredTextAwaits`), by convention for the SDK descriptor read. The declarations are assembled beside the list, and `workerAwaitCensus` compiles only when list and declarations agree in **both directions** — drift either way fails the build with the drifted operation named. Then the one-line fix turned it green; the channel-set pin moved in the same edit, and the list's own comment now names the census as its gate, demoting the runtime probe to backstop for an await nobody declared.

## The sibling sets, audited and brought under the same census

`SMELTER_AWAITED_OPERATIONS` and `WEAVER_AWAITED_OPERATIONS` were the same construct with the same gate story. The audit's measured result: **both were already correct** — all 4 smelter and 3 weaver `busRequest` sites map exactly onto their lists, neither process holds a session (so no SDK-hidden awaits exist), and their mains' import closures contain no other `busRequest`. Both are now under `smelterAwaitCensus`/`weaverAwaitCensus`, with the transferred gate proven to fire by a deliberate drift:

```
service-channels.ts(95,14): error TS2322: Type '"in-census"' is not assignable to type '"browse:events-requested"'.
```

Also reaped in passing: the doubly stale `contentReads` wiring comment (it described the checksum-addressed read reaped by #1297's follow-up and a worker-local extraction that no longer exists).

## Verification

`tsc --noEmit` clean and full vitest green in both touched workspaces (jobs: 526 passed; make-meaning: 591 passed / 1 expected-fail), plus both deliberate-drift probes above. **Not in this PR:** the live gate — specs 20 and 22 against a rebuilt worker image must show annotations > 0 on both PDF motivations and the scanned decline ending in `job:complete`; unit tests cannot close a bug that lives in a real transport's subscription set.

**Residual, named:** an await added through the SDK with no declaration is still caught only by the runtime probe. The recorded endgame is SDK bus-backed methods carrying their operation in their own type, so consumers derive rather than declare.
