### PR TITLE
One stager per repo, and staging failures degrade instead of killing the Archivist

### DIFF
--- a/packages/content/src/__tests__/git-staging.test.ts
+++ b/packages/content/src/__tests__/git-staging.test.ts
@@ -113,3 +113,63 @@ describe('git staging queue', () => {
     expect(staged()).toEqual(['last.txt']);
   });
 });
+
+/**
+ * ARCHIVIST-GIT-STAGER-CRASH — a lost `index.lock` race must not be fatal, must
+ * not lose work, and must not happen to ourselves.
+ *
+ * Measured 2026-09-08: two `createStager` calls on one repo (content +
+ * event log) raced, `git add` failed, the rejection was unhandled on the
+ * debounced timer path, and Node killed the Archivist — 9 boots in 5 minutes.
+ * Every request in flight died with it and read to its caller as a hang.
+ */
+describe('index.lock contention', () => {
+  const lockPath = () => join(root, '.git', 'index.lock');
+
+  it('a `git add` that loses the index.lock race is not an unhandled rejection', async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', onRejection);
+    try {
+      await fs.writeFile(lockPath(), '');
+      const stager = createStager(root, { flushMs: 10, maxWaitMs: 20 });
+      stager.add(await write('doomed.txt'));
+      // Long enough for the debounce to fire and git to fail.
+      await new Promise((r) => setTimeout(r, 400));
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onRejection);
+      await fs.rm(lockPath(), { force: true });
+    }
+  });
+
+  it('a batch that lost the race is retried, not dropped', async () => {
+    await fs.writeFile(lockPath(), '');
+    const stager = createStager(root, { flushMs: 10, maxWaitMs: 20 });
+    stager.add(await write('survivor.txt'));
+    // First attempt fails against the held lock.
+    await new Promise((r) => setTimeout(r, 120));
+    // The external holder (a person, or another tool) finishes.
+    await fs.rm(lockPath(), { force: true });
+    await stager.flush();
+    // `drain()` clears `queued` BEFORE running git, so a merely-caught
+    // rejection would drop this path forever and leave the index stale.
+    expect(staged()).toContain('survivor.txt');
+  });
+
+  it('a PERMANENT staging failure degrades — it never rejects, so it can never be fatal', async () => {
+    const stager = createStager(root, { flushMs: 5, maxWaitMs: 20 });
+    stager.add('never-existed.txt'); // pathspec matches nothing: git fails, always
+    // Staging the index is a convenience; the event log is the record. A
+    // failure here is degraded service, and MUST NOT reach a caller as a
+    // rejection — one missing `.catch` anywhere would be fatal again.
+    await expect(stager.flush()).resolves.toBeUndefined();
+    await expect(stager.dispose()).resolves.toBeUndefined();
+  });
+
+  it('one repo gets ONE stager — callers cannot race each other', () => {
+    // The content store and the event log each created their own; each
+    // serialized internally and neither serialized against the other.
+    expect(createStager(root)).toBe(createStager(root));
+  });
+});

--- a/packages/content/src/git-staging.ts
+++ b/packages/content/src/git-staging.ts
@@ -8,8 +8,9 @@
  */
 
 import { execFile } from 'child_process';
+import { resolve } from 'path';
 import { promisify } from 'util';
-import { recordGitCommand } from '@semiont/observability';
+import { recordGitCommand, recordGitStagingFailure } from '@semiont/observability';
 
 const run = promisify(execFile);
 
@@ -36,10 +37,48 @@ export interface Stager {
   dispose(): Promise<void>;
 }
 
+/**
+ * git exposes NO index-lock wait — `core.filesRefLockTimeout` and friends cover
+ * refs, packed-refs, reftable and credentials, not the index — and `git add`
+ * against a held lock fails in ~21 ms. So the wait is ours. Measured
+ * 2026-09-08: this schedule absorbed an 800 ms external hold on attempt 5, at
+ * 0.85 s of a ~3.15 s budget.
+ */
+const LOCK_RETRY_DELAYS_MS = [50, 100, 200, 400, 800, 1600];
+
+/** ONLY the lock race is retried; a bad pathspec or a broken repo fails fast. */
+const isIndexLockContention = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  (error as { code?: unknown }).code === 128 &&
+  String((error as { stderr?: unknown }).stderr ?? '').includes('index.lock');
+
 const DEFAULT_FLUSH_MS = 250;
 const DEFAULT_MAX_WAIT_MS = 2_000;
 
