### PR TITLE
Every remembered release step becomes a script, and the desktop flag stops defaulting off

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,13 @@ on:
         required: false
         type: boolean
         default: false
+      # Every release since 0.5.26 has wanted the desktop apps, so the flag
+      # defaults on. Turn it off deliberately for a release that ships none.
       desktop:
         description: 'Build and publish desktop apps'
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
   tag:

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ apps/*/scripts/*.d.ts.map
 # Ephemeral Planning Documents
 .plans
 
+# Assembled by scripts/release/notes-context.sh; quotes .plans content verbatim
+.release-notes-context.md
+
 # Compliance audit generated files
 **/scripts/symbols.json
 # Generated compliance reports (all of them — never enumerate outputs by hand)

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -7,22 +7,36 @@ Release lifecycle scripts. `version-bump.sh` runs on the host with just `jq` and
 
 | Script | Purpose | Requires |
 |--------|---------|----------|
+| `preflight.sh` | Decide whether origin/main is releasable | `gh`, `jq`, `git` |
+| `notes-context.sh` | Assemble PR bodies and planning docs for the post | `gh`, `jq` |
+| `announce.sh` | Lint a release post, and post it on `--post` | `gh` |
+| `verify-release.sh` | Check a published release across every channel | `gh`, `jq`, `curl` |
 | `version-bump.sh` | Bump version across all packages, commit, push the branch | `jq`, `git` |
 | `version.mjs` | Show, sync, or set version | `node` |
-| `verify-release.sh` | Check a published release across every channel | `gh`, `jq`, `curl` |
 
 ## Typical Release Flow
 
 One dispatch publishes everything; each stage triggers the next one it unblocks.
+Every step is a script, so none of it depends on remembering a flag.
 
 ```bash
-# 1. CI green on the commit you intend to release, then:
-gh workflow run release.yml --field desktop=true
+# 1. Is main releasable? Checks version sync, a free tag, and CI green on the
+#    exact origin/main sha. Prints the release command on success.
+./scripts/release/preflight.sh
 
-# 2. When the runs finish, verify the artifacts themselves:
-./scripts/release/verify-release.sh 0.5.33
+# 2. Publish every channel.
+gh workflow run release.yml
 
-# 3. Announce, then bump on a branch and open the PR:
+# 3. Write the post from assembled context, never from commit subjects.
+./scripts/release/notes-context.sh          # writes .release-notes-context.md
+#    ... read it, draft the post, first line = the discussion title ...
+./scripts/release/announce.sh 0.5.34 draft.md          # lint
+./scripts/release/announce.sh 0.5.34 draft.md --post   # publish
+
+# 4. Verify the artifacts themselves, not the workflow conclusions.
+./scripts/release/verify-release.sh 0.5.34
+
+# 5. Bump on a branch and open the PR.
 ./scripts/release/version-bump.sh patch
 ```
 
