### PR TITLE
A retried POST can no longer write a second resource — and detection sizes each chunk from the last

### DIFF
--- a/packages/core/src/__tests__/retry-rules.test.ts
+++ b/packages/core/src/__tests__/retry-rules.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The retry taxonomy: one place where every "is this worth another attempt"
+ * answer is visible beside the others.
+ *
+ * The defect is not that contexts disagree — a `500` mid-job is worth another
+ * attempt where the same `500` in a boot pass replays whatever broke it. It is
+ * that today two sites carry an argument, two carry a bare list, and no reader of
+ * either can see that the other exists.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RETRY_RULES } from '../retry-rules';
+
+describe('RETRY_RULES', () => {
+  it('gives one 500 two answers, from one taxonomy', () => {
+    // The whole plan as a single assertion. Today these two answers live in
+    // different packages and neither knows the other exists: core excludes 500
+    // on the record ("an unclassified server fault is not a promise to recover"),
+    // while jobs retries it because the alternative is discarding a 26-minute
+    // attempt over one fault.
+    expect(RETRY_RULES.boot.retryable({ status: 500 })).toBe(false);
+    expect(RETRY_RULES.job.retryable({ status: 500 })).toBe(true);
+  });
+
+  it('agrees with itself where the contexts agree', () => {
+    // A method is supplied because the transport rule needs one and the other two
+    // ignore it — a method-free 429 is deliberately `false` for transport, since
+    // "not stated" reads as unsafe rather than as permission.
+    for (const rule of Object.values(RETRY_RULES)) {
+      expect(rule.retryable({ status: 429, method: 'GET' }), `${rule.name} on 429`).toBe(true);
+      expect(rule.retryable({ status: 403, method: 'GET' }), `${rule.name} on 403`).toBe(false);
+    }
+  });
+
+  it('every rule carries a name and a rationale', () => {
+    // Catches OMISSION, which is the real failure mode here — sites 3, 4 and 6
+    // all answered by default rather than by choice. It cannot catch a lazy
+    // rationale, and does not claim to: there is no source to check one against.
+    for (const rule of Object.values(RETRY_RULES)) {
+      expect(rule.name).toMatch(/\S/);
+      expect(rule.rationale.length, `${rule.name} rationale`).toBeGreaterThan(80);
+    }
+  });
+
+  it('is the only way to reach a rule, so a new one cannot be unreachable-but-forgotten', () => {
+    // Reachability IS the census gate: rules are not exported individually, so a
+    // rule absent from this record cannot be consumed by anyone.
+    expect(Object.keys(RETRY_RULES).sort()).toEqual(['boot', 'job', 'transport']);
+    expect(Object.isFrozen(RETRY_RULES)).toBe(true);
+  });
+
+  describe('the transport rule keys on method as well as status', () => {
+    // The dimension a ReadonlySet<number> cannot express, and the reason the
+    // taxonomy is not typed as one. P3 consumes this.
+    it('retries a 401 on any method — the request was rejected, not processed', () => {
+      expect(RETRY_RULES.transport.retryable({ status: 401, method: 'POST' })).toBe(true);
+      expect(RETRY_RULES.transport.retryable({ status: 401, method: 'GET' })).toBe(true);
+    });
+
+    it('retries a 5xx only on methods that are safe to repeat', () => {
+      // The live hazard: a POST /resources that gets a 502 may already have been
+      // processed, and the Stower mints a fresh UUID — so a retry writes a
+      // SECOND resource whose id the caller never learns.
+      expect(RETRY_RULES.transport.retryable({ status: 502, method: 'GET' })).toBe(true);
+      expect(RETRY_RULES.transport.retryable({ status: 502, method: 'POST' })).toBe(false);
+      expect(RETRY_RULES.transport.retryable({ status: 504, method: 'PATCH' })).toBe(false);
+    });
+
+    it('treats an unstated method as unsafe', () => {
+      // Absence is not permission. A caller that cannot say which method it used
+      // gets the conservative answer rather than a silent yes.
+      expect(RETRY_RULES.transport.retryable({ status: 502 })).toBe(false);
+    });
+  });
+
+  describe('the boot and job rules ignore method, and say so by accepting facts without one', () => {
+    it('answers the same with or without a method', () => {
+      for (const rule of [RETRY_RULES.boot, RETRY_RULES.job]) {
+        expect(rule.retryable({ status: 503 })).toBe(rule.retryable({ status: 503, method: 'POST' }));
+      }
+    });
+  });
+
+  it('leaves the existing predicates answering exactly as they did', async () => {
+    // This phase is additive on purpose: behavior moves in P2/P3, so a
+    // regression there cannot be mistaken for a taxonomy bug.
+    const { isRetryableRequestError } = await import('../retry');
+    for (const status of [429, 503, 504]) {
+      expect(isRetryableRequestError(Object.assign(new Error('x'), { status }))).toBe(true);
+    }
+    for (const status of [400, 401, 403, 404, 500]) {
+      expect(isRetryableRequestError(Object.assign(new Error('x'), { status }))).toBe(false);
+    }
+  });
+});

