### PR TITLE
A lost acknowledgement is no longer a lost batch, and Go moves to 1.27.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,9 +80,10 @@ updates:
       prefix: "tests"
       include: "scope"
 
-  # Go launcher (apps/launcher). Stdlib-only today — no third-party module deps —
-  # so this mainly covers the `go` directive/toolchain and anything added later.
-  # Reachability-aware stdlib CVE scanning is handled by govulncheck in ci.yml.
+  # Go launcher (apps/launcher): go-toml, oapi-codegen/runtime, and
+  # packages/sdk-go through a replace directive, plus the `go`
+  # directive/toolchain. Reachability-aware stdlib CVE scanning is handled by
+  # govulncheck in ci.yml.
   # NB: kept to default-days only; the semver cooldown tiers are npm-oriented.
   - package-ecosystem: "gomod"
     directory: "/apps/launcher"
@@ -98,6 +99,32 @@ updates:
       - "launcher"
     commit-message:
       prefix: "launcher"
+      include: "scope"
+
+  # Go SDK (packages/sdk-go). Its OWN entry because gomod is not
+  # workspace-aware: this is a separate module, and the launcher's entry above
+  # updates the launcher's go.mod only.
+  #
+  # Without it the drift is invisible from inside the repo. The launcher
+  # `replace`s this module and MVS then resolves the HIGHER requirement, so a
+  # monorepo build and govulncheck both see the launcher's version
+  # (oapi-codegen/runtime v1.7.0) while this go.mod goes on declaring v1.6.0 —
+  # green everywhere, and nothing reports it. But sdk-go is consumed by module
+  # path, so an EXTERNAL consumer resolves the stale minimum declared here.
+  - package-ecosystem: "gomod"
+    directory: "/packages/sdk-go"
+    cooldown:
+      default-days: 5
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "sdk-go"
+    commit-message:
+      prefix: "sdk-go"
       include: "scope"
 
   # GitHub Actions dependencies

--- a/apps/gateway/src/__tests__/integration/sse-event-flow.test.ts
+++ b/apps/gateway/src/__tests__/integration/sse-event-flow.test.ts
@@ -198,7 +198,6 @@ describe('SSE Event Flow - End-to-End', () => {
         jobId: testJobId,
         jobType: 'reference-annotation',
         error: 'AI service unavailable',
-        details: 'Connection timeout after 30s'
       }
     });
 

--- a/apps/launcher/go.mod
+++ b/apps/launcher/go.mod
@@ -1,12 +1,17 @@
 module github.com/The-AI-Alliance/semiont/apps/launcher
 
-go 1.25
+go 1.27
 