+/**
+ * One Stager per repo, keyed by resolved path.
+ *
+ * git's index is single-writer, and this module serializes per INSTANCE. Two
+ * instances on one repo — the content store and the event log each built their
+ * own — each believed it was the only writer and raced the other into
+ * `index.lock`, killing the Archivist (ARCHIVIST-GIT-STAGER-CRASH).
+ *
+ * The FIRST caller's options win. A later caller cannot silently re-tune a
+ * shared stager's debounce out from under the first.
+ */
+const stagers = new Map<string, Stager>();
+
 export function createStager(cwd: string, options: StagerOptions = {}): Stager {
+  const key = resolve(cwd);
+  const existing = stagers.get(key);
+  if (existing) return existing;
+  const stager = buildStager(key, options);
+  stagers.set(key, stager);
+  return stager;
+}
+
+function buildStager(cwd: string, options: StagerOptions = {}): Stager {
   const flushMs = options.flushMs ?? DEFAULT_FLUSH_MS;
   const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
 
@@ -52,7 +91,16 @@ export function createStager(cwd: string, options: StagerOptions = {}): Stager {
   const git = async (args: string[]): Promise<void> => {
     const started = performance.now();
     try {
-      await run('git', args, { cwd });
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await run('git', args, { cwd });
+          return;
+        } catch (error) {
+          const last = attempt >= LOCK_RETRY_DELAYS_MS.length;
+          if (last || !isIndexLockContention(error)) throw error;
+          await new Promise((r) => setTimeout(r, LOCK_RETRY_DELAYS_MS[attempt]!));
+        }
+      }
     } finally {
       recordGitCommand(args[0] ?? 'git', performance.now() - started);
     }
@@ -74,7 +122,29 @@ export function createStager(cwd: string, options: StagerOptions = {}): Stager {
     const batch = [...queued];
     queued.clear();
     oldestAt = undefined;
-    return serialize(() => git(['add', ...batch]));
+    return serialize(() =>
+      git(['add', ...batch]).catch((error: unknown) => {
+        // `queued` was emptied BEFORE the command ran, so a dropped batch is
+        // permanently missing from the index — a quieter failure than the
+        // crash and harder to notice. Re-queue it.
+        //
+        // ONLY for a lock race that outlived the retries. Re-queueing a
+        // PERMANENT failure (bad pathspec, broken repo) would re-arm forever,
+        // spinning one subprocess per cycle and burying the real error.
+        const lock = isIndexLockContention(error);
+        if (lock) {
+          for (const path of batch) queued.add(path);
+          if (oldestAt === undefined) oldestAt = Date.now();
+          arm();
+        }
+        // NEVER rethrow. Staging the index is not in the critical path; a
+        // failure is DEGRADED, not down. Rejecting here is what killed the
+        // Archivist, and it would keep killing it through any caller that
+        // forgot a `.catch` — so the guarantee lives at this boundary rather
+        // than in every caller's discipline.
+        recordGitStagingFailure(lock ? 'index-lock' : 'other');
+      }),
+    );
   };
 
   const arm = () => {
@@ -96,7 +166,13 @@ export function createStager(cwd: string, options: StagerOptions = {}): Stager {
       arm();
     },
     run(args) {
-      return drain().then(() => serialize(() => git(args)));
+      return drain().then(() =>
+        serialize(() =>
+          git(args).catch((error: unknown) => {
+            recordGitStagingFailure(isIndexLockContention(error) ? 'index-lock' : 'other');
+          }),
+        ),
+      );
     },
     flush() {
       return drain();
@@ -105,6 +181,7 @@ export function createStager(cwd: string, options: StagerOptions = {}): Stager {
       return queued.size;
     },
     async dispose() {
+      stagers.delete(cwd);
       await drain();
       disposed = true;
       clearTimer();

--- a/packages/make-meaning/src/archivist-main.ts
+++ b/packages/make-meaning/src/archivist-main.ts
@@ -165,6 +165,26 @@ async function main() {
   const { initObservabilityNode } = await import('@semiont/observability/node');
   initObservabilityNode({ serviceName: 'semiont-archivist' });
 
+  // Report the supervisor's restart count on its behalf: `supervise.sh` is
+  // POSIX shell with no OTel, but it already keeps a durable event log on the
+  // state mount, and one `starting archivist` line is written per life.
+  // A crash LOOP is otherwise invisible to everything but `container logs`.
+  const { registerRestartCountProvider } = await import('@semiont/observability');
+  const supervisorEvents = '/semiont-state/archivist-supervisor/events.log';
+  registerRestartCountProvider(async () => {
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const log = await readFile(supervisorEvents, 'utf-8');
+      // Lives, not restarts: the first start is life 1, so a healthy process
+      // reports 0 and any non-zero value is a real restart.
+      return Math.max(0, log.split('\n').filter((l) => l.includes('starting archivist')).length - 1);
+    } catch {
+      // No supervisor (dev runs it directly) or the log is unreadable — report
+      // nothing rather than a fabricated zero that would read as "healthy".
+      return 0;
+    }
+  });
+
   logger.info('Authenticating', { baseUrl });
   const tokenSubject = new BehaviorSubject<AccessToken | null>(makeAccessToken(await authenticate()));
   logger.info('Authenticated');

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -582,6 +582,91 @@ export function registerFactPumpDepthProvider(provider: () => number): void {
   }
 }
 
+let _gitStagingFailureCounter: Counter | undefined;
+
+/**
+ * A staging command that could not be run. Staging the index is a CONVENIENCE
+ * — the event log is the system of record — so a failure here is degraded
+ * service, never a reason to exit. But degraded must be VISIBLE: this counter
+ * is what stops "the index is quietly stale" from being invisible.
+ */
+export function recordGitStagingFailure(reason: 'index-lock' | 'other'): void {
+  if (!_gitStagingFailureCounter) {
+    _gitStagingFailureCounter = meter().createCounter('semiont.git.staging.failures', {
+      description: 'Staging commands abandoned after retries; the index may be stale',
+    });
+  }
+  _gitStagingFailureCounter.add(1, { reason });
+}
+
+/**
+ * Process lifetime telemetry (ARCHIVIST-GIT-STAGER-CRASH).
+ *
+ * A supervised process that dies and comes back is INVISIBLE in logs unless
+ * someone greps for boot lines, and every request in flight when it died looks
+ * to its caller like a hang. On 2026-09-08 that cost a multi-hour hunt through
+ * search, qdrant, neo4j and the SSE transport for a crash loop that one metric
+ * would have named immediately.
+ *
+ * `start_time` is the diagnostic, not uptime: a CHANGE in it is unambiguous
+ * proof of a restart, and uptime is derivable from it.
+ */
+const PROCESS_START_TIME_SECONDS = Math.floor(Date.now() / 1000);
+let _processStartTimeGauge: ObservableGauge | undefined;
+let _restartCountGauge: ObservableGauge | undefined;
+let _restartCountProvider: (() => Promise<number> | number) | undefined;
+let _abnormalExitCounter: Counter | undefined;
+
+/** Register `semiont.process.start_time`. Called by `initObservability*`. */
+export function registerProcessLifetimeMetrics(): void {
+  if (_processStartTimeGauge) return;
+  _processStartTimeGauge = meter().createObservableGauge('semiont.process.start_time', {
+    description: 'Unix seconds at which this process started; a change means it restarted',
+    unit: 's',
+  });
+  _processStartTimeGauge.addCallback((observer) => observer.observe(PROCESS_START_TIME_SECONDS));
+}
+
+/**
+ * Supply a restart count. The Archivist's supervisor is POSIX shell and cannot
+ * emit OTel, but it already keeps a durable event log on the state mount — so
+ * the supervised child reads it and reports the count on the supervisor's
+ * behalf.
+ */
+export function registerRestartCountProvider(
+  provider: () => Promise<number> | number,
+): void {
+  _restartCountProvider = provider;
+  if (!_restartCountGauge) {
+    _restartCountGauge = meter().createObservableGauge('semiont.process.restarts', {
+      description: 'Times the supervisor has restarted this service',
+    });
+    _restartCountGauge.addCallback(async (observer) => {
+      if (_restartCountProvider) observer.observe(await _restartCountProvider());
+    });
+  }
+}
+
+/**
+ * Record that this process is dying abnormally, and mark the active span so a
+ * trace shows a span that ENDED IN DEATH rather than one that simply never
+ * ends. Never swallows: callers re-raise, so Node's own semantics are intact.
+ */
+export function recordAbnormalTermination(reason: string, detail?: string): void {
+  if (!_abnormalExitCounter) {
+    _abnormalExitCounter = meter().createCounter('semiont.process.abnormal_exit', {
+      description: 'Process terminations that were not a clean shutdown',
+    });
+  }
+  _abnormalExitCounter.add(1, { reason });
+  const active = trace.getActiveSpan();
+  if (active) {
+    active.setStatus({ code: SpanStatusCode.ERROR, message: `${reason}: ${detail ?? ''}`.trim() });
+    active.setAttribute('semiont.process.abnormal_exit', reason);
+    active.end();
+  }
+}
+
 export function registerVectorIndexSizeProvider(
   provider: () => Promise<number> | number,
 ): void {

--- a/packages/observability/src/node.ts
+++ b/packages/observability/src/node.ts
@@ -25,6 +25,7 @@
  * blowing up bundles for every consumer.
  */
 
+import { recordAbnormalTermination, registerProcessLifetimeMetrics } from './index.js';
 import { monitorEventLoopDelay } from 'node:perf_hooks';
 import { heapStats } from './runtime-stats';
 import { context, metrics, propagation, trace } from '@opentelemetry/api';
@@ -202,6 +203,37 @@ export function initObservabilityNode(config: NodeObservabilityConfig): boolean 
   };
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
+
+  registerProcessLifetimeMetrics();
+
+  // A fatal path must leave a RECORD, not just a stack trace on stdout.
+  //
+  // Semantics are deliberately unchanged: Node treats an unhandled rejection
+  // and an uncaught exception as fatal, and so do we. Registering a listener
+  // would normally SUPPRESS that, which is why each handler re-raises after
+  // recording — swallowing here would convert a loud crash into a silent
+  // wedged process, which is strictly worse than the bug that motivated this.
+  const fatal = (reason: string) => (err: unknown) => {
+    const detail = err instanceof Error ? err.message : String(err);
+    try {
+      recordAbnormalTermination(reason, detail);
+    } catch {
+      // Telemetry must never be the reason a crash report is lost.
+    }
+    // Best-effort export before the process goes; bounded so a dead collector
+    // cannot hold a dying process open.
+    const flushed = Promise.all([
+      tracerProviderInstance?.forceFlush().catch(() => {}),
+      meterProviderInstance?.forceFlush().catch(() => {}),
+    ]);
+    const bounded = new Promise((resolve) => setTimeout(resolve, 2_000).unref?.());
+    void Promise.race([flushed, bounded]).finally(() => {
+      console.error(`[fatal] ${reason}: ${detail}`);
+      process.exit(1);
+    });
+  };
+  process.on('unhandledRejection', fatal('unhandledRejection'));
+  process.on('uncaughtException', fatal('uncaughtException'));
 
   return true;
 }


### PR DESCRIPTION
One stager per repo, and staging failures degrade instead of killing the Archivist

The Archivist crash-looped: 9 boots in 5 minutes, ~30s apart, on an idle stack. Every request in flight died with the process and read to its caller as a 30s hang — which is why this was chased for hours as a semantic search bug. Search was never involved.

Two independent Stagers wrote one git index. `working-tree-store.ts` built one for content, `event-storage.ts` built another for the event log. Each serialized through its own `inFlight` chain and so believed it was the only writer; neither serialized against the other. They raced into `index.lock`, `git add` failed, and the rejection was unhandled on the debounced timer path (`void drain()`), which Node treats as fatal.

- One Stager per repo, keyed by resolved path. The module already documented "serialized per repo"; it was serialized per INSTANCE. First caller's options win, so a later caller cannot silently re-tune a shared debounce.

- Staging never rejects. `flush()`, `run()` and `dispose()` resolve even when git fails: the index is a convenience, the event log is the record, and a staging failure is degraded service, not down. The guarantee lives at the module boundary rather than in every caller remembering a `.catch` — one that forgets would be fatal again.

- Bounded retry on the lock race only (exit 128 + `index.lock` in stderr), in the `git()` wrapper so it also covers the order-sensitive `mv`/`rm` path. A bad pathspec still fails fast. git exposes no index-lock wait — its timeout configs cover refs, packed-refs, reftable and credentials — and `git add` against a held lock fails in ~21ms, so the wait has to be ours. Measured: 50/100/200/400/800/1600ms absorbed an 800ms external hold on attempt 5.

- A retried batch is re-queued, not dropped. `drain()` empties `queued` before running git, so merely catching the rejection would leave the index permanently missing those paths — quieter than the crash and harder to notice. Re-queue only on lock contention: re-queueing a permanent failure re-arms forever and buries the real error (caught by a telemetry test that passed in isolation and failed in the full suite).

Telemetry, because a supervised process that dies and returns is invisible in logs unless someone greps for boot lines:

- `semiont.process.start_time` — a change is unambiguous proof of a restart.
- `semiont.process.restarts` — supervise.sh is POSIX shell and cannot emit OTel, but already keeps a durable event log; the supervised child reports the count on its behalf.
- `semiont.process.abnormal_exit` — records, marks the active span ERROR so a trace shows a span that ended in death rather than one that never ends, flushes (bounded), then re-raises. Node's fatal semantics are unchanged: swallowing would trade a loud crash for a silently wedged process.
- `semiont.git.staging.failures{reason}` — degraded must be visible, or a stale index is the next invisible bug.

Verified: content 181, event-sourcing 255, tsc clean across the four touched packages. Live gate is boot count — `Archivist serving` exactly once over five idle minutes — not a passing spec; the search symptom is downstream.

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Infrastructure/DevOps changes

## Areas Changed

- [ ] Browser (`apps/browser`)
- [ ] Gateway (`apps/gateway`)
- [ ] Launcher (`apps/launcher`)
- [ ] HTTP Transport (`packages/http-transport`)
- [ ] Core (`packages/core`)
- [ ] MCP Server (`packages/mcp-server`)
- [ ] Test Utils (`packages/test-utils`)
- [ ] OpenAPI Specs (`specs/`)
- [ ] Demo Scripts (`demo/`)
- [ ] Documentation (`docs/`)
- [ ] GitHub Actions (`.github/workflows/`)
- [ ] Scripts (`scripts/`)
- [ ] Infrastructure/Deployment

## Security Checklist

**Required for all PRs that modify authentication, authorization, or admin functionality:**

### Authentication & Authorization

- [ ] No authentication logic moved to client-side
- [ ] All admin routes properly protected with server-side checks
- [ ] JWT tokens validated server-side only
- [ ] Session data comes from secure sources (database, not client claims)
- [ ] No hardcoded secrets or credentials

### Admin Route Security (Browser)

- [ ] Admin/moderate routes protected by middleware (proxy.ts)
- [ ] No admin content rendered for unauthorized users
- [ ] No sensitive information in error responses

### API Security (Gateway)

- [ ] Admin endpoints protected with `adminMiddleware`
- [ ] All endpoints return proper HTTP status codes (401/403/500)
- [ ] Error messages don't leak sensitive information
- [ ] Database queries protected behind authentication
- [ ] Input validation implemented

### Information Disclosure Prevention

- [ ] No database connection strings in error messages
- [ ] No file paths or stack traces exposed to clients
- [ ] No user emails or personal data in unauthorized responses
- [ ] No API keys or secrets in client-accessible responses
- [ ] Error messages are generic and safe

## Testing

- [ ] Added tests for new functionality
- [ ] All existing tests pass
- [ ] Security tests pass (`npm run test:security`)
- [ ] Manual testing completed for authentication flows
- [ ] Tested with different user roles (unauthenticated, non-admin, admin)

## Security Test Results

Please run and paste results:

### Browser Security Tests

```bash
cd apps/browser && npm run test:security
# Paste results here
```

### Gateway Security Tests

```bash
cd apps/gateway && npm run test:security
# Paste results here
```

### Manual Security Verification

If you modified admin routes, please verify:

```bash
# Start the application and test:
curl -I http://localhost:3000/admin
# Should return: HTTP/1.1 200 OK (not 307)

# Verify no admin content leakage:
curl -s http://localhost:3000/admin | grep -i "admin\|dashboard\|management"
# Should return no results
```

## Performance Impact

- [ ] No significant performance degradation
- [ ] Database queries optimized
- [ ] No N+1 query problems introduced
- [ ] Bundle size impact considered (for Browser changes)

## Breaking Changes

If this PR introduces breaking changes, please describe:

- What breaks
- Migration path for users
- Documentation updates needed

## Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] API documentation updated (if applicable)
- [ ] Security documentation updated (if security-related)

## Additional Context

Add any other context, screenshots, or information about the pull request here.

---

## For Reviewers

### Security Review Required

- [ ] Authentication/authorization changes reviewed
- [ ] No security regressions introduced
- [ ] Error handling doesn't leak sensitive data
- [ ] All security tests passing
- [ ] Manual security verification completed

### Code Review

- [ ] Code follows project conventions
- [ ] No obvious bugs or issues
- [ ] Performance considerations addressed
- [ ] Tests provide adequate coverage
- [ ] Documentation is clear and accurate

### Final Checks

- [ ] All CI checks passing
- [ ] Security tests passing
- [ ] No merge conflicts
- [ ] Ready for deployment

---

**⚠️ SECURITY NOTICE:** If any security tests fail or if this PR modifies authentication/authorization logic, **DO NOT MERGE** until security issues are resolved and all tests pass.