@@ -77,3 +91,32 @@ npm run version:show    # Display current version across all packages
 npm run version:sync    # Sync version.json to all package.json files
 npm run version:set     # Set a specific version
 ```
+
+## preflight.sh
+
+Reads `origin/main` over the wire with `git ls-remote` and the contents API, so a
+stale or dirty local clone cannot make a bad commit look releasable.
+
+CI status comes from that commit's own check runs. `gh run list --limit 1` is not
+used anywhere: it returns whatever run the API surfaces first, which is routinely
+not the newest, and has reported a phantom head more than once.
+
+## notes-context.sh
+
+Writes `.release-notes-context.md` (gitignored) holding every substantive PR
+merged since the last release **with its full body**, the dependency and bump PRs
+listed separately rather than filtered silently, and the planning docs modified
+in the same window.
+
+Commit subjects compress away the origin and the measurement — the thing that
+makes a post worth reading. Assembling the context first is what stops a post
+being written from titles.
+
+## announce.sh
+
+Blocking checks are objectively-wrong things: a release link that resolves
+nowhere, a title a reader cannot parse, a `.plans/` path nobody outside the
+working tree can open. Style calls — bullet length, whether a deep release
+carries a whitepaper section — warn but do not block, because a deliberately
+substantive bullet is a legitimate authorial choice and a gate that overrules
+taste just gets bypassed.

--- a/scripts/release/announce.sh
+++ b/scripts/release/announce.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Lint a release post against the conventions, and post it on --post.
+#
+#   scripts/release/announce.sh 0.5.34 draft.md            # lint only
+#   scripts/release/announce.sh 0.5.34 draft.md --post     # lint, then publish
+#
+# The file's first line is the discussion title; everything after it is the body.
+# Lint always runs first, and a blocking failure prevents posting. The rules are
+# the ones that have actually been broken: `.plans/` paths leaking into a post
+# where no reader can resolve them, and bullets swelling into paragraphs once the
+# whitepaper sections were dropped.
+
+set -uo pipefail
+
+REPO=The-AI-Alliance/semiont
+CATEGORY_NAME=General
+VERSION="${1:-}"; FILE="${2:-}"; MODE="${3:-}"
+[ -n "$VERSION" ] && [ -f "$FILE" ] || { echo "usage: $0 <version> <file.md> [--post]" >&2; exit 2; }
+
+# Blocking checks are the objectively-wrong ones: a link that resolves nowhere, a
+# title the reader cannot parse, a path no reader can open. Style calls warn but
+# do not block — a deliberately substantive bullet is a legitimate choice, and a
+# gate that overrules the author on taste just gets bypassed.
+FAIL=0; WARN=0
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33mwarn\033[0m %s\n' "$1"; WARN=$((WARN+1)); }
+ok()   { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+
+LINK="Release: https://github.com/$REPO/releases/tag/v$VERSION"
+printf '\nLinting %s against v%s\n\n' "$FILE" "$VERSION"
+
+grep -qxF "$LINK" "$FILE" && ok "release link present and correct" \
+  || bad "missing the exact release link line: $LINK"
+
+grep -q '\.plans' "$FILE" \
+  && bad "post references .plans/ — reviewers cannot see untracked files" \
+  || ok "no .plans references"
+
+grep -nE '🎉|🚀|✨|🔥|💥' "$FILE" >/dev/null \
+  && bad "post contains emoji" || ok "no emoji"
+
+grep -niE '\b(exciting|awesome|huge|game[- ]chang|revolutionary|blazing)\b' "$FILE" >/dev/null \
+  && bad "post contains hype language" || ok "no hype language"
+
+# Everything above the release link is the tight half. A bullet that grew past a
+# line means depth went into the bullets instead of into a section below.
+LINKLINE=$(grep -nxF "$LINK" "$FILE" | head -1 | cut -d: -f1)
+if [ -n "$LINKLINE" ]; then
+  long=$(head -n "$LINKLINE" "$FILE" | awk 'length > 200 && /^[-*] /{print NR": "length" chars"}')
+  if [ -n "$long" ]; then
+    while read -r l; do warn "bullet above the release link is long — $l"; done <<< "$long"
+  else
+    ok "bullets above the release link stay tight"
+  fi
+
+  above=$(head -n "$LINKLINE" "$FILE" | grep -c '^## ')
+  [ "$above" -eq 0 ] && ok "no ## sections above the release link" \
+    || warn "$above '## ' section(s) above the release link — depth belongs below it"
+
+  below=$(tail -n +"$LINKLINE" "$FILE" | grep -c '^## ')
+  bullets=$(head -n "$LINKLINE" "$FILE" | grep -c '^[-*] ')
+  if [ "$bullets" -ge 5 ] && [ "$below" -eq 0 ]; then
+    warn "$bullets bullets and no '## ' sections — a release this deep usually carries a whitepaper section"
+  else
+    ok "$bullets bullets, $below whitepaper section(s)"
+  fi
+fi
+
+TITLE=$(head -1 "$FILE" | sed 's/^# *//')
+case "$TITLE" in
+  v*) bad "title starts with 'v' — use the bare version" ;;
+  *" -- "*) ok "title uses the ' -- ' separator" ;;
+  *) bad "title is not '<version> -- <theme>': $TITLE" ;;
+esac
+case "$TITLE" in "$VERSION"*) ok "title starts with $VERSION" ;; *) bad "title does not start with $VERSION" ;; esac
+
+printf '\n'
+if [ "$FAIL" -ne 0 ]; then printf '\033[31m%d blocking failure(s) — not posting.\033[0m\n' "$FAIL"; exit 1; fi
+[ "$WARN" -eq 0 ] && printf '\033[32mLint clean.\033[0m\n' \
+                  || printf '\033[33m%d style warning(s) — review, then post if intended.\033[0m\n' "$WARN"
+
+[ "$MODE" = "--post" ] || { echo "Dry run. Re-run with --post to publish."; exit 0; }
+
+REPO_ID=$(gh api "repos/$REPO" --jq .node_id)
+CAT_ID=$(gh api graphql -f query="{repository(owner:\"${REPO%/*}\",name:\"${REPO#*/}\"){discussionCategories(first:20){nodes{id name}}}}" \
+         --jq ".data.repository.discussionCategories.nodes[] | select(.name==\"$CATEGORY_NAME\") | .id")
+[ -n "$CAT_ID" ] || { echo "cannot resolve the $CATEGORY_NAME category" >&2; exit 1; }
+
+# The first line is the title; the body is everything after it.
+BODY_FILE=$(mktemp); trap 'rm -f "$BODY_FILE"' EXIT
+tail -n +2 "$FILE" | sed '/./,$!d' > "$BODY_FILE"
+
+gh api graphql -F body=@"$BODY_FILE" -f repoId="$REPO_ID" -f catId="$CAT_ID" -f title="$TITLE" -f query='
+  mutation($repoId:ID!,$catId:ID!,$title:String!,$body:String!){
+    createDiscussion(input:{repositoryId:$repoId,categoryId:$catId,title:$title,body:$body}){
+      discussion { number url }
+    }
+  }' --jq '.data.createDiscussion.discussion | "posted #\(.number)  \(.url)"'

--- a/scripts/release/notes-context.sh
+++ b/scripts/release/notes-context.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Assemble everything needed to write a release post, so nothing is written from
+# commit subjects alone.
+#
+#   scripts/release/notes-context.sh [previous-tag]     # defaults to latest release
+#
+# Writes a single file and prints its path. Read that file, then write the post.
+# It carries every merged PR's FULL body — not titles, not a sample — plus the
+# planning docs touched in the same window, because the origin story and the
+# measurements that make a post worth reading live there and nowhere else.
+
+set -uo pipefail
+
+REPO=The-AI-Alliance/semiont
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+PREV="${1:-$(gh release list -R "$REPO" --limit 1 --json tagName --jq '.[0].tagName')}"
+[ -n "$PREV" ] || { echo "cannot determine previous tag" >&2; exit 2; }
+
+SINCE=$(gh api "repos/$REPO/git/ref/tags/${PREV#refs/tags/}" --jq .object.sha 2>/dev/null \
+        | xargs -I{} gh api "repos/$REPO/commits/{}" --jq .commit.committer.date 2>/dev/null)
+[ -n "$SINCE" ] || { echo "cannot date $PREV" >&2; exit 2; }
+
+OUT="$ROOT/.release-notes-context.md"
+NEXT=$(gh api "repos/$REPO/contents/version.json" --jq .content | base64 -d | jq -r .version)
+
+{
+  echo "# Release-notes context: $PREV -> $NEXT"
+  echo
+  echo "Window opens $SINCE (the $PREV tag)."
+  echo
+
+  echo "## Merged PRs"
+  echo
+} > "$OUT"
+
+# The skill drops dependabot from the post; this lists them separately rather
+# than filtering silently, so a security bump that mattered can still be seen.
+PRS=$(gh pr list -R "$REPO" --state merged --limit 100 \
+        --json number,title,author,mergedAt,url,body,files \
+        --jq "[.[] | select(.mergedAt > \"$SINCE\")] | sort_by(.number)")
+
+# Headings inside a PR body are demoted so they cannot be mistaken for this
+# document's own sections when skimming.
+echo "$PRS" | jq -r '
+  def noise: (.author.login | test("dependabot"))
+          or (.title | test("^[a-z-]+\\(deps(-dev)?\\):"))
+          or (.title | test("^bump version to "));
+  [ .[] | select(noise) ] as $bots
+  | [ .[] | select(noise | not) ] as $real
+  | ($real[] | "### PR #\(.number) — \(.title)\n_by \(.author.login), merged \(.mergedAt)_\n\nFiles: \([.files[].path] | length) changed\n\n\((.body // "_(no body)_") | gsub("(?m)^#"; "#####"))\n\n---\n")
+  , "\n## Dependency and bump PRs (excluded from the post body)\n"
+  , ($bots[] | "- #\(.number) \(.title)")
+' >> "$OUT" 2>/dev/null
+
+{
+  echo
+  echo "## Planning docs touched in this window"
+  echo
+  echo "_Untracked, so matched by modification time. Read the ones behind the big PRs —"
+  echo "their Date / Origin / Status headers usually carry the whole story._"
+  echo
+} >> "$OUT"
+
+if [ -d "$ROOT/.plans" ]; then
+  found=0
+  while IFS= read -r f; do
+    found=1
+    printf -- '- %s  (modified %s)\n' "${f#"$ROOT"/}" "$(date -r "$f" '+%Y-%m-%d %H:%M')"
+  done < <(find "$ROOT/.plans" -name '*.md' -newermt "$SINCE" 2>/dev/null | sort) >> "$OUT"
+  [ "$found" -eq 1 ] || echo "_none modified since ${SINCE}_" >> "$OUT"
+else
+  echo "_no .plans directory_" >> "$OUT"
+fi
+
+{
+  echo
+  echo "## Checklist before writing"
+  echo
+  echo "- [ ] Read every PR body above, not a sample. A template-only body means go to the plan."
+  echo "- [ ] Read the planning docs behind the substantial PRs."
+  echo "- [ ] Bullets stay one line each; depth goes in \`## Theme\` sections below the release link."
+  echo "- [ ] No \`.plans/\` paths anywhere in the post — reviewers cannot see untracked files."
+} >> "$OUT"
+
+n_real=$(echo "$PRS" | jq "[.[] | select(((.author.login | test(\"dependabot\")) or (.title | test(\"^[a-z-]+\\\\(deps(-dev)?\\\\):\")) or (.title | test(\"^bump version to \"))) | not)] | length")
+n_bot=$(echo "$PRS" | jq "[.[] | select((.author.login | test(\"dependabot\")) or (.title | test(\"^[a-z-]+\\\\(deps(-dev)?\\\\):\")) or (.title | test(\"^bump version to \")))] | length")
+echo "$n_real substantive PRs, $n_bot dependency PRs, window from $PREV"
+echo "$OUT"

--- a/scripts/release/preflight.sh
+++ b/scripts/release/preflight.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Decide whether main is releasable, and print the command that releases it.
+#
+#   scripts/release/preflight.sh
+#
+# Every check runs against what origin/main actually holds, read over the wire —
+# never the local working tree, which can be ahead, behind, or dirty with another
+# session's work. Exits non-zero if anything would make the release wrong.
+
+set -uo pipefail
+
+REPO=The-AI-Alliance/semiont
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+# ls-remote reads the remote without fetching, so this is accurate even when the
+# local clone is stale and leaves the working tree untouched.
+SHA=$(git ls-remote "https://github.com/$REPO" refs/heads/main | cut -f1)
+[ -n "$SHA" ] || { echo "cannot read origin/main"; exit 2; }
+printf '\norigin/main is \033[1m%s\033[0m\n\n' "${SHA:0:8}"
+
+# ---------------------------------------------------------- version consistency
+gh api "repos/$REPO/contents/version.json?ref=$SHA" --jq .content 2>/dev/null | base64 -d > "$WORK/version.json"
+VERSION=$(jq -r .version "$WORK/version.json" 2>/dev/null)
+if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+  echo "cannot read version.json at $SHA"; exit 2
+fi
+ok "version.json at origin/main says $VERSION"
+
+# release.yml fails the tag job on a mismatch. Catching it here costs seconds
+# instead of a dispatched run that dies after tagging nothing.
+mismatch=0
+while read -r path; do
+  v=$(gh api "repos/$REPO/contents/$path?ref=$SHA" --jq .content 2>/dev/null | base64 -d | jq -r .version)
+  [ "$v" = "$VERSION" ] || { bad "$path is at $v, expected $VERSION"; mismatch=1; }
+done < <(cd "$ROOT" && git ls-tree -r --name-only "origin/main" 2>/dev/null | grep -E '^(packages|apps)/[^/]+/package\.json$' \
+         || ls -d "$ROOT"/packages/*/package.json "$ROOT"/apps/*/package.json | sed "s|$ROOT/||")
+[ "$mismatch" -eq 0 ] && ok "all package.json files at $VERSION"
+
+# ------------------------------------------------------------------ tag is free
+if git ls-remote "https://github.com/$REPO" "refs/tags/v$VERSION" | grep -q .; then
+  bad "tag v$VERSION already exists on origin — bump before releasing"
+else
+  ok "tag v$VERSION is free"
+fi
+
+# ------------------------------------------------------------------- CI on HEAD
+# `gh run list --limit 1` returns whatever run the API surfaces first, which is
+# routinely NOT the newest and has reported a phantom head more than once. Ask
+# for this commit's own check runs instead.
+gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --jq '.check_runs[] | "\(.conclusion // .status)\t\(.name)"' > "$WORK/checks.txt" 2>/dev/null
+
+if [ ! -s "$WORK/checks.txt" ]; then
+  bad "no check runs reported for $SHA — CI may not have started"
+else
+  total=$(wc -l < "$WORK/checks.txt" | tr -d ' ')
+  failed=$(awk -F'\t' '$1!="success" && $1!="skipped" && $1!="neutral"' "$WORK/checks.txt")
+  if [ -z "$failed" ]; then
+    ok "all $total check runs on $SHA are green"
+  else
+    while IFS=$'\t' read -r st name; do bad "check '$name' is $st"; done <<< "$failed"
+  fi
+fi
+
+# --------------------------------------------------- previous release published
+PREV=$(gh release list -R "$REPO" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null | sed 's/^v//')
+if [ -n "$PREV" ]; then
+  ok "previous release is $PREV (verify it with: scripts/release/verify-release.sh $PREV)"
+fi
+
+# ---------------------------------------------------------------------- verdict
+printf '\n\033[1m%d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  printf '\n\033[31mNot releasable.\033[0m Fix the above first.\n'
+  exit 1
+fi
+
+cat <<EOF
+
+Releasable. One dispatch publishes every channel:
+
+  gh workflow run release.yml
+
+Then, once the runs finish:
+
+  scripts/release/verify-release.sh $VERSION
+EOF

--- a/scripts/release/preflight.sh
+++ b/scripts/release/preflight.sh
@@ -13,9 +13,10 @@ REPO=The-AI-Alliance/semiont
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
 
-PASS=0; FAIL=0
-ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; PASS=$((PASS+1)); }
-bad() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+PASS=0; FAIL=0; PENDING=0
+ok()    { printf '  \033[32mok\033[0m   %s\n' "$1"; PASS=$((PASS+1)); }
+bad()   { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+wait_() { printf '  \033[33mwait\033[0m %s\n' "$1"; PENDING=$((PENDING+1)); }
 
 # ls-remote reads the remote without fetching, so this is accurate even when the
 # local clone is stale and leaves the working tree untouched.
@@ -55,15 +56,18 @@ fi
 gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --jq '.check_runs[] | "\(.conclusion // .status)\t\(.name)"' > "$WORK/checks.txt" 2>/dev/null
 
 if [ ! -s "$WORK/checks.txt" ]; then
-  bad "no check runs reported for $SHA — CI may not have started"
+  wait_ "no check runs reported for $SHA yet — CI may not have started"
 else
   total=$(wc -l < "$WORK/checks.txt" | tr -d ' ')
-  failed=$(awk -F'\t' '$1!="success" && $1!="skipped" && $1!="neutral"' "$WORK/checks.txt")
-  if [ -z "$failed" ]; then
-    ok "all $total check runs on $SHA are green"
-  else
-    while IFS=$'\t' read -r st name; do bad "check '$name' is $st"; done <<< "$failed"
-  fi
+  # A check still running is not a failing check. Conflating them means every
+  # run in the minutes after a merge reports red, which teaches the reader to
+  # ignore red.
+  pending=$(awk -F'\t' '$1=="queued" || $1=="in_progress" || $1=="pending" || $1=="waiting"' "$WORK/checks.txt")
+  failed=$(awk -F'\t' '$1!="success" && $1!="skipped" && $1!="neutral" && $1!="queued" && $1!="in_progress" && $1!="pending" && $1!="waiting"' "$WORK/checks.txt")
+
+  [ -n "$failed" ] && while IFS=$'\t' read -r st name; do bad "check '$name' concluded $st"; done <<< "$failed"
+  [ -n "$pending" ] && while IFS=$'\t' read -r st name; do wait_ "check '$name' is still $st"; done <<< "$pending"
+  [ -z "$failed" ] && [ -z "$pending" ] && ok "all $total check runs on $SHA are green"
 fi
 
 # --------------------------------------------------- previous release published
@@ -73,10 +77,14 @@ if [ -n "$PREV" ]; then
 fi
 
 # ---------------------------------------------------------------------- verdict
-printf '\n\033[1m%d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
+printf '\n\033[1m%d passed, %d failed, %d pending\033[0m\n' "$PASS" "$FAIL" "$PENDING"
 if [ "$FAIL" -ne 0 ]; then
   printf '\n\033[31mNot releasable.\033[0m Fix the above first.\n'
   exit 1
+fi
+if [ "$PENDING" -ne 0 ]; then
+  printf '\n\033[33mNot ready yet.\033[0m Nothing has failed; re-run when CI finishes.\n'
+  exit 2
 fi
 
 cat <<EOF


### PR DESCRIPTION
# Pull Request

## Description

The 0.5.33 release published every version tag correctly and left all seven images' `:latest` on 0.5.32, because `publish-service-images.yml` and `publish-browser.yml` take a `tag_latest` input that defaults to `false` and the dispatch was typed by hand without it. Nothing was published wrong — the images were simply under-tagged, and since the fleet's compose resolves `${SEMIONT_VERSION:-latest}`, no fleet KB could run the release at all. It surfaced from a codespace reporting `"version":"0.5.32"` on `/api/health`, not from anything in the release output.

`baa81c62` (already on main) fixed the chain: `release.yml` now dispatches the launcher, the npm workflow dispatches both image workflows with `tag_latest=true`, and the npm-existence gate polls instead of failing on the registry's indexing lag.

This PR removes the remaining hand-typed steps.

**`desktop` stops defaulting off.** Every release since 0.5.26 passed `--field desktop=true` — 8 of 8. A flag that is always true in practice, defaulting to false, is the same defect as `tag_latest`; it just hadn't been forgotten yet. It now defaults on, and a release that ships no desktop apps turns it off deliberately.

**`scripts/release/preflight.sh`** decides whether `origin/main` is releasable: version sync across every `package.json`, the tag is free, and CI green on that commit's own check runs. It reads the remote with `git ls-remote` and the contents API rather than the local clone, which can be stale, behind, or dirty with another session's work. It deliberately does not use `gh run list --limit 1` — that returns whatever run the API surfaces first, which is routinely not the newest and has reported a phantom head more than once.

**`scripts/release/notes-context.sh`** assembles every substantive PR merged since the last release *with its full body*, lists dependency and version-bump PRs separately rather than filtering them silently, and gathers the planning docs modified in the same window. Commit subjects compress away the origin and the measurement, which is the part of a release post worth reading.

**`scripts/release/announce.sh`** lints a drafted post and publishes it on `--post`. Blocking checks are objectively-wrong things: a release link that resolves nowhere, a title a reader cannot parse, a path nobody outside the working tree can open. Bullet length and whether a deep release carries a whitepaper section only warn — a deliberately substantive bullet is a legitimate authorial choice, and a gate that overrules taste gets bypassed rather than obeyed.

Together with `verify-release.sh` from `baa81c62`, the release is:

```bash
./scripts/release/preflight.sh
gh workflow run release.yml
./scripts/release/notes-context.sh
./scripts/release/announce.sh <version> draft.md --post
./scripts/release/verify-release.sh <version>
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Infrastructure/DevOps changes