-// Pinned to the patch, not the minor: `go 1.25` let CI resolve to whatever
-// 1.25.x it had (1.25.12), which govulncheck fails on — five stdlib CVEs, all
-// fixed in 1.25.13. actions/setup-go reads this line from go-version-file, so
-// the scan and the build agree on one compiler.
-toolchain go1.25.13
+// Pinned to the patch, not the minor: `go 1.27` alone lets CI resolve to
+// whatever 1.27.x it happens to have, and a stdlib CVE fixed in a later patch
+// then fails govulncheck on a compiler nobody chose. actions/setup-go reads
+// this line from go-version-file, so the scan and the build agree on one
+// compiler.
+//
+// 1.25.13 -> 1.27.1 (2026-09-08): CI installs govulncheck @latest, v1.8.0
+// published requiring go >= 1.26, and every Go job went red against
+// GOTOOLCHAIN=local. The floor moves with the tool.
+toolchain go1.27.1
 
 require (
 	github.com/The-AI-Alliance/semiont/packages/sdk-go v0.0.0-00010101000000-000000000000

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -33,7 +33,7 @@
 import { GEN_REQUIRED, minimalContext } from './fixtures/generation-fixtures';
 import { referenceIdOf } from '../worker-process';
 import { Subject, BehaviorSubject } from 'rxjs';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { extractPdfTextLayer } from '@semiont/content';
 import type { SemiontSession } from '@semiont/sdk';
 import type { JobType } from '@semiont/core';
@@ -114,24 +114,52 @@ function makeFakeSessionAndAdapter() {
     if (!s) { s = new Subject(); replyStreams.set(channel, s); }
     return s;
   };
-  const commitSink: { mode: 'ok' | 'fail' | 'silent' } = { mode: 'ok' };
+  /**
+   * The stand-in Archivist's disposition — and, separately, what the log holds
+   * because of it. The two are not the same fact, which is the entire subject
+   * of COMMIT-ACK-FALSE-FAILURE:
+   *
+   *   ok         appended, acknowledged
+   *   ack-lost   APPENDED, acknowledgement never routed  ← the measured bug
+   *   silent     never arrived, so nothing appended, nothing answered
+   *   fail       refused, nothing appended
+   *
+   * `ack-lost` and `silent` are indistinguishable to the worker's `busRequest`
+   * — both are a `bus.timeout` — and they are opposite truths about the data.
+   * Telling them apart is what F1 is for, so the fake must be able to be each.
+   */
+  const commitSink: { mode: 'ok' | 'fail' | 'silent' | 'ack-lost' } = { mode: 'ok' };
+  /** The event log's annotation set for RID, as the stand-in Archivist holds it. */
+  const landed: Array<{ id: string }> = [];
 
   const transportEmit = vi.fn(async (channel: string, payload: Record<string, unknown>, scope?: string) => {
     busEmits.push({ channel, payload, scope });
-    if (channel === 'mark:commit' && commitSink.mode !== 'silent') {
+    if (channel === 'mark:commit') {
       const correlationId = payload.correlationId as string;
       const annotations = (payload.annotations ?? []) as Array<{ id: string }>;
-      // Answer on the next tick, as a real Archivist would.
-      queueMicrotask(() => {
-        if (commitSink.mode === 'ok') {
-          replyStream('mark:commit-ok').next({
-            correlationId,
-            response: { persisted: annotations.length, annotationIds: annotations.map((a) => String(a.id)) },
-          });
-        } else {
-          replyStream('mark:commit-failed').next({ correlationId, message: 'sink down' });
+      if (commitSink.mode === 'ok' || commitSink.mode === 'ack-lost') {
+        // Appended idempotently by annotation id — the contract F3 gives the
+        // real Stower. Modelling it here keeps this fake from claiming a
+        // property the log does not have; the double-SEND it cannot hide is
+        // asserted directly, by counting `mark:commit` emits.
+        for (const a of annotations) {
+          if (!landed.some((l) => String(l.id) === String(a.id))) landed.push(a);
         }
-      });
+      }
+      // Answer on the next tick, as a real Archivist would — unless the reply
+      // path is gone, which is both timeout modes.
+      if (commitSink.mode === 'ok' || commitSink.mode === 'fail') {
+        queueMicrotask(() => {
+          if (commitSink.mode === 'ok') {
+            replyStream('mark:commit-ok').next({
+              correlationId,
+              response: { persisted: annotations.length, annotationIds: annotations.map((a) => String(a.id)) },
+            });
+          } else {
+            replyStream('mark:commit-failed').next({ correlationId, message: 'sink down' });
+          }
+        });
+      }
     }
     return 1;
   });
@@ -170,6 +198,17 @@ function makeFakeSessionAndAdapter() {
         resourceAnchoredText: vi.fn(async (_rid: string) => ({
           kind: 'extracted', text: 'the content', items: [], method: 'pdf-text-layer',
         })),
+        // The durability probe (COMMIT-ACK-FALSE-FAILURE F1). What the log
+        // actually holds — the only evidence that can separate a lost
+        // acknowledgement from a lost batch. Rejects when absent, as the real
+        // read does (`browse:annotation-failed`, "Annotation not found").
+        annotation: vi.fn((_rid: string, aid: string) => ({
+          fresh: async () => {
+            const hit = landed.find((a) => String(a.id) === String(aid));
+            if (!hit) throw new Error('Annotation not found');
+            return hit;
+          },
+        })),
       },
       yield: {
         resource: vi.fn(async (data: Parameters<SemiontSession['client']['yield']['resource']>[0]) => {
@@ -188,7 +227,7 @@ function makeFakeSessionAndAdapter() {
     touchActivity: vi.fn(() => adapterCalls.push({ method: 'touchActivity', args: [] })),
   } as unknown as JobClaimAdapter;
 
-  return { session, transportHandlers, adapter, busEmits, yieldResourceCalls, adapterCalls };
+  return { session, transportHandlers, adapter, busEmits, yieldResourceCalls, adapterCalls, commitSink, landed };
 }
 
 function makeConfig(session: SemiontSession): WorkerProcessConfig {
@@ -1597,5 +1636,80 @@ describe('startWorkerProcess — job:fail carries the failure class (ABANDONED-I
 
     vi.doUnmock('../job-claim-adapter');
     vi.resetModules();
+  });
+});
+
+describe('a lost acknowledgement is not a lost batch (COMMIT-ACK-FALSE-FAILURE)', () => {
+  // Measured 2026-09-08: a Person detection ran 51 minutes over a 102-page PDF,
+  // the Archivist appended all 1,673 annotations, the gateway then went down,
+  // and 60 s later the job reported
+  //
+  //     Job failed — Bus request timed out after 60000ms on mark:commit-ok
+  //
+  // Nothing was lost. The status was simply wrong — and a user cannot tell that
+  // apart from total loss, which after 51 minutes of paid inference is the
+  // whole problem.
+  //
+  // The worker derives its outcome from whether a MESSAGE arrived. It must
+  // derive it from whether the WORK LANDED. Both facts are available: the
+  // annotations are addressable by their own (content-derived) ids.
+
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  /** Drive `handleJob` past `MARK_COMMIT_TIMEOUT_MS` without waiting a real minute. */
+  async function runPastCommitTimeout(h: ReturnType<typeof makeFakeSessionAndAdapter>) {
+    vi.mocked(processHighlightJob).mockResolvedValue({
+      annotations: [{ id: 'a1' }, { id: 'a2' }] as never,
+      result: { highlightsFound: 2, highlightsCreated: 2 } as never,
+    });
+    const run = handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
+    const settled = run.then(() => 'completed' as const, (e) => e as Error);
+    await vi.advanceTimersByTimeAsync(61_000);
+    return settled;
+  }
+
+  it('reports SUCCESS when the annotations are durable and only the ack was lost', async () => {
+    const h = makeFakeSessionAndAdapter();
+    h.commitSink.mode = 'ack-lost';
+
+    const outcome = await runPastCommitTimeout(h);
+
+    // The batch is in the log — that is the fact the outcome owes its answer to.
+    expect(h.landed.map((a) => a.id)).toEqual(['a1', 'a2']);
+    expect(outcome, `job reported failure over durable data: ${outcome instanceof Error ? outcome.message : ''}`)
+      .toBe('completed');
+    expect(h.busEmits.map((e) => e.channel)).toContain('job:complete');
+    expect(h.busEmits.map((e) => e.channel)).not.toContain('job:fail');
+  });
+
+  it('still FAILS when the batch never landed — the probe must not launder a real loss', async () => {
+    // The guard on the fix. `silent` and `ack-lost` are the same timeout to the
+    // worker and opposite truths about the data; a probe that answered "durable"
+    // for both would convert this plan's false failure into a false SUCCESS,
+    // which is the defect the acknowledgement was introduced to kill.
+    const h = makeFakeSessionAndAdapter();
+    h.commitSink.mode = 'silent';
+
+    const outcome = await runPastCommitTimeout(h);
+
+    expect(h.landed).toEqual([]);
+    expect(outcome).toBeInstanceOf(Error);
+    expect(h.busEmits.map((e) => e.channel)).not.toContain('job:complete');
+  });
+
+  it('does not re-send a batch it has verified durable', async () => {
+    // Pins the probe against ONE tempting wrong shape: "re-commit and see" —
+    // idempotency at the log (F3) makes a second commit harmless to the data,
+    // so it looks like a free way to answer the question. It is not. It doubles
+    // the work, and in the measured scenario the gateway is DOWN, so the
+    // re-commit just times out again and answers nothing. Ask the log what it
+    // holds; do not write to it to find out.
+    const h = makeFakeSessionAndAdapter();
+    h.commitSink.mode = 'ack-lost';
+
+    await runPastCommitTimeout(h);
+
+    expect(h.busEmits.filter((e) => e.channel === 'mark:commit')).toHaveLength(1);
   });
 });

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -36,6 +36,7 @@ import { Subject, BehaviorSubject } from 'rxjs';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { extractPdfTextLayer } from '@semiont/content';
 import type { SemiontSession } from '@semiont/sdk';
+import { BusRequestError } from '@semiont/core';
 import type { JobType } from '@semiont/core';
 import type { ActiveJob, JobClaimAdapter } from '../job-claim-adapter';
 import { handleJob, type WorkerProcessConfig } from '../worker-process';
@@ -128,16 +129,23 @@ function makeFakeSessionAndAdapter() {
    * — both are a `bus.timeout` — and they are opposite truths about the data.
    * Telling them apart is what F1 is for, so the fake must be able to be each.
    */
-  const commitSink: { mode: 'ok' | 'fail' | 'silent' | 'ack-lost' } = { mode: 'ok' };
+  const commitSink: { mode: 'ok' | 'fail' | 'silent' | 'ack-lost' | 'first-ok-then-lost' } = { mode: 'ok' };
+  let commitCount = 0;
   /** The event log's annotation set for RID, as the stand-in Archivist holds it. */
   const landed: Array<{ id: string }> = [];
+  /** Whether the durability probe can be answered at all. */
+  const probeSink: { mode: 'answer' | 'unreachable' } = { mode: 'answer' };
 
   const transportEmit = vi.fn(async (channel: string, payload: Record<string, unknown>, scope?: string) => {
     busEmits.push({ channel, payload, scope });
     if (channel === 'mark:commit') {
+      commitCount++;
       const correlationId = payload.correlationId as string;
       const annotations = (payload.annotations ?? []) as Array<{ id: string }>;
-      if (commitSink.mode === 'ok' || commitSink.mode === 'ack-lost') {
+      const mode = commitSink.mode === 'first-ok-then-lost'
+        ? (commitCount === 1 ? 'ok' : 'ack-lost')
+        : commitSink.mode;
+      if (mode === 'ok' || mode === 'ack-lost') {
         // Appended idempotently by annotation id — the contract F3 gives the
         // real Stower. Modelling it here keeps this fake from claiming a
         // property the log does not have; the double-SEND it cannot hide is
@@ -148,9 +156,9 @@ function makeFakeSessionAndAdapter() {
       }
       // Answer on the next tick, as a real Archivist would — unless the reply
       // path is gone, which is both timeout modes.
-      if (commitSink.mode === 'ok' || commitSink.mode === 'fail') {
+      if (mode === 'ok' || mode === 'fail') {
         queueMicrotask(() => {
-          if (commitSink.mode === 'ok') {
+          if (mode === 'ok') {
             replyStream('mark:commit-ok').next({
               correlationId,
               response: { persisted: annotations.length, annotationIds: annotations.map((a) => String(a.id)) },
@@ -204,8 +212,14 @@ function makeFakeSessionAndAdapter() {
         // read does (`browse:annotation-failed`, "Annotation not found").
         annotation: vi.fn((_rid: string, aid: string) => ({
           fresh: async () => {
+            // `probeSink` plays the read being UNANSWERABLE, which is a
+            // different fact from the read answering "no" — `bus.timeout`
+            // versus `bus.rejected`, and opposite epistemic states.
+            if (probeSink.mode === 'unreachable') {
+              throw new BusRequestError('Bus request timed out after 30000ms on browse:annotation-result', 'bus.timeout');
+            }
             const hit = landed.find((a) => String(a.id) === String(aid));
-            if (!hit) throw new Error('Annotation not found');
+            if (!hit) throw new BusRequestError('Annotation not found', 'bus.rejected');
             return hit;
           },
         })),
@@ -227,7 +241,7 @@ function makeFakeSessionAndAdapter() {
     touchActivity: vi.fn(() => adapterCalls.push({ method: 'touchActivity', args: [] })),
   } as unknown as JobClaimAdapter;
 
-  return { session, transportHandlers, adapter, busEmits, yieldResourceCalls, adapterCalls, commitSink, landed };
+  return { session, transportHandlers, adapter, busEmits, yieldResourceCalls, adapterCalls, commitSink, landed, probeSink };
 }
 
 function makeConfig(session: SemiontSession): WorkerProcessConfig {
@@ -796,7 +810,10 @@ describe('handleJob orchestration', () => {
         Object.keys(h.busEmits.find(e => e.channel === channel)!.payload as object).sort();
 
       expect(keysOf('job:start')).toEqual(['jobId', 'jobType', 'resourceId']);
-      expect(keysOf('job:complete')).toEqual(['jobId', 'jobType', 'resourceId', 'result']);
+      // `job:start` stays bare: nothing has been committed yet, so there is no
+      // durability to state. Every TERMINAL payload carries how durability was
+      // established (COMMIT-ACK-FALSE-FAILURE) — here, an acknowledged commit.
+      expect(keysOf('job:complete')).toEqual(['durability', 'jobId', 'jobType', 'resourceId', 'result']);
       // The commit carries a batch and a correlationId (busRequest sets the
       // latter), not a single annotation.
       expect(keysOf('mark:commit')).toEqual(['annotations', 'correlationId', 'resourceId']);
@@ -1711,5 +1728,148 @@ describe('a lost acknowledgement is not a lost batch (COMMIT-ACK-FALSE-FAILURE)'
     await runPastCommitTimeout(h);
 
     expect(h.busEmits.filter((e) => e.channel === 'mark:commit')).toHaveLength(1);
+  });
+});
+
+describe('the record says HOW durability was established (COMMIT-ACK-FALSE-FAILURE)', () => {
+  // Auditable provenance, not a status badge. After the probe landed there were
+  // four distinct evidentiary states collapsing into two records: an
+  // acknowledged completion read exactly like one inferred from a single
+  // annotation's presence, and "the log says it isn't there" read exactly like
+  // "the log never answered". A record that cannot tell diligence from a gap
+  // cannot be audited.
+  //
+  // The field carries the OBSERVATION, never a conclusion. `probe-refused` says
+  // the read returned a failure reply — not that the annotations are absent,
+  // which the worker does not know: a read that threw for its own reasons comes
+  // back on the same channel.
+
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  async function run(h: ReturnType<typeof makeFakeSessionAndAdapter>) {
+    vi.mocked(processHighlightJob).mockResolvedValue({
+      annotations: [{ id: 'a1' }, { id: 'a2' }] as never,
+      result: { highlightsFound: 2, highlightsCreated: 2 } as never,
+    });
+    const settled = handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'))
+      .then(() => 'completed' as const, (e) => e as Error);
+    await vi.advanceTimersByTimeAsync(61_000);
+    return settled;
+  }
+
+  const terminal = (h: ReturnType<typeof makeFakeSessionAndAdapter>, channel: string) =>
+    h.busEmits.find((e) => e.channel === channel)?.payload as Record<string, unknown> | undefined;
+
+  it('an acknowledged commit completes as acknowledged', async () => {
+    const h = makeFakeSessionAndAdapter();
+    await run(h);
+    expect(terminal(h, 'job:complete')).toMatchObject({ durability: 'acknowledged' });
+  });
+
+  it('a completion rescued by the probe says so — it is a weaker claim', async () => {
+    // Inferred from ONE annotation's presence, resting on the Stower's
+    // append-ordering invariant. True, and not the same evidence as an ack.
+    const h = makeFakeSessionAndAdapter();
+    h.commitSink.mode = 'ack-lost';
+    await run(h);
+    expect(terminal(h, 'job:complete')).toMatchObject({ durability: 'probe-confirmed' });
+  });
+
+  /**
+   * `job:fail` is emitted by the OUTER catch in startWorkerProcess, not by
+   * handleJob (which throws), so the failure-side record can only be observed
+   * through the real entry point.
+   */
+  async function runToFailure(setup: (h: ReturnType<typeof makeFakeSessionAndAdapter>) => void) {
+    const { BehaviorSubject } = await import('rxjs');
+    const activeJob$ = new BehaviorSubject<ActiveJob | null>(null);
+    vi.doMock('../job-claim-adapter', () => ({
+      createJobClaimAdapter: vi.fn(() => ({
+        activeJob$: activeJob$.asObservable(),
+        isProcessing$: { subscribe: vi.fn() }, jobsCompleted$: { subscribe: vi.fn() },
+        errors$: { subscribe: vi.fn() }, start: vi.fn(), stop: vi.fn(),
+        completeJob: vi.fn(), failJob: vi.fn(), dispose: vi.fn(), vitals: vi.fn(),
+        touchActivity: vi.fn(),
+      })),
+    }));
+    vi.resetModules();
+    const { startWorkerProcess } = await import('../worker-process');
+
+    vi.mocked(processHighlightJob).mockResolvedValue({
+      annotations: [{ id: 'a1' }, { id: 'a2' }] as never,
+      result: { highlightsFound: 2, highlightsCreated: 2 } as never,
+    });
+    const h = makeFakeSessionAndAdapter();
+    setup(h);
+    startWorkerProcess(makeConfig(h.session));
+    activeJob$.next(makeJob('highlight-annotation'));
+    // Past the commit's 60 s bound on the fake clock; advanceTimersByTimeAsync
+    // flushes the detached promise chain startWorkerProcess runs the job on.
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    vi.doUnmock('../job-claim-adapter');
+    vi.resetModules();
+    return h.busEmits.find((e) => e.channel === 'job:fail')?.payload as Record<string, unknown> | undefined;
+  }
+
+  it('a probe that was answered "no" is recorded as refused, not as absence', async () => {
+    const payload = await runToFailure((h) => { h.commitSink.mode = 'silent'; });
+    expect(payload).toMatchObject({ durability: 'probe-refused' });
+  });
+
+  it('a probe nobody answered is recorded as unreachable', async () => {
+    // The measured incident's own branch, and the one the plain record could
+    // never distinguish from the case above.
+    const payload = await runToFailure((h) => {
+      h.commitSink.mode = 'ack-lost';
+      h.probeSink.mode = 'unreachable';
+    });
+    expect(payload).toMatchObject({ durability: 'probe-unreachable' });
+  });
+
+  it('the original failure message survives — the field adds evidence, it does not replace it', async () => {
+    const payload = await runToFailure((h) => {
+      h.commitSink.mode = 'ack-lost';
+      h.probeSink.mode = 'unreachable';
+    });
+    expect(String(payload?.error)).toContain('mark:commit-ok');
+  });
+
+  it('a job whose LAST batch needed the probe does not claim the first batch\'s ack', async () => {
+    // Generation commits twice — provenance on the source, citations on the
+    // derived resource. If the fold kept the FIRST answer, a job could report
+    // 'acknowledged' while part of its output rests on an inferred probe: an
+    // overstatement, and precisely what this field exists to prevent. Weakest
+    // evidence wins, because that is the strongest claim still true of the job.
+    vi.mocked(processGenerationJob).mockResolvedValue({
+      content: new TextEncoder().encode('Paris is the capital of France.'),
+      title: 'Answer',
+      format: 'text/markdown',
+      citations: [{ resourceId: 'ctx-9', start: 0, end: 31, exact: 'Paris is the capital of France.' }],
+      result: {} as never,
+    } as never);
+    const h = makeFakeSessionAndAdapter();
+    h.commitSink.mode = 'first-ok-then-lost';
+
+    const settled = handleJob(h.adapter, makeConfig(h.session), makeJob('generation', { cite: true }))
+      .then(() => 'completed' as const, (e) => e as Error);
+    await vi.advanceTimersByTimeAsync(61_000);
+    expect(await settled).toBe('completed');
+
+    expect(h.busEmits.filter((e) => e.channel === 'mark:commit')).toHaveLength(2);
+    expect(terminal(h, 'job:complete')).toMatchObject({ durability: 'probe-confirmed' });
+  });
+
+  it('a job that committed nothing states nothing — absent is not a value', async () => {
+    // No batch, so no durability question arose. Writing 'acknowledged' here
+    // would be a manufactured claim.
+    vi.mocked(processHighlightJob).mockResolvedValue({
+      annotations: [] as never,
+      result: { highlightsFound: 0, highlightsCreated: 0 } as never,
+    });
+    const h = makeFakeSessionAndAdapter();
+    await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
+    expect(terminal(h, 'job:complete')).not.toHaveProperty('durability');
   });
 });

--- a/packages/jobs/src/__tests__/worker-runtime.test.ts
+++ b/packages/jobs/src/__tests__/worker-runtime.test.ts
@@ -421,6 +421,11 @@ describe('worker-runtime — narrowed SSE subscription (worker OOM, 2026-09-03)'
       // (.plans/WORKER-ANCHORED-TEXT-CHANNEL.md).
       'browse:anchored-text-failed',
       'browse:anchored-text-result',
+      // The durability probe for a commit whose ack never routed
+      // (COMMIT-ACK-FALSE-FAILURE F1). The SINGULAR annotation read, chosen
+      // precisely so the list channel below stays out.
+      'browse:annotation-failed',
+      'browse:annotation-result',
       'browse:resource-failed',
       'browse:resource-result',
       'job:claim-failed',

--- a/packages/jobs/src/failure-class.ts
+++ b/packages/jobs/src/failure-class.ts
@@ -14,11 +14,13 @@
  * to avoid. The class rides the `job:fail` payload; `failJob` consumes it.
  */
 
-import { isNumber, isObject, isString } from '@semiont/core';
+import { isNumber, isObject, isString, type components } from '@semiont/core';
 import { StructuredReadError } from '@semiont/inference';
 import { InferenceTimeoutError } from './workers/inference-call';
 
-export type FailureClass = 'transient' | 'deterministic';
+/** Derived from the spec, not restated: the wire owns this vocabulary
+ *  (`FailureClass.json`, referenced by job:fail and job:failed alike). */
+export type FailureClass = components['schemas']['FailureClass'];
 
 /**
  * Marker for failures WE know cannot succeed on a second identical attempt —

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -29,7 +29,7 @@ import {
 } from './types';
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
-import { isGenerationJobParams, getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, annotationId as makeAnnotationId, findClaimSpan, capabilitiesOf, type EventMap, busRequest, BusRequestError } from '@semiont/core';
+import { isGenerationJobParams, getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, annotationId as makeAnnotationId, findClaimSpan, capabilitiesOf, isObject, isString, type EventMap, busRequest, BusRequestError } from '@semiont/core';
 
 import type { InferenceClient } from '@semiont/inference';
 import type { Logger, components, AssembledAnnotation } from '@semiont/core';
@@ -72,6 +72,8 @@ export function referenceIdOf(job: { type: string; params: Record<string, unknow
 }
 
 type Agent = components['schemas']['Agent'];
+/** Derived from the spec; the wire owns this vocabulary. */
+type DurabilityEvidence = components['schemas']['DurabilityEvidence'];
 
 /**
  * What the user is told when a resource cannot be read. Keyed by the
@@ -161,8 +163,8 @@ async function commitAnnotations(
   session: SemiontSession,
   resourceId: string,
   annotations: readonly { readonly id: string }[],
-): Promise<void> {
-  if (annotations.length === 0) return;
+): Promise<DurabilityEvidence | undefined> {
+  if (annotations.length === 0) return undefined;
   try {
     await busRequest(
       workerBusAsPrimitive((session.client.transport as HttpTransport).actor),
@@ -170,11 +172,33 @@ async function commitAnnotations(
       { resourceId, annotations },
       MARK_COMMIT_TIMEOUT_MS,
     );
+    return 'acknowledged';
   } catch (error) {
     if (!(error instanceof BusRequestError) || error.code !== 'bus.timeout') throw error;
-    if (!(await batchIsDurable(session, resourceId, annotations))) throw error;
+    const evidence = await probeDurability(session, resourceId, annotations);
     // The batch is in the log; only the acknowledgement was lost. Returning
-    // here IS the fix — see `batchIsDurable`.
+    // here IS the fix — see `probeDurability`.
+    if (evidence === 'probe-confirmed') return evidence;
+    // Not established. The failure carries WHAT WAS OBSERVED out to the
+    // terminal record, which is the only place it can still be told.
+    throw new CommitDurabilityError(error.message, evidence, error);
+  }
+}
+
+/**
+ * A commit that could not be established as durable, carrying the observation
+ * out to `job:fail`.
+ *
+ * Subclasses nothing meaningful on purpose: `classifyFailure` recognises
+ * neither this nor the `BusRequestError` it wraps, so both land `undefined` —
+ * retryable — exactly as before. The message is the original's, so the
+ * persisted `error` string is unchanged; this adds evidence beside it rather
+ * than replacing it.
+ */
+export class CommitDurabilityError extends Error {
+  override readonly name = 'CommitDurabilityError';
+  constructor(message: string, readonly durability: DurabilityEvidence, cause: unknown) {
+    super(message, { cause });
   }
 }
 
@@ -203,20 +227,31 @@ async function commitAnnotations(
  * probe is unreachable the truthful answer is neither, and forcing it into
  * failure here is the INDETERMINATE state this plan's F2 exists to name.
  */
-async function batchIsDurable(
+async function probeDurability(
   session: SemiontSession,
   resourceId: string,
   annotations: readonly { readonly id: string }[],
-): Promise<boolean> {
+): Promise<Exclude<DurabilityEvidence, 'acknowledged'>> {
   const last = annotations[annotations.length - 1];
-  if (!last) return false;
+  if (!last) return 'probe-unreachable';
   try {
     await session.client.browse
       .annotation(makeResourceId(resourceId), makeAnnotationId(String(last.id)))
       .fresh();
-    return true;
-  } catch {
-    return false;
+    return 'probe-confirmed';
+  } catch (error) {
+    // A failure REPLY (`bus.rejected`) means the read was answered and did not
+    // produce the annotation. That is not the same as "the annotations are
+    // absent" — a read that threw for its own reasons answers on the same
+    // channel — so the record says what was observed and lets the reader judge.
+    // Anything else (`bus.timeout`, `bus.closed`) means nobody answered.
+    // Discriminated STRUCTURALLY, on the code the error carries, not by
+    // `instanceof`: a second copy of @semiont/core anywhere in the tree makes
+    // the prototype check fail, and it would fail SILENTLY — degrading a
+    // refusal into "unreachable", which is the one distinction this field
+    // exists to make. (Observed exactly that under vi.resetModules.)
+    const code = isObject(error) && isString(error.code) ? error.code : undefined;
+    return code === 'bus.rejected' ? 'probe-refused' : 'probe-unreachable';
   }
 }
 
@@ -297,6 +332,10 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
             error: message,
             ...(completedUnits && completedUnits.length > 0 ? { completedUnits } : {}),
             ...(failureClass !== undefined ? { failureClass } : {}),
+            // What the commit path OBSERVED about durability, when the failure
+            // came from a commit at all. Present only on that path: absent means
+            // the question never arose, never that durability was ruled out.
+            ...(error instanceof CommitDurabilityError ? { durability: error.durability } : {}),
             // Whether this failure is the END, answered by the same predicate
             // the queue applies at failJob (JOB-RESTART-SAFETY P5). Without
             // it a client cannot tell a recovering run from a dead one: it
@@ -402,6 +441,20 @@ async function handleJobInner(
   // ignores it. UI consumers filter by `jobType` and/or `annotationId`
   // in the payload.
 
+  // What this job's commits ESTABLISHED, folded across every batch it makes
+  // (a reference job commits per unit; generation commits on two resources).
+  // Weakest wins: one batch rescued by the probe makes the whole completion a
+  // probe-confirmed claim, because that is the strongest thing still true of
+  // the job as a whole. Undefined until a batch actually commits — a job that
+  // mints nothing states nothing.
+  let durability: DurabilityEvidence | undefined;
+  const record = (evidence: DurabilityEvidence | undefined) => {
+    if (evidence === undefined) return;
+    if (durability === undefined || durability === 'acknowledged') durability = evidence;
+  };
+  /** Every TERMINAL payload; `job:start` deliberately uses the bare base. */
+  const terminalBase = () => ({ ...lifecycleBase, ...(durability ? { durability } : {}) });
+
   await emitEvent(session, 'job:start', lifecycleBase);
 
   if (!config.jobTypes.includes(jobType)) {
@@ -459,7 +512,7 @@ async function handleJobInner(
       // empty) — the resource legitimately has nothing to detect over. A clean
       // completion carrying the reason, not a failure.
       await emitEvent(session, 'job:complete', {
-        ...lifecycleBase,
+        ...terminalBase(),
         result: {
           kind: 'declined',
           declined: true,
@@ -484,7 +537,7 @@ async function handleJobInner(
     // P2 gave the processors codes worth forwarding.)
     adapter.touchActivity();
     emitEvent(session, 'job:report-progress', {
-      ...lifecycleBase,
+      ...terminalBase(),
       percentage,
       progress: {
         percentage, message,
@@ -500,9 +553,9 @@ async function handleJobInner(
     );
     // Durable before the job claims success: `job:complete` after a lost batch
     // is the silent-loss shape P6 removes.
-    await commitAnnotations(session, String(resourceId), annotations);
+    record(await commitAnnotations(session, String(resourceId), annotations));
     await emitEvent(session, 'job:complete', {
-      ...lifecycleBase,
+      ...terminalBase(),
       result,
     });
     adapter.completeJob();
@@ -513,9 +566,9 @@ async function handleJobInner(
     );
     // Durable before the job claims success: `job:complete` after a lost batch
     // is the silent-loss shape P6 removes.
-    await commitAnnotations(session, String(resourceId), annotations);
+    record(await commitAnnotations(session, String(resourceId), annotations));
     await emitEvent(session, 'job:complete', {
-      ...lifecycleBase,
+      ...terminalBase(),
       result,
     });
     adapter.completeJob();
@@ -526,9 +579,9 @@ async function handleJobInner(
     );
     // Durable before the job claims success: `job:complete` after a lost batch
     // is the silent-loss shape P6 removes.
-    await commitAnnotations(session, String(resourceId), annotations);
+    record(await commitAnnotations(session, String(resourceId), annotations));
     await emitEvent(session, 'job:complete', {
-      ...lifecycleBase,
+      ...terminalBase(),
       result,
     });
     adapter.completeJob();
@@ -567,7 +620,7 @@ async function handleJobInner(
         // fraction that already landed changes nothing. That is required, not
         // belt-and-braces — the ack itself can be lost after a successful
         // append, so at-least-once is unavoidable here.
-        await commitAnnotations(session, String(resourceId), annotations);
+        record(await commitAnnotations(session, String(resourceId), annotations));
         committed.push(unit);
         // Durable checkpoint the moment the unit lands (JOB-RESTART-SAFETY
         // P2): if this worker dies before the next unit — or before any
@@ -590,14 +643,14 @@ async function handleJobInner(
     // clean terminal, not a failure.
     if (signal?.aborted) {
       await emitEvent(session, 'job:cancel', {
-        ...lifecycleBase,
+        ...terminalBase(),
         ...(committed.length > 0 ? { completedUnits: [...committed] } : {}),
       });
       adapter.completeJob();
       return;
     }
     await emitEvent(session, 'job:complete', {
-      ...lifecycleBase,
+      ...terminalBase(),
       result,
     });
     adapter.completeJob();
@@ -608,9 +661,9 @@ async function handleJobInner(
     );
     // Durable before the job claims success: `job:complete` after a lost batch
     // is the silent-loss shape P6 removes.
-    await commitAnnotations(session, String(resourceId), annotations);
+    record(await commitAnnotations(session, String(resourceId), annotations));
     await emitEvent(session, 'job:complete', {
-      ...lifecycleBase,
+      ...terminalBase(),
       result,
     });
     adapter.completeJob();
@@ -691,7 +744,7 @@ async function handleJobInner(
         },
         generator,
       );
-      await commitAnnotations(session, String(resourceId), [provenanceRef]);
+      record(await commitAnnotations(session, String(resourceId), [provenanceRef]));
     }
 
     // Inline citations: mint each as a linking annotation ON THE DERIVED
@@ -764,10 +817,10 @@ async function handleJobInner(
       }
     }
 
-    await commitAnnotations(session, String(newResourceId), citationRefs);
+    record(await commitAnnotations(session, String(newResourceId), citationRefs));
 
     await emitEvent(session, 'job:complete', {
-      ...lifecycleBase,
+      ...terminalBase(),
       result: { kind: 'generation', resourceId: newResourceId, resourceName: genResult.title, truncated: genResult.result.truncated },
     });
     adapter.completeJob();

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -29,10 +29,10 @@ import {
 } from './types';
 import type { SemiontSession } from '@semiont/sdk';
 import { type HttpTransport } from '@semiont/http-transport';
-import { isGenerationJobParams, getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, findClaimSpan, capabilitiesOf, type EventMap, busRequest} from '@semiont/core';
+import { isGenerationJobParams, getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, annotationId as makeAnnotationId, findClaimSpan, capabilitiesOf, type EventMap, busRequest, BusRequestError } from '@semiont/core';
 
 import type { InferenceClient } from '@semiont/inference';
-import type { Logger, components } from '@semiont/core';
+import type { Logger, components, AssembledAnnotation } from '@semiont/core';
 import { workerBusAsPrimitive } from './worker-bus-primitive.js';
 import { extractPdfTextLayer, type ContentReads } from '@semiont/content';
 import { prepareDetection } from './workers/detection/prepare-detection';
@@ -114,14 +114,25 @@ export interface WorkerProcessConfig {
  */
 /**
  * Census declarations (`WORKER_AWAITED_OPERATIONS`, worker-runtime.ts) for the
- * two operations THIS module awaits. `MarkCommitAwaits` is tied to its call by
- * a `satisfies`; the descriptor read has no operation literal to tie to — it
- * awaits through the SDK (`session.client.browse.resource(...).fresh()`), so
- * its declaration is by convention until SDK bus-backed methods carry their
+ * three operations THIS module awaits. `MarkCommitAwaits` is tied to its call by
+ * a `satisfies`; the other two have no operation literal to tie to — they
+ * await through the SDK (`session.client.browse.*(...).fresh()`), so
+ * their declarations are by convention until SDK bus-backed methods carry their
  * operation in their own type (the census's recorded endgame).
  */
 export type MarkCommitAwaits = 'mark:commit';
 export type DescriptorReadAwaits = 'browse:resource-requested';
+/**
+ * The durability probe (COMMIT-ACK-FALSE-FAILURE F1).
+ *
+ * Deliberately the SINGULAR read, not `browse:annotations-requested`. Reply
+ * channels are global fan-out, and the annotation LIST channel is the one
+ * measured at ~85 multi-MB frames/min during the 2026-09-03 worker OOM — the
+ * reason `WORKER_CHANNELS` was narrowed in the first place. Re-subscribing it
+ * to serve a rare error path would undo that fix; one annotation's frame is
+ * small.
+ */
+export type DurabilityProbeAwaits = 'browse:annotation-requested';
 
 /**
  * How long a unit's commit may take before the worker treats the sink as down.
@@ -149,15 +160,64 @@ const MARK_COMMIT_TIMEOUT_MS = 60_000;
 async function commitAnnotations(
   session: SemiontSession,
   resourceId: string,
-  annotations: readonly unknown[],
+  annotations: readonly { readonly id: string }[],
 ): Promise<void> {
   if (annotations.length === 0) return;
-  await busRequest(
-    workerBusAsPrimitive((session.client.transport as HttpTransport).actor),
-    'mark:commit' satisfies MarkCommitAwaits,
-    { resourceId, annotations },
-    MARK_COMMIT_TIMEOUT_MS,
-  );
+  try {
+    await busRequest(
+      workerBusAsPrimitive((session.client.transport as HttpTransport).actor),
+      'mark:commit' satisfies MarkCommitAwaits,
+      { resourceId, annotations },
+      MARK_COMMIT_TIMEOUT_MS,
+    );
+  } catch (error) {
+    if (!(error instanceof BusRequestError) || error.code !== 'bus.timeout') throw error;
+    if (!(await batchIsDurable(session, resourceId, annotations))) throw error;
+    // The batch is in the log; only the acknowledgement was lost. Returning
+    // here IS the fix — see `batchIsDurable`.
+  }
+}
+
+/**
+ * Did the batch land? (COMMIT-ACK-FALSE-FAILURE F1.)
+ *
+ * A lost `mark:commit-ok` says nothing about the event log. Measured
+ * 2026-09-08: a 51-minute Person detection appended all 1,673 of its
+ * annotations, the gateway then went down, the ack could not route, and the
+ * job reported FAILED over durable data — indistinguishable, to a user, from
+ * having produced nothing. The outcome must follow the durable fact, not the
+ * arrival of a message.
+ *
+ * Only the LAST annotation is probed, and that is sufficient rather than
+ * approximate: `handleMarkCommit` appends a batch strictly in order and stops
+ * at the first failure (`stower.ts`, pinned by
+ * `stower-commit-idempotence.test.ts`), so the last id being present means every
+ * earlier one is too. Probing all of them would be 1,673 round trips; probing
+ * the list channel would re-subscribe the frames that OOM'd the worker (see
+ * `DurabilityProbeAwaits`).
+ *
+ * Every non-answer resolves to `false` — retry — and that asymmetry is
+ * deliberate. Since F3 the log refuses a duplicate, so a needless retry costs
+ * one re-run of the unit; a wrong `true` loses the whole unit silently, which
+ * is the false-success the acknowledgement was introduced to kill. When the
+ * probe is unreachable the truthful answer is neither, and forcing it into
+ * failure here is the INDETERMINATE state this plan's F2 exists to name.
+ */
+async function batchIsDurable(
+  session: SemiontSession,
+  resourceId: string,
+  annotations: readonly { readonly id: string }[],
+): Promise<boolean> {
+  const last = annotations[annotations.length - 1];
+  if (!last) return false;
+  try {
+    await session.client.browse
+      .annotation(makeResourceId(resourceId), makeAnnotationId(String(last.id)))
+      .fresh();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function emitEvent<K extends keyof EventMap>(
@@ -650,7 +710,7 @@ async function handleJobInner(
     // resource, so they are one batch keyed by `newResourceId` — a different
     // resource from the provenance edge above, which is why they cannot share
     // a commit.
-    const citationRefs: unknown[] = [];
+    const citationRefs: AssembledAnnotation['annotation'][] = [];
     if (genResult.format === 'application/pdf' && genResult.citations.length > 0) {
       const layer = await extractPdfTextLayer(genResult.content);
       if (!layer) {

--- a/packages/jobs/src/worker-runtime.ts
+++ b/packages/jobs/src/worker-runtime.ts
@@ -14,7 +14,7 @@
  */
 
 import { startWorkerProcess } from './worker-process';
-import type { MarkCommitAwaits, DescriptorReadAwaits } from './worker-process';
+import type { MarkCommitAwaits, DescriptorReadAwaits, DurabilityProbeAwaits } from './worker-process';
 import type { WorkerVitals, JobClaimAwaits } from './job-claim-adapter';
 import type { ConsultAnchoredTextAwaits } from './workers/detection/prepare-detection';
 import type { InferenceClient } from '@semiont/inference';
@@ -217,6 +217,11 @@ export const WORKER_AWAITED_OPERATIONS = [
   // annotations are in the event log — so its replies must be in the narrow
   // channel set or every commit fails fast with `bus.unsubscribed`.
   'mark:commit',
+  // The durability probe for a commit whose acknowledgement never routed
+  // (COMMIT-ACK-FALSE-FAILURE F1). SINGULAR by design: the annotation LIST
+  // channel is the multi-MB fan-out this narrowing exists to keep out, and a
+  // rare error path is no reason to let it back in.
+  'browse:annotation-requested',
 ] as const satisfies readonly BusOperationKey[];
 
 /** The derived global SSE channel set for a worker's transport. */
@@ -240,6 +245,7 @@ type DeclaredWorkerAwaits =
   | JobClaimAwaits             // job-claim-adapter.ts — claiming an announced job
   | DescriptorReadAwaits       // worker-process.ts — the resource descriptor read
   | MarkCommitAwaits           // worker-process.ts — the durability ack (JOB-RESTART-SAFETY P6)
+  | DurabilityProbeAwaits      // worker-process.ts — did the batch land? (COMMIT-ACK-FALSE-FAILURE F1)
   | ConsultAnchoredTextAwaits; // prepare-detection.ts — canonical geometry (SMELTER-OWNS-OCR P2)
 
 type WorkerAwaitCensusDrift =

--- a/packages/make-meaning/src/__tests__/annotation-operations.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-operations.test.ts
@@ -871,7 +871,13 @@ describe('AnnotationOperations', () => {
       const failBus = new EventBus();
       const failingStores: StowerStores = {
         content: { register: vi.fn(), move: vi.fn(), remove: vi.fn(), resolveUri: vi.fn() } as unknown as StowerStores['content'],
-        eventStore: { appendEvent: vi.fn().mockRejectedValue(new Error('disk full')) } as StowerStores['eventStore'],
+        eventStore: {
+          appendEvent: vi.fn().mockRejectedValue(new Error('disk full')),
+          // `mark:commit` diffs its batch against the resource's view before
+          // appending (COMMIT-ACK-FALSE-FAILURE F3); an empty resource holds
+          // nothing, so every annotation is new and the append still runs.
+          viewStorage: { get: vi.fn().mockResolvedValue(null) },
+        } as StowerStores['eventStore'],
       };
       const failStower = new Stower(failingStores, failBus, suiteProject, mockLogger);
       await failStower.initialize();

--- a/packages/make-meaning/src/__tests__/archivist-decoupling.test.ts
+++ b/packages/make-meaning/src/__tests__/archivist-decoupling.test.ts
@@ -75,6 +75,7 @@ describe('Stower constructs from capability doubles (EXTRACT-ARCHIVIST P1)', () 
       },
       eventStore: {
         appendEvent: vi.fn().mockResolvedValue({}),
+        viewStorage: { get: vi.fn().mockResolvedValue(null) },
       },
     } satisfies StowerStores;
     return stores;
@@ -437,7 +438,7 @@ describe('channel rosters match actual subscriptions (census gate)', () => {
         const stower = new Stower(
           {
             content: { register: vi.fn(), move: vi.fn(), remove: vi.fn(), resolveUri: vi.fn() },
-            eventStore: { appendEvent: vi.fn() },
+            eventStore: { appendEvent: vi.fn(), viewStorage: { get: vi.fn().mockResolvedValue(null) } },
           },
           bus, tp.project, mockLogger,
         );

--- a/packages/make-meaning/src/__tests__/stower-commit-idempotence.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-commit-idempotence.test.ts
@@ -1,0 +1,177 @@
+/**
+ * `mark:commit` is at-least-once, and the event log is the system of record.
+ *
+ * COMMIT-ACK-FALSE-FAILURE V2. Two things were already idempotent by annotation
+ * id — the resource view (`view-materializer.ts`) and the graph
+ * (`weaver.ts`) — and both of them are PROJECTIONS. The log itself appends
+ * whatever it is handed. So a re-committed batch leaves a green graph over a
+ * doubled log, which is the failure mode hardest to notice and impossible to
+ * undo.
+ *
+ * Two paths re-send a batch that already landed, and neither is exotic:
+ *
+ *   1. The acknowledgement is lost after a successful append. The unit is never
+ *      checkpointed (`worker-process.ts` pushes to `committed` only AFTER the
+ *      commit resolves), so the retry re-runs exactly the unit that landed.
+ *   2. A batch fails partway. The Stower reports failure without a partial
+ *      count and the worker retries the WHOLE unit, re-appending the prefix.
+ *
+ * These tests therefore assert on APPENDS, never on a projection: every
+ * projection already passes them and would hide the defect.
+ *
+ * What is NOT under test here, deliberately: id determinism (pinned in
+ * `@semiont/jobs`'s annotation-idempotence.test.ts and core's id tests) and the
+ * projections' own at-least-once guards, which stay — delivery duplication and
+ * log duplication are different concerns.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventBus, type Annotation, type Logger, type ResourceId } from '@semiont/core';
+import type { SemiontProject } from '@semiont/core/node';
+import { Stower } from '../stower';
+
+const silentLogger: Logger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(() => silentLogger),
+};
+
+const RID = 'res-commit-idem';
+const USER = 'did:web:test:users:test';
+
+const annotation = (id: string) => ({ id, type: 'Annotation', motivation: 'highlighting' }) as unknown as Annotation;
+
+/**
+ * An event log that behaves like the real one — it appends what it is told —
+ * paired with the materialized view the real EventStore keeps in step with it.
+ *
+ * The view is DERIVED from the appended events here, exactly as
+ * `materializeIncremental` derives it in production, so this fake cannot
+ * accidentally answer a question the real store would answer differently.
+ */
+function fakeStore() {
+  const appended: Array<{ type: string; payload: any }> = [];
+  const appendEvent = vi.fn(async (event: { type: string; payload: any }) => {
+    appended.push(event);
+    return event;
+  });
+  const viewStorage = {
+    get: vi.fn(async (_rid: ResourceId) => ({
+      resource: {} as never,
+      annotations: {
+        resourceId: _rid,
+        // Idempotent by id, as the materializer is.
+        annotations: appended
+          .filter((e) => e.type === 'mark:added')
+          .map((e) => e.payload.annotation as Annotation)
+          .filter((a, i, all) => all.findIndex((b) => b.id === a.id) === i),
+        version: appended.length,
+        updatedAt: new Date().toISOString(),
+      },
+    })),
+  };
+  const markAddedIds = () =>
+    appended.filter((e) => e.type === 'mark:added').map((e) => String(e.payload.annotation.id));
+
+  return { appendEvent, viewStorage, appended, markAddedIds, stores: { eventStore: { appendEvent, viewStorage } } as never };
+}
+
+describe('mark:commit does not duplicate the event log', () => {
+  let bus: EventBus;
+  let stower: Stower;
+  let store: ReturnType<typeof fakeStore>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    bus = new EventBus();
+    store = fakeStore();
+    stower = new Stower(store.stores, bus, {} as SemiontProject, silentLogger);
+    await stower.initialize();
+  });
+
+  afterEach(async () => {
+    await stower.stop?.();
+    bus.destroy();
+  });
+
+  /** The handler runs inside a concatMap; give the queue a turn. */
+  const settle = () => new Promise((r) => setTimeout(r, 20));
+
+  const commit = async (ids: string[], correlationId = 'c1') => {
+    bus.get('mark:commit').next({
+      resourceId: RID,
+      correlationId,
+      annotations: ids.map(annotation),
+      _userId: USER,
+    } as never);
+    await settle();
+  };
+
+  it('re-committing an identical batch appends nothing the second time', async () => {
+    // The measured scenario: 1,673 annotations durable, acknowledgement lost,
+    // job retried. Today this appends 1,673 more.
+    await commit(['a1', 'a2', 'a3'], 'first');
+    expect(store.markAddedIds()).toEqual(['a1', 'a2', 'a3']);
+
+    await commit(['a1', 'a2', 'a3'], 'retry');
+
+    expect(store.markAddedIds()).toEqual(['a1', 'a2', 'a3']);
+  });
+
+  it('a retried partial batch appends only the annotations still missing', async () => {
+    // Path 2: the first commit died after `a1`, so the worker retried the unit
+    // whole. `a1` must not land twice, and `a2`/`a3` must still land.
+    await commit(['a1'], 'partial');
+
+    await commit(['a1', 'a2', 'a3'], 'retry');
+
+    expect(store.markAddedIds()).toEqual(['a1', 'a2', 'a3']);
+  });
+
+  it('still acknowledges the retry — a durable batch is a successful commit', async () => {
+    // The worker cannot advance without an ack. A commit that appends nothing
+    // because everything is already durable has SUCCEEDED, and saying so is
+    // what stops the retry loop.
+    const acks: any[] = [];
+    bus.get('mark:commit-ok').subscribe((e) => acks.push(e));
+
+    await commit(['a1', 'a2'], 'first');
+    await commit(['a1', 'a2'], 'retry');
+
+    expect(acks).toHaveLength(2);
+    expect(acks[1].correlationId).toBe('retry');
+    // `persisted` is the DURABLE count the schema promises ("every annotation
+    // named by the command is in the event log"), not an append tally — so it
+    // reads the same on the retry as on the first commit. A caller cannot tell
+    // the two apart, and must not need to.
+    expect(acks[1].response.persisted).toBe(2);
+    expect(acks[1].response.annotationIds).toEqual(['a1', 'a2']);
+  });
+
+  it('appends in batch order and stops at the first failure', async () => {
+    // A CROSS-PACKAGE invariant, gated here because this side owns it.
+    // `batchIsDurable` in @semiont/jobs probes only the LAST annotation of a
+    // batch and reads its presence as "the whole batch landed". That is sound
+    // exactly while appends run in order and abort on the first failure — so
+    // if someone parallelizes this loop, the worker's probe silently starts
+    // reporting success over partial data. It fails here first instead.
+    store.appendEvent.mockImplementation(async (event: any) => {
+      if (event.payload?.annotation?.id === 'a2') throw new Error('disk full');
+      store.appended.push(event);
+      return event;
+    });
+
+    await commit(['a1', 'a2', 'a3'], 'partial');
+
+    expect(store.markAddedIds()).toEqual(['a1']);
+  });
+
+  it('distinct annotations on one resource all land', async () => {
+    // The guard on the guard: a dedupe keyed too coarsely (by resource, by
+    // batch, by count) would silently collapse a real detection run into one
+    // annotation and pass every test above.
+    await commit(['a1', 'a2'], 'first');
+    await commit(['b1', 'b2'], 'second');
+
+    expect(store.markAddedIds()).toEqual(['a1', 'a2', 'b1', 'b2']);
+  });
+});

--- a/packages/make-meaning/src/__tests__/stower-job-events.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-job-events.test.ts
@@ -150,6 +150,22 @@ describe('Stower job:* handlers', () => {
   });
 
   it.each([
+    ['job:complete', 'job:completed', 'probe-confirmed'],
+    ['job:fail', 'job:failed', 'probe-unreachable'],
+  ])('%s persists how durability was established', async (channel, persisted, durability) => {
+    // The evidentiary half of the same rule: an acknowledged completion and one
+    // inferred from a probe are different claims, and "the log said no" is a
+    // different claim from "the log never answered". Four states, and without
+    // this field the log holds two.
+    bus.get(channel as 'job:complete').next(jobEvent({ error: 'e', durability }) as never);
+    await settle();
+
+    const event = appendEvent.mock.calls[0][0];
+    expect(event.type).toBe(persisted);
+    expect(event.payload.durability).toBe(durability);
+  });
+
+  it.each([
     ['job:start'],
     ['job:complete'],
     ['job:fail'],

--- a/packages/make-meaning/src/__tests__/stower-job-events.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-job-events.test.ts
@@ -110,6 +110,45 @@ describe('Stower job:* handlers', () => {
     expect('annotationId' in appendEvent.mock.calls[0][0].payload).toBe(false);
   });
 
+  // ── job:failed carries the worker's JUDGMENTS, not just its message ──────
+  //
+  // The durable record must not be lossier than the producer that wrote it.
+  // `failureClass` and `willRetry` are computed in the worker, where the error
+  // is still typed; at the log they are unrecoverable, because the only other
+  // witness is a flattened English string. Without them an auditor reading a
+  // run of job:failed events cannot tell a recovering job from a dead one, nor
+  // a deterministic refusal from weather — and job:failed is a permanent fact
+  // of the resource, not operational state.
+  it('persists failureClass and willRetry onto job:failed', async () => {
+    bus.get('job:fail').next(jobEvent({
+      error: 'Bus request timed out after 60000ms on mark:commit-ok',
+      failureClass: 'transient',
+      willRetry: true,
+    }) as never);
+    await settle();
+
+    const event = appendEvent.mock.calls[0][0];
+    expect(event.type).toBe('job:failed');
+    expect(event.payload).toMatchObject({
+      error: 'Bus request timed out after 60000ms on mark:commit-ok',
+      failureClass: 'transient',
+      willRetry: true,
+    });
+  });
+
+  it('omits either when the worker did not state it — absent is not false', async () => {
+    // Absent `failureClass` means UNRECOGNISED, which is a different claim from
+    // 'transient'; `willRetry: false` asserts the run is over. Defaulting either
+    // would write a judgment nobody made into a log nobody can rewrite — the
+    // same rule the annotationId case above follows.
+    bus.get('job:fail').next(jobEvent({ error: 'boom' }) as never);
+    await settle();
+
+    const payload = appendEvent.mock.calls[0][0].payload;
+    expect('failureClass' in payload).toBe(false);
+    expect('willRetry' in payload).toBe(false);
+  });
+
   it.each([
     ['job:start'],
     ['job:complete'],

--- a/packages/make-meaning/src/__tests__/stower-job-events.test.ts
+++ b/packages/make-meaning/src/__tests__/stower-job-events.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { firstValueFrom, take } from 'rxjs';
 import { EventBus, resourceId, type Logger } from '@semiont/core';
 import type { SemiontProject } from '@semiont/core/node';
-import { Stower } from '../stower';
+import { Stower, type StowerStores } from '../stower';
 
 const silentLogger: Logger = {
   debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
@@ -22,10 +22,28 @@ const silentLogger: Logger = {
 const RID = 'res-job-under-test';
 const USER = 'did:web:test:users:test';
 
-/** Only `eventStore.appendEvent` is exercised by these three handlers. */
+/**
+ * The write seam these handlers use, typed as `StowerStores` rather than cast.
+ *
+ * It was `as never`, and that cast cost three green tests: when `mark:commit`
+ * grew its at-least-once guard (COMMIT-ACK-FALSE-FAILURE F3) and the seam grew
+ * `viewStorage`, `tsc` had nothing to check and the stub went on satisfying a
+ * shape that no longer existed — the failure surfaced only at runtime, as
+ * "Cannot read properties of undefined". Typed, the next widening fails the
+ * BUILD here, naming the missing member.
+ */
 function stubStores() {
   const appendEvent = vi.fn().mockResolvedValue(undefined);
-  return { appendEvent, stores: { eventStore: { appendEvent } } as never };
+  const stores: StowerStores = {
+    content: { register: vi.fn(), move: vi.fn(), remove: vi.fn(), resolveUri: vi.fn() } as unknown as StowerStores['content'],
+    eventStore: {
+      appendEvent,
+      // No resource holds anything yet, so every annotation in a batch is new
+      // and every append still runs.
+      viewStorage: { get: vi.fn().mockResolvedValue(null) },
+    } as unknown as StowerStores['eventStore'],
+  };
+  return { appendEvent, stores };
 }
 
 const jobEvent = (over: Record<string, unknown> = {}) => ({

--- a/packages/make-meaning/src/knowledge-base.ts
+++ b/packages/make-meaning/src/knowledge-base.ts
@@ -55,10 +55,23 @@ export interface KnowledgeBase {
  *  accessions, moves, removes and resolves — it never serves bytes. */
 export type ContentLifecycle = Pick<WorkingTreeStore, 'register' | 'move' | 'remove' | 'resolveUri'>;
 
-/** The record's single write seam. `Stower` is the only appendEvent caller
- *  anywhere in make-meaning or the gateway (post-#1252): single-owner by
- *  construction. A second caller is a design smell, not a wiring chore. */
-export type EventAppends = Pick<EventStore, 'appendEvent'>;
+/**
+ * The record's single write seam. `Stower` is the only appendEvent caller
+ * anywhere in make-meaning or the gateway (post-#1252): single-owner by
+ * construction. A second caller is a design smell, not a wiring chore.
+ *
+ * It carries a read — `viewStorage.get`, narrowed to `get` — because one write
+ * path is at-least-once and must not duplicate the log
+ * (COMMIT-ACK-FALSE-FAILURE F3): `mark:commit` diffs its batch against what the
+ * resource already holds. This does NOT reverse JOB-RESTART-SAFETY HD1, which
+ * rejected read-before-write for a WORKER reading a REMOTE store mid-recovery
+ * — "the thing it would read is exactly what is down". This read is inside the
+ * Archivist, against the store it is about to write, and cannot be down
+ * relative to itself.
+ */
+export type EventAppends = Pick<EventStore, 'appendEvent'> & {
+  readonly viewStorage: Pick<ViewStorage, 'get'>;
+};
 
 /** Read-only reach into the event store: the log for queries, the
  *  materializer for on-demand view assembly (`assembleResourceGraph`). */

--- a/packages/make-meaning/src/stower.ts
+++ b/packages/make-meaning/src/stower.ts
@@ -693,6 +693,10 @@ export class Stower {
         jobType: event.jobType,
         ...(event.annotationId ? { annotationId: event.annotationId } : {}),
         result: event.result,
+        // How durability was ESTABLISHED (COMMIT-ACK-FALSE-FAILURE). An
+        // acknowledged batch and one inferred from a probe are different
+        // claims; absent means the question never arose.
+        ...(event.durability !== undefined ? { durability: event.durability } : {}),
       },
     });
   }
@@ -719,6 +723,10 @@ export class Stower {
         // nobody made into a log nobody can rewrite.
         ...(event.failureClass !== undefined ? { failureClass: event.failureClass } : {}),
         ...(event.willRetry !== undefined ? { willRetry: event.willRetry } : {}),
+        // How durability was ESTABLISHED (COMMIT-ACK-FALSE-FAILURE). An
+        // acknowledged batch and one inferred from a probe are different
+        // claims; absent means the question never arose.
+        ...(event.durability !== undefined ? { durability: event.durability } : {}),
       },
     });
   }

--- a/packages/make-meaning/src/stower.ts
+++ b/packages/make-meaning/src/stower.ts
@@ -382,38 +382,61 @@ export class Stower {
    *
    * Appends are sequential, not concurrent: the event log is the system of
    * record and a batch that half-lands under concurrency is harder to reason
-   * about than one that stops at the first failure. A partial batch is
-   * reported as a failure and the worker retries the WHOLE unit, which is safe
-   * because ids are deterministic (P3) and the annotation fold is idempotent
-   * by id — re-appending what already landed changes nothing.
+   * about than one that stops at the first failure.
+   *
+   * This channel is AT-LEAST-ONCE, and the log must not grow on a repeat
+   * (COMMIT-ACK-FALSE-FAILURE F3). Two paths re-send a batch that already
+   * landed: an acknowledgement lost after a successful append (the unit is
+   * never checkpointed, so the retry re-runs exactly the unit that landed), and
+   * a partial batch, reported as a failure and retried whole. Deterministic ids
+   * (JOB-RESTART-SAFETY P3) made those safe for the PROJECTIONS — the resource
+   * view and the graph both refuse a duplicate id — but a projection's guard
+   * says nothing about the log, which appends whatever it is handed. The result
+   * was a green graph over a doubled log: silent, and not undoable.
+   *
+   * So the batch is diffed against what the resource already holds. ONE view
+   * read per commit, never per annotation: the view for a 1,673-annotation
+   * resource is ~3 MB, and re-reading it per append would cost gigabytes of
+   * parsing for a single job.
    */
   private async handleMarkCommit(event: EventMap['mark:commit']): Promise<void> {
     if (!event._userId) {
       throw new Error('mark:commit missing _userId (gateway injection)');
     }
     const annotations = (event.annotations ?? []) as Annotation[];
+    const rid = resourceId(event.resourceId);
     try {
-      let persisted = 0;
+      const view = await this.stores.eventStore.viewStorage.get(rid);
+      const present = new Set((view?.annotations.annotations ?? []).map((a) => String(a.id)));
+
       for (const annotation of annotations) {
+        if (present.has(String(annotation.id))) continue;
         await this.stores.eventStore.appendEvent({
           type: 'mark:added',
-          resourceId: resourceId(event.resourceId),
+          resourceId: rid,
           userId: makeUserId(event._userId),
           version: 1,
           payload: { annotation },
         });
-        persisted++;
+        // A batch may name the same annotation twice; the view read cannot see
+        // an append this loop just made.
+        present.add(String(annotation.id));
       }
       this.logger.debug('Committed annotation batch', {
-        correlationId: event.correlationId, resourceId: event.resourceId, persisted,
+        correlationId: event.correlationId, resourceId: event.resourceId, persisted: annotations.length,
       });
       this.eventBus.get('mark:commit-ok').next({
         correlationId: event.correlationId,
-        response: { persisted, annotationIds: annotations.map((a) => String(a.id)) },
+        // The DURABLE count, which is what the acknowledgement means ("every
+        // annotation named by the command is in the event log"). Not an append
+        // tally: a retry whose annotations are all already present has
+        // succeeded, and must be indistinguishable from the first commit or the
+        // caller would have to interpret a 0 that means "all good".
+        response: { persisted: annotations.length, annotationIds: annotations.map((a) => String(a.id)) },
       });
     } catch (error) {
       // No partial success is reported. The worker retries the unit whole, and
-      // the idempotent fold makes the already-landed fraction a no-op.
+      // the diff above makes the already-landed fraction a no-op.
       this.logger.error('Failed to commit annotation batch', {
         correlationId: event.correlationId, error: errField(error),
       });

--- a/packages/make-meaning/src/stower.ts
+++ b/packages/make-meaning/src/stower.ts
@@ -711,6 +711,14 @@ export class Stower {
         jobType: event.jobType,
         ...(event.annotationId ? { annotationId: event.annotationId } : {}),
         error: event.error,
+        // The worker's JUDGMENTS, not just its message. Both are computed where
+        // the error is still typed and are unrecoverable here — the only other
+        // witness in the log is `error`, a flattened English string. Spread
+        // conditionally: absent `failureClass` means UNRECOGNISED, a different
+        // claim from 'transient', and defaulting either would write a judgment
+        // nobody made into a log nobody can rewrite.
+        ...(event.failureClass !== undefined ? { failureClass: event.failureClass } : {}),
+        ...(event.willRetry !== undefined ? { willRetry: event.willRetry } : {}),
       },
     });
   }

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -290,6 +290,30 @@ func (e DiscoveryDocumentVersion) Valid() bool {
 	}
 }
 
+// Defines values for DurabilityEvidence.
+const (
+	Acknowledged     DurabilityEvidence = "acknowledged"
+	ProbeConfirmed   DurabilityEvidence = "probe-confirmed"
+	ProbeRefused     DurabilityEvidence = "probe-refused"
+	ProbeUnreachable DurabilityEvidence = "probe-unreachable"
+)
+
+// Valid indicates whether the value is a known member of the DurabilityEvidence enum.
+func (e DurabilityEvidence) Valid() bool {
+	switch e {
+	case Acknowledged:
+		return true
+	case ProbeConfirmed:
+		return true
+	case ProbeRefused:
+		return true
+	case ProbeUnreachable:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ExtractedTextKind.
 const (
 	Extracted ExtractedTextKind = "extracted"
@@ -2291,6 +2315,9 @@ type DiscoveryDocument struct {
 // DiscoveryDocumentVersion Document schema version. Consumers MUST check it and ignore documents they do not understand.
 type DiscoveryDocumentVersion int
 
+// DurabilityEvidence How a job's annotations were established as durable — the OBSERVATION, never a conclusion drawn from it. 'acknowledged': the event log confirmed the batch (mark:commit-ok). 'probe-confirmed': the acknowledgement was lost and a later read found the batch's last annotation present — true, but a weaker claim than an ack, since it rests on the log appending a batch in order and stopping at the first failure. 'probe-refused': the read returned a failure reply; note this does NOT assert the annotations are absent, because a read that failed for its own reasons answers on the same channel. 'probe-unreachable': no answer came at all, so nothing was established either way. ABSENT means the question never arose — a job that committed no annotations. Never defaulted: a manufactured value here is a claim nobody made, in a log nobody can rewrite.
+type DurabilityEvidence string
+
 // EnrichedResourceEvent defines model for EnrichedResourceEvent.
 type EnrichedResourceEvent struct {
 	Annotation *Annotation `json:"annotation,omitempty"`
@@ -2944,7 +2971,10 @@ type JobCompleteCommand struct {
 
 	// AnnotationId Annotation this job is attached to, when applicable. Lets the UI route completion feedback (toast, resolve state) to a specific annotation.
 	AnnotationId *string `json:"annotationId,omitempty"`
-	JobId        string  `json:"jobId"`
+
+	// Durability How a job's annotations were established as durable — the OBSERVATION, never a conclusion drawn from it. 'acknowledged': the event log confirmed the batch (mark:commit-ok). 'probe-confirmed': the acknowledgement was lost and a later read found the batch's last annotation present — true, but a weaker claim than an ack, since it rests on the log appending a batch in order and stopping at the first failure. 'probe-refused': the read returned a failure reply; note this does NOT assert the annotations are absent, because a read that failed for its own reasons answers on the same channel. 'probe-unreachable': no answer came at all, so nothing was established either way. ABSENT means the question never arose — a job that committed no annotations. Never defaulted: a manufactured value here is a claim nobody made, in a log nobody can rewrite.
+	Durability *DurabilityEvidence `json:"durability,omitempty"`
+	JobId      string              `json:"jobId"`
 
 	// JobType Type of background job
 	JobType    JobType `json:"jobType"`
@@ -2961,6 +2991,9 @@ type JobCompletedPayload struct {
 
 	// AnnotationUri For generation: URI of annotation that triggered generation
 	AnnotationUri *string `json:"annotationUri,omitempty"`
+
+	// Durability How a job's annotations were established as durable — the OBSERVATION, never a conclusion drawn from it. 'acknowledged': the event log confirmed the batch (mark:commit-ok). 'probe-confirmed': the acknowledgement was lost and a later read found the batch's last annotation present — true, but a weaker claim than an ack, since it rests on the log appending a batch in order and stopping at the first failure. 'probe-refused': the read returned a failure reply; note this does NOT assert the annotations are absent, because a read that failed for its own reasons answers on the same channel. 'probe-unreachable': no answer came at all, so nothing was established either way. ABSENT means the question never arose — a job that committed no annotations. Never defaulted: a manufactured value here is a claim nobody made, in a log nobody can rewrite.
+	Durability *DurabilityEvidence `json:"durability,omitempty"`
 
 	// FoundCount For detection: total entities found
 	FoundCount *int   `json:"foundCount,omitempty"`
@@ -3030,7 +3063,10 @@ type JobFailCommand struct {
 
 	// CompletedUnits Entity-type units whose annotations were fully emitted before this failure (checkpointed resume). The queue records them on the retried job's metadata; a retried claim skips them so completed work is neither redone nor duplicated.
 	CompletedUnits *[]string `json:"completedUnits,omitempty"`
-	Error          string    `json:"error"`
+
+	// Durability How a job's annotations were established as durable — the OBSERVATION, never a conclusion drawn from it. 'acknowledged': the event log confirmed the batch (mark:commit-ok). 'probe-confirmed': the acknowledgement was lost and a later read found the batch's last annotation present — true, but a weaker claim than an ack, since it rests on the log appending a batch in order and stopping at the first failure. 'probe-refused': the read returned a failure reply; note this does NOT assert the annotations are absent, because a read that failed for its own reasons answers on the same channel. 'probe-unreachable': no answer came at all, so nothing was established either way. ABSENT means the question never arose — a job that committed no annotations. Never defaulted: a manufactured value here is a claim nobody made, in a log nobody can rewrite.
+	Durability *DurabilityEvidence `json:"durability,omitempty"`
+	Error      string              `json:"error"`
 
 	// FailureClass Worker-side classification of a job failure, made where the error is still typed (at the gateway it is already a flattened string, and message-regex classification is the drift this exists to avoid). 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget. ABSENT means unrecognised, which is deliberately not the same claim as 'transient': only KNOWN-deterministic failures carry the class, because mis-reading a transient failure as deterministic halves reliability while the reverse costs one wasted attempt.
 	FailureClass *FailureClass `json:"failureClass,omitempty"`
@@ -3048,7 +3084,10 @@ type JobFailCommand struct {
 type JobFailedPayload struct {
 	// AnnotationId Annotation this job was attached to, when applicable
 	AnnotationId *string `json:"annotationId,omitempty"`
-	Error        string  `json:"error"`
+
+	// Durability How a job's annotations were established as durable — the OBSERVATION, never a conclusion drawn from it. 'acknowledged': the event log confirmed the batch (mark:commit-ok). 'probe-confirmed': the acknowledgement was lost and a later read found the batch's last annotation present — true, but a weaker claim than an ack, since it rests on the log appending a batch in order and stopping at the first failure. 'probe-refused': the read returned a failure reply; note this does NOT assert the annotations are absent, because a read that failed for its own reasons answers on the same channel. 'probe-unreachable': no answer came at all, so nothing was established either way. ABSENT means the question never arose — a job that committed no annotations. Never defaulted: a manufactured value here is a claim nobody made, in a log nobody can rewrite.
+	Durability *DurabilityEvidence `json:"durability,omitempty"`
+	Error      string              `json:"error"`
 
 	// FailureClass Worker-side classification of a job failure, made where the error is still typed (at the gateway it is already a flattened string, and message-regex classification is the drift this exists to avoid). 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget. ABSENT means unrecognised, which is deliberately not the same claim as 'transient': only KNOWN-deterministic failures carry the class, because mis-reading a transient failure as deterministic halves reliability while the reverse costs one wasted attempt.
 	FailureClass *FailureClass `json:"failureClass,omitempty"`

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -404,6 +404,24 @@ func (e ExtractionDeclinedKind) Valid() bool {
 	}
 }
 
+// Defines values for FailureClass.
+const (
+	Deterministic FailureClass = "deterministic"
+	Transient     FailureClass = "transient"
+)
+
+// Valid indicates whether the value is a known member of the FailureClass enum.
+func (e FailureClass) Valid() bool {
+	switch e {
+	case Deterministic:
+		return true
+	case Transient:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FileEntryType.
 const (
 	File FileEntryType = "file"
@@ -614,24 +632,6 @@ func (e JobDeclinedResultReason) Valid() bool {
 	case JobDeclinedResultReasonNoTextLayer:
 		return true
 	case JobDeclinedResultReasonTooLarge:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for JobFailCommandFailureClass.
-const (
-	Deterministic JobFailCommandFailureClass = "deterministic"
-	Transient     JobFailCommandFailureClass = "transient"
-)
-
-// Valid indicates whether the value is a known member of the JobFailCommandFailureClass enum.
-func (e JobFailCommandFailureClass) Valid() bool {
-	switch e {
-	case Deterministic:
-		return true
-	case Transient:
 		return true
 	default:
 		return false
@@ -2413,6 +2413,9 @@ type ExtractionOutcome struct {
 	union json.RawMessage
 }
 
+// FailureClass Worker-side classification of a job failure, made where the error is still typed (at the gateway it is already a flattened string, and message-regex classification is the drift this exists to avoid). 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget. ABSENT means unrecognised, which is deliberately not the same claim as 'transient': only KNOWN-deterministic failures carry the class, because mis-reading a transient failure as deterministic halves reliability while the reverse costs one wasted attempt.
+type FailureClass string
+
 // FileEntry defines model for FileEntry.
 type FileEntry struct {
 	// AnnotationCount Number of annotations on this resource (only when tracked is true)
@@ -3029,9 +3032,9 @@ type JobFailCommand struct {
 	CompletedUnits *[]string `json:"completedUnits,omitempty"`
 	Error          string    `json:"error"`
 
-	// FailureClass Worker-side classification of the failure, made where the error is still typed. 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget; absent or 'transient' retries as before. Only KNOWN-deterministic failures carry the class.
-	FailureClass *JobFailCommandFailureClass `json:"failureClass,omitempty"`
-	JobId        string                      `json:"jobId"`
+	// FailureClass Worker-side classification of a job failure, made where the error is still typed (at the gateway it is already a flattened string, and message-regex classification is the drift this exists to avoid). 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget. ABSENT means unrecognised, which is deliberately not the same claim as 'transient': only KNOWN-deterministic failures carry the class, because mis-reading a transient failure as deterministic halves reliability while the reverse costs one wasted attempt.
+	FailureClass *FailureClass `json:"failureClass,omitempty"`
+	JobId        string        `json:"jobId"`
 
 	// JobType Type of background job
 	JobType    JobType `json:"jobType"`
@@ -3041,19 +3044,21 @@ type JobFailCommand struct {
 	WillRetry *bool `json:"willRetry,omitempty"`
 }
 
-// JobFailCommandFailureClass Worker-side classification of the failure, made where the error is still typed. 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget; absent or 'transient' retries as before. Only KNOWN-deterministic failures carry the class.
-type JobFailCommandFailureClass string
-
-// JobFailedPayload Payload for job:failed domain event
+// JobFailedPayload Payload for the job:failed domain event — a permanent fact of the resource, not operational state. It carries the judgments the worker COMPUTED, not just its message: at the log they are otherwise unrecoverable, the only remaining witness being a flattened English string.
 type JobFailedPayload struct {
 	// AnnotationId Annotation this job was attached to, when applicable
 	AnnotationId *string `json:"annotationId,omitempty"`
-	Details      *string `json:"details,omitempty"`
 	Error        string  `json:"error"`
-	JobId        string  `json:"jobId"`
+
+	// FailureClass Worker-side classification of a job failure, made where the error is still typed (at the gateway it is already a flattened string, and message-regex classification is the drift this exists to avoid). 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget. ABSENT means unrecognised, which is deliberately not the same claim as 'transient': only KNOWN-deterministic failures carry the class, because mis-reading a transient failure as deterministic halves reliability while the reverse costs one wasted attempt.
+	FailureClass *FailureClass `json:"failureClass,omitempty"`
+	JobId        string        `json:"jobId"`
 
 	// JobType Type of background job
 	JobType JobType `json:"jobType"`
+
+	// WillRetry Whether the worker computed that the queue would re-queue this job (same predicate the queue applies, `willRetryAfter`). Absent means the worker stated nothing. Without it a reader of the log cannot tell a run recovering across several job:failed events from that many dead jobs.
+	WillRetry *bool `json:"willRetry,omitempty"`
 }
 
 // JobGenerationResult Result of a completed generation job. The worker creates the resource first (the yield:create round-trip returns the id), then emits job:complete carrying it — so resourceId is always present on the wire.

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -3474,7 +3474,7 @@ type MarkCommitOk struct {
 		// AnnotationIds Ids the batch covers, whether appended now or already present.
 		AnnotationIds []string `json:"annotationIds"`
 
-		// Persisted Annotations this commit appended to the event log. Equals the batch size on success — a retry re-appends what already landed rather than counting it out, because the annotation fold is idempotent by id and the log is append-only. Not a dedupe count.
+		// Persisted Annotations the command named that are durable in the event log. Equals the batch size on success, on a first commit and on a retry alike — the commit appends only what the resource does not already hold, so a wholly-redundant retry has still succeeded and says so. Not an append tally: a caller must never have to read a 0 as 'all good'.
 		Persisted int `json:"persisted"`
 	} `json:"response"`
 }

--- a/packages/sdk-go/go.mod
+++ b/packages/sdk-go/go.mod
@@ -1,12 +1,17 @@
 module github.com/The-AI-Alliance/semiont/packages/sdk-go
 
-go 1.25
+go 1.27
 
-// Pinned to the patch, not the minor: `go 1.25` let CI resolve to whatever
-// 1.25.x it had (1.25.12), which govulncheck fails on — five stdlib CVEs, all
-// fixed in 1.25.13. actions/setup-go reads this line from go-version-file, so
-// the scan and the build agree on one compiler.
-toolchain go1.25.13
+// Pinned to the patch, not the minor: `go 1.27` alone lets CI resolve to
+// whatever 1.27.x it happens to have, and a stdlib CVE fixed in a later patch
+// then fails govulncheck on a compiler nobody chose. actions/setup-go reads
+// this line from go-version-file, so the scan and the build agree on one
+// compiler.
+//
+// 1.25.13 -> 1.27.1 (2026-09-08): CI installs govulncheck @latest, v1.8.0
+// published requiring go >= 1.26, and every Go job went red against
+// GOTOOLCHAIN=local. The floor moves with the tool.
+toolchain go1.27.1
 
 require (
 	github.com/google/uuid v1.6.0

--- a/scripts/ci/local-build.sh
+++ b/scripts/ci/local-build.sh
@@ -58,6 +58,23 @@ detect_runtime() {
 
 RT=$(detect_runtime)
 
+# --- Go toolchain (derived, not restated) ---
+#
+# The Go version is a fact apps/launcher/go.mod owns. Every workflow already
+# derives it (actions/setup-go's go-version-file); this script was the one place
+# it was hand-copied, in four spots. That mattered: the whole reason go.mod pins
+# the PATCH is so the scan and the build agree on one compiler, and a local build
+# silently using a different one defeats exactly that.
+#
+# No fallback. A missing toolchain line fails here rather than quietly selecting
+# some other compiler.
+GO_TOOLCHAIN="$(sed -n 's/^toolchain go\([0-9][0-9.]*\)$/\1/p' "$REPO_ROOT/apps/launcher/go.mod")"
+if [[ -z "$GO_TOOLCHAIN" ]]; then
+  fail "No 'toolchain goX.Y.Z' line in apps/launcher/go.mod — cannot choose a Go image."
+  exit 1
+fi
+GO_IMAGE="golang:${GO_TOOLCHAIN}"
+
 # --- Failure cleanup trap ---
 # On failure, stop and remove the Verdaccio container so the next run starts
 # clean. Disabled at the end of the happy path so Verdaccio keeps running for
@@ -311,7 +328,7 @@ $RT run --rm \
   -v "$GOMODCACHE_DIR":/go/pkg/mod \
   -e GOPROXY="$GOPROXY_CACHED" \
   -w /workspace \
-  golang:1.27 \
+  "$GO_IMAGE" \
   sh -c 'go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0 \
            -generate types,client,skip-prune -package semiont \
            -o /tmp/client_gen.check.go specs/openapi.json || exit 3
@@ -895,10 +912,10 @@ fi
 #
 # The semiont launcher is a static Go binary that runs on the HOST and drives
 # the :local images (SEMIONT_VERSION=local semiont start). Built inside
-# golang:1.27 targeting the host platform — no Go toolchain on the host, the
-# same philosophy as the npm builds above. The Go build cache persists under
-# /tmp/semiont-gocache-build (/tmp, not $TMPDIR — Apple Container cannot
-# sustain mounts from /var/folders).
+# $GO_IMAGE (derived from apps/launcher/go.mod) targeting the host platform — no
+# Go toolchain on the host, the same philosophy as the npm builds above. The Go
+# build cache persists under /tmp/semiont-gocache-build (/tmp, not $TMPDIR —
+# Apple Container cannot sustain mounts from /var/folders).
 
 banner "LAUNCHER"
 
@@ -914,7 +931,7 @@ case "$(uname -m)" in
 esac
 
 mkdir -p "$GOCACHE_DIR" "$GOMODCACHE_DIR"
-step "Building the semiont launcher (${LAUNCHER_GOOS}/${LAUNCHER_GOARCH}) in golang:1.27..."
+step "Building the semiont launcher (${LAUNCHER_GOOS}/${LAUNCHER_GOARCH}) in ${GO_IMAGE}..."
 $RT run --rm \
   -v "$REPO_ROOT":/workspace \
   -v "$GOCACHE_DIR":/root/.cache/go-build \
@@ -922,7 +939,7 @@ $RT run --rm \
   -w /workspace/apps/launcher \
   -e GOPROXY="$GOPROXY_CACHED" \
   -e GOOS="$LAUNCHER_GOOS" -e GOARCH="$LAUNCHER_GOARCH" -e CGO_ENABLED=0 \
-  golang:1.27 \
+  "$GO_IMAGE" \
   go build -o dist/semiont .
 ok "apps/launcher/dist/semiont built"
 

--- a/scripts/ci/local-build.sh
+++ b/scripts/ci/local-build.sh
@@ -311,7 +311,7 @@ $RT run --rm \
   -v "$GOMODCACHE_DIR":/go/pkg/mod \
   -e GOPROXY="$GOPROXY_CACHED" \
   -w /workspace \
-  golang:1.25 \
+  golang:1.27 \
   sh -c 'go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0 \
            -generate types,client,skip-prune -package semiont \
            -o /tmp/client_gen.check.go specs/openapi.json || exit 3
@@ -895,7 +895,7 @@ fi
 #
 # The semiont launcher is a static Go binary that runs on the HOST and drives
 # the :local images (SEMIONT_VERSION=local semiont start). Built inside
-# golang:1.25 targeting the host platform — no Go toolchain on the host, the
+# golang:1.27 targeting the host platform — no Go toolchain on the host, the
 # same philosophy as the npm builds above. The Go build cache persists under
 # /tmp/semiont-gocache-build (/tmp, not $TMPDIR — Apple Container cannot
 # sustain mounts from /var/folders).
@@ -914,7 +914,7 @@ case "$(uname -m)" in
 esac
 
 mkdir -p "$GOCACHE_DIR" "$GOMODCACHE_DIR"
-step "Building the semiont launcher (${LAUNCHER_GOOS}/${LAUNCHER_GOARCH}) in golang:1.25..."
+step "Building the semiont launcher (${LAUNCHER_GOOS}/${LAUNCHER_GOARCH}) in golang:1.27..."
 $RT run --rm \
   -v "$REPO_ROOT":/workspace \
   -v "$GOCACHE_DIR":/root/.cache/go-build \
@@ -922,7 +922,7 @@ $RT run --rm \
   -w /workspace/apps/launcher \
   -e GOPROXY="$GOPROXY_CACHED" \
   -e GOOS="$LAUNCHER_GOOS" -e GOARCH="$LAUNCHER_GOARCH" -e CGO_ENABLED=0 \
-  golang:1.25 \
+  golang:1.27 \
   go build -o dist/semiont .
 ok "apps/launcher/dist/semiont built"
 

--- a/specs/src/components/schemas/DurabilityEvidence.json
+++ b/specs/src/components/schemas/DurabilityEvidence.json
@@ -1,0 +1,5 @@
+{
+  "type": "string",
+  "enum": ["acknowledged", "probe-confirmed", "probe-refused", "probe-unreachable"],
+  "description": "How a job's annotations were established as durable — the OBSERVATION, never a conclusion drawn from it. 'acknowledged': the event log confirmed the batch (mark:commit-ok). 'probe-confirmed': the acknowledgement was lost and a later read found the batch's last annotation present — true, but a weaker claim than an ack, since it rests on the log appending a batch in order and stopping at the first failure. 'probe-refused': the read returned a failure reply; note this does NOT assert the annotations are absent, because a read that failed for its own reasons answers on the same channel. 'probe-unreachable': no answer came at all, so nothing was established either way. ABSENT means the question never arose — a job that committed no annotations. Never defaulted: a manufactured value here is a claim nobody made, in a log nobody can rewrite."
+}

--- a/specs/src/components/schemas/FailureClass.json
+++ b/specs/src/components/schemas/FailureClass.json
@@ -1,0 +1,5 @@
+{
+  "type": "string",
+  "enum": ["transient", "deterministic"],
+  "description": "Worker-side classification of a job failure, made where the error is still typed (at the gateway it is already a flattened string, and message-regex classification is the drift this exists to avoid). 'deterministic' — the same request cannot succeed on a second attempt — skips the retry budget. ABSENT means unrecognised, which is deliberately not the same claim as 'transient': only KNOWN-deterministic failures carry the class, because mis-reading a transient failure as deterministic halves reliability while the reverse costs one wasted attempt."
+}

--- a/specs/src/components/schemas/JobCompleteCommand.json
+++ b/specs/src/components/schemas/JobCompleteCommand.json
@@ -21,6 +21,9 @@
     },
     "result": {
       "$ref": "./JobResult.json"
+    },
+    "durability": {
+      "$ref": "./DurabilityEvidence.json"
     }
   },
   "required": [

--- a/specs/src/components/schemas/JobCompletedPayload.json
+++ b/specs/src/components/schemas/JobCompletedPayload.json
@@ -2,14 +2,42 @@
   "type": "object",
   "description": "Payload for job:completed domain event",
   "properties": {
-    "jobId": { "type": "string" },
-    "jobType": { "$ref": "JobType.json" },
-    "annotationId": { "type": "string", "description": "Annotation this job was attached to, when applicable" },
-    "totalSteps": { "type": "integer" },
-    "foundCount": { "type": "integer", "description": "For detection: total entities found" },
-    "resultResourceId": { "type": "string", "description": "For generation: ID of generated resource" },
-    "annotationUri": { "type": "string", "description": "For generation: URI of annotation that triggered generation" },
-    "result": { "type": "object", "additionalProperties": true, "description": "Full result object for extensibility" }
+    "jobId": {
+      "type": "string"
+    },
+    "jobType": {
+      "$ref": "JobType.json"
+    },
+    "annotationId": {
+      "type": "string",
+      "description": "Annotation this job was attached to, when applicable"
+    },
+    "totalSteps": {
+      "type": "integer"
+    },
+    "foundCount": {
+      "type": "integer",
+      "description": "For detection: total entities found"
+    },
+    "resultResourceId": {
+      "type": "string",
+      "description": "For generation: ID of generated resource"
+    },
+    "annotationUri": {
+      "type": "string",
+      "description": "For generation: URI of annotation that triggered generation"
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Full result object for extensibility"
+    },
+    "durability": {
+      "$ref": "./DurabilityEvidence.json"
+    }
   },
-  "required": ["jobId", "jobType"]
+  "required": [
+    "jobId",
+    "jobType"
+  ]
 }

--- a/specs/src/components/schemas/JobFailCommand.json
+++ b/specs/src/components/schemas/JobFailCommand.json
@@ -35,6 +35,9 @@
     "willRetry": {
       "type": "boolean",
       "description": "Whether the queue will re-queue this job for another attempt. Computed by the worker from the SAME predicate the queue applies at failJob (one decision site, `willRetryAfter` in @semiont/jobs) using the retry budget carried on the claimed record. FALSE (or absent) means this failure is TERMINAL: a client's job-watch stream ends here. TRUE means the work continues on a fresh attempt \u2014 the failure is an event, not the end, and a stream that terminated on it would report a recovering run as a failed one (JOB-RESTART-SAFETY P5)."
+    },
+    "durability": {
+      "$ref": "./DurabilityEvidence.json"
     }
   },
   "required": [

--- a/specs/src/components/schemas/JobFailCommand.json
+++ b/specs/src/components/schemas/JobFailCommand.json
@@ -30,12 +30,7 @@
       "description": "Entity-type units whose annotations were fully emitted before this failure (checkpointed resume). The queue records them on the retried job's metadata; a retried claim skips them so completed work is neither redone nor duplicated."
     },
     "failureClass": {
-      "type": "string",
-      "enum": [
-        "transient",
-        "deterministic"
-      ],
-      "description": "Worker-side classification of the failure, made where the error is still typed. 'deterministic' \u2014 the same request cannot succeed on a second attempt \u2014 skips the retry budget; absent or 'transient' retries as before. Only KNOWN-deterministic failures carry the class."
+      "$ref": "./FailureClass.json"
     },
     "willRetry": {
       "type": "boolean",

--- a/specs/src/components/schemas/JobFailedPayload.json
+++ b/specs/src/components/schemas/JobFailedPayload.json
@@ -1,12 +1,31 @@
 {
   "type": "object",
-  "description": "Payload for job:failed domain event",
+  "description": "Payload for the job:failed domain event \u2014 a permanent fact of the resource, not operational state. It carries the judgments the worker COMPUTED, not just its message: at the log they are otherwise unrecoverable, the only remaining witness being a flattened English string.",
   "properties": {
-    "jobId": { "type": "string" },
-    "jobType": { "$ref": "JobType.json" },
-    "annotationId": { "type": "string", "description": "Annotation this job was attached to, when applicable" },
-    "error": { "type": "string" },
-    "details": { "type": "string" }
+    "jobId": {
+      "type": "string"
+    },
+    "jobType": {
+      "$ref": "JobType.json"
+    },
+    "annotationId": {
+      "type": "string",
+      "description": "Annotation this job was attached to, when applicable"
+    },
+    "error": {
+      "type": "string"
+    },
+    "failureClass": {
+      "$ref": "./FailureClass.json"
+    },
+    "willRetry": {
+      "type": "boolean",
+      "description": "Whether the worker computed that the queue would re-queue this job (same predicate the queue applies, `willRetryAfter`). Absent means the worker stated nothing. Without it a reader of the log cannot tell a run recovering across several job:failed events from that many dead jobs."
+    }
   },
-  "required": ["jobId", "jobType", "error"]
+  "required": [
+    "jobId",
+    "jobType",
+    "error"
+  ]
 }

--- a/specs/src/components/schemas/JobFailedPayload.json
+++ b/specs/src/components/schemas/JobFailedPayload.json
@@ -21,6 +21,9 @@
     "willRetry": {
       "type": "boolean",
       "description": "Whether the worker computed that the queue would re-queue this job (same predicate the queue applies, `willRetryAfter`). Absent means the worker stated nothing. Without it a reader of the log cannot tell a run recovering across several job:failed events from that many dead jobs."
+    },
+    "durability": {
+      "$ref": "./DurabilityEvidence.json"
     }
   },
   "required": [

--- a/specs/src/components/schemas/MarkCommitOk.json
+++ b/specs/src/components/schemas/MarkCommitOk.json
@@ -12,7 +12,7 @@
       "properties": {
         "persisted": {
           "type": "integer",
-          "description": "Annotations this commit appended to the event log. Equals the batch size on success — a retry re-appends what already landed rather than counting it out, because the annotation fold is idempotent by id and the log is append-only. Not a dedupe count."
+          "description": "Annotations the command named that are durable in the event log. Equals the batch size on success, on a first commit and on a retry alike — the commit appends only what the resource does not already hold, so a wholly-redundant retry has still succeeded and says so. Not an append tally: a caller must never have to read a 0 as 'all good'."
         },
         "annotationIds": {
           "type": "array",

--- a/specs/src/openapi.json
+++ b/specs/src/openapi.json
@@ -402,6 +402,12 @@
       "GatherSummaryRequest": {
         "$ref": "components/schemas/GatherSummaryRequest.json"
       },
+      "DurabilityEvidence": {
+        "$ref": "components/schemas/DurabilityEvidence.json"
+      },
+      "FailureClass": {
+        "$ref": "components/schemas/FailureClass.json"
+      },
       "GatheredContext": {
         "$ref": "components/schemas/GatheredContext.json"
       },


### PR DESCRIPTION
A Person detection ran 51 minutes over a 102-page PDF, produced 1,673 annotations, and the Archivist wrote every one of them:

```
events-000001.jsonl   2,970,215 bytes   1,675 events
  mark:added 1673    yield:created 1    job:started 1
```

The gateway then went down, the worker's `mark:commit` acknowledgement could not route, and 60 s later:

```
Job failed — Bus request timed out after 60000ms on mark:commit-ok
```

Nothing was lost. The status was simply wrong — and a user cannot tell that apart from total loss, which after 51 minutes of paid inference is the whole problem.

## The acknowledgement is not the defect

`mark:commit` exists because `mark:create` was fire-and-forget: its emit resolves when the gateway accepts the frame, which says nothing about the Stower having appended anything, so a down Archivist once discarded a job's whole output while the job reported success. The ack was introduced to kill **false success**. It now produces **false failure** — the same defect wearing the opposite sign: *the outcome is derived from whether a message arrived, not from whether the work landed.* So the ack stays, and the outcome learns to follow the durable fact.

## The trap: the retry was the dangerous part

`classifyFailure` has no branch for a bus timeout, so it returns `undefined`, which the codebase treats as transient. And a unit is checkpointed only **after** its commit resolves — so an ack timeout leaves the very unit that landed un-checkpointed, and the retry re-runs and re-commits it. (That also answers whether `job:fail`'s `completedUnits` could have been reused instead of a probe: it cannot, because it deliberately omits that unit.)

Two things were already idempotent by annotation id, and both are **projections**: the resource view and the graph fold. The log itself appends whatever it is handed. So a retry left a green graph over a **doubled log** — silent, not undoable, and it poisons the very evidence above, since the event count is what the diagnosis rested on.

## The log stops duplicating

`handleMarkCommit` now reads the resource's materialized annotation set once per batch and appends only what is absent. One read per commit, never per annotation: the view for a 1,673-annotation resource is ~3 MB, and re-reading it per append would cost gigabytes of parsing for one job.

The projections keep their id guards — they defend against at-least-once *delivery*, which is a different concern from log integrity, and they are not a second home for this decision.

`persisted` becomes the **durable** count rather than an append tally, so a wholly-redundant retry acknowledges identically to a first commit and no caller has to read a `0` as "all good". The schema description had documented the defect as intent — *"a retry re-appends what already landed"* — and was rewritten; `specs/` → `core/types.ts` → `sdk-go/client_gen.go` regenerated.

This is worth doing independent of the probe: the same duplication happens on the partial-batch path the Stower already documents, which no probe touches.

## The worker asks instead of guessing

`commitAnnotations` catches `bus.timeout` **only** — the typed code, never the message — probes, and returns if the batch is durable.

The probe is the **singular** `browse:annotation-requested`, deliberately not the annotation list. Reply channels are global fan-out, and the list channel is the one measured at ~85 multi-MB frames/min during the 2026-09-03 worker OOM — the reason the worker's subscription set was narrowed in the first place. Re-subscribing it to serve a rare error path would undo that fix. The new await joins `WORKER_AWAITED_OPERATIONS` under the existing build-time census, which was observed failing by name when the operation was removed:

```
worker-runtime.ts(254,14): error TS2322: Type '"in-census"' is not assignable to type '"browse:annotation-requested"'.
```

Only the batch's **last** id is probed. That is sufficient rather than approximate — the Stower appends in order and stops at the first failure — but it is an invariant spanning two packages with nothing holding it, so it now has a test on the side that owns it.

Every non-answer resolves to *retry*, never *success*. Since the log refuses duplicates, a needless retry costs one re-run; a wrong "durable" loses a unit silently, which is the false success the ack exists to kill.

## Seam change

`EventAppends` gained `viewStorage.get`, narrowed to `get`. Both production call sites already pass the full `EventStore`, so only test doubles moved. This does not reverse the earlier ruling that deterministic ids make re-emission "a no-op with no read": that objection was about a *worker* reading a *remote* store mid-recovery — "the thing it would read is exactly what is down". This read is inside the Archivist, against the store it is about to write, and cannot be down relative to itself. The "no-op" claim was only ever true of the projections.

One of those doubles was cast `as never` and had been silently satisfying a shape that no longer existed; `tsc` had nothing to check and the breakage surfaced only at runtime. It is typed now, so the next widening fails the build there.

## The build went red mid-review, on nobody's change

`govulncheck` is installed `@latest`. v1.8.0 published between main's last green run and this branch's first, requiring Go ≥ 1.26 while the workflows pin Go from `go.mod` with `GOTOOLCHAIN=local`:

```
golang.org/x/vuln@v1.8.0 requires go >= 1.26.0 (running go 1.25.13; GOTOOLCHAIN=local)
```

It fails at tool *install*, before anything compiles; main's next run would have hit it identically. Go moves to the latest stable, **1.27.1**. That the shipped Homebrew binary gets a new compiler is the point, not a side effect — the scan exists to protect that binary, so keeping the scanner runnable is what the toolchain pin is for.

`@latest` is deliberate and stays. A pinned version inside a workflow `run:` line is watched by nothing — Dependabot's `github-actions` ecosystem tracks `uses:`, `gomod` tracks `go.mod` — so it would rot silently, a stale analysis engine still printing "No vulnerabilities found" against a fresh remote DB. Failing loudly about once a year, with the remedy in the error text, is the better trade.

Two cleanups rode along:

**`packages/sdk-go` now has its own Dependabot entry.** `gomod` is not workspace-aware, so the launcher's entry only ever updated the launcher. The drift is invisible from inside the repo: the launcher `replace`s sdk-go and MVS resolves the higher requirement, so builds and govulncheck both see `oapi-codegen/runtime v1.7.0` while sdk-go's own `go.mod` goes on declaring v1.6.0. But sdk-go is consumed by module path, so an external consumer resolves that stale minimum. (Also fixed a stale comment claiming the launcher is "stdlib-only — no third-party module deps"; it has three direct requires.)

**The Go version is derived, not restated.** `local-build.sh` hardcoded the image tag in four places while every workflow already derived theirs from `go-version-file`. It now reads the `toolchain` line from `apps/launcher/go.mod`, with no fallback — a missing line fails loudly rather than quietly selecting another compiler. Side benefit: it derives the exact patch (`golang:1.27.1`) where the hardcode was the minor tag, and pinning the patch is precisely what makes the scan and the build agree on one compiler.

## Verification

RED was watched failing for the measured reason on both halves before either fix: the worker returned `BusRequestError { code: 'bus.timeout' }` on `mark:commit-ok` verbatim, and the Stower's log read `['a1','a1','a2','a3']`.

Green after: jobs **529 passed / 1 skipped**, make-meaning **596 passed / 1 expected fail**, `tsc --noEmit` clean in both, bus `--check` and Go schema coverage green.

Three mutations confirm the guards bite rather than merely pass:

| Mutation | Caught by |
|---|---|
| Drop the probe operation from the census | build fails, naming the operation |
| Parallelize the Stower's append loop | ordering gate fails with `['a1','a3']` — the partial state that would make the last-id probe lie |
| Hardcode the probe to "durable" | the launder-a-real-loss test fails |

The Go half was verified by running the actual CI steps in `golang:1.27.1`: gofmt clean, `go vet`, sdk-go build + test, launcher suite (194.0s + 4.3s, ok), `govulncheck@latest` resolving v1.8.0 with **no vulnerabilities found**, and the generated-client drift check in sync.

## Residual, named

When the probe itself is unreachable, the job still reports failure — today's behavior, preserved. That state is neither success nor failure, and it has no name in the vocabulary yet; forcing it into failure is a guess in one of two possible worlds. It bites when the gateway is up and the Archivist is not, which is likelier than a whole-gateway outage: the worker can report an outcome and has no evidence for the one it reports. Naming it is a product decision (surface it as its own terminal state, or park the job for re-verification with a bound) and is deliberately not settled here.

Also unrun: the live gate — stop the gateway during a real detection's commit window, restart it, and confirm the job does not report failure over durable data and the annotation count does not double, measured in the **event log** rather than the graph.