--- a/packages/core/src/chunking.ts
+++ b/packages/core/src/chunking.ts
@@ -33,6 +33,57 @@ export function estimateTokens(text: string): number {
  * boundaries, then word boundaries. Each chunk overlaps with the previous
  * by `overlap` tokens worth of text.
  */
+/**
+ * One chunk, cut from `at`, plus where the next one starts.
+ *
+ * The boundary rule lives HERE and `chunkText` loops over it, so a caller that
+ * must cut lazily — sizing chunk N+1 from what chunk N produced — shares the
+ * exact boundary logic instead of restating it. `next === at` never happens:
+ * the cursor always advances, so a caller's loop terminates.
+ */
+export function cutChunk(
+  text: string,
+  at: number,
+  config: ChunkingConfig = DEFAULT_CHUNKING_CONFIG,
+): { piece: string; next: number } {
+  const chunkChars = config.chunkSize * 4;
+  const overlapChars = config.overlap * 4;
+  let end = Math.min(at + chunkChars, text.length);
+
+  // Try to break at a paragraph boundary
+  if (end < text.length) {
+    const paraBreak = text.lastIndexOf('\n\n', end);
+    if (paraBreak > at + chunkChars / 2) {
+      end = paraBreak;
+    } else {
+      // Try sentence boundary
+      const sentenceBreak = text.lastIndexOf('. ', end);
+      if (sentenceBreak > at + chunkChars / 2) {
+        end = sentenceBreak + 1;
+      } else {
+        // Try word boundary
+        const wordBreak = text.lastIndexOf(' ', end);
+        if (wordBreak > at + chunkChars / 2) {
+          end = wordBreak;
+        }
+      }
+    }
+  }
+
+  // Reaching the end ends the walk. Backing `next` off by the overlap here
+  // would hand the caller one more cut covering only text the piece just
+  // returned already contains — a whole extra inference call per document,
+  // yielding nothing but duplicate spans for the dedupe layer to discard.
+
+
+
+  if (end >= text.length) {
+    return { piece: text.slice(at, end).trim(), next: text.length };
+  }
+  const nextStart = end - overlapChars;
+  return { piece: text.slice(at, end).trim(), next: nextStart > at ? nextStart : end };
+}
+
 export function chunkText(text: string, config: ChunkingConfig = DEFAULT_CHUNKING_CONFIG): string[] {
   if (text.length === 0) return [];
   const totalTokens = estimateTokens(text);
@@ -40,37 +91,13 @@ export function chunkText(text: string, config: ChunkingConfig = DEFAULT_CHUNKIN
     return [text];
   }
 
-  const chunkChars = config.chunkSize * 4;
-  const overlapChars = config.overlap * 4;
   const chunks: string[] = [];
   let start = 0;
 
   while (start < text.length) {
-    let end = Math.min(start + chunkChars, text.length);
-
-    // Try to break at a paragraph boundary
-    if (end < text.length) {
-      const paraBreak = text.lastIndexOf('\n\n', end);
-      if (paraBreak > start + chunkChars / 2) {
-        end = paraBreak;
-      } else {
-        // Try sentence boundary
-        const sentenceBreak = text.lastIndexOf('. ', end);
-        if (sentenceBreak > start + chunkChars / 2) {
-          end = sentenceBreak + 1;
-        } else {
-          // Try word boundary
-          const wordBreak = text.lastIndexOf(' ', end);
-          if (wordBreak > start + chunkChars / 2) {
-            end = wordBreak;
-          }
-        }
-      }
-    }
-
-    chunks.push(text.slice(start, end).trim());
-    const nextStart = end - overlapChars;
-    start = nextStart > start ? nextStart : end;
+    const { piece, next } = cutChunk(text, start, config);
+    chunks.push(piece);
+    start = next;
     if (start >= text.length) break;
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -353,7 +353,7 @@ export type { GoogleAuthRequest } from './auth-types';
 
 // ID generation
 export { generateUuid, uuidV4 } from './id-generation';
-export { chunkText, estimateTokens, DEFAULT_CHUNKING_CONFIG } from './chunking';
+export { chunkText, cutChunk, estimateTokens, DEFAULT_CHUNKING_CONFIG } from './chunking';
 export type { ChunkingConfig } from './chunking';
 
 // State-unit pattern — the disposable contract shared by every layer (sdk,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,6 +141,11 @@ export { serializePerKey } from './serialize-per-key';
 // Bounded concurrency across callers (for a shared downstream: one local model
 // process, a rate-limited API). Sibling to serializePerKey, which bounds per key.
 export { boundedGate } from './bounded-gate';
+
+// Which failures are worth another attempt, per context — one catalog so the
+// contexts' disagreements are visible rather than distributed.
+export { RETRY_RULES } from './retry-rules';
+export type { RetryRule, RetryFacts } from './retry-rules';
 export type { BatchPolicy } from './bounded-gate';
 
 // Logger interface (framework-agnostic)

--- a/packages/core/src/retry-rules.ts
+++ b/packages/core/src/retry-rules.ts
@@ -1,0 +1,115 @@
+/**
+ * Which failures are worth another attempt — one catalog, several contexts.
+ *
+ * **Not `RetryPolicy`, which is next door and means something else.** That is a
+ * timing budget: how long to keep trying. A `RetryRule` is which failures to try
+ * again at all. `STARTUP_FETCH_RETRY: RetryPolicy` and `RETRY_RULES.boot` answer
+ * different questions about the same attempt.
+ *
+ * ## Why one file, when the contexts genuinely differ
+ *
+ * They do differ, and collapsing them to one answer would break something: a
+ * `500` mid-job is worth another attempt, where the same `500` in a boot pass
+ * replays whatever broke it. The defect being fixed is not divergence — it is
+ * that the divergence was **undeclared**. Four sites decided this question, two
+ * with an argument and two with a bare list, and no reader of any file could see
+ * that the others existed. Where a list and an argument disagreed, the list won
+ * silently.
+ *
+ * So the rules sit together *because* they disagree. A reader comparing two lines
+ * here sees a decision; a reader of one package could only ever see a default.
+ *
+ * This is the opposite call from `retry.ts`'s "judgment with its caller", and
+ * deliberately: that rule governs timing budgets, where one number shared across
+ * peers that answer differently caused a measured bug. Here the failure mode is
+ * invisibility, and co-location is its cure. A context still owns its *choice* —
+ * it picks a rule by name — it does not own a private copy of the reasoning.
+ *
+ * ## The census gate is reachability
+ *
+ * Rules are exported only through `RETRY_RULES`. A rule missing from that record
+ * cannot be consumed, which is a stronger gate than a parallel list a new rule
+ * could simply be left out of.
+ */
+
+/**
+ * What is known about a failure at the moment someone asks.
+ *
+ * `method` exists because retryability depends on the REQUEST as well as the
+ * failure: a `504` on a GET is safe to repeat, a `504` on a POST may already have
+ * been processed upstream. Optional, because only the transport rule has an
+ * answer for it — and unstated reads as unsafe rather than as permission.
+ *
+ * Deliberately not a `ReadonlySet<number>`: a status set cannot say *`401` on any
+ * method, `5xx` on idempotent methods only*, which is exactly what the transport
+ * needs to say.
+ */
+export interface RetryFacts {
+  status?: number;
+  /** HTTP method, any case. Absent means "not stated", which is treated as unsafe. */
+  method?: string;
+}
+
+export interface RetryRule {
+  readonly name: string;
+  /** Why this context answers the way it does. Not decoration: the two bare
+   *  lists this taxonomy replaces were bare because nobody had to write one. */
+  readonly rationale: string;
+  retryable(facts: RetryFacts): boolean;
+}
+
+/** Repeating these cannot cause a second effect upstream (RFC 9110 §9.2.2). */
+const IDEMPOTENT_METHODS: ReadonlySet<string> = new Set([
+  'GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS', 'TRACE',
+]);
+
+const boot: RetryRule = {
+  name: 'boot',
+  rationale:
+    'A boot pass or a bus request, where the peer is usually seconds from being ready. ' +
+    '429/503/504 are the server saying "up, but not now" — retrying is compliance with its ' +
+    'own instruction. 500 is excluded on the record: 503 and 504 are promises to recover, ' +
+    'an unclassified server fault is not, and replaying it inside a boot pass re-runs ' +
+    'whatever broke it. Auth and validation failures stay out for the same reason a 401 ' +
+    'does — the gateway is up and rejected us.',
+  retryable: ({ status }) => status === 429 || status === 503 || status === 504,
+};
+
+const job: RetryRule = {
+  name: 'job',
+  rationale:
+    'A job retry budget, where the cost of NOT retrying is a discarded long-running ' +
+    'attempt. 5xx is included where the boot rule excludes it, because the alternative is ' +
+    'throwing away paid work over one unclassified fault. 408 joins as an explicit timeout. ' +
+    'The price of a wrong "transient" is a re-pay, not a corrupted write — which is what ' +
+    'makes the wider answer affordable here and not at boot.',
+  retryable: ({ status }) =>
+    status === 408 || status === 429 || (status !== undefined && status >= 500),
+};
+
+const transport: RetryRule = {
+  name: 'transport',
+  rationale:
+    'An HTTP client with a token refresher. 401 is retried on ANY method: the request was ' +
+    'rejected rather than processed, and a refreshed token makes it valid. Every other ' +
+    'retryable status applies only to idempotent methods, because a POST that got a 502 may ' +
+    'already have been processed — and one of them mints a fresh resource id, so a repeat ' +
+    'writes a second resource the caller never learns about. Method-level is enough: no ' +
+    'per-endpoint registry, because these methods were never retried before a widening that ' +
+    'was meant to add 401 alone.',
+  retryable: ({ status, method }) => {
+    if (status === undefined) return false;
+    if (status === 401) return true;
+    const repeatable = method !== undefined && IDEMPOTENT_METHODS.has(method.toUpperCase());
+    if (!repeatable) return false;
+    return status === 408 || status === 413 || status === 429 || status === 500
+      || status === 502 || status === 503 || status === 504;
+  },
+};
+
+/**
+ * Every rule, and the only way to reach one.
+ *
+ * Frozen and exhaustive on purpose — see the census-gate note above.
+ */
+export const RETRY_RULES = Object.freeze({ boot, job, transport });

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -38,6 +38,7 @@
  */
 
 import { BusRequestError } from './bus-request';
+import { RETRY_RULES } from './retry-rules';
 
 export interface RetryPolicy {
   /** Total attempts, including the first one. */
@@ -149,25 +150,19 @@ export interface HttpStatusError extends Error {
   readonly status: number;
 }
 
-/**
- * Statuses that mean *up, but not now* — the server is answering, and its
- * answer is "try again".
- *
- *  - `429` — the gateway's own rate limiter; its body says to retry when one
- *            settles. Retrying is compliance, not hope.
- *  - `503` — unavailable, explicitly temporary by RFC 9110.
- *  - `504` — an upstream deadline, which the next attempt may well beat.
- *
- * Everything else is excluded deliberately, including `500`: 503 and 504 are
- * promises to recover, while an unclassified server fault is not — retrying it
- * inside a boot pass just replays whatever broke it.
- */
-const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([429, 503, 504]);
+
 
 /**
  * True for failures worth another attempt: the connection never landed
  * (`isTransientFetchError`), the server answered "not now"
- * (`RETRYABLE_STATUSES`), or our own deadline expired.
+ * (`RETRY_RULES.boot`), or our own deadline expired.
+ *
+ * The status half is DERIVED from `RETRY_RULES.boot` rather than restated here.
+ * It used to be a private `RETRYABLE_STATUSES` set holding the same three
+ * numbers, which made the taxonomy a second opinion instead of the answer — and
+ * a second opinion in the same package is the exact defect RETRY-CLASSIFICATION
+ * exists to remove. The reasoning for those three, and for excluding `500`, now
+ * lives once, in the rule.
  *
  * The timeout case is the one that is easy to get wrong. `AbortSignal.timeout()`
  * rejects with a **DOMException named `TimeoutError`**, not a `TypeError` —
@@ -211,7 +206,7 @@ export function isRetryableRequestError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   if ((error as { name?: unknown }).name === 'TimeoutError') return true;
   const status = (error as { status?: unknown }).status;
-  return typeof status === 'number' && RETRYABLE_STATUSES.has(status);
+  return typeof status === 'number' && RETRY_RULES.boot.retryable({ status });
 }
 
 /**

--- a/packages/http-transport/src/transport/__tests__/http-transport.hooks.test.ts
+++ b/packages/http-transport/src/transport/__tests__/http-transport.hooks.test.ts
@@ -33,6 +33,7 @@ vi.mock('ky', () => {
 });
 
 import ky, { HTTPError } from 'ky';
+import { RETRY_RULES } from '@semiont/core';
 import { HttpTransport } from '../http-transport';
 import { APIError } from '../api-error';
 
@@ -155,6 +156,156 @@ describe('HttpTransport ky hooks', () => {
     });
 
     expect(returned).toBe(response);
+  });
+});
+
+// ── RETRY-CLASSIFICATION P3: shouldRetry is the retry gate ──────────────
+// ky's `methods`/`statusCodes` are ANDed independently — there is no
+// per-status method list, so "the widened methods apply to 401 only" cannot
+// be said with them. `shouldRetry` says it instead, deriving from
+// `RETRY_RULES.transport` rather than restating a set of numbers.
+//
+// The gate is here and not in `beforeRetry` because ky awaits the full
+// backoff before running that hook: a rejection there would sleep first.
+// ky's own docs draw the same line — `shouldRetry` controls WHETHER,
+// `beforeRetry` runs after a retry is confirmed to modify the request.
+//
+// These tests read the decision directly. What a rejected retry looks like
+// to a caller is `http-transport.retry.test.ts`, which drives real ky.
+
+describe('HttpTransport shouldRetry — the transport retry rule', () => {
+  let shouldRetry: (state: { error: Error; retryCount: number }) => false | undefined;
+  let retryConfig: { statusCodes: number[] };
+
+  beforeEach(() => {
+    vi.mocked(ky.create).mockReturnValue({
+      get: vi.fn(),
+      post: vi.fn(),
+    } as unknown as ReturnType<typeof ky.create>);
+    vi.mocked(ky.create).mockClear();
+
+    new HttpTransport({
+      baseUrl: testBaseUrl,
+      timeout: 10_000,
+      tokenRefresher: async () => 'fresh-token',
+    });
+    retryConfig = vi.mocked(ky.create).mock.calls.at(-1)![0]!.retry as typeof retryConfig;
+    shouldRetry = (retryConfig as unknown as { shouldRetry: typeof shouldRetry }).shouldRetry;
+  });
+
+  /** Ask the gate about a request of `method` that failed with `status`. */
+  function verdict(method: string, status: number) {
+    const error = Object.assign(httpError({ status, statusText: 'x', json: async () => ({}) }), {
+      request: { method },
+    });
+    return shouldRetry({ error, retryCount: 1 });
+  }
+
+  test('a POST that got a 504 is NOT retried — it may already have been processed', () => {
+    expect(verdict('POST', 504)).toBe(false);
+  });
+
+  test('a POST that got a 502 is NOT retried — the upload case that bites', () => {
+    // `POST /resources` mints a fresh UUID in the Stower, so a duplicate
+    // writes a second resource the caller never learns about (P0 row 8).
+    expect(verdict('POST', 502)).toBe(false);
+  });
+
+  test('a POST that got a 401 is left to ky — token refresh survives', () => {
+    // `undefined`, not `true`: the gate only ever narrows, so ky's own
+    // checks still run and `beforeRetry` still gets to refresh the token.
+    expect(verdict('POST', 401)).toBeUndefined();
+  });
+
+  test('a GET that got a 504 is still retried — the fix must not over-narrow', () => {
+    expect(verdict('GET', 504)).toBeUndefined();
+  });
+
+  test('a PATCH that got a 500 is NOT retried, and a PUT that got a 500 is', () => {
+    // The axis is idempotency, not "POST is special": PUT is repeatable by
+    // RFC 9110 and PATCH is not, so they part company on the same status.
+    expect(verdict('PATCH', 500)).toBe(false);
+    expect(verdict('PUT', 500)).toBeUndefined();
+  });
+
+  test('a 413 is never force-retried — ky keeps its retry-timing-header rule', () => {
+    // The gate returns `undefined` rather than `true` for an approved
+    // status, so ky still retries 413 only when the response says when.
+    expect(verdict('GET', 413)).toBeUndefined();
+  });
+
+  test('a non-HTTP error (socket hang up) is left to ky to decide', () => {
+    // No status to classify. The rule answers only about statuses; transport
+    // faults are ky's own retry domain and stay there.
+    expect(shouldRetry({ error: new Error('socket hang up'), retryCount: 1 })).toBeUndefined();
+  });
+
+  test('census: ky\'s statusCodes stay a SUPERSET of what the rule can approve', () => {
+    // The gate can only reject what ky admits — a status the rule would
+    // approve but the pre-filter omits is never retried, and nothing else
+    // would fail. So the two may differ, but only in one direction.
+    const admitted = new Set(retryConfig.statusCodes);
+
+    const approved = [];
+    for (let status = 400; status < 600; status++) {
+      for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']) {
+        if (RETRY_RULES.transport.retryable({ status, method })) approved.push(status);
+      }
+    }
+
+    expect(approved.length).toBeGreaterThan(0);
+    expect([...new Set(approved)].filter((s) => !admitted.has(s))).toEqual([]);
+  });
+});
+
+describe('HttpTransport beforeRetry — refresh only, once a retry is confirmed', () => {
+  let hooks: NonNullable<NonNullable<Parameters<typeof ky.create>[0]>['hooks']>;
+
+  function build(refresher: () => Promise<string | null>) {
+    vi.mocked(ky.create).mockReturnValue({
+      get: vi.fn(),
+      post: vi.fn(),
+    } as unknown as ReturnType<typeof ky.create>);
+    vi.mocked(ky.create).mockClear();
+    new HttpTransport({ baseUrl: testBaseUrl, timeout: 10_000, tokenRefresher: refresher });
+    hooks = vi.mocked(ky.create).mock.calls.at(-1)![0]!.hooks!;
+    const beforeRetry = hooks.beforeRetry![0]!;
+    type State = Parameters<typeof beforeRetry>[0];
+    const request = { method: 'POST', headers: new Headers() } as unknown as State['request'];
+    const error = httpError({ status: 401, statusText: 'x', json: async () => ({}) });
+    return {
+      request,
+      error,
+      run: () =>
+        beforeRetry({
+          request,
+          options: {} as unknown as State['options'],
+          error,
+          retryCount: 1,
+        }),
+    };
+  }
+
+  test('a 401 gets the refreshed credential on the outgoing request', async () => {
+    const { request, run } = build(async () => 'fresh-token');
+    await expect(run()).resolves.toBeUndefined();
+    expect(request.headers.get('Authorization')).toBe('Bearer fresh-token');
+  });
+
+  test('a refresher that returns null rethrows the original error, never ky.stop', async () => {
+    // `ky.stop` would resolve the caller's promise with `undefined`; the
+    // rethrow keeps ky's request-error path so `beforeError` still runs.
+    const { error, run } = build(async () => null);
+    await expect(run()).rejects.toBe(error);
+  });
+
+  test('a refresher that throws also rethrows the original error', async () => {
+    const { error, run } = build(async () => {
+      throw new Error('refresh endpoint down');
+    });
+    // The caller learns the request failed with 401 — the reason the refresh
+    // itself failed is the session's problem, not this request's.
+    await expect(run()).rejects.toBe(error);
   });
 });
 

--- a/packages/http-transport/src/transport/__tests__/http-transport.retry.test.ts
+++ b/packages/http-transport/src/transport/__tests__/http-transport.retry.test.ts
@@ -1,0 +1,149 @@
+/**
+ * What a stopped retry looks like TO THE CALLER (RETRY-CLASSIFICATION P3).
+ *
+ * The sibling hooks suite invokes `beforeRetry` directly against a mocked
+ * `ky`, which pins the classification but says nothing about what a caller
+ * awaiting `.json()` actually receives. That is the contract this phase must
+ * not change, so these tests use **real ky** with `fetch` stubbed and drive
+ * the transport's public methods end to end.
+ *
+ * It matters because the two ways to stop a retry are not interchangeable:
+ * `ky.stop` resolves the caller's promise with `undefined`, after which the
+ * `.json()` shortcut dereferences it (`Ky.js:127`, then `response.text()`);
+ * rethrowing the original error preserves the request-error path, which is
+ * why ky guards on `hookError !== error` (`Ky.js:845`). Only the rethrow
+ * reaches `beforeError`, and `beforeError` is what turns the failure into
+ * the `APIError` every caller of this transport is written against.
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { baseUrl, email } from '@semiont/core';
+import { HttpTransport } from '../http-transport';
+import { APIError } from '../api-error';
+
+const testBaseUrl = baseUrl('http://localhost:4000');
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+/**
+ * A `fetch` result ky will treat as an HTTP failure with `status`.
+ *
+ * Returns a NEW `Response` per call — ky clones the response to build its
+ * `HTTPError`, and a single instance reused across attempts fails with
+ * "Body has already been consumed" instead of the failure under test.
+ */
+function failWith(status: number): Response {
+  return new Response(JSON.stringify({ message: 'nope' }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('HttpTransport retry — what the caller receives', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  test('a POST that got a 502 rejects with the usual APIError, and is sent ONCE', async () => {
+    fetchMock.mockImplementation(async () => failWith(502));
+    const transport = new HttpTransport({
+      baseUrl: testBaseUrl,
+      timeout: 10_000,
+      tokenRefresher: async () => 'fresh-token',
+    });
+
+    const thrown = await transport
+      .getMediaToken('res-1' as Parameters<HttpTransport['getMediaToken']>[0])
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    // The contract callers are written against, unchanged: `beforeError`
+    // still runs, so this is the same `APIError` an unretried failure has
+    // always produced — not a TypeError from dereferencing `undefined`, and
+    // not a resolved `undefined` masquerading as success.
+    expect(thrown).toBeInstanceOf(APIError);
+    expect((thrown as APIError).status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    transport.dispose();
+  });
+
+  test('a GET that got a 504 is still retried — one attempt plus one retry', async () => {
+    fetchMock.mockResolvedValueOnce(failWith(504));
+    fetchMock.mockResolvedValueOnce(okJson({ email: 'a@b.c' }));
+    const transport = new HttpTransport({
+      baseUrl: testBaseUrl,
+      timeout: 10_000,
+      tokenRefresher: async () => 'fresh-token',
+    });
+
+    await expect(transport.getCurrentUser()).resolves.toMatchObject({ email: 'a@b.c' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    transport.dispose();
+  });
+
+  test('a POST that got a 401 is retried once with the refreshed token', async () => {
+    fetchMock.mockResolvedValueOnce(failWith(401));
+    fetchMock.mockResolvedValueOnce(okJson({ token: 'media-tok' }));
+    const transport = new HttpTransport({
+      baseUrl: testBaseUrl,
+      timeout: 10_000,
+      tokenRefresher: async () => 'fresh-token',
+    });
+
+    await expect(
+      transport.getMediaToken('res-1' as Parameters<HttpTransport['getMediaToken']>[0]),
+    ).resolves.toEqual({ token: 'media-tok' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const retried = fetchMock.mock.calls[1]![0] as Request;
+    expect(retried.headers.get('Authorization')).toBe('Bearer fresh-token');
+
+    transport.dispose();
+  });
+
+  test('a failed refresh surfaces the 401 as an APIError, not as a TypeError', async () => {
+    // The pre-existing `ky.stop` branch. A refresher that returns null stops
+    // the retry, and the caller must still learn the request failed with 401
+    // — `ky.stop` alone resolves the promise with `undefined`, so `.json()`
+    // then dereferences nothing and the caller catches a TypeError naming an
+    // internal instead of an auth failure it can act on.
+    fetchMock.mockImplementation(async () => failWith(401));
+    const transport = new HttpTransport({
+      baseUrl: testBaseUrl,
+      timeout: 10_000,
+      tokenRefresher: async () => null,
+    });
+
+    const thrown = await transport
+      .authenticatePassword(email('a@b.c'), 'pw')
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(thrown).toBeInstanceOf(APIError);
+    expect((thrown as APIError).status).toBe(401);
+
+    transport.dispose();
+  });
+
+  test('without a refresher, a POST is not retried at all — ky defaults exclude POST', async () => {
+    fetchMock.mockImplementation(async () => failWith(503));
+    const transport = new HttpTransport({ baseUrl: testBaseUrl, timeout: 10_000 });
+
+    await expect(
+      transport.getMediaToken('res-1' as Parameters<HttpTransport['getMediaToken']>[0]),
+    ).rejects.toBeInstanceOf(APIError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    transport.dispose();
+  });
+});

--- a/packages/http-transport/src/transport/http-transport.ts
+++ b/packages/http-transport/src/transport/http-transport.ts
@@ -45,7 +45,7 @@ import type {
   UpdateUserResponse,
   ListUsersResponse,
 } from '@semiont/core';
-import { BRIDGED_CHANNELS } from '@semiont/core';
+import { BRIDGED_CHANNELS, RETRY_RULES } from '@semiont/core';
 
 type AuthResponse = components['schemas']['AuthResponse'];
 type TokenRefreshResponse = components['schemas']['TokenRefreshResponse'];
@@ -137,13 +137,46 @@ export class HttpTransport implements ITransport, IGatewayOperations {
     this.token$ = config.token$ ?? new BehaviorSubject<AccessToken | null>(null);
     this.logger = logger;
 
-    // Retry policy: when a refresher is configured, expand retry to also
-    // cover 401 (one attempt). Otherwise use the plain `retry` number.
+    // Retry policy: when a refresher is configured, a 401 earns one attempt
+    // after refreshing the token — on ANY method, since the request was
+    // rejected rather than processed. Otherwise use the plain `retry` number,
+    // which leaves ky's own defaults in place (they never retried POST).
+    //
+    // **`methods`/`statusCodes` are a superset PRE-FILTER, not the decision.**
+    // ky ANDs them independently, so they cannot express "the widened methods
+    // apply to 401 only" — the widening that lets a POST reach a 401 retry
+    // also admits POST/504. `shouldRetry` is the authoritative gate and
+    // rejects what the lists over-admit; the hooks suite's census test pins
+    // that the lists stay a superset of what `RETRY_RULES.transport` can
+    // approve, so the two cannot drift apart.
     const retryConfig = tokenRefresher
       ? {
           limit: 1,
           methods: ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'],
           statusCodes: [401, 408, 413, 429, 500, 502, 503, 504],
+          // One rule, stated in core with its reasoning: 401 on any method,
+          // every other status on idempotent methods only. A POST that got a
+          // 502 may already have been processed, and one of them mints a
+          // fresh resource id, so a repeat writes a second resource the
+          // caller never learns about.
+          //
+          // Narrowing only — `false` or `undefined`, never `true`. A `true`
+          // here would bypass ky's own remaining checks, including the one
+          // that retries `413` only when the response carries a retry-timing
+          // header. Deferring keeps that behavior exactly as it is.
+          //
+          // This is the gate rather than `beforeRetry` because ky awaits the
+          // full backoff delay before running that hook: rejecting there
+          // means sleeping ~300ms first, every time, to reach a decision
+          // that never depended on waiting.
+          shouldRetry: ({ error }: { error: Error }): false | undefined =>
+            error instanceof HTTPError &&
+            !RETRY_RULES.transport.retryable({
+              status: error.response.status,
+              method: error.request.method,
+            })
+              ? false
+              : undefined,
         }
       : retry;
 
@@ -166,18 +199,35 @@ export class HttpTransport implements ITransport, IGatewayOperations {
         ],
         beforeRetry: tokenRefresher
           ? [
+              // Whether to retry is `shouldRetry`'s decision, above. This
+              // hook runs only once a retry is already confirmed, and does
+              // the one thing it is for: put a fresh credential on the
+              // request before it goes out again.
               async ({ request, error }) => {
                 if (!(error instanceof HTTPError) || error.response.status !== 401) {
                   return undefined;
                 }
+
+                // A 401 earns its retry only if a fresh credential arrives.
+                // Without one, repeating the request just gets rejected
+                // again, so the caller should have the 401 now.
+                //
+                // Stop by RETHROWING, never with `ky.stop`: `stop` resolves
+                // the caller's promise with `undefined`, after which the
+                // `.json()` shortcut dereferences nothing and the caller
+                // catches a TypeError instead of the auth failure. A
+                // rethrown original keeps ky's request-error path, so
+                // `beforeError` still runs and callers see the `APIError`
+                // they have always seen.
+                let newToken: string | null;
                 try {
-                  const newToken = await tokenRefresher();
-                  if (!newToken) return ky.stop;
-                  request.headers.set('Authorization', `Bearer ${newToken}`);
-                  return undefined;
+                  newToken = await tokenRefresher();
                 } catch {
-                  return ky.stop;
+                  throw error;
                 }
+                if (!newToken) throw error;
+                request.headers.set('Authorization', `Bearer ${newToken}`);
+                return undefined;
               },
             ]
           : [],

--- a/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
+++ b/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
@@ -563,10 +563,82 @@ describe('AnnotationDetection', () => {
 
       const totalChunks = client.calls.length;
       expect(totalChunks).toBeGreaterThan(1);
+      // A boundary sits BETWEEN chunks: N chunks → N−1 boundary events. Each
+      // carries (consumedChars, totalChars) — characters, not ordinals, because
+      // chunk sizing is now decided as the run goes and there is no chunk total
+      // to divide by. The cursor was always the more honest numerator anyway:
+      // boundary-seeking made chunks unequal long before sizing did, so
+      // "chunk 3 of 10" was never 30% of the document.
       expect(onChunk.mock.calls.length).toBe(totalChunks - 1);
-      onChunk.mock.calls.forEach(([completed, total], idx) => {
-        expect(completed).toBe(idx + 1);
-        expect(total).toBe(totalChunks);
+      let previous = 0;
+      onChunk.mock.calls.forEach(([consumed, total]) => {
+        expect(consumed).toBeGreaterThan(previous);
+        expect(consumed).toBeLessThan(bigContent.length);
+        expect(total).toBe(bigContent.length);
+        previous = consumed;
+      });
+    });
+
+    // ── adaptive sizing, end to end (DETECTION-QUALITY-THROUGHPUT P2) ──────
+    //
+    // `detectInChunks` is ONE loop shared by highlight, comment, assessment and
+    // tag — four of the five detection types. The reference path has the same
+    // tests in its own suite; without these, mutating this loop to discard the
+    // measurement it just took left every suite green.
+    describe('adaptive chunk sizing', () => {
+      // Separate ceilings, so the window leaves headroom above the 1:2 density
+      // guess (a shared window is allocated to the last token by construction).
+      const HEADROOM_LIMITS = { contextTokens: 4_000, maxOutputTokens: 1_200, outputTokensPerHour: 3_600_000_000 };
+      const longContent = Array.from(
+        { length: 900 },
+        (_, i) => `Paragraph ${i} states something ordinary about the subject under study.`,
+      ).join(' ');
+
+      /** Records each model call's prompt length; the scaffold is constant, so
+       * differences between prompts ARE differences between chunks. */
+      function sizingClient(usage?: { inputTokens: number; outputTokens: number }) {
+        const promptChars: number[] = [];
+        const client = {
+          type: 'mock' as const,
+          modelId: 'mock-model',
+          limits: async () => HEADROOM_LIMITS,
+          generateText: async () => '[]',
+          generateStructured: async (prompt: string) => {
+            promptChars.push(prompt.length);
+            return { items: [], stopReason: 'end_turn', ...(usage ? { usage } : {}) };
+          },
+        } as unknown as InferenceClient;
+        return { client, promptChars };
+      }
+
+      it('grows the chunk once measured output shows the budget going unused', async () => {
+        const { client, promptChars } = sizingClient({ inputTokens: 400, outputTokens: 60 });
+
+        await AnnotationDetection.detectHighlights(longContent, client);
+
+        expect(promptChars.length).toBeGreaterThan(2);
+        expect(promptChars[1]!).toBeGreaterThan(promptChars[0]! * 1.2);
+        expect(promptChars[2]!).toBeGreaterThan(promptChars[1]! * 1.2);
+      });
+
+      it('eases the chunk down once measured output nears the budget', async () => {
+        const { client, promptChars } = sizingClient({ inputTokens: 400, outputTokens: 1_150 });
+
+        await AnnotationDetection.detectHighlights(longContent, client);
+
+        expect(promptChars.length).toBeGreaterThan(2);
+        expect(promptChars[1]!).toBeLessThan(promptChars[0]! * 0.85);
+      });
+
+      it('holds the chunk when the provider reports no usage at all', async () => {
+        // Absent is not zero — see the identical case on the reference path.
+        const { client, promptChars } = sizingClient();
+
+        await AnnotationDetection.detectHighlights(longContent, client);
+
+        expect(promptChars.length).toBeGreaterThan(2);
+        const steady = promptChars.slice(0, -1);
+        expect(Math.max(...steady) - Math.min(...steady)).toBeLessThan(steady[0]! * 0.05);
       });
     });
 
@@ -616,14 +688,16 @@ describe('AnnotationDetection', () => {
         const activity: Array<[number, number]> = [];
         const pending = AnnotationDetection.detectHighlights(
           testContent, client, undefined, undefined, undefined,
-          (completed, total) => activity.push([completed, total]),
+          (consumed, total) => activity.push([consumed, total]),
         );
 
         await vi.advanceTimersByTimeAsync(45_000);
 
         expect(activity.length).toBeGreaterThanOrEqual(2);
         // Liveness, not invented progress: the position never advances (D3).
-        expect(activity.every(([completed, total]) => completed === 0 && total === 1)).toBe(true);
+        // …and it does NOT invent progress: the cursor stays put (D3). Nothing
+        // has been consumed, because the one call has not returned.
+        expect(activity.every(([consumed, total]) => consumed === 0 && total === testContent.length)).toBe(true);
 
         finish({ items: [], stopReason: 'end_turn' });
         await pending;

--- a/packages/jobs/src/__tests__/workers/detection/chunk-cursor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/chunk-cursor.test.ts
@@ -1,0 +1,285 @@
+/**
+ * `runAdaptiveChunks` — the lazy cursor that makes `nextChunkSize` real.
+ *
+ * `chunk-size-controller.test.ts` pins the sizing RULE in isolation; the rule
+ * changed nothing until something cut text with it. The gap between those two
+ * files is the whole of DETECTION-QUALITY-THROUGHPUT P2: `chunkText` fixes every
+ * boundary up front from provider limits alone, so a measurement taken on chunk
+ * N has nowhere to land. This driver cuts chunk N+1 only after chunk N has
+ * reported, which is the only ordering in which feedback can act.
+ *
+ * What is asserted here is the LOOP, not the rule: that the cursor covers the
+ * document exactly once however the size moves, that a reported outcome reaches
+ * the next cut, and that progress stays exact while the denominator it used to
+ * be divided by no longer exists.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  runAdaptiveChunks,
+  deriveDetectionBudget,
+  type AdaptiveChunk,
+} from '../../../workers/detection/detection-chunking';
+import type { CallOutcome } from '../../../workers/detection/chunk-size-controller';
+
+/** Ollama shape — a shared window, the config the live gate runs on. No
+ * published output rate, so the assumed-floor duration bound applies, exactly
+ * as it does in production. (The budget suite's `outputTokensPerHour:
+ * 3_600_000_000` exists to switch that bound OFF while pinning allocation
+ * arithmetic; borrowing it here would test a provider that does not exist.) */
+const LIMITS = { contextTokens: 32_768, maxOutputTokens: 32_768 };
+const budgetFor = (typesPerCall = 1) => deriveDetectionBudget(LIMITS, 500, typesPerCall);
+
+/** Prose long enough to need many chunks, with real sentence boundaries for the
+ * cutter to find. Content never enters the sizing — only its length matters. */
+function prose(sentences: number): string {
+  return Array.from(
+    { length: sentences },
+    (_, i) => `Sentence number ${i} carries some ordinary words for the cutter to break on.`,
+  ).join(' ');
+}
+
+/** Run the driver, recording every chunk it hands out, answering each with a
+ * fixed outcome. */
+async function run(
+  text: string,
+  outcome: (chunk: AdaptiveChunk, outputBudget: number) => CallOutcome,
+  typesPerCall = 1,
+) {
+  const seen: AdaptiveChunk[] = [];
+  const budget = budgetFor(typesPerCall);
+  await runAdaptiveChunks(text, budget, async (chunk) => {
+    seen.push(chunk);
+    return outcome(chunk, budget.outputBudget);
+  });
+  return { seen, budget };
+}
+
+/** An outcome that leaves most of the budget unused — the grow signal. */
+const sparse = (budget: number): CallOutcome => ({ outputTokens: Math.floor(budget * 0.1), truncated: false });
+/** An outcome that nearly fills it — the ease-off signal. */
+const dense = (budget: number): CallOutcome => ({ outputTokens: Math.floor(budget * 0.95), truncated: false });
+/** Squarely inside the band — hold. */
+const steady = (budget: number): CallOutcome => ({ outputTokens: Math.floor(budget * 0.65), truncated: false });
+
+describe('runAdaptiveChunks', () => {
+  it('covers the document exactly once, in order, however the size moves', async () => {
+    // The safety property that must survive adaptivity: no text may be skipped
+    // and no chunk may fail to advance. Overlap means pieces re-read each
+    // other's edges (by design — a span on a boundary must be seeable whole),
+    // so coverage is asserted by the cursor, not by concatenating pieces.
+    const text = prose(400);
+    const { seen } = await run(text, (_c, out) => sparse(out));
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen[0]!.at).toBe(0);
+    for (const [i, chunk] of seen.entries()) {
+      expect(chunk.piece.length).toBeGreaterThan(0);
+      expect(chunk.next).toBeGreaterThan(chunk.at);
+      expect(chunk.totalChars).toBe(text.length);
+      if (i > 0) expect(chunk.at).toBe(seen[i - 1]!.next);
+    }
+    expect(seen.at(-1)!.next).toBeGreaterThanOrEqual(text.length);
+  });
+
+  it('makes a one-chunk document one call, with no sizing at all', async () => {
+    // Adaptivity must not cost the small-document case its single call.
+    const { seen } = await run('A short document that fits in one chunk.', () => ({ outputTokens: 1, truncated: false }));
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ at: 0, piece: 'A short document that fits in one chunk.' });
+  });
+
+  it('grows the next cut when a call leaves the output budget unused', async () => {
+    // The calibration case, end to end: the sizer said grow, and the CUTTER
+    // must have obeyed. `chunkText` cannot express this at all — every one of
+    // its boundaries is fixed before the first call returns.
+    const { seen } = await run(prose(1500), (_c, out) => sparse(out));
+
+    expect(seen.length).toBeGreaterThan(2);
+    expect(seen[1]!.piece.length).toBeGreaterThan(seen[0]!.piece.length);
+    // And it keeps growing while the evidence keeps saying so.
+    expect(seen[2]!.piece.length).toBeGreaterThan(seen[1]!.piece.length);
+  });
+
+  it('eases the next cut down when a call nears the budget', async () => {
+    const { seen } = await run(prose(600), (_c, out) => dense(out));
+
+    expect(seen.length).toBeGreaterThan(2);
+    // Against the SHRINK FACTOR, not merely "shorter". Boundary-seeking alone
+    // makes a later cut a little shorter than an earlier one, so `<` passes on
+    // a loop that ignores the sizer entirely — measured: mutating the feedback
+    // away left this test green. The step has to be visible as a step.
+    expect(seen[1]!.piece.length).toBeLessThan(seen[0]!.piece.length * 0.8);
+    expect(seen[2]!.piece.length).toBeLessThan(seen[1]!.piece.length * 0.8);
+  });
+
+  it('stops at the end instead of re-cutting the tail it just returned', async () => {
+    // `chunkText` backed the cursor off by the overlap unconditionally, so
+    // after the chunk that reached the end it took ONE more — covering only
+    // text that chunk already contained. Measured across four document sizes,
+    // every one paid exactly one extra inference call whose entire span sat
+    // inside its predecessor, yielding nothing but duplicate spans for the
+    // dedupe layer to drop. One free call per document, per detection type.
+    const { seen } = await run(prose(1500), (_c, out) => steady(out));
+
+    // Measured against the text FRONTIER, not the cursor: `next` is deliberately
+    // backed off by the overlap, so a chunk that re-reads its predecessor whole
+    // still reports a `next` past it. What must advance is the furthest
+    // character any piece has actually carried.
+    let frontier = 0;
+    for (const [i, chunk] of seen.entries()) {
+      const reach = chunk.at + chunk.piece.length;
+      expect(reach, `chunk ${i} at ${chunk.at} carries no text past ${frontier}`).toBeGreaterThan(frontier);
+      frontier = reach;
+    }
+  });
+
+  it('shrinks after a chunk that only succeeded by subdividing', async () => {
+    // `truncated` here means "the size did not fit", including a chunk that
+    // subdivision rescued. Paying the descent and then re-cutting at the same
+    // size would pay it again on the next chunk.
+    const { seen } = await run(prose(600), (_c, out) => ({ outputTokens: Math.floor(out * 0.1), truncated: true }));
+
+    expect(seen[1]!.piece.length).toBeLessThan(seen[0]!.piece.length);
+  });
+
+  it('holds the opening size end to end when the provider reports no usage', async () => {
+    // The whole loop's version of the same rule: against a provider that never
+    // reports token counts, an adaptive run must be indistinguishable from the
+    // static one it replaced — not a run that climbs to the ceiling because
+    // "nothing reported" was read as "nothing produced".
+    const { seen } = await run(prose(1500), () => ({ truncated: false }));
+
+    const lengths = seen.slice(0, -1).map((c) => c.piece.length);
+    expect(lengths.length).toBeGreaterThan(2);
+    expect(Math.max(...lengths) - Math.min(...lengths)).toBeLessThan(lengths[0]! * 0.05);
+  });
+
+  it('holds the opening size while the evidence stays inside the band', async () => {
+    // No drift when nothing is learned: a steady document is cut the way
+    // `chunkText` would have cut it.
+    const { seen } = await run(prose(600), (_c, out) => steady(out));
+
+    const lengths = seen.slice(0, -1).map((c) => c.piece.length);
+    const spread = Math.max(...lengths) - Math.min(...lengths);
+    // Boundary-seeking still moves each cut a little; sizing does not.
+    expect(spread).toBeLessThan(lengths[0]! * 0.25);
+  });
+
+  it('never cuts above the provider ceiling, however sparse the document', async () => {
+    const { seen, budget } = await run(prose(3000), (_c, out) => sparse(out));
+
+    // The ceiling is a token budget; chars are the cutter's unit. `cutChunk`
+    // takes chunkSize * 4 chars, so that product is the bound a piece cannot
+    // pass. (Boundary-seeking only ever cuts a piece SHORTER.)
+    for (const chunk of seen) {
+      expect(chunk.piece.length).toBeLessThanOrEqual(budget.bounds.ceiling * 4);
+    }
+    // It actually reached up, rather than passing vacuously.
+    expect(Math.max(...seen.map((c) => c.piece.length))).toBeGreaterThan(budget.chunking.chunkSize * 4);
+  });
+
+  it('never cuts below the floor, however dense', async () => {
+    const { seen, budget } = await run(prose(3000), (_c, out) => ({ outputTokens: out, truncated: true }));
+
+    const floorChars = budget.bounds.floor * 4;
+    // Every piece but the last (a remainder, legitimately short) respects it.
+    for (const chunk of seen.slice(0, -1)) {
+      // Boundary-seeking can trim up to half, which is the cutter's own
+      // contract; the floor bounds the REQUEST, so half of it bounds the piece.
+      expect(chunk.piece.length).toBeGreaterThan(floorChars / 2);
+    }
+    expect(budget.bounds.floor).toBeLessThanOrEqual(budget.chunking.chunkSize);
+  });
+
+  it('reports exact character progress that never runs backwards', async () => {
+    // The denominator adaptivity destroys. `i / chunks.length` needed a chunk
+    // count known in advance; with sizes moving there is none, and a PROJECTED
+    // count would make a shrink look like regress. Characters are exact, and
+    // were always more honest than chunk index — boundary-seeking already made
+    // chunks unequal, so "chunk 3 of 10" was never 30% of the document.
+    const text = prose(800);
+    let previous = -1;
+    let flip = false;
+    await run(text, (chunk, out) => {
+      expect(chunk.at).toBeGreaterThan(previous);
+      expect(chunk.at).toBeLessThan(text.length);
+      previous = chunk.at;
+      // Alternate grow/shrink so the size genuinely moves both ways.
+      flip = !flip;
+      return flip ? sparse(out) : dense(out);
+    });
+    expect(previous).toBeGreaterThan(0);
+  });
+
+  it('propagates a failure from a chunk without advancing past it', async () => {
+    // A chunk that throws must stop the run where it stands: the cursor is
+    // what CHUNK-GRAIN-RESUME will checkpoint, and a cursor that advanced past
+    // an unprocessed chunk would checkpoint a lie.
+    const seen: AdaptiveChunk[] = [];
+    const budget = budgetFor();
+    await expect(runAdaptiveChunks(prose(600), budget, async (chunk) => {
+      seen.push(chunk);
+      if (seen.length === 2) throw new Error('chunk 2 failed');
+      return sparse(budget.outputBudget);
+    })).rejects.toThrow('chunk 2 failed');
+
+    expect(seen).toHaveLength(2);
+  });
+});
+
+describe('deriveDetectionBudget bounds', () => {
+  it('opens at the density guess and ceilings at what the window can actually hold', async () => {
+    // The 1:2 allocation is a GUESS about density — the only one #1121 left in
+    // place — and it is the number the sizer exists to replace with
+    // measurement. So it opens the run, and the window fit (context minus
+    // scaffold minus the reserved output budget) is the hard cap above it.
+    const budget = budgetFor();
+    expect(budget.bounds.ceiling).toBeGreaterThan(budget.chunking.chunkSize);
+    expect(budget.bounds.floor).toBeLessThanOrEqual(budget.chunking.chunkSize);
+    expect(budget.bounds.outputBudget).toBe(budget.outputBudget);
+  });
+
+  it('has no headroom when a shared window is fully allocated — and says so', async () => {
+    // The honest edge. A shared window with a published rate high enough to
+    // disable the duration bound is allocated to the last token: input + output
+    // + scaffold IS the context. Input cannot then grow without shrinking the
+    // output reservation, which this phase does not size — so the ceiling meets
+    // the opening and the sizer keeps only its ease-off half. That is a
+    // property of the provider's shape, not a defect, and it is pinned here so
+    // a later reading of `ceiling === chunkSize` is not mistaken for a bug.
+    const allocated = deriveDetectionBudget(
+      { contextTokens: 32_768, maxOutputTokens: 32_768, outputTokensPerHour: 3_600_000_000 }, 500, 1,
+    );
+    expect(allocated.bounds.ceiling).toBe(allocated.chunking.chunkSize);
+    expect(allocated.chunking.chunkSize + allocated.outputBudget + 500).toBe(32_768);
+  });
+
+  it('leaves headroom on every provider shape, shared window included', async () => {
+    // The ceiling cannot be read off either derived input number. On a SHARED
+    // window (Ollama — what the live gate runs) the 1:3 split and the duration
+    // rescale both preserve input = outputBudget / 2 exactly, so both come back
+    // AT the density guess: a ceiling taken from them is 1.00x, and the growth
+    // half of this feature would be dead on precisely the self-hosted providers
+    // it was built for. Measured from the window instead, every shape has room.
+    for (const limits of [
+      { contextTokens: 32_768, maxOutputTokens: 32_768 },                                     // shared
+      { contextTokens: 200_000, maxOutputTokens: 64_000, outputTokensPerHour: 128_000 },      // separate ceilings
+      { contextTokens: 200_000, maxOutputTokens: 8_000 },                                     // small output ceiling
+    ]) {
+      const b = deriveDetectionBudget(limits, 500, 1);
+      expect(b.bounds.ceiling).toBeGreaterThan(b.chunking.chunkSize * 2);
+      // And the ceiling still FITS: a full-size chunk leaves the whole output
+      // budget room beside it inside the context window.
+      expect(b.bounds.ceiling + b.outputBudget + 500).toBeLessThanOrEqual(limits.contextTokens);
+    }
+  });
+
+  it('keeps the floor under the opening size even on a cramped window', async () => {
+    // A window barely wide enough to chunk at all must still produce usable
+    // bounds rather than floor > opening, which would clamp every proposal up.
+    const cramped = deriveDetectionBudget({ contextTokens: 4_000, maxOutputTokens: 4_000 }, 3_000, 1);
+    expect(cramped.bounds.floor).toBeLessThanOrEqual(cramped.chunking.chunkSize);
+    expect(cramped.bounds.ceiling).toBeGreaterThanOrEqual(cramped.chunking.chunkSize);
+  });
+});

--- a/packages/jobs/src/__tests__/workers/detection/chunk-size-controller.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/chunk-size-controller.test.ts
@@ -74,6 +74,21 @@ describe('nextChunkSize', () => {
     expect(next).toBe(Math.floor(5_333 * 3)); // 15,999 — the policy governed, not the default
   });
 
+  it('holds when the provider reported no usage — absent is not zero', () => {
+    // `usage` is optional on the inference interface and BOTH shipped clients
+    // emit it conditionally. Reading its absence as zero output would put
+    // utilization at 0%%, i.e. below `growBelow`, i.e. grow — every chunk, all
+    // the way to the ceiling, having measured nothing at all. The sizer moves
+    // on evidence or it does not move.
+    expect(nextChunkSize({ truncated: false }, 1_000, BOUNDS)).toBe(1_000);
+  });
+
+  it('still shrinks on a truncation with no usage reported', () => {
+    // A truncation IS evidence — the chunk demonstrably did not fit — and it
+    // needs no count to say so. Only the count-based branch requires a count.
+    expect(nextChunkSize({ truncated: true }, 1_000, BOUNDS)).toBe(700);
+  });
+
   it('holds on a degenerate (zero) budget rather than dividing by zero', () => {
     const next = nextChunkSize({ outputTokens: 0, truncated: false }, 6_000, { ...BOUNDS, outputBudget: 0 });
     expect(next).toBe(6_000);

--- a/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/detection-chunking.test.ts
@@ -233,7 +233,7 @@ describe('callChunkSubdividing', () => {
 
   it('passes a successful call through untouched — one invocation, no subdivision', async () => {
     const calls: string[] = [];
-    const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
+    const { items: result } = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
       calls.push(piece);
       return { items: ['a', 'b'] };
     });
@@ -243,7 +243,7 @@ describe('callChunkSubdividing', () => {
 
   it('a timeout on the full chunk retries with smaller pieces and collects their results', async () => {
     const calls: string[] = [];
-    const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
+    const { items: result } = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
       calls.push(piece);
       if (piece.length === CHUNK.length) throw new InferenceTimeoutError('bound');
       return { items: [`ok:${piece.length}`] };
@@ -261,7 +261,7 @@ describe('callChunkSubdividing', () => {
       new StructuredReadError('response is not valid JSON', 'max_tokens'),
     ]) {
       let first = true;
-      const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
+      const { items: result } = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
         if (first) { first = false; throw boom; }
         return { items: [piece.length] };
       });
@@ -280,7 +280,7 @@ describe('callChunkSubdividing', () => {
     // descend and change nothing.
     const calls: string[] = [];
     let first = true;
-    const result = await callChunkSubdividing('reference', CHUNK, CHUNKING, async (piece) => {
+    const { items: result } = await callChunkSubdividing('reference', CHUNK, CHUNKING, async (piece) => {
       calls.push(piece);
       if (first) { first = false; throw new StructuredReadError('response is not valid JSON', 'unknown'); }
       return { items: [piece.length] };
@@ -330,7 +330,7 @@ describe('callChunkSubdividing', () => {
     // returns the identical collapse, so changing the input is the one lever.
     const calls: string[] = [];
     let first = true;
-    const result = await callChunkSubdividing('reference', CHUNK, CHUNKING, async (piece) => {
+    const { items: result } = await callChunkSubdividing('reference', CHUNK, CHUNKING, async (piece) => {
       calls.push(piece);
       if (first) { first = false; throw new YieldCollapseError('found 3 of 50 counted mentions', [], { found: 3, counted: 50, pieceChars: 100 }); }
       return { items: [piece.length] };
@@ -348,7 +348,7 @@ describe('callChunkSubdividing', () => {
   describe('accepted pieces report their count', () => {
     it('every successful piece with a count reports it', async () => {
       const counts: number[] = [];
-      const result = await callChunkSubdividing('reference', CHUNK, CHUNKING,
+      const { items: result } = await callChunkSubdividing('reference', CHUNK, CHUNKING,
         async () => ({ items: ['a', 'b'], counted: 7 }),
         undefined, undefined, (c) => { counts.push(c); });
       expect(result).toEqual(['a', 'b']);
@@ -382,7 +382,7 @@ describe('callChunkSubdividing', () => {
       const tiny = 'word '.repeat(20);
       const counts: number[] = [];
       const reported: unknown[] = [];
-      const result = await callChunkSubdividing<string>(
+      const { items: result } = await callChunkSubdividing<string>(
         'reference', tiny, { chunkSize: 1_000, overlap: 16 },
         async () => { throw new YieldCollapseError('found 1 of 4', ['kept'], { found: 1, counted: 4, pieceChars: tiny.length }); },
         undefined, (v) => { reported.push(v); }, (c) => { counts.push(c); });
@@ -411,7 +411,7 @@ describe('callChunkSubdividing', () => {
       );
       const reported: unknown[] = [];
 
-      const result = await callChunkSubdividing<string>(
+      const { items: result } = await callChunkSubdividing<string>(
         'reference', tiny, { chunkSize: 1_000, overlap: 16 },
         async () => { throw boom; },
         undefined,
@@ -424,7 +424,7 @@ describe('callChunkSubdividing', () => {
 
     it('a successful call reports nothing', async () => {
       const reported: unknown[] = [];
-      const result = await callChunkSubdividing('entity', CHUNK, CHUNKING,
+      const { items: result } = await callChunkSubdividing('entity', CHUNK, CHUNKING,
         async () => ({ items: ['a'] }), undefined, (v) => { reported.push(v); });
       expect(result).toEqual(['a']);
       expect(reported).toEqual([]);
@@ -433,7 +433,7 @@ describe('callChunkSubdividing', () => {
     it('a collapse healed by descent reports nothing — the descent is telemetry, not result', async () => {
       let first = true;
       const reported: unknown[] = [];
-      const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
+      const { items: result } = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
         if (first) {
           first = false;
           throw new YieldCollapseError('found 3 of 50', [], verdictOf(3, 50, piece.length));
@@ -455,7 +455,7 @@ describe('callChunkSubdividing', () => {
     it('descends and keeps the other pieces’ work', async () => {
       const calls: string[] = [];
       let first = true;
-      const result = await callChunkSubdividing('reference', CHUNK, CHUNKING, async (piece) => {
+      const { items: result } = await callChunkSubdividing('reference', CHUNK, CHUNKING, async (piece) => {
         calls.push(piece);
         if (first) { first = false; throw new StructuredReadError('response is not valid JSON', 'end_turn'); }
         return { items: [piece.length] };
@@ -516,7 +516,7 @@ describe('callChunkSubdividing', () => {
     const boom = new YieldCollapseError('found 1 of 4 counted mentions', ['the-one-found'], { found: 1, counted: 4, pieceChars: 100 });
     const tiny = 'word '.repeat(20); // ~25 tokens — fits any half-size here
     const calls: string[] = [];
-    const result = await callChunkSubdividing<string>('reference', tiny, { chunkSize: 1_000, overlap: 16 }, async (piece) => {
+    const { items: result } = await callChunkSubdividing<string>('reference', tiny, { chunkSize: 1_000, overlap: 16 }, async (piece) => {
       calls.push(piece);
       throw boom;
     });
@@ -551,7 +551,7 @@ describe('callChunkSubdividing', () => {
     const warn = vi.fn();
     const logger = { warn, info: vi.fn(), debug: vi.fn(), error: vi.fn() } as never;
 
-    const result = await callChunkSubdividing<string>('reference', small, { chunkSize: 8, overlap: 16 }, async (piece) => {
+    const { items: result } = await callChunkSubdividing<string>('reference', small, { chunkSize: 8, overlap: 16 }, async (piece) => {
       calls.push(piece);
       throw boom;
     }, logger);
@@ -588,7 +588,7 @@ describe('callChunkSubdividing', () => {
     // overlap-derived size floor — only size-based descent can get there.
     const BIG = Array.from({ length: 400 }, (_, i) => `entry ${i} lorem ipsum dolor sit amet `).join('');
     const succeededAt: number[] = [];
-    const result = await callChunkSubdividing('entity', BIG, { chunkSize: 4_000, overlap: 16 }, async (piece) => {
+    const { items: result } = await callChunkSubdividing('entity', BIG, { chunkSize: 4_000, overlap: 16 }, async (piece) => {
       if (piece.length > 1_200) throw new StructuredReadError('response is not valid JSON', 'max_tokens');
       succeededAt.push(piece.length);
       return { items: [piece.length] };
@@ -603,7 +603,7 @@ describe('callChunkSubdividing', () => {
     // re-roll usually escapes; the deterministic rethrow alone would kill
     // a job the same piece passes on the next roll.
     const seen = new Map<string, number>();
-    const result = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
+    const { items: result } = await callChunkSubdividing('entity', CHUNK, CHUNKING, async (piece) => {
       const n = (seen.get(piece) ?? 0) + 1;
       seen.set(piece, n);
       if (n === 1) throw new StructuredReadError('response is not valid JSON', 'max_tokens');
@@ -704,7 +704,7 @@ describe('callChunkSubdividing telemetry', () => {
     // RESOLVES — but the call's own record still says 'collapsed': acceptance
     // is a policy above the telemetry, and the metric is the durable trace of
     // every under-report, accepted or not.
-    const result = await callChunkSubdividing<string>('reference', 'a'.repeat(400), { chunkSize: 8, overlap: 16 }, async () => {
+    const { items: result } = await callChunkSubdividing<string>('reference', 'a'.repeat(400), { chunkSize: 8, overlap: 16 }, async () => {
       throw new YieldCollapseError('found 3 of 50 counted mentions', [], { found: 3, counted: 50, pieceChars: 100 });
     });
     expect(result).toEqual([]);

--- a/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
@@ -296,12 +296,19 @@ describe('extractEntities', () => {
 
       const totalChunks = client.calls.length;
       expect(totalChunks).toBeGreaterThan(1);
-      // A boundary sits between chunks: N chunks → N−1 boundary events, each
-      // (completedChunks, totalChunks) with completedChunks increasing.
+      // A boundary sits BETWEEN chunks: N chunks → N−1 boundary events. Each
+      // carries (consumedChars, totalChars) — characters, not ordinals, because
+      // chunk sizing is now decided as the run goes and there is no chunk total
+      // to divide by. The cursor was always the more honest numerator anyway:
+      // boundary-seeking made chunks unequal long before sizing did, so
+      // "chunk 3 of 10" was never 30% of the document.
       expect(onChunk.mock.calls.length).toBe(totalChunks - 1);
-      onChunk.mock.calls.forEach(([completed, total], idx) => {
-        expect(completed).toBe(idx + 1);
-        expect(total).toBe(totalChunks);
+      let previous = 0;
+      onChunk.mock.calls.forEach(([consumed, total]) => {
+        expect(consumed).toBeGreaterThan(previous);
+        expect(consumed).toBeLessThan(bigText.length);
+        expect(total).toBe(bigText.length);
+        previous = consumed;
       });
     });
 
@@ -410,10 +417,11 @@ describe('extractEntities', () => {
         } as unknown as InferenceClient;
 
         const activity: Array<[number, number]> = [];
+        const content = 'Alice went to Paris.';
         // Small content → exactly one chunk → zero boundary events.
         const pending = extractEntities(
-          'Alice went to Paris.', ['Person'], client, false, LOGGER, undefined,
-          (completed, total) => activity.push([completed, total]),
+          content, ['Person'], client, false, LOGGER, undefined,
+          (consumed, total) => activity.push([consumed, total]),
         );
 
         // Let limits()/derivation settle, then sit inside the model call.
@@ -421,14 +429,84 @@ describe('extractEntities', () => {
 
         // Liveness arrived without any chunk boundary being crossed…
         expect(activity.length).toBeGreaterThanOrEqual(2);
-        // …and it does NOT invent progress: the count stays put (D3).
-        expect(activity.every(([completed, total]) => completed === 0 && total === 1)).toBe(true);
+        // …and it does NOT invent progress: the cursor stays put (D3). Nothing
+        // has been consumed, because the one call has not returned.
+        expect(activity.every(([consumed, total]) => consumed === 0 && total === content.length)).toBe(true);
 
         finish({ items: [], stopReason: 'end_turn' });
         await pending;
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    // ── adaptive sizing, end to end (DETECTION-QUALITY-THROUGHPUT P2) ──────
+    //
+    // The driver and the sizing rule have their own suites. What only a test
+    // here can show is that THIS loop is wired to them: that a measurement
+    // taken on chunk N reaches the cut of chunk N+1, through
+    // `callChunkSubdividing`'s outcome and `runAdaptiveChunks`' cursor.
+    describe('adaptive chunk sizing', () => {
+      // Separate ceilings, so the window leaves real headroom above the 1:2
+      // density guess. (The shared-window fixture above is allocated to the
+      // last token by construction — nothing to grow into.)
+      const HEADROOM_LIMITS = { contextTokens: 4_000, maxOutputTokens: 1_200, outputTokensPerHour: 3_600_000_000 };
+      const longText = Array.from(
+        { length: 900 },
+        (_, i) => `Paragraph ${i} mentions Alice and Bob among some ordinary filler words.`,
+      ).join(' ');
+
+      /** Records each model call's prompt length. The scaffold is constant, so
+       * differences between prompts ARE differences between chunks. */
+      function sizingClient(usage?: { inputTokens: number; outputTokens: number }) {
+        const promptChars: number[] = [];
+        const client = {
+          type: 'mock' as const,
+          modelId: 'mock-model',
+          limits: async () => HEADROOM_LIMITS,
+          generateText: async () => '[]',
+          generateStructured: async (prompt: string) => {
+            promptChars.push(prompt.length);
+            return { items: [], stopReason: 'end_turn', ...(usage ? { usage } : {}) };
+          },
+        } as unknown as InferenceClient;
+        return { client, promptChars };
+      }
+
+      it('grows the chunk once measured output shows the budget going unused', async () => {
+        // 60 of a 1200-token budget — 5%%, far under `growBelow`.
+        const { client, promptChars } = sizingClient({ inputTokens: 400, outputTokens: 60 });
+
+        await extractEntities(longText, ['Person'], client, false, LOGGER);
+
+        expect(promptChars.length).toBeGreaterThan(2);
+        expect(promptChars[1]!).toBeGreaterThan(promptChars[0]! * 1.2);
+        expect(promptChars[2]!).toBeGreaterThan(promptChars[1]! * 1.2);
+      });
+
+      it('holds the chunk when the provider reports no usage at all', async () => {
+        // `usage` is optional on the inference interface. Absent must read as
+        // "nothing measured" and hold — never as "produced nothing", which is
+        // 0%% utilization and would grow every chunk to the ceiling having
+        // learned nothing. Against a silent provider an adaptive run is
+        // indistinguishable from the static one it replaced.
+        const { client, promptChars } = sizingClient();
+
+        await extractEntities(longText, ['Person'], client, false, LOGGER);
+
+        expect(promptChars.length).toBeGreaterThan(2);
+        const steady = promptChars.slice(0, -1);
+        expect(Math.max(...steady) - Math.min(...steady)).toBeLessThan(steady[0]! * 0.05);
+      });
+
+      it('eases the chunk down once measured output nears the budget', async () => {
+        const { client, promptChars } = sizingClient({ inputTokens: 400, outputTokens: 1_150 });
+
+        await extractEntities(longText, ['Person'], client, false, LOGGER);
+
+        expect(promptChars.length).toBeGreaterThan(2);
+        expect(promptChars[1]!).toBeLessThan(promptChars[0]! * 0.85);
+      });
     });
 
     it('makes exactly one call and no boundary reports when content fits the derived budget', async () => {

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -379,7 +379,7 @@ export async function processHighlightJob(
   await AnnotationDetection.detectHighlights(
     content, inferenceClient, params.instructions, params.density, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
-    (completed, total) => onProgress(30 + Math.round((completed / total) * 30), { code: 'analyzing' }, echo),
+    (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
     async (matches) => {
       found += matches.length;
       // Highlights carry no body — motivation:'highlighting' on a target
@@ -447,7 +447,7 @@ export async function processCommentJob(
     content, inferenceClient, params.instructions, params.tone, params.density,
     params.language, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
-    (completed, total) => onProgress(30 + Math.round((completed / total) * 30), { code: 'analyzing' }, echo),
+    (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
     async (comments) => {
       found += comments.length;
       const fresh = dedupe(comments.map((c) =>
@@ -493,7 +493,7 @@ export async function processAssessmentJob(
     content, inferenceClient, params.instructions, params.tone, params.density,
     params.language, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
-    (completed, total) => onProgress(30 + Math.round((completed / total) * 30), { code: 'analyzing' }, echo),
+    (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
     async (assessments) => {
       found += assessments.length;
       const fresh = dedupe(assessments.map((a) =>
@@ -748,8 +748,8 @@ export async function processTagJob(
       content, inferenceClient, params.schema, category, params.sourceLanguage,
       // Liveness (chunk boundaries + in-flight heartbeat): this category's
       // slice of the 30–60 band.
-      (completed, total) => onProgress(
-        30 + Math.round(((c + completed / total) / params.categories.length) * 30),
+      (consumedChars, totalChars) => onProgress(
+        30 + Math.round(((c + consumedChars / totalChars) / params.categories.length) * 30),
         { code: 'analyzing-tags' },
         position(),
       ),

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -11,9 +11,9 @@
  */
 
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
-import { chunkText, estimateTokens } from '@semiont/core';
+import { estimateTokens } from '@semiont/core';
 import { boundedGenerateStructured } from './inference-call';
-import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, DETECTION_TEMPERATURE } from './detection/detection-chunking';
+import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, DETECTION_TEMPERATURE } from './detection/detection-chunking';
 import { MotivationPrompts } from './detection/motivation-prompts';
 import {
   MotivationParsers,
@@ -52,7 +52,7 @@ async function detectInChunks<T>(
   motivation: string,
   elementSchema: ElementSchema,
   parse: (items: unknown[]) => T[],
-  onActivity?: (completedChunks: number, totalChunks: number) => void,
+  onActivity?: (consumedChars: number, totalChars: number) => void,
   /**
    * This chunk's parsed matches, awaited before the loop continues: the
    * caller commits them, and the loop must not run ahead of durability.
@@ -65,33 +65,38 @@ async function detectInChunks<T>(
   const scaffoldTokens = estimateTokens(buildPrompt(''));
   // One motivation's spans per call — the single span family this prompt
   // asks for, the motivation-path analogue of one entity type.
-  const { chunking, outputBudget } = deriveDetectionBudget(limits, scaffoldTokens, 1);
-  const chunks = chunkText(content, chunking);
+  const budget = deriveDetectionBudget(limits, scaffoldTokens, 1);
+  const { outputBudget } = budget;
 
   const collected: T[] = [];
-  for (let i = 0; i < chunks.length; i++) {
+  await runAdaptiveChunks(content, budget, async ({ piece: chunk, size, at, next, totalChars }) => {
     // Structured surface: parsed elements or a throw — an unreadable model
     // response fails the job rather than reading as an empty detection. A
     // size-shaped failure (duration bound, truncation) subdivides in place
     // and retries smaller before it is allowed to fail the job.
-    const items = await callChunkSubdividing<unknown>(motivation, chunks[i]!, chunking, async (piece) => {
-      const response = await boundedGenerateStructured<unknown>(
-        client, buildPrompt(piece), outputBudget, DETECTION_TEMPERATURE, elementSchema,
-        // Still alive, same position (a long single call is otherwise silent).
-        () => onActivity?.(i, chunks.length),
-      );
-      assertNotTruncated(response, `${motivation} detection`, i + 1, chunks.length, outputBudget);
-      // Usage rides back so the telemetry record carries what the call COST
-      // beside what it yielded — the provider's own counts, not an estimate.
-      return { items: response.items, ...(response.usage ? { usage: response.usage } : {}) };
-    });
+    const { items, outcome } = await callChunkSubdividing<unknown>(
+      motivation, chunk, { chunkSize: size, overlap: budget.chunking.overlap },
+      async (piece) => {
+        const response = await boundedGenerateStructured<unknown>(
+          client, buildPrompt(piece), outputBudget, DETECTION_TEMPERATURE, elementSchema,
+          // Still alive, same position (a long single call is otherwise silent).
+          () => onActivity?.(at, totalChars),
+        );
+        assertNotTruncated(response, `${motivation} detection`, at, totalChars, outputBudget);
+        // Usage rides back so the telemetry record carries what the call COST
+        // beside what it yielded — the provider's own counts, not an estimate.
+        return { items: response.items, ...(response.usage ? { usage: response.usage } : {}) };
+      },
+    );
     const fromChunk = parse(items);
     collected.push(...fromChunk);
     await onChunkResults?.(fromChunk);
-    if (i < chunks.length - 1) {
-      onActivity?.(i + 1, chunks.length);
-    }
-  }
+    // Chunk boundary: the cursor advances (real progress). Only when text
+    // remains — the final cut has no boundary after it, and the caller reports
+    // the unit's completion itself.
+    if (next < totalChars) onActivity?.(next, totalChars);
+    return outcome;
+  });
   return collected;
 }
 
@@ -113,7 +118,7 @@ export class AnnotationDetection {
     density?: number,
     language?: string,
     sourceLanguage?: string,
-    onActivity?: (completedChunks: number, totalChunks: number) => void,
+    onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
     onChunkResults?: (matches: CommentMatch[]) => Promise<void>,
   ): Promise<CommentMatch[]> {
@@ -140,7 +145,7 @@ export class AnnotationDetection {
     instructions?: string,
     density?: number,
     sourceLanguage?: string,
-    onActivity?: (completedChunks: number, totalChunks: number) => void,
+    onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
     onChunkResults?: (matches: HighlightMatch[]) => Promise<void>,
   ): Promise<HighlightMatch[]> {
@@ -169,7 +174,7 @@ export class AnnotationDetection {
     density?: number,
     language?: string,
     sourceLanguage?: string,
-    onActivity?: (completedChunks: number, totalChunks: number) => void,
+    onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
     onChunkResults?: (matches: AssessmentMatch[]) => Promise<void>,
   ): Promise<AssessmentMatch[]> {
@@ -201,7 +206,7 @@ export class AnnotationDetection {
     schema: TagSchema,
     category: string,
     sourceLanguage?: string,
-    onActivity?: (completedChunks: number, totalChunks: number) => void,
+    onActivity?: (consumedChars: number, totalChars: number) => void,
     /**
      * This chunk's matches, ANCHORED before they leave: `parse` here yields
      * raw tags, so this path runs `validateTagOffsets` per chunk — a per-item

--- a/packages/jobs/src/workers/detection/chunk-size-controller.ts
+++ b/packages/jobs/src/workers/detection/chunk-size-controller.ts
@@ -1,5 +1,5 @@
 /**
- * Adaptive chunk sizing (DETECTION-QUALITY-THROUGHPUT P2) — DRAFT.
+ * Adaptive chunk sizing (DETECTION-QUALITY-THROUGHPUT P2) — the sizing RULE.
  *
  * `deriveDetectionBudget` picks ONE input size for every document from provider
  * limits alone. It cannot see the document, so it is sized for a worst-case
@@ -14,7 +14,9 @@
  * halved-and-retried, a chunk that outruns the guillotine times out and is
  * halved-and-retried. So the sizer does not model truncation or duration; it
  * only keeps chunks in a band that uses the budget well, and the net below it
- * forgives an overshoot. That safety net is why this is a step rule and not a
+ * forgives an overshoot. `bounds.ceiling` is therefore the WINDOW fit, not either
+ * derived input size: on a shared window both of those come back at exactly the
+ * density guess this function exists to replace, leaving nothing to grow into. That safety net is why this is a step rule and not a
  * control loop (user direction, 2026-09-04: keep it simple).
  *
  * "Maximize, don't predict": the only thing that grows a chunk is a MEASURED
@@ -22,9 +24,11 @@
  * (#1121's ban). Re-evaluated every chunk, so it tracks a gradient (sparse
  * intro → dense index) rather than betting the run on the first sample.
  *
- * Pure and feedback-only — unit-testable in isolation. Wiring into
- * `detectInChunks` (and the checkpoint interaction a variable boundary implies)
- * is the GREEN step, deliberately not here.
+ * Pure and feedback-only — unit-testable in isolation. The loop that applies it is
+ * `runAdaptiveChunks` in `detection-chunking.ts`, which both detection paths drive:
+ * `extractEntities` (reference) and `detectInChunks` (highlight, comment, assessment,
+ * tag). It cuts chunk N+1 only after chunk N has reported, which is the only ordering
+ * in which this function's output can reach anything.
  */
 
 /** What one chunk's call produced — the minimum the sizer needs. Duration and
@@ -32,8 +36,15 @@
  * backstopped by subdivision, so utilization is the only signal that sizing
  * acts on. (P1 telemetry records the fuller picture separately.) */
 export interface CallOutcome {
-  /** Provider-reported output tokens for the chunk. */
-  outputTokens: number;
+  /** Provider-reported output tokens for the chunk, ABSENT when the provider
+   * reported none.
+   *
+   * Absent is not zero. `usage` is optional on the inference interface and both
+   * real clients emit it conditionally, so a run against a provider that stays
+   * silent would read as "this chunk produced nothing", i.e. 0%% of the budget,
+   * i.e. grow — every chunk, to the ceiling, on no evidence whatsoever. That is
+   * the precise inverse of "maximize, don't predict". Unmeasured holds. */
+  outputTokens?: number;
   /** The chunk hit a size-shaped bound (truncation or the guillotine), even if
    * subdivision then recovered it. Forces a shrink regardless of the count —
    * the signal that the last size was too big for this stretch. */
@@ -98,7 +109,7 @@ function clamp(value: number, lo: number, hi: number): number {
  *
  * A truncated chunk, or one whose output filled more than `shrinkAbove` of the
  * budget, eases the next chunk down; one that used less than `growBelow` grows
- * it; in between, hold. Always clamped to `[floor, ceiling]`. That is the whole
+ * it; in between — or with nothing measured at all — hold. Always clamped to `[floor, ceiling]`. That is the whole
  * rule — the hard bounds are subdivision's job, not this function's.
  */
 export function nextChunkSize(
@@ -112,6 +123,9 @@ export function nextChunkSize(
   const hold = () => clamp(current, bounds.floor, bounds.ceiling);
 
   if (outcome.truncated) return shrink();
+  // No measurement, no move. A truncation above is evidence even without a
+  // count; an absent count on its own is not.
+  if (outcome.outputTokens === undefined) return hold();
   // A zero/absent budget cannot inform utilization; hold rather than divide by
   // zero or grow blindly.
   if (bounds.outputBudget <= 0) return hold();

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -24,11 +24,12 @@
  *   not a cost.
  */
 
-import { chunkText, type ChunkingConfig, type Logger } from '@semiont/core';
+import { chunkText, cutChunk, type ChunkingConfig, type Logger } from '@semiont/core';
 import { StructuredReadError, type InferenceLimits, type TokenUsage } from '@semiont/inference';
 import { recordDetectionCall } from '@semiont/observability';
 import { DeterministicJobError } from '../../failure-class';
 import { INFERENCE_TIMEOUT_MS, InferenceTimeoutError } from '../inference-call';
+import { nextChunkSize, type CallOutcome, type SizingBounds } from './chunk-size-controller';
 
 /**
  * A `max_tokens` stop reason means the model's JSON was cut off mid-stream.
@@ -42,9 +43,9 @@ import { INFERENCE_TIMEOUT_MS, InferenceTimeoutError } from '../inference-call';
  * input truncates the same way, so a retry is guaranteed waste and the
  * throw carries the deterministic class (ABANDONED-INFERENCE P3, A4).
  */
-export function assertNotTruncated(response: { stopReason: string }, label: string, chunk: number, totalChunks: number, outputBudget: number): void {
+export function assertNotTruncated(response: { stopReason: string }, label: string, at: number, totalChars: number, outputBudget: number): void {
   if (response.stopReason === 'max_tokens') {
-    throw new DeterministicJobError(`${label} response truncated (max_tokens) on chunk ${chunk}/${totalChunks} despite the derived output budget of ${outputBudget} tokens — failing the job rather than under-reporting annotations.`);
+    throw new DeterministicJobError(`${label} response truncated (max_tokens) at character ${at} of ${totalChars} despite the derived output budget of ${outputBudget} tokens — failing the job rather than under-reporting annotations.`);
   }
 }
 
@@ -138,10 +139,15 @@ export class YieldCollapseError extends DeterministicJobError {
 }
 
 export interface DetectionBudget {
-  /** Feed to `chunkText` — `chunkSize` is the derived input budget (tokens). */
+  /** The chunk size a run OPENS at (tokens), plus the overlap every cut keeps.
+   * Opening, not fixed: `runAdaptiveChunks` moves the size within `bounds` as
+   * the document reports what it actually costs. */
   chunking: ChunkingConfig;
   /** Pass as `maxTokens` on every per-chunk inference call. */
   outputBudget: number;
+  /** How far the sizer may move the chunk size, in either direction. Derived
+   * from the same provider arithmetic — never tuning. */
+  bounds: SizingBounds;
 }
 
 /**
@@ -221,6 +227,20 @@ export function deriveDetectionBudget(
   // The demand is PER TYPE ASKED FOR, so a K-type call divides the input
   // share by K. Still no density modeling: same one policy, content never
   // enters.
+  // The window fit: the largest input that still leaves the WHOLE output budget
+  // room beside it. This is the sizer's ceiling, and it is the only hard bound
+  // on input there is — the two derivations above are not.
+  //
+  // The 1:2 rule below is a GUESS about how much output a chunk will demand,
+  // and on a shared window it is baked into the 1:3 split as well, which is why
+  // the ceiling cannot be read off either of them (both come back at exactly
+  // the guess, leaving no room to grow into on precisely the self-hosted
+  // providers the live gate runs). The duration bound is real but bounds
+  // GENERATION, so it belongs to `outputBudget`; it reaches input only through
+  // the same ratio guess. `nextChunkSize` exists to replace that guess with
+  // measurement, so the guess opens the run and the window caps it.
+  const capacityInput = contextTokens - scaffoldTokens - outputBudget;
+
   inputBudget = Math.min(inputBudget, Math.floor(outputBudget / (2 * typesPerCall)));
 
   if (inputBudget <= OVERLAP_TOKENS) {
@@ -232,7 +252,69 @@ export function deriveDetectionBudget(
   return {
     chunking: { chunkSize: inputBudget, overlap: OVERLAP_TOKENS },
     outputBudget,
+    bounds: {
+      // Two overlaps: at the floor a chunk is still half text it has not seen
+      // before, so the cursor keeps making progress rather than re-reading its
+      // own tail. Clamped under the opening size, because a cramped window can
+      // derive an opening below even that — and a floor above the opening would
+      // clamp every proposal upward, silently reversing the sizer.
+      floor: Math.min(inputBudget, 2 * OVERLAP_TOKENS),
+      // Never below the opening: a degenerate window can make the fit
+      // arithmetic smaller than the size already chosen, and a ceiling under
+      // the opening would clamp every proposal DOWN on the first call.
+      ceiling: Math.max(inputBudget, capacityInput),
+      outputBudget,
+    },
   };
+}
+
+/** One chunk handed out by `runAdaptiveChunks`, with the cursor either side of
+ * it. `at`/`next` over `totalChars` is exact progress — and, once
+ * CHUNK-GRAIN-RESUME lands, the checkpoint identity a variable boundary forces
+ * (an ordinal cannot name a chunk whose size is decided while the job runs). */
+export interface AdaptiveChunk {
+  piece: string;
+  /** The token size this piece was cut at. Hand it to `callChunkSubdividing`:
+   * a descent halves from the size that actually failed, not from the size the
+   * run opened at, which adaptivity has long since left behind. */
+  size: number;
+  /** Characters consumed BEFORE this chunk — the in-flight liveness position. */
+  at: number;
+  /** Characters consumed once this chunk completes — the boundary position. */
+  next: number;
+  /** The document's length. */
+  totalChars: number;
+}
+
+/**
+ * Walk a document in chunks whose size is decided by the chunks before them.
+ *
+ * `chunkText` fixes every boundary up front from provider limits alone, which
+ * is why the sizing rule could exist for a week and change nothing: a
+ * measurement taken on chunk N had nowhere to land. Here chunk N+1 is cut only
+ * after chunk N has reported, so the run opens at the static density guess and
+ * then moves — a sparse document climbing toward the window's real capacity
+ * (fewer, bigger calls), a dense one easing off before it pays a subdivision.
+ *
+ * `onChunk` returns what the chunk cost. It is awaited, so the caller's own
+ * durability (committing the chunk's annotations) still gates the next cut, and
+ * a throw stops the walk where it stands rather than advancing past unprocessed
+ * text.
+ */
+export async function runAdaptiveChunks(
+  text: string,
+  budget: DetectionBudget,
+  onChunk: (chunk: AdaptiveChunk) => Promise<CallOutcome>,
+): Promise<void> {
+  let at = 0;
+  let size = budget.chunking.chunkSize;
+
+  while (at < text.length) {
+    const { piece, next } = cutChunk(text, at, { chunkSize: size, overlap: budget.chunking.overlap });
+    const outcome = await onChunk({ piece, size, at, next, totalChars: text.length });
+    at = next;
+    size = nextChunkSize(outcome, size, budget.bounds);
+  }
 }
 
 /**
@@ -305,6 +387,15 @@ function truncation(error: unknown): boolean {
  * span-keyed dedupe. On a failure subdivision cannot fix, the ORIGINAL
  * error propagates so classification sees what actually happened.
  */
+/** What `callChunkSubdividing` produced AND what it cost — the second half is
+ * what `runAdaptiveChunks` sizes the next chunk from. Accumulated across the
+ * whole descent, because the caller's own `call` closure sees one piece at a
+ * time and cannot know a subdivision happened at all. */
+export interface SubdividedCall<T> {
+  items: T[];
+  outcome: CallOutcome;
+}
+
 export interface ChunkCallResult<T> {
   items: T[];
   /** The provider's own token counts, when it reported any. Never estimated. */
@@ -340,7 +431,17 @@ export async function callChunkSubdividing<T>(
    * nothing: its children's counts replace it, or the same text is priced
    * twice. */
   onCounted?: (counted: number) => void,
-): Promise<T[]> {
+): Promise<SubdividedCall<T>> {
+  // The chunk's cost, summed over however many calls its descent takes. Both
+  // are recorded where EVERY call passes, so a subdivision cannot hide from
+  // them.
+  let outputTokens = 0;
+  let sizeShaped = false;
+  // A descent's calls must ALL report usage for the sum to mean anything: a
+  // partial sum under-counts, and under-counting biases toward growth — the
+  // one direction that costs a truncation to discover was wrong.
+  let callsMade = 0;
+  let callsMeasured = 0;
   // One telemetry record per model call, successes AND failures
   // (DETECTION-QUALITY-THROUGHPUT P1). This is the only place `depth` and
   // `reroll` exist, so it is the only place a complete record can be written.
@@ -348,6 +449,11 @@ export async function callChunkSubdividing<T>(
     const start = performance.now();
     try {
       const result = await call(piece);
+      callsMade += 1;
+      if (result.usage) {
+        callsMeasured += 1;
+        outputTokens += result.usage.outputTokens;
+      }
       recordDetectionCall({
         label, pieceChars: piece.length, durationMs: performance.now() - start,
         items: result.items.length, depth, reroll, outcome: 'success',
@@ -372,6 +478,10 @@ export async function callChunkSubdividing<T>(
       return (await recorded(piece, depth, false)).items;
     } catch (error) {
       if (!subdividable(error)) throw error;
+      // Size-shaped, so the size was wrong — true whether or not the descent
+      // below rescues it. The next chunk must not be cut at a size this one
+      // already paid to discover was too big.
+      sizeShaped = true;
       const half = Math.floor(chunkSize / 2);
       // Truncation descends by SIZE: demand halves with each subdivision,
       // so descent terminates — and list-dense text (registers, indexes)
@@ -432,5 +542,10 @@ export async function callChunkSubdividing<T>(
       return collected;
     }
   }
-  return attempt(chunk, chunking.chunkSize, 0);
+  const items = await attempt(chunk, chunking.chunkSize, 0);
+  const measured = callsMade > 0 && callsMeasured === callsMade;
+  return {
+    items,
+    outcome: { truncated: sizeShaped, ...(measured ? { outputTokens } : {}) },
+  };
 }

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -1,7 +1,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
-import { chunkText, estimateTokens, getLocaleEnglishName, isObject, isString, type Logger } from '@semiont/core';
+import { estimateTokens, getLocaleEnglishName, isObject, isString, type Logger } from '@semiont/core';
 import { boundedGenerateStructured, boundedGenerateWithMetadata } from '../inference-call';
-import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, DETECTION_TEMPERATURE, YIELD_COLLAPSE_BAND, YieldCollapseError, type UnderReportedPiece } from './detection-chunking';
+import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, DETECTION_TEMPERATURE, YIELD_COLLAPSE_BAND, YieldCollapseError, type UnderReportedPiece } from './detection-chunking';
 
 /**
  * Entity reference extracted from text — pre-reconciliation.
@@ -61,10 +61,13 @@ const ENTITY_ELEMENT_SCHEMA: ElementSchema = {
  *   anchor decisions, drops). Required so dropped/filtered entities never
  *   disappear silently.
  * @param sourceLanguage - BCP-47 tag for the source content's language
- * @param onActivity - Invoked with (completedChunks, totalChunks) whenever
- *   the extraction is demonstrably alive: at each chunk boundary (the count
+ * @param onActivity - Invoked with (consumedChars, totalChars) whenever the
+ *   extraction is demonstrably alive: at each chunk boundary (the cursor
  *   advances) AND periodically while a single inference call is in flight
- *   (the count repeats — liveness, not progress). The caller MUST forward
+ *   (the position repeats — liveness, not progress). Characters, not chunk
+ *   ordinals: chunk sizing is decided as the run goes, so there is no chunk
+ *   total to divide by — and the cursor was always the more honest numerator,
+ *   since boundary-seeking already made chunks unequal. The caller MUST forward
  *   this to its progress channel: progress is the worker's liveness
  *   heartbeat for the stall watchdog, and the client's timeout is an
  *   INTER-EMISSION one, so a silent single-chunk run kills a healthy job
@@ -151,7 +154,7 @@ export async function extractEntities(
   includeDescriptiveReferences: boolean,
   logger: Logger,
   sourceLanguage?: string,
-  onActivity?: (completedChunks: number, totalChunks: number) => void,
+  onActivity?: (consumedChars: number, totalChars: number) => void,
   /** A floor-accepted piece's evidence, as it is accepted. */
   onUnderReport?: (verdict: UnderReportedPiece) => void,
   /** Each accepted piece's count-verifier expectation — the denominator. */
@@ -244,59 +247,68 @@ Example output:
   const scaffoldTokens = estimateTokens(buildPrompt(''));
   // One call asks for every type in `entityTypes` — the processor's per-type
   // loop passes one, so this is 1 in production today.
-  const { chunking, outputBudget } = deriveDetectionBudget(limits, scaffoldTokens, entityTypes.length);
-  const chunks = chunkText(exact, chunking);
+  const budget = deriveDetectionBudget(limits, scaffoldTokens, entityTypes.length);
+  const { chunking, outputBudget } = budget;
 
   logger.debug('Sending entity extraction request', {
     entityTypes: entityTypesDescription,
-    chunks: chunks.length,
-    chunkSizeTokens: chunking.chunkSize,
+    chars: exact.length,
+    // The size the run OPENS at, and how far measured yield may move it. The
+    // chunk COUNT is deliberately absent: with sizing decided as the run goes,
+    // there is no honest total until the cursor reaches the end.
+    openingChunkSizeTokens: chunking.chunkSize,
+    ceilingChunkSizeTokens: budget.bounds.ceiling,
     outputBudget,
   });
 
   const collected: ExtractedEntity[] = [];
-  for (let i = 0; i < chunks.length; i++) {
+  await runAdaptiveChunks(exact, budget, async ({ piece: chunk, size, at, next, totalChars }) => {
     // The structured surface returns parsed elements or THROWS — an
     // unreadable model response is a job failure, never a silent []. A
     // size-shaped failure (duration bound, truncation) subdivides in place
     // and retries smaller before it is allowed to fail the job.
-    const items = await callChunkSubdividing<unknown>('reference', chunks[i]!, chunking, async (piece) => {
-      const response = await boundedGenerateStructured<unknown>(
-        client,
-        buildPrompt(piece),
-        outputBudget,
-        DETECTION_TEMPERATURE,
-        ENTITY_ELEMENT_SCHEMA,
-        // Still alive, same position: a long single call would otherwise emit
-        // nothing at all between start and finish.
-        () => onActivity?.(i, chunks.length),
-        logger,
-      );
-      logger.debug('Got entity extraction response', {
-        chunk: i + 1,
-        chunks: chunks.length,
-        pieceChars: piece.length,
-        items: response.items.length,
-      });
+    const { items, outcome } = await callChunkSubdividing<unknown>(
+      'reference', chunk, { chunkSize: size, overlap: chunking.overlap },
+      async (piece) => {
+        const response = await boundedGenerateStructured<unknown>(
+          client,
+          buildPrompt(piece),
+          outputBudget,
+          DETECTION_TEMPERATURE,
+          ENTITY_ELEMENT_SCHEMA,
+          // Still alive, same position: a long single call would otherwise emit
+          // nothing at all between start and finish.
+          () => onActivity?.(at, totalChars),
+          logger,
+        );
+        logger.debug('Got entity extraction response', {
+          at,
+          totalChars,
+          chunkSizeTokens: size,
+          pieceChars: piece.length,
+          items: response.items.length,
+        });
 
-      // Truncation is data loss, not "no entities" — check it BEFORE
-      // consuming: a truncated structured response can still carry a valid
-      // partial array, so the items themselves cannot signal the loss.
-      assertNotTruncated(response, 'Entity extraction', i + 1, chunks.length, outputBudget);
-      // And a CLEAN response can still be a silent under-report (F7) — the
-      // count-verifier is the only signal for that, and a flag throws the
-      // collapse verdict so subdivision changes the input.
-      const counted = verifyYield
-        ? await assertYieldNotCollapsed(client, piece, response.items, entityTypesDescription, logger)
-        : undefined;
-      // Usage rides back so the telemetry record carries what the call COST
-      // beside what it yielded — the provider's own counts, not an estimate.
-      return {
-        items: response.items,
-        ...(response.usage ? { usage: response.usage } : {}),
-        ...(counted !== undefined ? { counted } : {}),
-      };
-    }, logger, onUnderReport, onCounted);
+        // Truncation is data loss, not "no entities" — check it BEFORE
+        // consuming: a truncated structured response can still carry a valid
+        // partial array, so the items themselves cannot signal the loss.
+        assertNotTruncated(response, 'Entity extraction', at, totalChars, outputBudget);
+        // And a CLEAN response can still be a silent under-report (F7) — the
+        // count-verifier is the only signal for that, and a flag throws the
+        // collapse verdict so subdivision changes the input.
+        const counted = verifyYield
+          ? await assertYieldNotCollapsed(client, piece, response.items, entityTypesDescription, logger)
+          : undefined;
+        // Usage rides back so the telemetry record carries what the call COST
+        // beside what it yielded — the provider's own counts, not an estimate.
+        return {
+          items: response.items,
+          ...(response.usage ? { usage: response.usage } : {}),
+          ...(counted !== undefined ? { counted } : {}),
+        };
+      },
+      logger, onUnderReport, onCounted,
+    );
 
     const fromChunk: ExtractedEntity[] = [];
     for (const e of items) {
@@ -316,11 +328,12 @@ Example output:
     collected.push(...fromChunk);
     await onChunkResults?.(fromChunk);
 
-    // Chunk boundary: the count advances (real progress).
-    if (i < chunks.length - 1) {
-      onActivity?.(i + 1, chunks.length);
-    }
-  }
+    // Chunk boundary: the cursor advances (real progress). Only when text
+    // remains — the final cut has no boundary after it, and the caller reports
+    // the unit's completion itself.
+    if (next < totalChars) onActivity?.(next, totalChars);
+    return outcome;
+  });
 
   return collected;
 }


### PR DESCRIPTION
Four places decided "is this failure worth another attempt": the boot predicate in core, the job classifier, the HTTP transport's ky config, and the inference SDK's default. Two of them argued their case; two were bare lists. Where a list and an argument disagreed, the list won silently, and no reader of either file could see the other existed. This PR gives those rules one home, fixes the one place where an inherited default could corrupt data, and — on the detection side — wires up a sizing rule that had been sitting without a caller.

## One catalog of retry rules (`@semiont/core`)

`retry-rules.ts` holds `boot`, `job` and `transport` together **because they disagree**: a 500 mid-job is worth another attempt, while the same 500 in a boot pass replays whatever broke it. The defect was never the divergence — it was that the divergence was undeclared. Each rule carries its name, its reasoning, and a predicate.

- **`RetryRule` is not `RetryPolicy`.** The policy next door is a timing budget (how long to keep trying); a rule is which failures to try again at all. Two different questions about the same attempt.
- **The census gate is reachability.** Rules are exported only through the frozen `RETRY_RULES` record, so a rule missing from it cannot be consumed by anyone — stronger than a parallel list a new rule could simply be left out of.
- **Facts include the request method, not just the status.** A 504 on a GET is safe to repeat; a 504 on a POST may already have been processed. A status set cannot say "401 on any method, 5xx on idempotent methods only", which is exactly what the transport needs to say. An unstated method reads as unsafe — absence is not permission.
- `isRetryableRequestError` now derives its status half from the boot rule instead of keeping a second copy of `{429, 503, 504}` in the same package. Provably behavior-neutral: identical statuses.

## A retried POST can no longer write a second resource (`@semiont/http-transport`)

When a token refresher is configured, the transport widened ky's retry to every method so that a 401 could reach the refresh. Widening the method list also admitted POST and PATCH for 408, 413, 429 and every 5xx — a side effect of adding 401, never a decision.

Enumerating the client's POST/PATCH calls: seven of eight are safe to repeat. The eighth is the resource upload, which mints its id client-side, so a duplicate after an ambiguous 502 writes **a second resource to the event log** and the caller only ever learns the second id. The exposure is runtime-split: browsers take the XHR path, which was never retried, so this was a server-side SDK bug — the KB fleet, my-chat, agents. A second, different bug sat behind `yield.cloneFrom`, which passes no options and so takes the ky path everywhere: its clone token is single-use, so it does not duplicate, it fails a create that actually succeeded.

- The transport rule is now the gate, through ky's `shouldRetry`: **401 on any method, every other retryable status on idempotent methods only.**
- It only ever narrows — `false` or `undefined`, never `true` — so ky's own remaining checks still apply, including the one that retries 413 only when the response carries a retry-timing header.
- `shouldRetry` rather than `beforeRetry`, because ky awaits the full backoff before running the latter: rejecting there meant sleeping ~300ms every time to reach a decision that never depended on waiting.
- ky's `methods`/`statusCodes` stay as a **superset pre-filter**, since narrowing them back would stop a POST/401 from reaching the refresh at all. A census test fails if they drift below what the rule can approve (verified to fail on deliberate growth).
- **A pre-existing defect, fixed here:** a failed token refresh returned `ky.stop`, which resolves the caller's promise with `undefined` — the `.json()` shortcut then dereferenced nothing and the caller caught `TypeError: Cannot read properties of undefined` instead of the 401. It rethrows now, so callers see the same `APIError` every other failure produces.

## Detection sizes each chunk from what the last one cost (`@semiont/jobs`, `@semiont/core`)

The sizing rule existed for a week and changed nothing, because every chunk boundary was fixed up front from provider limits alone: a measurement taken on chunk N had nowhere to land.

- **`runAdaptiveChunks` is the single cursor both detection loops drive** — reference detection and the four motivation types — and `cutChunk` in core is the single boundary rule it shares with `chunkText`. `callChunkSubdividing` now returns what a chunk produced *and* what it cost, accumulated across a whole subdivision descent, so the cost reaches the next cut.
- A run opens at the static density guess and then moves: a sparse document climbs toward the window's real capacity (fewer, larger calls), a dense one eases off before it pays for a subdivision.
- **The ceiling is the window fit** (context − scaffold − output budget), not the static input budget. Measured, the latter leaves exactly 1.00x headroom on every shared-window provider — growth would have been dead on the configuration the live gate runs. Headroom by provider: 5.17x on a shared 32K window, 35.4x on 200K/64K, 185x on 1M/64K. A shared window whose published rate disables the duration bound genuinely has no headroom, and that case is pinned as its own test so `ceiling === chunkSize` is never misread as a bug.
- **Absent usage means unmeasured, not zero.** Summing optional usage as `?? 0` would have read "the provider reported nothing" as "the chunk produced nothing" — 0% utilization, i.e. grow every chunk to the ceiling on no evidence. Caught by mutation testing rather than review; in production it would have been invisible, showing up only as chunks quietly getting large.
- **One wasted inference call per document, per detection type, found in passing.** `chunkText` backed its cursor off by the overlap unconditionally, so after the chunk that reached the end it took one more covering only text that chunk already held. Measured at four sizes — 11→10, 30→29, 74→73, 199→198 chunks — with the dropped chunk fully inside its predecessor every time. The smelter embeds through the same path: one fewer redundant embedding, no orphans.
- **Progress units moved** from (completed chunks, total chunks) to (consumed characters, total characters), since sizing decided as the run goes leaves no chunk total to divide by — and characters were always the more honest numerator, because boundary-seeking already made chunks unequal. All four consumers took it unchanged and the N−1 boundary-event contract is preserved exactly.

## Verification

- core 725 tests (2 pre-existing failures are environmental — no git binary in the container image), jobs 592, http-transport 150/150, the sdk session suite 80/80. Typecheck and build clean across core, jobs, make-meaning, sdk and http-transport.
- Five of the transport's new tests drive **real ky** with `fetch` stubbed, because the hook-level suite mocks ky and therefore cannot see what a caller actually receives — which is the contract this change promised not to alter.
- Mutation-tested, with restores by string reversal: the loop ignoring the controller fails 3 driver tests; removing the ceiling fails 2 bounds tests; the `?? 0` bug fails the silent-provider test; each loop dropping its measurement fails its wiring tests. The motivation loop initially bit nothing — four of the five detection types share that loop and the first pass had wiring tests only on the reference path — so it now has three of its own.
- **The chunk-sizing payoff is still a projection.** The shrink half exercises anywhere; the grow half only where the window leaves headroom, so a live run is still owed.

## Still open

The job classifier keeps its own status list for now, and the inference SDK's retry count is still an inherited default rather than a chosen one — both are follow-on work, tracked separately.