## Areas Changed

- [x] GitHub Actions (`.github/workflows/`)
- [x] Scripts (`scripts/`)
- [x] Documentation (`docs/`)

## Security Checklist

Not applicable — this PR touches no authentication, authorization, or admin functionality, and adds no runtime code. It changes one workflow input default and adds three operator scripts.

Two notes that are security-relevant anyway:

- No secrets are introduced or handled. `announce.sh` and `preflight.sh` use the operator's existing `gh` authentication; nothing is written to disk that carries a credential.
- `notes-context.sh` writes `.release-notes-context.md`, which quotes untracked planning-document filenames and full PR bodies. It is added to `.gitignore` in this PR so it cannot be committed.

## Testing

No automated tests. These are operator scripts, and each was run against real release data rather than fixtures:

- `verify-release.sh 0.5.33` → **60 passed, 0 failed**, after `:latest` was repointed.
- `verify-release.sh 0.5.32` → correctly reports all seven `:latest` tags stale, which is the defect this work exists to catch. Negative path confirmed rather than assumed.
- `preflight.sh` against current main → 5 passed, 0 failed; resolves `origin/main`, reads 36 check runs on that exact sha, and prints the release command.
- `notes-context.sh v0.5.32` → 7 substantive PRs with full bodies, 2 dependency/bump PRs listed separately.
- `announce.sh 0.5.33` against the post that actually shipped → clean on all blocking checks, 2 style warnings for the two long bullets (which are long deliberately — that material was folded down from cut sections).
- `announce.sh` against a deliberately malformed post → 6 blocking failures, exit 1, refuses to post.
- All five workflow files parse; all four scripts pass `bash -n`.

## Breaking Changes

None. `desktop` defaulting to `true` changes what a bare `gh workflow run release.yml` does — it now builds desktop apps, which is what every release since 0.5.26 asked for explicitly. Pass `--field desktop=false` to skip them.

## Documentation

- [x] Code comments updated
- [x] README updated (if needed)

`scripts/release/README.md` documents the full flow and corrects two stale claims: that the bump pushes to main (branch-and-PR only since the August change), and that the release is a single `gh workflow run` with no follow-up steps.

## Additional Context

`launcher-release.yml` previously declared `on: push: tags: ['v*']`, and it had never fired — 15 of 15 runs were `workflow_dispatch`. Tags are pushed by `release.yml` using `GITHUB_TOKEN`, and GitHub does not raise workflow-triggering events for `GITHUB_TOKEN`-authored pushes, so the trigger was dead configuration while a human dispatched the launcher by hand every release. That was removed in `baa81c62`; the reason is recorded in a comment there so it does not get re-added.
