### PR TITLE
A detection job that dies mid-document resumes where it stopped — and the last two retry defaults become decisions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,7 @@ export type {
   JobCommentAnnotationResult,
   JobAssessmentAnnotationResult,
   JobTagAnnotationResult,
+  UnitCursor,
   GenerationJobParams,
   SelectionData,
   JobType,

--- a/packages/core/src/payload-types.ts
+++ b/packages/core/src/payload-types.ts
@@ -28,6 +28,14 @@ export type JobHighlightAnnotationResult = components['schemas']['JobHighlightAn
 export type JobCommentAnnotationResult = components['schemas']['JobCommentAnnotationResult'];
 export type JobAssessmentAnnotationResult = components['schemas']['JobAssessmentAnnotationResult'];
 export type JobTagAnnotationResult = components['schemas']['JobTagAnnotationResult'];
+
+/**
+ * How far one unit of a job got, for a resume that starts mid-unit
+ * (CHUNK-GRAIN-RESUME P2). Spec-owned: it crosses the wire on three job
+ * commands and is read back off the claimed record's metadata, so the queue,
+ * the worker and the Go client all have to mean the same `{ next, size }`.
+ */
+export type UnitCursor = components['schemas']['UnitCursor'];
 /**
  * The `job:create` params shape for `jobType: 'generation'` — one type shared
  * by the write side (sdk `yield.fromContext` → `runGeneration`) and the read

--- a/packages/core/src/retry-rules.ts
+++ b/packages/core/src/retry-rules.ts
@@ -82,7 +82,14 @@ const job: RetryRule = {
     'attempt. 5xx is included where the boot rule excludes it, because the alternative is ' +
     'throwing away paid work over one unclassified fault. 408 joins as an explicit timeout. ' +
     'The price of a wrong "transient" is a re-pay, not a corrupted write — which is what ' +
-    'makes the wider answer affordable here and not at boot.',
+    'makes the wider answer affordable here and not at boot. Two facts, both settled ' +
+    '2026-09-12, say how affordable: a 5xx arriving at a job has ALREADY failed three ' +
+    'times at the call (the inference client retries twice, pinned deliberately — ' +
+    'RETRY-CLASSIFICATION P4), so this is a considered second chance rather than a ' +
+    'hair-trigger; and since CHUNK-GRAIN-RESUME the re-pay is about ONE CHUNK, not the ' +
+    'whole prefix it used to be (~26 min on the 1958 document). Both push the same way. ' +
+    'If either changes — the client stops retrying, or resume stops working — this rule ' +
+    'is the line to revisit.',
   retryable: ({ status }) =>
     status === 408 || status === 429 || (status !== undefined && status >= 500),
 };

--- a/packages/inference/src/__tests__/anthropic.test.ts
+++ b/packages/inference/src/__tests__/anthropic.test.ts
@@ -3,16 +3,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock the Anthropic SDK so we can assert the exact request shape and feed
 // canned responses. `vi.hoisted` makes the mocks available inside the
 // (hoisted) mock factory.
-const { createMock, retrieveMock, streamMock } = vi.hoisted(() => ({
+const { createMock, retrieveMock, streamMock, ctorMock } = vi.hoisted(() => ({
   createMock: vi.fn(),
   retrieveMock: vi.fn(),
   streamMock: vi.fn(),
+  ctorMock: vi.fn(),
 }));
 
 vi.mock('@anthropic-ai/sdk', () => ({
   default: class MockAnthropic {
     messages = { create: createMock, stream: streamMock };
     models = { retrieve: retrieveMock };
+    constructor(options: unknown) { ctorMock(options); }
   },
 }));
 
@@ -27,6 +29,21 @@ const CAPABLE_MODEL = {
   max_tokens: 64_000,
   capabilities: { structured_outputs: { supported: true } },
 };
+
+describe('AnthropicInferenceClient — the retry count is CHOSEN, not inherited', () => {
+  // RETRY-CLASSIFICATION P4. This was the last census site running on an
+  // unchosen vendor default, and that plan's whole finding is that unchosen
+  // defaults win silently. The value below happens to equal SDK 0.123.0's
+  // default, which is the point: writing it down changes no behavior today and
+  // stops a future SDK bump from changing it for us without anyone noticing.
+  it('passes maxRetries explicitly when constructing the SDK client', () => {
+    ctorMock.mockClear();
+    new AnthropicInferenceClient('key', 'model');
+
+    const options = ctorMock.mock.calls[0]![0] as { maxRetries?: number };
+    expect(options.maxRetries).toBe(2);
+  });
+});
 
 describe('AnthropicInferenceClient - structured generation is output_config, not tools or prefill', () => {
   beforeEach(() => {

--- a/packages/inference/src/implementations/anthropic.ts
+++ b/packages/inference/src/implementations/anthropic.ts
@@ -44,6 +44,35 @@ interface ModelDiscovery {
   structuredOutputsSupported: boolean;
 }
 
+/**
+ * Call-level retries, CHOSEN (RETRY-CLASSIFICATION P4) rather than inherited.
+ *
+ * Two is also SDK 0.123.0's default, and writing it down is the point: this was
+ * the last site in that plan's census still running on a vendor default, and the
+ * plan's finding is that unchosen defaults win silently. Pinned, a future SDK
+ * bump cannot change our retry behavior without someone editing this line.
+ *
+ * Two is right here on measured grounds, not taste:
+ * - **Fast failures cost almost nothing.** A 429, 409 or quick 5xx returns in
+ *   seconds, so three attempts are seconds — and the SDK honors `retry-after`,
+ *   which matters more now that entity types run concurrently
+ *   (DETECTION-QUALITY-THROUGHPUT P6) and 429 is the expected pushback.
+ * - **Slow failures never reach the retries.** `boundedGenerateStructured` wraps
+ *   the whole call in one 10-minute timer, and the SDK's own default timeout is
+ *   also 10 minutes, so a hung call trips OUR bound during the first attempt.
+ *
+ * What would change it: a repeatable mid-duration 5xx — a call that generates
+ * for minutes and then fails — is the one shape where these retries hurt, because
+ * attempt-plus-retry can outlast our bound and surface as `InferenceTimeoutError`,
+ * which `callChunkSubdividing` treats as size-shaped and answers by SUBDIVIDING.
+ * Smaller chunks cannot fix a server error. Depth-capping keeps that bounded, and
+ * it has not been observed; if it ever is, lower this number rather than teaching
+ * the subdivider about HTTP.
+ *
+ * Anthropic only. Nothing here is claimed about Ollama's client.
+ */
+const ANTHROPIC_MAX_RETRIES = 2;
+
 export class AnthropicInferenceClient implements InferenceClient {
   readonly type = 'anthropic' as const;
   // Hosted API: a single detection job uses a sliver of the account rate limit
@@ -65,6 +94,7 @@ export class AnthropicInferenceClient implements InferenceClient {
     this.client = new Anthropic({
       apiKey,
       baseURL: baseURL || 'https://api.anthropic.com',
+      maxRetries: ANTHROPIC_MAX_RETRIES,
     });
     this.modelId = model;
     this.logger = logger;

--- a/packages/jobs/src/__tests__/failure-class.test.ts
+++ b/packages/jobs/src/__tests__/failure-class.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { StructuredReadError } from '@semiont/inference';
+import { RETRY_RULES } from '@semiont/core';
 import { classifyFailure, DeterministicJobError } from '../failure-class';
 import { YieldCollapseError } from '../workers/detection/detection-chunking';
 import { InferenceTimeoutError } from '../workers/inference-call';
@@ -29,7 +30,12 @@ describe('classifyFailure (A4)', () => {
   });
 
   it('environmental provider statuses are transient: 408, 429, 5xx', () => {
-    for (const status of [408, 429, 500, 529]) {
+    // 502/503/504 are included deliberately, not for padding: they are exactly
+    // where the three rules DISAGREE — boot retries 503/504 but refuses 500,
+    // transport retries all of them on idempotent methods only, and this rule
+    // takes the whole range. Pinning them here makes the job's answer visible at
+    // the job's own site rather than only in the taxonomy.
+    for (const status of [408, 429, 500, 502, 503, 504, 529]) {
       expect(classifyFailure(Object.assign(new Error(`http ${status}`), { status }))).toBe('transient');
     }
   });
@@ -57,7 +63,22 @@ describe('classifyFailure (A4)', () => {
     expect(classifyFailure(new YieldCollapseError('found 3 of 50 counted mentions', [], { found: 3, counted: 50, pieceChars: 100 }))).toBe('deterministic');
   });
 
-  it('an unreadable structured response with any other stop reason stays retryable — sampling may fix it', () => {
+  it('a depth-exhausted end_turn stays retryable — because the RETRY re-cuts it, not because sampling might', () => {
+    // RETRY-CLASSIFICATION P2, the site 3 ↔ site 5 disagreement, decided
+    // 2026-09-12. This test used to say "sampling may fix it", which was never
+    // true: `DETECTION_TEMPERATURE` is 0, so an identical call returns an
+    // identical answer, and that is precisely `subdividable()`'s argument for
+    // the opposite verdict.
+    //
+    // The real reason it stays retryable arrived with CHUNK-GRAIN-RESUME HD2
+    // (option C): a resumed unit seeds the checkpoint's size and then takes one
+    // shrink step, so the retry reads the poison text in a DIFFERENT piece. The
+    // retry is no longer the same call. And the price of being wrong fell from a
+    // whole re-paid prefix (~26 min on the 1958 document) to one chunk.
+    //
+    // Still `undefined`, not `'transient'`: the wire vocabulary has two values
+    // and this is neither — not weather, but "the next attempt reads different
+    // input". Absent says unrecognised-so-retryable, which is what is true.
     expect(classifyFailure(new StructuredReadError('parsed to object, not an array', 'end_turn'))).toBeUndefined();
   });
 
@@ -73,6 +94,33 @@ describe('classifyFailure (A4)', () => {
     // server deserves its retry budget; the subdivision fix is what keeps the
     // deterministic-in-practice case from burning that budget at same size.
     expect(classifyFailure(new StructuredReadError('response is not valid JSON', 'unknown'))).toBeUndefined();
+  });
+
+  // ── the status branch is DERIVED, not restated (RETRY-CLASSIFICATION P2) ──
+  describe('status classification follows RETRY_RULES.job', () => {
+    it('agrees with the rule on every status, so the two cannot drift apart', () => {
+      // The census's finding was not that four sites disagreed — it was that
+      // two of them asserted a bare list nobody could see was a second opinion,
+      // and where a list and an argument disagreed the LIST won silently. This
+      // is the gate that makes that impossible here: change the rule and this
+      // file follows, change only one and this fails.
+      for (let status = 100; status < 600; status++) {
+        const viaRule = RETRY_RULES.job.retryable({ status });
+        const viaClassifier = classifyFailure({ status }) === 'transient';
+        expect(viaClassifier, `status ${status}`).toBe(viaRule);
+      }
+    });
+
+    it('keeps 413 deterministic — a payload too large is not weather', () => {
+      // Green on arrival, and pinned as a DECISION rather than left as the side
+      // effect of branch order: 413 is below 500 and outside the rule's
+      // transient set, so it falls to the >= 400 rejection branch. The transport
+      // rule retries it (with a Retry-After) and this one does not — a genuine
+      // per-context disagreement, which is what the taxonomy exists to make
+      // visible rather than accidental.
+      expect(classifyFailure({ status: 413 })).toBe('deterministic');
+      expect(RETRY_RULES.job.retryable({ status: 413 })).toBe(false);
+    });
   });
 
   it('everything unrecognized is unclassified — retryable by default (HD2 gates only KNOWN-deterministic)', () => {

--- a/packages/jobs/src/__tests__/job-claim-adapter.test.ts
+++ b/packages/jobs/src/__tests__/job-claim-adapter.test.ts
@@ -303,6 +303,54 @@ describe('claimed-job checkpoint (A3)', () => {
     adapter.dispose();
   });
 
+  it('surfaces metadata.unitCursors on the ActiveJob (CHUNK-GRAIN-RESUME P3)', async () => {
+    const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+    adapter.start();
+
+    h.pushEvent('job:queued', { jobId: 'jc-cur', jobType: 'reference-annotation', resourceId: 'r1' });
+    await new Promise((r) => setTimeout(r, 0));
+    h.pushEvent('job:claimed', {
+      correlationId: h.emits[0]!.payload.correlationId,
+      response: { params: {}, metadata: {
+        userId: 'u1', completedUnits: [],
+        unitCursors: { Person: { next: 12_400, size: 560, found: 20, emitted: 18 } },
+      } },
+    });
+
+    const active = await firstValueFrom(adapter.activeJob$.pipe(skip(1), take(1)));
+    expect(active?.unitCursors).toEqual({ Person: { next: 12_400, size: 560, found: 20, emitted: 18 } });
+
+    adapter.dispose();
+  });
+
+  it('drops a cursor missing its tallies WHOLE rather than resuming without them', async () => {
+    // A position without counts would let the retry take the saving and then
+    // report a terminal record describing only the remainder — the lie HD3
+    // exists to remove. Dropping costs one re-run and yields a true record, and
+    // it is also how a checkpoint written before the tallies existed reads.
+    const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
+    adapter.start();
+
+    h.pushEvent('job:queued', { jobId: 'jc-cur2', jobType: 'reference-annotation', resourceId: 'r1' });
+    await new Promise((r) => setTimeout(r, 0));
+    h.pushEvent('job:claimed', {
+      correlationId: h.emits[0]!.payload.correlationId,
+      response: { params: {}, metadata: {
+        userId: 'u1', completedUnits: [],
+        unitCursors: {
+          Person: { next: 12_400, size: 560 },                              // pre-tally shape
+          Location: { next: 900, size: 300, found: 4, emitted: 4 },          // complete
+        },
+      } },
+    });
+
+    const active = await firstValueFrom(adapter.activeJob$.pipe(skip(1), take(1)));
+    // The position is dropped with the counts — not kept and zero-filled.
+    expect(active?.unitCursors).toEqual({ Location: { next: 900, size: 300, found: 4, emitted: 4 } });
+
+    adapter.dispose();
+  });
+
   it('defaults completedUnits to empty when the record carries none', async () => {
     const adapter = createJobClaimAdapter({ bus: h.bus, jobTypes: [] });
     adapter.start();

--- a/packages/jobs/src/__tests__/job-queue.test.ts
+++ b/packages/jobs/src/__tests__/job-queue.test.ts
@@ -836,21 +836,21 @@ describe('JobQueue', () => {
   describe('checkpointUnits() — per-unit cursors', () => {
     test('records how far an unfinished unit got, beside the finished ones', async () => {
       await jobQueue.createJob(createRunningDetectionJob('job-cur1'));
-      await jobQueue.checkpointUnits(jobId('job-cur1'), [], { Person: { next: 5_000, size: 800 } });
+      await jobQueue.checkpointUnits(jobId('job-cur1'), [], { Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
 
       const j = await jobQueue.getJob(jobId('job-cur1'));
-      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 5_000, size: 800 } });
+      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
       // The unit is NOT complete — that is the whole point of the grain.
       expect(j?.metadata.completedUnits ?? []).toEqual([]);
     });
 
     test('advances a cursor as its unit progresses', async () => {
       await jobQueue.createJob(createRunningDetectionJob('job-cur2'));
-      await jobQueue.checkpointUnits(jobId('job-cur2'), [], { Person: { next: 5_000, size: 800 } });
-      await jobQueue.checkpointUnits(jobId('job-cur2'), [], { Person: { next: 9_000, size: 560 } });
+      await jobQueue.checkpointUnits(jobId('job-cur2'), [], { Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
+      await jobQueue.checkpointUnits(jobId('job-cur2'), [], { Person: { next: 9_000, size: 560, found: 0, emitted: 0 } });
 
       const j = await jobQueue.getJob(jobId('job-cur2'));
-      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 9_000, size: 560 } });
+      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 9_000, size: 560, found: 0, emitted: 0 } });
     });
 
     test('an out-of-order checkpoint never moves a cursor backward', async () => {
@@ -858,24 +858,24 @@ describe('JobQueue', () => {
       // safe here and a last-writer-wins would not: the resume position would
       // regress and the job would re-pay for chunks it already committed.
       await jobQueue.createJob(createRunningDetectionJob('job-cur3'));
-      await jobQueue.checkpointUnits(jobId('job-cur3'), [], { Person: { next: 9_000, size: 560 } });
-      await jobQueue.checkpointUnits(jobId('job-cur3'), [], { Person: { next: 2_000, size: 4_500 } });
+      await jobQueue.checkpointUnits(jobId('job-cur3'), [], { Person: { next: 9_000, size: 560, found: 0, emitted: 0 } });
+      await jobQueue.checkpointUnits(jobId('job-cur3'), [], { Person: { next: 2_000, size: 4_500, found: 0, emitted: 0 } });
 
       const j = await jobQueue.getJob(jobId('job-cur3'));
       // And `size` did not come from the loser either — the pair is ONE
       // observation, and a mix would describe a chunk that never existed.
-      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 9_000, size: 560 } });
+      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 9_000, size: 560, found: 0, emitted: 0 } });
     });
 
     test('tracks each unit independently', async () => {
       await jobQueue.createJob(createRunningDetectionJob('job-cur4'));
-      await jobQueue.checkpointUnits(jobId('job-cur4'), [], { Person: { next: 5_000, size: 800 } });
-      await jobQueue.checkpointUnits(jobId('job-cur4'), [], { Location: { next: 1_200, size: 900 } });
+      await jobQueue.checkpointUnits(jobId('job-cur4'), [], { Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
+      await jobQueue.checkpointUnits(jobId('job-cur4'), [], { Location: { next: 1_200, size: 900, found: 0, emitted: 0 } });
 
       const j = await jobQueue.getJob(jobId('job-cur4'));
       expect(j?.metadata.unitCursors).toEqual({
-        Person: { next: 5_000, size: 800 },
-        Location: { next: 1_200, size: 900 },
+        Person: { next: 5_000, size: 800, found: 0, emitted: 0 },
+        Location: { next: 1_200, size: 900, found: 0, emitted: 0 },
       });
     });
 
@@ -884,7 +884,7 @@ describe('JobQueue', () => {
       // rather than left as a rule every reader has to remember: a completed
       // unit simply has no cursor to misread.
       await jobQueue.createJob(createRunningDetectionJob('job-cur5'));
-      await jobQueue.checkpointUnits(jobId('job-cur5'), [], { Person: { next: 5_000, size: 800 } });
+      await jobQueue.checkpointUnits(jobId('job-cur5'), [], { Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
       await jobQueue.checkpointUnits(jobId('job-cur5'), ['Person']);
 
       const j = await jobQueue.getJob(jobId('job-cur5'));
@@ -897,7 +897,7 @@ describe('JobQueue', () => {
       // that has since completed must not resurrect its cursor.
       await jobQueue.createJob(createRunningDetectionJob('job-cur6'));
       await jobQueue.checkpointUnits(jobId('job-cur6'), ['Person']);
-      await jobQueue.checkpointUnits(jobId('job-cur6'), [], { Person: { next: 5_000, size: 800 } });
+      await jobQueue.checkpointUnits(jobId('job-cur6'), [], { Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
 
       const j = await jobQueue.getJob(jobId('job-cur6'));
       expect(j?.metadata.unitCursors ?? {}).toEqual({});
@@ -920,7 +920,7 @@ describe('JobQueue', () => {
       // so only the durable running-file write can carry the cursor into the
       // re-queued job for a later claim to read.
       await jobQueue.createJob(createRunningDetectionJob('job-cur8'));
-      await jobQueue.checkpointUnits(jobId('job-cur8'), [], { Person: { next: 5_000, size: 800 } });
+      await jobQueue.checkpointUnits(jobId('job-cur8'), [], { Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
 
       const filePath = path.join(project.jobsDir, 'running', 'job-cur8.json');
       const past = new Date(Date.now() - 31 * 60_000);
@@ -929,7 +929,7 @@ describe('JobQueue', () => {
       expect(await jobQueue.recoverStaleRunningJobs()).toBe(1);
       const requeued = await jobQueue.getJob(jobId('job-cur8'));
       expect(requeued?.status).toBe('pending');
-      expect(requeued?.metadata.unitCursors).toEqual({ Person: { next: 5_000, size: 800 } });
+      expect(requeued?.metadata.unitCursors).toEqual({ Person: { next: 5_000, size: 800, found: 0, emitted: 0 } });
     });
   });
 

--- a/packages/jobs/src/__tests__/job-queue.test.ts
+++ b/packages/jobs/src/__tests__/job-queue.test.ts
@@ -825,6 +825,114 @@ describe('JobQueue', () => {
     });
   });
 
+  // ── per-unit cursors (CHUNK-GRAIN-RESUME P2) ──────────────────────────────
+  //
+  // `completedUnits` records whole units, so a job with ONE unit — every
+  // motivation job, and the 1958 document's single `Person` type — could record
+  // nothing until the entire document was done. A cursor is the finer grain, and
+  // it cannot be merged the way a set is: a set only grows, so a union converges
+  // on its own, while a cursor converges only if a stale snapshot can never move
+  // it back.
+  describe('checkpointUnits() — per-unit cursors', () => {
+    test('records how far an unfinished unit got, beside the finished ones', async () => {
+      await jobQueue.createJob(createRunningDetectionJob('job-cur1'));
+      await jobQueue.checkpointUnits(jobId('job-cur1'), [], { Person: { next: 5_000, size: 800 } });
+
+      const j = await jobQueue.getJob(jobId('job-cur1'));
+      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 5_000, size: 800 } });
+      // The unit is NOT complete — that is the whole point of the grain.
+      expect(j?.metadata.completedUnits ?? []).toEqual([]);
+    });
+
+    test('advances a cursor as its unit progresses', async () => {
+      await jobQueue.createJob(createRunningDetectionJob('job-cur2'));
+      await jobQueue.checkpointUnits(jobId('job-cur2'), [], { Person: { next: 5_000, size: 800 } });
+      await jobQueue.checkpointUnits(jobId('job-cur2'), [], { Person: { next: 9_000, size: 560 } });
+
+      const j = await jobQueue.getJob(jobId('job-cur2'));
+      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 9_000, size: 560 } });
+    });
+
+    test('an out-of-order checkpoint never moves a cursor backward', async () => {
+      // Two snapshots in flight; the older one lands last. A union would be
+      // safe here and a last-writer-wins would not: the resume position would
+      // regress and the job would re-pay for chunks it already committed.
+      await jobQueue.createJob(createRunningDetectionJob('job-cur3'));
+      await jobQueue.checkpointUnits(jobId('job-cur3'), [], { Person: { next: 9_000, size: 560 } });
+      await jobQueue.checkpointUnits(jobId('job-cur3'), [], { Person: { next: 2_000, size: 4_500 } });
+
+      const j = await jobQueue.getJob(jobId('job-cur3'));
+      // And `size` did not come from the loser either — the pair is ONE
+      // observation, and a mix would describe a chunk that never existed.
+      expect(j?.metadata.unitCursors).toEqual({ Person: { next: 9_000, size: 560 } });
+    });
+
+    test('tracks each unit independently', async () => {
+      await jobQueue.createJob(createRunningDetectionJob('job-cur4'));
+      await jobQueue.checkpointUnits(jobId('job-cur4'), [], { Person: { next: 5_000, size: 800 } });
+      await jobQueue.checkpointUnits(jobId('job-cur4'), [], { Location: { next: 1_200, size: 900 } });
+
+      const j = await jobQueue.getJob(jobId('job-cur4'));
+      expect(j?.metadata.unitCursors).toEqual({
+        Person: { next: 5_000, size: 800 },
+        Location: { next: 1_200, size: 900 },
+      });
+    });
+
+    test('a unit that completes drops its cursor — the two states are exclusive', async () => {
+      // "Skipped whole, whatever cursor it last carried" is made structural
+      // rather than left as a rule every reader has to remember: a completed
+      // unit simply has no cursor to misread.
+      await jobQueue.createJob(createRunningDetectionJob('job-cur5'));
+      await jobQueue.checkpointUnits(jobId('job-cur5'), [], { Person: { next: 5_000, size: 800 } });
+      await jobQueue.checkpointUnits(jobId('job-cur5'), ['Person']);
+
+      const j = await jobQueue.getJob(jobId('job-cur5'));
+      expect(j?.metadata.completedUnits).toEqual(['Person']);
+      expect(j?.metadata.unitCursors ?? {}).toEqual({});
+    });
+
+    test('a late cursor for an already-completed unit is dropped again', async () => {
+      // The convergence half of the rule above: a stale snapshot naming a unit
+      // that has since completed must not resurrect its cursor.
+      await jobQueue.createJob(createRunningDetectionJob('job-cur6'));
+      await jobQueue.checkpointUnits(jobId('job-cur6'), ['Person']);
+      await jobQueue.checkpointUnits(jobId('job-cur6'), [], { Person: { next: 5_000, size: 800 } });
+
+      const j = await jobQueue.getJob(jobId('job-cur6'));
+      expect(j?.metadata.unitCursors ?? {}).toEqual({});
+    });
+
+    test('a job that dies BETWEEN units behaves exactly as today', async () => {
+      // No regression to the landed unit-grain path: with no cursor reported,
+      // nothing new appears on the record — not an empty object, which would be
+      // a claim that units were tracked and none had progress.
+      await jobQueue.createJob(createRunningDetectionJob('job-cur7'));
+      await jobQueue.checkpointUnits(jobId('job-cur7'), ['Person']);
+
+      const j = await jobQueue.getJob(jobId('job-cur7'));
+      expect(j?.metadata.completedUnits).toEqual(['Person']);
+      expect('unitCursors' in (j?.metadata ?? {})).toBe(false);
+    });
+
+    test('a cursor survives a worker death into janitor recovery', async () => {
+      // P2's headline RED. The worker dies mid-unit without emitting job:fail,
+      // so only the durable running-file write can carry the cursor into the
+      // re-queued job for a later claim to read.
+      await jobQueue.createJob(createRunningDetectionJob('job-cur8'));
+      await jobQueue.checkpointUnits(jobId('job-cur8'), [], { Person: { next: 5_000, size: 800 } });
+
+      const filePath = path.join(project.jobsDir, 'running', 'job-cur8.json');
+      const past = new Date(Date.now() - 31 * 60_000);
+      await fs.utimes(filePath, past, past);
+
+      expect(await jobQueue.recoverStaleRunningJobs()).toBe(1);
+      const requeued = await jobQueue.getJob(jobId('job-cur8'));
+      expect(requeued?.status).toBe('pending');
+      expect(requeued?.metadata.unitCursors).toEqual({ Person: { next: 5_000, size: 800 } });
+    });
+  });
+
   describe('persistence across process restart (JOB-RESTART-SAFETY P1)', () => {
     // Job state lives on disk, so a job outlives the process that created it:
     // a SECOND queue instance over the SAME directory recovers a job the first

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -327,7 +327,7 @@ describe('processReferenceJob', () => {
         Organization: [{ exact: 'Sony', entityType: 'Organization' }],
       };
       const items = map[t] ?? [];
-      await onChunkResults?.(items);
+      await onChunkResults?.(items, { next: 1_000, size: 250 });
       return items;
     });
 
@@ -397,7 +397,7 @@ describe('processReferenceJob', () => {
       const items = t === 'Location'
         ? (await new Promise((r) => setTimeout(r, 20)), [{ exact: 'Paris', entityType: 'Location' }])
         : [{ exact: 'Ada', entityType: 'Person' }];
-      await onChunkResults?.(items as any);
+      await onChunkResults?.(items as any, { next: 1_000, size: 250 });
       return items as any;
     });
 
@@ -1960,10 +1960,10 @@ describe('processReferenceJob — unit commits (A3)', () => {
       const t = String(types[0]);
       if (t === 'Person') {
         const items = [{ exact: 'Greeley', start: 0, end: 7, entityType: 'Person' }];
-        await onChunkResults?.(items as never);
+        await onChunkResults?.(items as never, { next: 1_000, size: 250 });
         return items as never;
       }
-      if (t === 'Date') { await onChunkResults?.([] as never); return [] as never; } // legitimately-empty unit (RED v)
+      if (t === 'Date') { await onChunkResults?.([] as never, { next: 1_000, size: 250 }); return [] as never; } // legitimately-empty unit (RED v)
       throw new Error('Location stalled');
     });
 
@@ -2058,8 +2058,8 @@ describe('chunk-grain emission — processors', () => {
     // Two chunks: the mocked loop hands each to the processor in turn.
     vi.mocked(AnnotationDetection.detectHighlights).mockImplementation(
       async (_c, _cl, _i, _d, _sl, _onActivity, onChunkResults) => {
-        await onChunkResults!([at('important')] as never);
-        await onChunkResults!([at('critical')] as never);
+        await onChunkResults!([at('important')] as never, { next: 1_000, size: 250 });
+        await onChunkResults!([at('critical')] as never, { next: 2_000, size: 250 });
         return [at('important'), at('critical')] as never;
       },
     );
@@ -2077,8 +2077,8 @@ describe('chunk-grain emission — processors', () => {
   it('an overlap duplicate spanning two chunks is committed ONCE', async () => {
     vi.mocked(AnnotationDetection.detectHighlights).mockImplementation(
       async (_c, _cl, _i, _d, _sl, _onActivity, onChunkResults) => {
-        await onChunkResults!([at('important')] as never);
-        await onChunkResults!([at('important'), at('critical')] as never);
+        await onChunkResults!([at('important')] as never, { next: 1_000, size: 250 });
+        await onChunkResults!([at('important'), at('critical')] as never, { next: 2_000, size: 250 });
         return [] as never;
       },
     );
@@ -2098,8 +2098,8 @@ describe('chunk-grain emission — processors', () => {
   it('processReferenceJob emits per chunk; onUnitComplete is the checkpoint, carrying no annotations', async () => {
     vi.mocked(extractEntities).mockImplementation(
       async (_c, _t, _cl, _i, _l, _sl, _onActivity, _verdicts, _counts, onChunkResults) => {
-        await onChunkResults!([{ exact: 'important', entityType: 'Person' }] as never);
-        await onChunkResults!([{ exact: 'critical', entityType: 'Person' }] as never);
+        await onChunkResults!([{ exact: 'important', entityType: 'Person' }] as never, { next: 1_000, size: 250 });
+        await onChunkResults!([{ exact: 'critical', entityType: 'Person' }] as never, { next: 2_000, size: 250 });
         return [] as never;
       },
     );

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -319,7 +319,7 @@ describe('processReferenceJob', () => {
   it('runs multiple entity types and commits each exactly once', async () => {
     // Each type returns its own entity (verbatim in the content so anchoring holds).
     const content = 'Paris and Ada and Sony are here.';
-    vi.mocked(extractEntities).mockImplementation(async (_c, types, _cl, _i, _l, _sl, _act, _verdicts, _counts, onChunkResults) => {
+    vi.mocked(extractEntities).mockImplementation(async (_c, types, _cl, _i, _l, _sl, _act, _verdicts, _counts, _resume, onChunkResults) => {
       const t = String(types[0]);
       const map: Record<string, any> = {
         Location: [{ exact: 'Paris', entityType: 'Location' }],
@@ -392,7 +392,7 @@ describe('processReferenceJob', () => {
   it('reports each unit once even when types finish OUT OF ORDER', async () => {
     const content = 'Paris and Ada are here.';
     // Location resolves slowly, Person fast — completion order reversed.
-    vi.mocked(extractEntities).mockImplementation(async (_c, types, _cl, _i, _l, _sl, _act, _verdicts, _counts, onChunkResults) => {
+    vi.mocked(extractEntities).mockImplementation(async (_c, types, _cl, _i, _l, _sl, _act, _verdicts, _counts, _resume, onChunkResults) => {
       const t = String(types[0]);
       const items = t === 'Location'
         ? (await new Promise((r) => setTimeout(r, 20)), [{ exact: 'Paris', entityType: 'Location' }])
@@ -1190,6 +1190,7 @@ describe('locale threading', () => {
       expect(AnnotationDetection.detectHighlights).toHaveBeenCalledWith(
         'content', client, undefined, undefined, 'fr',
         expect.any(Function), // chunk-boundary progress heartbeat (Phase 3b)
+        undefined,            // resume cursor — absent on a first attempt
         expect.any(Function), // chunk-results emission
       );
     });
@@ -1206,6 +1207,7 @@ describe('locale threading', () => {
       expect(AnnotationDetection.detectComments).toHaveBeenCalledWith(
         'content', client, undefined, undefined, undefined, 'de', 'fr',
         expect.any(Function), // chunk-boundary progress heartbeat (Phase 3b)
+        undefined,            // resume cursor — absent on a first attempt
         expect.any(Function), // chunk-results emission
       );
     });
@@ -1222,6 +1224,7 @@ describe('locale threading', () => {
       expect(AnnotationDetection.detectAssessments).toHaveBeenCalledWith(
         'content', client, undefined, undefined, undefined, 'es', 'pt',
         expect.any(Function), // chunk-boundary progress heartbeat (Phase 3b)
+        undefined,            // resume cursor — absent on a first attempt
         expect.any(Function), // chunk-results emission
       );
     });
@@ -1242,6 +1245,7 @@ describe('locale threading', () => {
         expect.any(Function), // chunk-boundary progress heartbeat
         expect.any(Function), // under-report verdicts
         expect.any(Function), // accepted-piece counts
+        undefined,            // resume cursor — absent on a first attempt
         expect.any(Function), // chunk-results emission
       );
     });
@@ -1260,6 +1264,7 @@ describe('locale threading', () => {
       expect(AnnotationDetection.detectTags).toHaveBeenCalledWith(
         'content', client, SCHEMA_1, 'Issue', 'fr',
         expect.any(Function), // chunk-boundary progress heartbeat (Phase 3b)
+        undefined,            // resume cursor — absent on a first attempt
         expect.any(Function), // chunk-results emission
       );
     });
@@ -1274,6 +1279,7 @@ describe('locale threading', () => {
       expect(AnnotationDetection.detectHighlights).toHaveBeenCalledWith(
         'content', client, undefined, undefined, undefined,
         expect.any(Function), // chunk-boundary progress heartbeat (Phase 3b)
+        undefined,            // resume cursor — absent on a first attempt
         expect.any(Function), // chunk-results emission
       );
     });
@@ -1956,7 +1962,7 @@ describe('processReferenceJob — unit commits (A3)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('checkpoints each completed unit — including empty ones — and stops at the failing unit', async () => {
-    vi.mocked(extractEntities).mockImplementation(async (_c, types, _cl, _i, _l, _sl, _act, _verdicts, _counts, onChunkResults) => {
+    vi.mocked(extractEntities).mockImplementation(async (_c, types, _cl, _i, _l, _sl, _act, _verdicts, _counts, _resume, onChunkResults) => {
       const t = String(types[0]);
       if (t === 'Person') {
         const items = [{ exact: 'Greeley', start: 0, end: 7, entityType: 'Person' }];
@@ -2057,7 +2063,7 @@ describe('chunk-grain emission — processors', () => {
   it('processHighlightJob commits each chunk as it lands, not one batch at the end', async () => {
     // Two chunks: the mocked loop hands each to the processor in turn.
     vi.mocked(AnnotationDetection.detectHighlights).mockImplementation(
-      async (_c, _cl, _i, _d, _sl, _onActivity, onChunkResults) => {
+      async (_c, _cl, _i, _d, _sl, _onActivity, _resume, onChunkResults) => {
         await onChunkResults!([at('important')] as never, { next: 1_000, size: 250 });
         await onChunkResults!([at('critical')] as never, { next: 2_000, size: 250 });
         return [at('important'), at('critical')] as never;
@@ -2076,7 +2082,7 @@ describe('chunk-grain emission — processors', () => {
 
   it('an overlap duplicate spanning two chunks is committed ONCE', async () => {
     vi.mocked(AnnotationDetection.detectHighlights).mockImplementation(
-      async (_c, _cl, _i, _d, _sl, _onActivity, onChunkResults) => {
+      async (_c, _cl, _i, _d, _sl, _onActivity, _resume, onChunkResults) => {
         await onChunkResults!([at('important')] as never, { next: 1_000, size: 250 });
         await onChunkResults!([at('important'), at('critical')] as never, { next: 2_000, size: 250 });
         return [] as never;
@@ -2097,7 +2103,7 @@ describe('chunk-grain emission — processors', () => {
 
   it('processReferenceJob emits per chunk; onUnitComplete is the checkpoint, carrying no annotations', async () => {
     vi.mocked(extractEntities).mockImplementation(
-      async (_c, _t, _cl, _i, _l, _sl, _onActivity, _verdicts, _counts, onChunkResults) => {
+      async (_c, _t, _cl, _i, _l, _sl, _onActivity, _verdicts, _counts, _resume, onChunkResults) => {
         await onChunkResults!([{ exact: 'important', entityType: 'Person' }] as never, { next: 1_000, size: 250 });
         await onChunkResults!([{ exact: 'critical', entityType: 'Person' }] as never, { next: 2_000, size: 250 });
         return [] as never;
@@ -2131,7 +2137,7 @@ describe('under-report verdicts on the terminal surface', () => {
   it('a floor-accepted piece surfaces on the unit entry and the result aggregate', async () => {
     vi.mocked(extractEntities).mockImplementation(async (...args: unknown[]) => {
       const onUnderReport = args[7] as (v: unknown) => void;
-      const onChunkResults = args[9] as (i: unknown[]) => Promise<void>;
+      const onChunkResults = args[10] as (i: unknown[]) => Promise<void>;
       onUnderReport({ found: 1, counted: 4, pieceChars: 530 });
       await onChunkResults([{ exact: 'Paris', entityType: 'Location' }]);
       return [] as never;
@@ -2154,12 +2160,85 @@ describe('under-report verdicts on the terminal surface', () => {
     expect(outcome.result.underReportedPieces).toBe(1);
   });
 
+  // ── the unit → cursor lookup (CHUNK-GRAIN-RESUME P3) ────────────────────
+  //
+  // The processors are where a job's units get their NAMES — an entity type
+  // here, a category for tags, the motivation for the other three — so they are
+  // the only place the checkpoint's key can be matched to the run that has to
+  // consume it. A wrong or missing key is silent: the unit simply starts at the
+  // top and the retry re-pays for everything, with nothing in the record to say
+  // a resume was even attempted. (Mutating the lookup away left every other
+  // suite green, which is why these exist.)
+  describe('resume cursors reach the right unit', () => {
+    it('processHighlightJob hands its motivation\'s cursor to the detector', async () => {
+      let seen: unknown;
+      vi.mocked(AnnotationDetection.detectHighlights).mockImplementation((async (...args: unknown[]) => {
+        seen = args[6];
+        const cb = args[args.length - 1];
+        if (typeof cb === 'function') await (cb as (m: unknown[], c: unknown) => Promise<void>)([], { next: 1, size: 1 });
+        return [] as never;
+      }) as never);
+
+      await collected((onChunkComplete) => processHighlightJob(
+        'content', makeInferenceClient(), { resourceId: RID },
+        textBuild('content'), vi.fn(), onChunkComplete,
+        { highlighting: { next: 8_000, size: 400 } },
+      ));
+
+      expect(seen).toEqual({ next: 8_000, size: 400 });
+    });
+
+    it('processReferenceJob gives each entity type ITS OWN cursor', async () => {
+      // The keys are dynamic here, so a lookup that used the wrong one would
+      // resume a unit at another unit's position — reading the right number of
+      // characters into the wrong place, with no error anywhere.
+      const byType = new Map<string, unknown>();
+      vi.mocked(extractEntities).mockImplementation((async (...args: unknown[]) => {
+        byType.set(String((args[1] as string[])[0]), args[9]);
+        await (args[10] as (i: unknown[], c: unknown) => Promise<void>)([], { next: 1, size: 1 });
+        return [] as never;
+      }) as never);
+
+      await processReferenceJob(
+        'content', makeInferenceClient(),
+        { resourceId: RID, entityTypes: [entityType('Person'), entityType('Location')] },
+        textBuild('content'), vi.fn(), LOGGER, async () => {}, undefined, async () => {},
+        { Person: { next: 12_400, size: 560 }, Location: { next: 300, size: 900 } },
+      );
+
+      expect(byType.get('Person')).toEqual({ next: 12_400, size: 560 });
+      expect(byType.get('Location')).toEqual({ next: 300, size: 900 });
+    });
+
+    it('processTagJob keys on the CATEGORY, not the motivation', async () => {
+      // A tag job's units are its categories — each walks the whole document —
+      // so a single 'tagging' key would give every category one shared cursor.
+      const byCategory = new Map<string, unknown>();
+      vi.mocked(AnnotationDetection.detectTags).mockImplementation((async (...args: unknown[]) => {
+        byCategory.set(String(args[3]), args[6]);
+        const cb = args[args.length - 1];
+        if (typeof cb === 'function') await (cb as (m: unknown[], c: unknown) => Promise<void>)([], { next: 1, size: 1 });
+        return [] as never;
+      }) as never);
+
+      await processTagJob(
+        'content', makeInferenceClient(),
+        { resourceId: RID, schema: SCHEMA_1, categories: ['catA', 'catB'] } as never,
+        textBuild('content'), vi.fn(), async () => {},
+        { catA: { next: 4_000, size: 300 }, catB: { next: 9_000, size: 700 } },
+      );
+
+      expect(byCategory.get('catA')).toEqual({ next: 4_000, size: 300 });
+      expect(byCategory.get('catB')).toEqual({ next: 9_000, size: 700 });
+    });
+  });
+
   it('two flagged pieces in one unit fold into one summary', async () => {
     vi.mocked(extractEntities).mockImplementation(async (...args: unknown[]) => {
       const onUnderReport = args[7] as (v: unknown) => void;
       onUnderReport({ found: 1, counted: 4, pieceChars: 530 });
       onUnderReport({ found: 2, counted: 9, pieceChars: 610 });
-      await (args[9] as (i: unknown[]) => Promise<void>)([]);
+      await (args[10] as (i: unknown[]) => Promise<void>)([]);
       return [] as never;
     });
     const progress = vi.fn();
@@ -2213,7 +2292,7 @@ describe('entitiesExpected on the progress surface', () => {
   it('accumulates count-verifier expectations across chunks and units', async () => {
     vi.mocked(extractEntities).mockImplementation(async (...args: unknown[]) => {
       const onCounted = args[8] as (c: number) => void;
-      const onChunkResults = args[9] as (i: unknown[]) => Promise<void>;
+      const onChunkResults = args[10] as (i: unknown[]) => Promise<void>;
       onCounted(4);
       await onChunkResults([{ exact: 'Paris', entityType: 'Location' }]);
       onCounted(3);
@@ -2243,7 +2322,7 @@ describe('entitiesExpected on the progress surface', () => {
     // painting all the while. Found and emitted must move as chunks COMMIT.
     vi.mocked(extractEntities).mockImplementation(async (...args: unknown[]) => {
       const onCounted = args[8] as (c: number) => void;
-      const onChunkResults = args[9] as (i: unknown[]) => Promise<void>;
+      const onChunkResults = args[10] as (i: unknown[]) => Promise<void>;
       onCounted(4);
       await onChunkResults([{ exact: 'Paris', entityType: 'Location' }]);
       onCounted(3);

--- a/packages/jobs/src/__tests__/processors.test.ts
+++ b/packages/jobs/src/__tests__/processors.test.ts
@@ -2160,6 +2160,80 @@ describe('under-report verdicts on the terminal surface', () => {
     expect(outcome.result.underReportedPieces).toBe(1);
   });
 
+  // ── the terminal record describes the DOCUMENT, not one attempt ─────────
+  //
+  // `totalFound` is documented as "Total entities found", and before this a
+  // retry reported only the chunks it happened to run: measured at 19 where the
+  // document yielded 25. The landed unit-grain retry had the same defect at
+  // coarser grain — every skipped unit's counts simply vanished. The tallies
+  // ride the checkpoint (HD3, user 2026-09-12) precisely so a resumed attempt
+  // can continue the count instead of restarting it.
+  describe('resumed tallies', () => {
+    it('seeds the unit counters from the checkpoint so the result covers the whole document', async () => {
+      vi.mocked(extractEntities).mockImplementation((async (...args: unknown[]) => {
+        await (args[10] as (i: unknown[], c: unknown) => Promise<void>)(
+          [{ exact: 'Paris', entityType: 'Location' }],
+          { next: 9_000, size: 250, found: 0, emitted: 0 },
+        );
+        return [] as never;
+      }) as never);
+
+      const outcome = await processReferenceJob(
+        content, makeInferenceClient(),
+        { resourceId: RID, entityTypes: [entityType('Location')] },
+        textBuild(content), vi.fn(), LOGGER, async () => {}, undefined, async () => {},
+        // An earlier attempt already found 20 and committed 18 for this unit.
+        { Location: { next: 5_000, size: 250, found: 20, emitted: 18 } },
+      );
+
+      // 20 + this attempt's 1 found; 18 + this attempt's 1 emitted.
+      expect(outcome.result.totalFound).toBe(21);
+      expect(outcome.result.totalEmitted).toBe(19);
+    });
+
+    it('starts at zero for a unit with no checkpoint — a first attempt is unchanged', async () => {
+      vi.mocked(extractEntities).mockImplementation((async (...args: unknown[]) => {
+        await (args[10] as (i: unknown[], c: unknown) => Promise<void>)(
+          [{ exact: 'Paris', entityType: 'Location' }],
+          { next: 9_000, size: 250, found: 0, emitted: 0 },
+        );
+        return [] as never;
+      }) as never);
+
+      const outcome = await processReferenceJob(
+        content, makeInferenceClient(),
+        { resourceId: RID, entityTypes: [entityType('Location')] },
+        textBuild(content), vi.fn(), LOGGER, async () => {}, undefined, async () => {});
+
+      expect(outcome.result.totalFound).toBe(1);
+      expect(outcome.result.totalEmitted).toBe(1);
+    });
+
+    it('reports the RUNNING tallies on each chunk checkpoint, not just this attempt\'s', async () => {
+      // The checkpoint a resumed attempt writes has to be continuable in turn —
+      // a third attempt seeds from it. Reporting only the current attempt's
+      // share would reset the count every time the job died.
+      const seen: unknown[] = [];
+      vi.mocked(extractEntities).mockImplementation((async (...args: unknown[]) => {
+        await (args[10] as (i: unknown[], c: unknown) => Promise<void>)(
+          [{ exact: 'Paris', entityType: 'Location' }],
+          { next: 9_000, size: 250, found: 0, emitted: 0 },
+        );
+        return [] as never;
+      }) as never);
+
+      await processReferenceJob(
+        content, makeInferenceClient(),
+        { resourceId: RID, entityTypes: [entityType('Location')] },
+        textBuild(content), vi.fn(), LOGGER, async () => {}, undefined,
+        async (_a, checkpoint) => { seen.push(checkpoint.cursor); },
+        { Location: { next: 5_000, size: 250, found: 20, emitted: 18 } },
+      );
+
+      expect(seen).toEqual([{ next: 9_000, size: 250, found: 21, emitted: 19 }]);
+    });
+  });
+
   // ── the unit → cursor lookup (CHUNK-GRAIN-RESUME P3) ────────────────────
   //
   // The processors are where a job's units get their NAMES — an entity type
@@ -2182,10 +2256,10 @@ describe('under-report verdicts on the terminal surface', () => {
       await collected((onChunkComplete) => processHighlightJob(
         'content', makeInferenceClient(), { resourceId: RID },
         textBuild('content'), vi.fn(), onChunkComplete,
-        { highlighting: { next: 8_000, size: 400 } },
+        { highlighting: { next: 8_000, size: 400, found: 0, emitted: 0 } },
       ));
 
-      expect(seen).toEqual({ next: 8_000, size: 400 });
+      expect(seen).toEqual({ next: 8_000, size: 400, found: 0, emitted: 0 });
     });
 
     it('processReferenceJob gives each entity type ITS OWN cursor', async () => {
@@ -2203,11 +2277,11 @@ describe('under-report verdicts on the terminal surface', () => {
         'content', makeInferenceClient(),
         { resourceId: RID, entityTypes: [entityType('Person'), entityType('Location')] },
         textBuild('content'), vi.fn(), LOGGER, async () => {}, undefined, async () => {},
-        { Person: { next: 12_400, size: 560 }, Location: { next: 300, size: 900 } },
+        { Person: { next: 12_400, size: 560, found: 0, emitted: 0 }, Location: { next: 300, size: 900, found: 0, emitted: 0 } },
       );
 
-      expect(byType.get('Person')).toEqual({ next: 12_400, size: 560 });
-      expect(byType.get('Location')).toEqual({ next: 300, size: 900 });
+      expect(byType.get('Person')).toEqual({ next: 12_400, size: 560, found: 0, emitted: 0 });
+      expect(byType.get('Location')).toEqual({ next: 300, size: 900, found: 0, emitted: 0 });
     });
 
     it('processTagJob keys on the CATEGORY, not the motivation', async () => {
@@ -2225,11 +2299,11 @@ describe('under-report verdicts on the terminal surface', () => {
         'content', makeInferenceClient(),
         { resourceId: RID, schema: SCHEMA_1, categories: ['catA', 'catB'] } as never,
         textBuild('content'), vi.fn(), async () => {},
-        { catA: { next: 4_000, size: 300 }, catB: { next: 9_000, size: 700 } },
+        { catA: { next: 4_000, size: 300, found: 0, emitted: 0 }, catB: { next: 9_000, size: 700, found: 0, emitted: 0 } },
       );
 
-      expect(byCategory.get('catA')).toEqual({ next: 4_000, size: 300 });
-      expect(byCategory.get('catB')).toEqual({ next: 9_000, size: 700 });
+      expect(byCategory.get('catA')).toEqual({ next: 4_000, size: 300, found: 0, emitted: 0 });
+      expect(byCategory.get('catB')).toEqual({ next: 9_000, size: 700, found: 0, emitted: 0 });
     });
   });
 

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -256,7 +256,7 @@ const emitting = (r: { annotations: unknown[]; result: unknown; unit?: string })
     // grew a second argument, and the omission surfaced only at runtime as
     // "Cannot read properties of undefined (reading 'unit')".
     const onChunkComplete = args[5] as (a: unknown[], c: UnitCheckpoint) => Promise<void>;
-    await onChunkComplete(r.annotations, { unit: r.unit ?? 'highlighting', cursor: { next: 900, size: 220 } });
+    await onChunkComplete(r.annotations, { unit: r.unit ?? 'highlighting', cursor: { next: 900, size: 220, found: 0, emitted: 0 } });
     return { result: r.result } as never;
   }) as never;
 
@@ -1506,10 +1506,10 @@ describe('reference-annotation — checkpointed resume', () => {
   it('commits once per unit, awaiting durability, with no post-run re-emission', async () => {
     vi.mocked(processReferenceJob).mockImplementation(
       async (_content, _client, _params, _build, _progress, _logger, onUnitComplete, _signal, onChunkComplete) => {
-        await onChunkComplete!([{ id: 'r1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220 } });
+        await onChunkComplete!([{ id: 'r1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220, found: 0, emitted: 0 } });
         await onUnitComplete('Person');
         await onUnitComplete('Date'); // empty unit: nothing to commit, still checkpoints
-        await onChunkComplete!([{ id: 'r2' }, { id: 'r3' }] as never, { unit: 'Location', cursor: { next: 1_800, size: 330 } });
+        await onChunkComplete!([{ id: 'r2' }, { id: 'r3' }] as never, { unit: 'Location', cursor: { next: 1_800, size: 330, found: 0, emitted: 0 } });
         await onUnitComplete('Location');
         return { result: { kind: 'reference-annotation', totalFound: 3, totalEmitted: 3, errors: 0 } as never };
       },
@@ -1557,10 +1557,10 @@ describe('reference-annotation — checkpointed resume', () => {
     // absent is the honest encoding of "nothing is partway" — an empty object
     // would claim units were tracked and none had progress.
     expect(checkpoints.map(c => c.unitCursors)).toEqual([
-      { Person: { next: 900, size: 220 } },
+      { Person: { next: 900, size: 220, found: 0, emitted: 0 } },
       undefined,
       undefined,
-      { Location: { next: 1_800, size: 330 } },
+      { Location: { next: 1_800, size: 330, found: 0, emitted: 0 } },
       undefined,
     ]);
     expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
@@ -1578,7 +1578,7 @@ describe('reference-annotation — checkpointed resume', () => {
       }) as never,
     );
     const h = makeFakeSessionAndAdapter();
-    const cursors = { Person: { next: 12_400, size: 560 } };
+    const cursors = { Person: { next: 12_400, size: 560, found: 0, emitted: 0 } };
 
     await handleJob(
       h.adapter, makeConfig(h.session),
@@ -1599,7 +1599,7 @@ describe('reference-annotation — checkpointed resume', () => {
       }) as never,
     );
     const h = makeFakeSessionAndAdapter();
-    const cursors = { highlighting: { next: 8_000, size: 400 } };
+    const cursors = { highlighting: { next: 8_000, size: 400, found: 0, emitted: 0 } };
 
     await handleJob(
       h.adapter, makeConfig(h.session),
@@ -1618,7 +1618,7 @@ describe('reference-annotation — checkpointed resume', () => {
     // done, and never fails it.
     vi.mocked(processReferenceJob).mockImplementation(
       async (_content, _client, _params, _build, _progress, _logger, onUnitComplete, _signal, onChunkComplete) => {
-        await onChunkComplete!([{ id: 'r1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220 } });
+        await onChunkComplete!([{ id: 'r1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220, found: 0, emitted: 0 } });
         await onUnitComplete('Person');
         return { result: { kind: 'reference-annotation', totalFound: 1, totalEmitted: 1, errors: 0 } as never };
       },
@@ -1688,7 +1688,7 @@ describe('startWorkerProcess — job:fail carries the checkpoint (A3 i/iv feed)'
     // name what completed so the retry can skip it.
     vi.mocked(processReferenceJob).mockImplementation(
       async (_content, _client, _params, _build, _progress, _logger, onUnitComplete, _signal, onChunkComplete) => {
-        await onChunkComplete!([{ id: 'a1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220 } });
+        await onChunkComplete!([{ id: 'a1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220, found: 0, emitted: 0 } });
         await onUnitComplete('Person');
         await onUnitComplete('Date');
         throw new Error('Location stalled');
@@ -1996,7 +1996,7 @@ describe('every event says which attempt produced it', () => {
       const onProgress = args[4] as (p: number, m: unknown) => void;
       const onChunkComplete = args[5] as (a: unknown[], c: UnitCheckpoint) => Promise<void>;
       onProgress(60, { code: 'creating-annotations', count: 1 });
-      await onChunkComplete([{ id: 'a1' }], { unit: 'highlighting', cursor: { next: 900, size: 220 } });
+      await onChunkComplete([{ id: 'a1' }], { unit: 'highlighting', cursor: { next: 900, size: 220, found: 0, emitted: 0 } });
       return { result: { highlightsFound: 1, highlightsCreated: 1 } } as never;
     }) as never);
     const h = makeFakeSessionAndAdapter();

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -32,6 +32,7 @@
 
 import { GEN_REQUIRED, minimalContext } from './fixtures/generation-fixtures';
 import { referenceIdOf } from '../worker-process';
+import type { UnitCheckpoint } from '../processors';
 import { Subject, BehaviorSubject } from 'rxjs';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { extractPdfTextLayer } from '@semiont/content';
@@ -248,10 +249,14 @@ function makeFakeSessionAndAdapter() {
  * Stub a motivation processor: annotations leave through the awaited
  * chunk-commit callback (argument 5), the return carries only the result.
  */
-const emitting = (r: { annotations: unknown[]; result: unknown }) =>
+const emitting = (r: { annotations: unknown[]; result: unknown; unit?: string }) =>
   (async (...args: unknown[]) => {
-    const onChunkComplete = args[5] as (a: unknown[]) => Promise<void>;
-    await onChunkComplete(r.annotations);
+    // Typed with the checkpoint it actually takes: the looser
+    // `(a: unknown[]) => …` cast this replaced kept compiling when the seam
+    // grew a second argument, and the omission surfaced only at runtime as
+    // "Cannot read properties of undefined (reading 'unit')".
+    const onChunkComplete = args[5] as (a: unknown[], c: UnitCheckpoint) => Promise<void>;
+    await onChunkComplete(r.annotations, { unit: r.unit ?? 'highlighting', cursor: { next: 900, size: 220 } });
     return { result: r.result } as never;
   }) as never;
 
@@ -279,6 +284,9 @@ function makeJob(
   // Default: no retries budgeted, so a failure is terminal unless a test
   // says otherwise (JOB-RESTART-SAFETY P5).
   budget: { retryCount: number; maxRetries: number } = { retryCount: 0, maxRetries: 0 },
+  /** Mid-unit resume positions from an earlier attempt (CHUNK-GRAIN-RESUME
+   * P2). Empty is the first-attempt case every test but the resume ones want. */
+  unitCursors: ActiveJob['unitCursors'] = {},
 ): ActiveJob {
   return {
     jobId: JID,
@@ -290,6 +298,7 @@ function makeJob(
     // guard enforces it); overrides still win.
     params: { resourceId: RID, ...(type === 'generation' ? GEN_REQUIRED : {}), ...paramsOverride },
     completedUnits,
+    unitCursors,
   } as ActiveJob;
 }
 
@@ -339,7 +348,11 @@ describe('handleJob orchestration', () => {
       await handleJob(h.adapter, makeConfig(h.session), makeJob('highlight-annotation'));
 
       expect(h.busEmits.map(e => e.channel))
-        .toEqual(['job:start', 'mark:commit', 'job:complete']);
+        // A `job:checkpoint` now trails every committed chunk, not only every
+        // completed unit (CHUNK-GRAIN-RESUME P2). For a one-unit job that is
+        // the ONLY checkpoint there can be before the job ends — which is
+        // precisely why the unit grain was too coarse for these four types.
+        .toEqual(['job:start', 'mark:commit', 'job:checkpoint', 'job:complete']);
       expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload)
         .toMatchObject({ jobType: 'highlight-annotation', result: { highlightsFound: 2 } });
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
@@ -357,7 +370,11 @@ describe('handleJob orchestration', () => {
       await handleJob(h.adapter, makeConfig(h.session), makeJob('comment-annotation'));
 
       expect(h.busEmits.map(e => e.channel))
-        .toEqual(['job:start', 'mark:commit', 'job:complete']);
+        // A `job:checkpoint` now trails every committed chunk, not only every
+        // completed unit (CHUNK-GRAIN-RESUME P2). For a one-unit job that is
+        // the ONLY checkpoint there can be before the job ends — which is
+        // precisely why the unit grain was too coarse for these four types.
+        .toEqual(['job:start', 'mark:commit', 'job:checkpoint', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
   });
@@ -373,7 +390,11 @@ describe('handleJob orchestration', () => {
       await handleJob(h.adapter, makeConfig(h.session), makeJob('assessment-annotation'));
 
       expect(h.busEmits.map(e => e.channel))
-        .toEqual(['job:start', 'mark:commit', 'job:complete']);
+        // A `job:checkpoint` now trails every committed chunk, not only every
+        // completed unit (CHUNK-GRAIN-RESUME P2). For a one-unit job that is
+        // the ONLY checkpoint there can be before the job ends — which is
+        // precisely why the unit grain was too coarse for these four types.
+        .toEqual(['job:start', 'mark:commit', 'job:checkpoint', 'job:complete']);
       expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
     });
   });
@@ -393,7 +414,11 @@ describe('handleJob orchestration', () => {
       await handleJob(h.adapter, makeConfig(h.session), makeJob('tag-annotation'));
 
       expect(h.busEmits.map(e => e.channel))
-        .toEqual(['job:start', 'mark:commit', 'job:complete']);
+        // A `job:checkpoint` now trails every committed chunk, not only every
+        // completed unit (CHUNK-GRAIN-RESUME P2). For a one-unit job that is
+        // the ONLY checkpoint there can be before the job ends — which is
+        // precisely why the unit grain was too coarse for these four types.
+        .toEqual(['job:start', 'mark:commit', 'job:checkpoint', 'job:complete']);
       expect(h.busEmits.find(e => e.channel === 'job:complete')!.payload).toMatchObject({
         jobType: 'tag-annotation',
         result: { tagsFound: 1, tagsCreated: 1 },
@@ -1481,10 +1506,10 @@ describe('reference-annotation — checkpointed resume', () => {
   it('commits once per unit, awaiting durability, with no post-run re-emission', async () => {
     vi.mocked(processReferenceJob).mockImplementation(
       async (_content, _client, _params, _build, _progress, _logger, onUnitComplete, _signal, onChunkComplete) => {
-        await onChunkComplete!([{ id: 'r1' }] as never);
+        await onChunkComplete!([{ id: 'r1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220 } });
         await onUnitComplete('Person');
         await onUnitComplete('Date'); // empty unit: nothing to commit, still checkpoints
-        await onChunkComplete!([{ id: 'r2' }, { id: 'r3' }] as never);
+        await onChunkComplete!([{ id: 'r2' }, { id: 'r3' }] as never, { unit: 'Location', cursor: { next: 1_800, size: 330 } });
         await onUnitComplete('Location');
         return { result: { kind: 'reference-annotation', totalFound: 3, totalEmitted: 3, errors: 0 } as never };
       },
@@ -1501,9 +1526,12 @@ describe('reference-annotation — checkpointed resume', () => {
     expect(h.busEmits.map(e => e.channel))
       .toEqual([
         'job:start',
-        'mark:commit', 'job:checkpoint',   // Person (1 annotation)
-        'job:checkpoint',                   // Date (no annotations, no commit)
-        'mark:commit', 'job:checkpoint',    // Location (2 annotations, ONE batch)
+        // Two checkpoints per non-empty unit now: one trailing the chunk's
+        // commit (the mid-unit cursor), one at the unit boundary (the unit is
+        // complete and drops its cursor).
+        'mark:commit', 'job:checkpoint', 'job:checkpoint',  // Person (1 annotation)
+        'job:checkpoint',                                    // Date (empty unit, no commit)
+        'mark:commit', 'job:checkpoint', 'job:checkpoint',  // Location (2 annotations, ONE batch)
         'job:complete',
       ]);
 
@@ -1512,9 +1540,29 @@ describe('reference-annotation — checkpointed resume', () => {
     const commits = h.busEmits.filter(e => e.channel === 'mark:commit');
     expect(commits.map(c => (c.payload as { annotations: unknown[] }).annotations.length)).toEqual([1, 2]);
     // Each checkpoint carries the cumulative completed-unit set, so recovery
-    // after a crash between any two units resumes from the right place.
-    expect(h.busEmits.filter(e => e.channel === 'job:checkpoint').map(e => (e.payload as { completedUnits: string[] }).completedUnits))
-      .toEqual([['Person'], ['Person', 'Date'], ['Person', 'Date', 'Location']]);
+    // after a crash between any two units resumes from the right place. The
+    // chunk-grain checkpoints sit BEFORE their unit joins the set — a chunk
+    // being durable is not its unit being finished.
+    const checkpoints = h.busEmits.filter(e => e.channel === 'job:checkpoint')
+      .map(e => e.payload as { completedUnits: string[]; unitCursors?: Record<string, { next: number; size: number }> });
+    expect(checkpoints.map(c => c.completedUnits)).toEqual([
+      [],                                  // Person's chunk committed; the unit is still open
+      ['Person'],                          // Person complete
+      ['Person', 'Date'],                  // Date complete (empty unit)
+      ['Person', 'Date'],                  // Location's chunk committed
+      ['Person', 'Date', 'Location'],      // Location complete
+    ]);
+    // And the cursor appears while its unit is open, then goes ABSENT when the
+    // unit completes: "partway here" and "finished" are never both true, and
+    // absent is the honest encoding of "nothing is partway" — an empty object
+    // would claim units were tracked and none had progress.
+    expect(checkpoints.map(c => c.unitCursors)).toEqual([
+      { Person: { next: 900, size: 220 } },
+      undefined,
+      undefined,
+      { Location: { next: 1_800, size: 330 } },
+      undefined,
+    ]);
     expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
   });
 
@@ -1527,7 +1575,7 @@ describe('reference-annotation — checkpointed resume', () => {
     // done, and never fails it.
     vi.mocked(processReferenceJob).mockImplementation(
       async (_content, _client, _params, _build, _progress, _logger, onUnitComplete, _signal, onChunkComplete) => {
-        await onChunkComplete!([{ id: 'r1' }] as never);
+        await onChunkComplete!([{ id: 'r1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220 } });
         await onUnitComplete('Person');
         return { result: { kind: 'reference-annotation', totalFound: 1, totalEmitted: 1, errors: 0 } as never };
       },
@@ -1597,7 +1645,7 @@ describe('startWorkerProcess — job:fail carries the checkpoint (A3 i/iv feed)'
     // name what completed so the retry can skip it.
     vi.mocked(processReferenceJob).mockImplementation(
       async (_content, _client, _params, _build, _progress, _logger, onUnitComplete, _signal, onChunkComplete) => {
-        await onChunkComplete!([{ id: 'a1' }] as never);
+        await onChunkComplete!([{ id: 'a1' }] as never, { unit: 'Person', cursor: { next: 900, size: 220 } });
         await onUnitComplete('Person');
         await onUnitComplete('Date');
         throw new Error('Location stalled');
@@ -1903,9 +1951,9 @@ describe('every event says which attempt produced it', () => {
   it('progress and the terminal event both carry the attempt number', async () => {
     vi.mocked(processHighlightJob).mockImplementation((async (...args: unknown[]) => {
       const onProgress = args[4] as (p: number, m: unknown) => void;
-      const onChunkComplete = args[5] as (a: unknown[]) => Promise<void>;
+      const onChunkComplete = args[5] as (a: unknown[], c: UnitCheckpoint) => Promise<void>;
       onProgress(60, { code: 'creating-annotations', count: 1 });
-      await onChunkComplete([{ id: 'a1' }]);
+      await onChunkComplete([{ id: 'a1' }], { unit: 'highlighting', cursor: { next: 900, size: 220 } });
       return { result: { highlightsFound: 1, highlightsCreated: 1 } } as never;
     }) as never);
     const h = makeFakeSessionAndAdapter();

--- a/packages/jobs/src/__tests__/worker-process.test.ts
+++ b/packages/jobs/src/__tests__/worker-process.test.ts
@@ -1566,6 +1566,49 @@ describe('reference-annotation — checkpointed resume', () => {
     expect(h.adapterCalls.filter(c => c.method === 'completeJob')).toHaveLength(1);
   });
 
+  it('hands the claimed cursors to the processor so a partway unit resumes (CHUNK-GRAIN-RESUME P3)', async () => {
+    // The last link: P2 makes the cursor durable and puts it back on the claim,
+    // but a worker that never passes it on leaves the retry restarting from the
+    // top with the record showing a resume that never happened.
+    let seen: unknown;
+    vi.mocked(processReferenceJob).mockImplementation(
+      (async (...args: unknown[]) => {
+        seen = args[9];
+        return { result: { kind: 'reference-annotation', totalFound: 0, totalEmitted: 0, errors: 0 } } as never;
+      }) as never,
+    );
+    const h = makeFakeSessionAndAdapter();
+    const cursors = { Person: { next: 12_400, size: 560 } };
+
+    await handleJob(
+      h.adapter, makeConfig(h.session),
+      makeJob('reference-annotation', { entityTypes: ['Person'] }, [], { retryCount: 1, maxRetries: 3 }, cursors),
+    );
+
+    expect(seen).toEqual(cursors);
+  });
+
+  it('hands the claimed cursors to a motivation processor too', async () => {
+    // Four of the five types go through a different branch; wiring only the
+    // reference one would leave them silently restarting.
+    let seen: unknown;
+    vi.mocked(processHighlightJob).mockImplementation(
+      (async (...args: unknown[]) => {
+        seen = args[6];
+        return { result: { highlightsFound: 0, highlightsCreated: 0 } } as never;
+      }) as never,
+    );
+    const h = makeFakeSessionAndAdapter();
+    const cursors = { highlighting: { next: 8_000, size: 400 } };
+
+    await handleJob(
+      h.adapter, makeConfig(h.session),
+      makeJob('highlight-annotation', {}, [], { retryCount: 1, maxRetries: 3 }, cursors),
+    );
+
+    expect(seen).toEqual(cursors);
+  });
+
   it('cancellation stops at a unit boundary: emits job:cancel with the checkpoint, not job:complete (JOB-RESTART-SAFETY P4)', async () => {
     // The signal is aborted (a cancel was requested for this job). The real
     // processReferenceJob breaks its loop at the next unit boundary; the mock

--- a/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
+++ b/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
@@ -677,7 +677,7 @@ describe('AnnotationDetection', () => {
 
         await AnnotationDetection.detectHighlights(
           longContent, client, undefined, undefined, undefined, undefined,
-          { next: at, size: 600 },
+          { next: at, size: 600, found: 0, emitted: 0 },
         );
 
         expect(prompts.length).toBeGreaterThan(0);

--- a/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
+++ b/packages/jobs/src/__tests__/workers/annotation-detection.test.ts
@@ -461,7 +461,7 @@ describe('AnnotationDetection', () => {
         const emitted: string[][] = [];
 
         await AnnotationDetection.detectHighlights(
-          bigContent, client, undefined, undefined, undefined, undefined,
+          bigContent, client, undefined, undefined, undefined, undefined, undefined,
           async (matches) => { emitted.push(matches.map((m) => m.exact)); },
         );
 
@@ -486,7 +486,7 @@ describe('AnnotationDetection', () => {
         const emitted: any[] = [];
 
         await AnnotationDetection.detectTags(
-          bigContent, client, IMRAD_SCHEMA, 'introduction', undefined, undefined,
+          bigContent, client, IMRAD_SCHEMA, 'introduction', undefined, undefined, undefined,
           async (matches) => { emitted.push(...matches); },
         );
 
@@ -509,7 +509,7 @@ describe('AnnotationDetection', () => {
 
         await expect(
           AnnotationDetection.detectHighlights(
-            bigContent, client, undefined, undefined, undefined, undefined,
+            bigContent, client, undefined, undefined, undefined, undefined, undefined,
             async () => { throw new Error('mark:commit failed: sink down'); },
           ),
         ).rejects.toThrow(/sink down/);
@@ -639,6 +639,58 @@ describe('AnnotationDetection', () => {
         expect(promptChars.length).toBeGreaterThan(2);
         const steady = promptChars.slice(0, -1);
         expect(Math.max(...steady) - Math.min(...steady)).toBeLessThan(steady[0]! * 0.05);
+      });
+    });
+
+    // ── resuming a unit (CHUNK-GRAIN-RESUME P3) ────────────────────────────
+    //
+    // Four of the five detection types share `detectInChunks`, and each of them
+    // runs exactly one unit (tags one per category), so before the cursor a
+    // motivation job could checkpoint NOTHING until the whole document was
+    // done — a mid-document death restarted from zero every time.
+    describe('resuming from a checkpoint', () => {
+      const RESUME_LIMITS = { contextTokens: 4_000, maxOutputTokens: 1_200, outputTokensPerHour: 3_600_000_000 };
+      const opener = 'OPENING_MARKER begins the document and appears nowhere else.';
+      const longContent = [opener, ...Array.from(
+        { length: 900 },
+        (_, i) => `Paragraph ${i} states something ordinary about the subject under study.`,
+      )].join(' ');
+
+      function promptRecordingClient() {
+        const prompts: string[] = [];
+        const client = {
+          type: 'mock' as const,
+          modelId: 'mock-model',
+          limits: async () => RESUME_LIMITS,
+          generateText: async () => '[]',
+          generateStructured: async (prompt: string) => {
+            prompts.push(prompt);
+            return { items: [], stopReason: 'end_turn', usage: { inputTokens: 400, outputTokens: 700 } };
+          },
+        } as unknown as InferenceClient;
+        return { client, prompts };
+      }
+
+      it('starts its first model call at the checkpoint, not the top', async () => {
+        const { client, prompts } = promptRecordingClient();
+        const at = 30_000;
+
+        await AnnotationDetection.detectHighlights(
+          longContent, client, undefined, undefined, undefined, undefined,
+          { next: at, size: 600 },
+        );
+
+        expect(prompts.length).toBeGreaterThan(0);
+        expect(prompts[0]).not.toContain('OPENING_MARKER');
+        expect(prompts[0]).toContain(longContent.slice(at, at + 40));
+      });
+
+      it('reads the whole document when there is no checkpoint', async () => {
+        const { client, prompts } = promptRecordingClient();
+
+        await AnnotationDetection.detectHighlights(longContent, client);
+
+        expect(prompts[0]).toContain('OPENING_MARKER');
       });
     });
 

--- a/packages/jobs/src/__tests__/workers/detection/chunk-cursor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/chunk-cursor.test.ts
@@ -20,7 +20,8 @@ import {
   deriveDetectionBudget,
   type AdaptiveChunk,
 } from '../../../workers/detection/detection-chunking';
-import type { CallOutcome } from '../../../workers/detection/chunk-size-controller';
+import { nextChunkSize, type CallOutcome } from '../../../workers/detection/chunk-size-controller';
+import type { UnitCursor } from '@semiont/core';
 
 /** Ollama shape — a shared window, the config the live gate runs on. No
  * published output rate, so the assumed-floor duration bound applies, exactly
@@ -45,13 +46,14 @@ async function run(
   text: string,
   outcome: (chunk: AdaptiveChunk, outputBudget: number) => CallOutcome,
   typesPerCall = 1,
+  resume?: UnitCursor,
 ) {
   const seen: AdaptiveChunk[] = [];
   const budget = budgetFor(typesPerCall);
   await runAdaptiveChunks(text, budget, async (chunk) => {
     seen.push(chunk);
     return outcome(chunk, budget.outputBudget);
-  });
+  }, resume);
   return { seen, budget };
 }
 
@@ -225,6 +227,66 @@ describe('runAdaptiveChunks', () => {
     })).rejects.toThrow('chunk 2 failed');
 
     expect(seen).toHaveLength(2);
+  });
+});
+
+// ── resuming from a checkpoint (CHUNK-GRAIN-RESUME P3) ────────────────────
+//
+// P2 made the cursor durable; this is the half that spends it. Without it the
+// cursor is a record nobody reads, and a retried job re-pays for every chunk it
+// already committed — the 26-minute attempt this arc exists to stop repeating.
+describe('runAdaptiveChunks — resuming', () => {
+  it('starts at the checkpointed position, not the top', async () => {
+    const text = prose(1500);
+    const { seen } = await run(text, (_c, out) => steady(out), 1, { next: 40_000, size: 4_500 });
+
+    expect(seen[0]!.at).toBe(40_000);
+    // And nothing before it is read again — the point is that the INFERENCE is
+    // not re-paid, not merely that the log would dedupe the annotations.
+    expect(Math.min(...seen.map((c) => c.at))).toBe(40_000);
+  });
+
+  it('seeds the size from the checkpoint and takes ONE shrink step (HD2 option C)', async () => {
+    // Neither of the losing options. Opening at the default would discard the
+    // calibration the dead attempt paid for over its earlier chunks; seeding
+    // unchanged would re-cut the identical failing piece, and at
+    // DETECTION_TEMPERATURE 0 an identical call returns an identical failure.
+    // The resume opens as if the last outcome were a failure — which it was,
+    // the job died.
+    const budget = budgetFor();
+    const seeded = 4_000;
+    const expected = nextChunkSize({ truncated: true }, seeded, budget.bounds);
+    expect(expected).toBeLessThan(seeded);
+
+    const { seen } = await run(prose(1500), (_c, out) => steady(out), 1, { next: 10_000, size: seeded });
+    expect(seen[0]!.size).toBe(expected);
+  });
+
+  it('opens at the budget when there is no checkpoint — a first attempt is unchanged', async () => {
+    const budget = budgetFor();
+    const { seen } = await run(prose(1500), (_c, out) => steady(out));
+
+    expect(seen[0]!.at).toBe(0);
+    expect(seen[0]!.size).toBe(budget.chunking.chunkSize);
+  });
+
+  it('keeps adapting after the resume — the seed is a start, not a lock', async () => {
+    // "Attempts should learn from previous attempts, but not be beholden to
+    // them." One shrink step of conservatism, then the ordinary feedback takes
+    // over and grows again on the first low-utilization outcome.
+    const { seen } = await run(prose(1500), (_c, out) => sparse(out), 1, { next: 10_000, size: 4_000 });
+
+    expect(seen.length).toBeGreaterThan(2);
+    expect(seen[1]!.piece.length).toBeGreaterThan(seen[0]!.piece.length);
+  });
+
+  it('does nothing when the checkpoint is already at the end', async () => {
+    // The unit finished its last chunk but died before it could be marked
+    // complete. Re-running it must cost no inference at all.
+    const text = prose(400);
+    const { seen } = await run(text, (_c, out) => steady(out), 1, { next: text.length, size: 4_500 });
+
+    expect(seen).toHaveLength(0);
   });
 });
 

--- a/packages/jobs/src/__tests__/workers/detection/chunk-cursor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/chunk-cursor.test.ts
@@ -238,7 +238,7 @@ describe('runAdaptiveChunks', () => {
 describe('runAdaptiveChunks — resuming', () => {
   it('starts at the checkpointed position, not the top', async () => {
     const text = prose(1500);
-    const { seen } = await run(text, (_c, out) => steady(out), 1, { next: 40_000, size: 4_500 });
+    const { seen } = await run(text, (_c, out) => steady(out), 1, { next: 40_000, size: 4_500, found: 0, emitted: 0 });
 
     expect(seen[0]!.at).toBe(40_000);
     // And nothing before it is read again — the point is that the INFERENCE is
@@ -258,7 +258,7 @@ describe('runAdaptiveChunks — resuming', () => {
     const expected = nextChunkSize({ truncated: true }, seeded, budget.bounds);
     expect(expected).toBeLessThan(seeded);
 
-    const { seen } = await run(prose(1500), (_c, out) => steady(out), 1, { next: 10_000, size: seeded });
+    const { seen } = await run(prose(1500), (_c, out) => steady(out), 1, { next: 10_000, size: seeded, found: 0, emitted: 0 });
     expect(seen[0]!.size).toBe(expected);
   });
 
@@ -274,7 +274,7 @@ describe('runAdaptiveChunks — resuming', () => {
     // "Attempts should learn from previous attempts, but not be beholden to
     // them." One shrink step of conservatism, then the ordinary feedback takes
     // over and grows again on the first low-utilization outcome.
-    const { seen } = await run(prose(1500), (_c, out) => sparse(out), 1, { next: 10_000, size: 4_000 });
+    const { seen } = await run(prose(1500), (_c, out) => sparse(out), 1, { next: 10_000, size: 4_000, found: 0, emitted: 0 });
 
     expect(seen.length).toBeGreaterThan(2);
     expect(seen[1]!.piece.length).toBeGreaterThan(seen[0]!.piece.length);
@@ -284,7 +284,7 @@ describe('runAdaptiveChunks — resuming', () => {
     // The unit finished its last chunk but died before it could be marked
     // complete. Re-running it must cost no inference at all.
     const text = prose(400);
-    const { seen } = await run(text, (_c, out) => steady(out), 1, { next: text.length, size: 4_500 });
+    const { seen } = await run(text, (_c, out) => steady(out), 1, { next: text.length, size: 4_500, found: 0, emitted: 0 });
 
     expect(seen).toHaveLength(0);
   });

--- a/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
@@ -339,7 +339,7 @@ describe('extractEntities', () => {
         const emitted: string[][] = [];
 
         await extractEntities(
-          bigText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined,
+          bigText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined, undefined,
           async (items) => { order.push(`emit:${emitted.length}`); emitted.push(items.map((e) => e.exact)); },
         );
 
@@ -361,7 +361,7 @@ describe('extractEntities', () => {
 
         await expect(
           extractEntities(
-            bigText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined,
+            bigText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined, undefined,
             async () => { throw new Error('mark:commit failed: sink down'); },
           ),
         ).rejects.toThrow(/sink down/);
@@ -506,6 +506,70 @@ describe('extractEntities', () => {
 
         expect(promptChars.length).toBeGreaterThan(2);
         expect(promptChars[1]!).toBeLessThan(promptChars[0]! * 0.85);
+      });
+    });
+
+    // ── resuming a unit (CHUNK-GRAIN-RESUME P3) ────────────────────────────
+    describe('resuming from a checkpoint', () => {
+      const RESUME_LIMITS = { contextTokens: 4_000, maxOutputTokens: 1_200, outputTokensPerHour: 3_600_000_000 };
+      const opener = 'OPENING_MARKER begins the document and appears nowhere else.';
+      const longText = [opener, ...Array.from(
+        { length: 900 },
+        (_, i) => `Paragraph ${i} mentions Alice and Bob among some ordinary filler words.`,
+      )].join(' ');
+
+      function promptRecordingClient() {
+        const prompts: string[] = [];
+        const client = {
+          type: 'mock' as const,
+          modelId: 'mock-model',
+          limits: async () => RESUME_LIMITS,
+          generateText: async () => '[]',
+          generateStructured: async (prompt: string) => {
+            prompts.push(prompt);
+            return { items: [], stopReason: 'end_turn', usage: { inputTokens: 400, outputTokens: 700 } };
+          },
+        } as unknown as InferenceClient;
+        return { client, prompts };
+      }
+
+      it('starts its first model call at the checkpoint, not the top of the document', async () => {
+        // The whole point of the arc: the retry must not RE-PAY for inference
+        // the dead attempt already bought. The log would dedupe the annotations
+        // either way — that is not the saving being claimed here.
+        const { client, prompts } = promptRecordingClient();
+        const at = 30_000;
+
+        await extractEntities(
+          longText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined,
+          { next: at, size: 600 },
+        );
+
+        expect(prompts.length).toBeGreaterThan(0);
+        expect(prompts[0]).not.toContain('OPENING_MARKER');
+        // And it really is at the cursor: the text there is in the first prompt.
+        expect(prompts[0]).toContain(longText.slice(at, at + 40));
+      });
+
+      it('reads the whole document when there is no checkpoint', async () => {
+        const { client, prompts } = promptRecordingClient();
+
+        await extractEntities(longText, ['Person'], client, false, LOGGER);
+
+        expect(prompts[0]).toContain('OPENING_MARKER');
+      });
+
+      it('costs no inference when the checkpoint is already at the end', async () => {
+        // The unit finished its last chunk and died before it could be marked
+        // complete. Re-running it must make no model call at all.
+        const { client, prompts } = promptRecordingClient();
+
+        await extractEntities(
+          longText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined,
+          { next: longText.length, size: 600 },
+        );
+
+        expect(prompts).toHaveLength(0);
       });
     });
 

--- a/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
+++ b/packages/jobs/src/__tests__/workers/detection/entity-extractor.test.ts
@@ -542,7 +542,7 @@ describe('extractEntities', () => {
 
         await extractEntities(
           longText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined,
-          { next: at, size: 600 },
+          { next: at, size: 600, found: 0, emitted: 0 },
         );
 
         expect(prompts.length).toBeGreaterThan(0);
@@ -566,7 +566,7 @@ describe('extractEntities', () => {
 
         await extractEntities(
           longText, ['Person'], client, false, LOGGER, undefined, undefined, undefined, undefined,
-          { next: longText.length, size: 600 },
+          { next: longText.length, size: 600, found: 0, emitted: 0 },
         );
 
         expect(prompts).toHaveLength(0);

--- a/packages/jobs/src/failure-class.ts
+++ b/packages/jobs/src/failure-class.ts
@@ -14,7 +14,7 @@
  * to avoid. The class rides the `job:fail` payload; `failJob` consumes it.
  */
 
-import { isNumber, isObject, isString, type components } from '@semiont/core';
+import { isNumber, isObject, isString, RETRY_RULES, type components } from '@semiont/core';
 import { StructuredReadError } from '@semiont/inference';
 import { InferenceTimeoutError } from './workers/inference-call';
 
@@ -37,11 +37,15 @@ export class DeterministicJobError extends Error {
 /**
  * The taxonomy, and its provider coupling — THE part that will drift:
  *
- * - `@anthropic-ai/sdk` errors carry a numeric `status`. 408/429/5xx are
- *   environmental (throttles, overload, gateway weather) → transient. The
- *   remaining 4xx mean the request itself was rejected — invalid, too
- *   large, unauthorized — and re-sending it unchanged is guaranteed waste
- *   → deterministic.
+ * - `@anthropic-ai/sdk` errors carry a numeric `status`, and WHICH statuses are
+ *   worth another attempt is not decided here: it is `RETRY_RULES.job`
+ *   (RETRY-CLASSIFICATION P2). This file used to restate the same three
+ *   conditions, which made it a second opinion on a question core already
+ *   answered — and the census that found it showed that where a bare list and a
+ *   reasoned rule disagree, the list wins silently. The rule carries the
+ *   reasoning; this file carries the ONE thing the rule cannot know: that
+ *   anything else at or above 400 is a rejected request, and re-sending it
+ *   unchanged is guaranteed waste → deterministic.
  * - Aborts (`APIUserAbortError` from the SDK, `AbortError` from fetch/mock)
  *   are our own bound or shutdown tearing the transport down — nothing was
  *   judged → transient.
@@ -59,6 +63,24 @@ export function classifyFailure(error: unknown): FailureClass | undefined {
   if (error instanceof DeterministicJobError) return 'deterministic';
   if (error instanceof InferenceTimeoutError) return 'transient';
   if (error instanceof StructuredReadError && error.stopReason === 'max_tokens') return 'deterministic';
+  // A `StructuredReadError` with any OTHER stop reason falls through to
+  // `undefined` — retryable, and DECIDED rather than defaulted
+  // (RETRY-CLASSIFICATION P2, 2026-09-12).
+  //
+  // It only reaches here having exhausted `MAX_SUBDIVISION_DEPTH`, so
+  // `subdividable()` has already argued the opposite: at
+  // `DETECTION_TEMPERATURE` 0 the identical call returns the identical failure.
+  // That argument was decisive while chunk boundaries were fixed up front. It is
+  // not any more — CHUNK-GRAIN-RESUME HD2 (option C) seeds a resumed unit's size
+  // from the checkpoint and then takes one shrink step, so the retry re-cuts the
+  // poison piece at a DIFFERENT size and can genuinely come out differently. The
+  // price of being wrong fell with it: one chunk, not the whole prefix.
+  //
+  // It stays `undefined` rather than becoming `'transient'` on purpose. The wire
+  // vocabulary has two values, and this is neither: it is not weather, it is
+  // "retryable because the next attempt reads different input". Claiming
+  // `transient` would assert an environmental cause nobody established, and
+  // absent already means exactly what is true — unrecognised, so retryable.
   if (!isObject(error)) return undefined;
 
   const name = isString(error.name) ? error.name : '';
@@ -67,7 +89,7 @@ export function classifyFailure(error: unknown): FailureClass | undefined {
 
   const status = isNumber(error.status) ? error.status : undefined;
   if (status !== undefined) {
-    if (status === 408 || status === 429 || status >= 500) return 'transient';
+    if (RETRY_RULES.job.retryable({ status })) return 'transient';
     if (status >= 400) return 'deterministic';
   }
 

--- a/packages/jobs/src/fs-job-queue.ts
+++ b/packages/jobs/src/fs-job-queue.ts
@@ -10,7 +10,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import type { AnyJob, JobStatus, JobQueryFilters, CancelledJob, CompleteJob, FailedJob, PendingJob, RunningJob } from './types';
 import type { SemiontState } from '@semiont/core/node';
-import { jobId as toJobId, type JobId, type Logger, type EventBus } from '@semiont/core';
+import { jobId as toJobId, type JobId, type Logger, type EventBus, type UnitCursor } from '@semiont/core';
 import type { JobQueue } from './job-queue-interface';
 import { willRetryAfter } from './will-retry';
 
@@ -40,6 +40,42 @@ const STALE_RUNNING_MS = 30 * 60_000;
 
 /** Minimum spacing between progress writes per job — workers can be chatty. */
 const PROGRESS_WRITE_MIN_INTERVAL_MS = 5_000;
+
+/**
+ * Merge per-unit cursors monotonically (CHUNK-GRAIN-RESUME P2).
+ *
+ * `completedUnits` is a set, so unioning it converges under concurrent
+ * snapshots for free — a set only grows. A cursor has no such property: two
+ * checkpoints can be in flight at once and the OLDER one can land last, so a
+ * last-writer-wins would drag the resume position backward and the retry would
+ * re-pay for chunks it already committed. Keeping the furthest `next` per unit
+ * is what makes the merge order-independent.
+ *
+ * `next` and `size` move together because they are ONE observation of one
+ * chunk. Taking the furthest `next` from one snapshot and the `size` from
+ * another would describe a chunk that was never cut.
+ *
+ * A unit in `completed` has no cursor at all: "in progress, here" and
+ * "finished" are then structurally exclusive rather than a rule each reader has
+ * to remember, and a stale snapshot cannot resurrect a finished unit's cursor.
+ */
+function mergeUnitCursors(
+  existing: Record<string, UnitCursor> | undefined,
+  incoming: Record<string, UnitCursor> | undefined,
+  completed: string[],
+): Record<string, UnitCursor> {
+  const done = new Set(completed);
+  const merged: Record<string, UnitCursor> = {};
+  for (const [unit, cursor] of Object.entries({ ...existing })) {
+    if (!done.has(unit)) merged[unit] = cursor;
+  }
+  for (const [unit, cursor] of Object.entries({ ...incoming })) {
+    if (done.has(unit)) continue;
+    const held = merged[unit];
+    if (!held || cursor.next > held.next) merged[unit] = cursor;
+  }
+  return merged;
+}
 
 /** Terminal jobs (complete/failed/cancelled) are pruned after this long. */
 const RETENTION_HOURS = 24;
@@ -259,7 +295,7 @@ export class FsJobQueue implements JobQueue {
    * re-announced); after that it lands in `failed` with the error.
    * Returns null (and changes nothing) if the job isn't running.
    */
-  async failJob(jobId: JobId, error: string, completedUnits?: string[], failureClass?: 'transient' | 'deterministic'): Promise<'retried' | 'failed' | null> {
+  async failJob(jobId: JobId, error: string, completedUnits?: string[], failureClass?: 'transient' | 'deterministic', unitCursors?: Record<string, UnitCursor>): Promise<'retried' | 'failed' | null> {
     const job = await this.getJob(jobId);
     if (!job || job.status !== 'running') {
       return null;
@@ -273,9 +309,18 @@ export class FsJobQueue implements JobQueue {
     // every later rebuild) carries it forward; the terminal failed record
     // keeps it too, so the waste of a discarded run stays visible (D3).
     const checkpoint = [...new Set([...(job.metadata.completedUnits ?? []), ...(completedUnits ?? [])])];
-    const metadata = checkpoint.length > 0
-      ? { ...job.metadata, completedUnits: checkpoint }
-      : job.metadata;
+    // The mid-unit half of the same checkpoint (CHUNK-GRAIN-RESUME P2), merged
+    // by the same monotone rule the durable per-chunk writes use — `failJob`
+    // and `checkpointUnits` race on the same record, and whichever lands last
+    // must not drag a cursor back.
+    const cursors = mergeUnitCursors(job.metadata.unitCursors, unitCursors, checkpoint);
+    const { unitCursors: superseded, ...base } = job.metadata;
+    void superseded;
+    const metadata = {
+      ...base,
+      ...(checkpoint.length > 0 ? { completedUnits: checkpoint } : {}),
+      ...(Object.keys(cursors).length > 0 ? { unitCursors: cursors } : {}),
+    };
 
     // A known-deterministic failure skips the budget outright: the same
     // request cannot succeed on a second attempt, so a retry is guaranteed
@@ -319,15 +364,28 @@ export class FsJobQueue implements JobQueue {
    * non-running jobs. Written directly, like `recordProgress`, so it also
    * refreshes the mtime heartbeat.
    */
-  async checkpointUnits(jobId: JobId, completedUnits: string[]): Promise<void> {
+  async checkpointUnits(jobId: JobId, completedUnits: string[], unitCursors?: Record<string, UnitCursor>): Promise<void> {
     const job = await this.getJob(jobId);
     if (!job || job.status !== 'running') {
       return;
     }
     const merged = [...new Set([...(job.metadata.completedUnits ?? []), ...completedUnits])];
+    const cursors = mergeUnitCursors(job.metadata.unitCursors, unitCursors, merged);
+    // The prior value is destructured OUT rather than spread over: omitting a
+    // key from a spread leaves the old one in place, so the last unit to finish
+    // would keep a cursor pointing into work that is done.
+    const { unitCursors: superseded, ...metadata } = job.metadata;
+    void superseded;
     const updated: RunningJob<any, any> = {
       ...job,
-      metadata: { ...job.metadata, completedUnits: merged },
+      metadata: {
+        ...metadata,
+        completedUnits: merged,
+        // Absent rather than `{}`: an empty object would assert that units were
+        // tracked and none had progress, a different claim from a job that
+        // never reported a cursor at all.
+        ...(Object.keys(cursors).length > 0 ? { unitCursors: cursors } : {}),
+      },
     };
     await fs.writeFile(this.getJobPath(jobId, 'running'), JSON.stringify(updated, null, 2), 'utf-8');
   }

--- a/packages/jobs/src/job-claim-adapter.ts
+++ b/packages/jobs/src/job-claim-adapter.ts
@@ -56,9 +56,16 @@ function readUnitCursors(raw: unknown, completedUnits: string[]): Record<string,
   const cursors: Record<string, UnitCursor> = {};
   for (const [unit, value] of Object.entries(raw)) {
     if (done.has(unit) || !isObject(value)) continue;
-    const { next, size } = value;
+    const { next, size, found, emitted } = value;
     if (!isNumber(next) || !isNumber(size) || next < 0 || size < 1) continue;
-    cursors[unit] = { next, size };
+    // The tallies are required, and a cursor missing them is dropped WHOLE
+    // rather than resumed without them. Resuming would take the saving and then
+    // report a terminal record that counts only the remainder — the exact lie
+    // HD3 exists to remove. Dropping costs one re-run of a unit and yields a
+    // record that is true; a checkpoint written before this field existed reads
+    // as absent and takes that trade.
+    if (!isNumber(found) || !isNumber(emitted) || found < 0 || emitted < 0) continue;
+    cursors[unit] = { next, size, found, emitted };
   }
   return cursors;
 }

--- a/packages/jobs/src/job-claim-adapter.ts
+++ b/packages/jobs/src/job-claim-adapter.ts
@@ -21,7 +21,8 @@
  */
 
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { busRequest, isArray, isNumber, isString } from '@semiont/core';
+import { busRequest, isArray, isNumber, isObject, isString } from '@semiont/core';
+import type { UnitCursor } from '@semiont/core';
 import type { WorkerBus } from '@semiont/sdk';
 import { workerBusAsPrimitive } from './worker-bus-primitive.js';
 
@@ -39,6 +40,29 @@ export interface JobAssignment {
   resourceId: string;
 }
 
+/**
+ * Narrow the claimed record's `unitCursors` metadata to usable cursors.
+ *
+ * A malformed or partial entry is DROPPED, never repaired: the unit then starts
+ * from the top, which costs inference but is always correct, whereas a
+ * manufactured position would skip text nobody ever read and the gap would be
+ * undetectable afterwards. Cursors for units already in `completedUnits` are
+ * dropped too — the queue keeps those sets disjoint, and a reader that trusted
+ * a stale one would resume a unit that is done.
+ */
+function readUnitCursors(raw: unknown, completedUnits: string[]): Record<string, UnitCursor> {
+  if (!isObject(raw)) return {};
+  const done = new Set(completedUnits);
+  const cursors: Record<string, UnitCursor> = {};
+  for (const [unit, value] of Object.entries(raw)) {
+    if (done.has(unit) || !isObject(value)) continue;
+    const { next, size } = value;
+    if (!isNumber(next) || !isNumber(size) || next < 0 || size < 1) continue;
+    cursors[unit] = { next, size };
+  }
+  return cursors;
+}
+
 export interface ActiveJob {
   jobId: string;
   type: string;
@@ -52,6 +76,14 @@ export interface ActiveJob {
    * neither redoes nor duplicates completed work. Empty on first attempts.
    */
   completedUnits: string[];
+  /**
+   * How far each UNFINISHED unit got on an earlier attempt
+   * (CHUNK-GRAIN-RESUME P2) — the grain `completedUnits` cannot express, and
+   * the only checkpoint a one-unit job can produce before it finishes. Empty
+   * on first attempts, and never overlapping `completedUnits`: a unit is
+   * either finished or partway, never both.
+   */
+  unitCursors: Record<string, UnitCursor>;
   /**
    * The claimed record's retry budget, carried so the worker can report
    * `willRetry` on `job:fail` (JOB-RESTART-SAFETY P5). It is the same budget
@@ -166,12 +198,13 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
       // it to the claimed-job shape the worker reads.
       const job = (await busRequest(requestBus, 'job:claim' satisfies JobClaimAwaits, { jobId: assignment.jobId }, 10_000)) as {
         params?: Record<string, unknown>;
-        metadata?: { userId?: string; completedUnits?: unknown; retryCount?: unknown; maxRetries?: unknown };
+        metadata?: { userId?: string; completedUnits?: unknown; unitCursors?: unknown; retryCount?: unknown; maxRetries?: unknown };
       };
 
       const completedUnits = isArray(job.metadata?.completedUnits)
         ? job.metadata.completedUnits.filter(isString)
         : [];
+      const unitCursors = readUnitCursors(job.metadata?.unitCursors, completedUnits);
 
       return {
         jobId: assignment.jobId,
@@ -180,6 +213,7 @@ export function createJobClaimAdapter(options: JobClaimAdapterOptions): JobClaim
         userId: (job.metadata?.userId ?? '') as string,
         params: (job.params ?? {}) as Record<string, unknown>,
         completedUnits,
+        unitCursors,
         // Absent or malformed metadata reads as "no budget left" — a worker
         // that cannot see the budget must not claim a retry is coming.
         retryCount: isNumber(job.metadata?.retryCount) ? job.metadata.retryCount : 0,

--- a/packages/jobs/src/job-queue-interface.ts
+++ b/packages/jobs/src/job-queue-interface.ts
@@ -1,5 +1,5 @@
 import type { AnyJob, JobStatus } from './types';
-import type { JobId } from '@semiont/core';
+import type { JobId, UnitCursor } from '@semiont/core';
 
 export interface JobQueue {
   initialize(): Promise<void>;
@@ -18,7 +18,7 @@ export interface JobQueue {
    * `failureClass` of 'deterministic' goes straight to `failed` with any
    * budget remaining — a second identical attempt cannot succeed (P3).
    */
-  failJob(jobId: JobId, error: string, completedUnits?: string[], failureClass?: 'transient' | 'deterministic'): Promise<'retried' | 'failed' | null>;
+  failJob(jobId: JobId, error: string, completedUnits?: string[], failureClass?: 'transient' | 'deterministic', unitCursors?: Record<string, UnitCursor>): Promise<'retried' | 'failed' | null>;
   /**
    * Persist a running job's completed-unit checkpoint AT unit completion —
    * not only when a job fails (JOB-RESTART-SAFETY P2). `failJob` carries the
@@ -28,8 +28,25 @@ export interface JobQueue {
    * file's metadata as each unit lands, unioned with any existing
    * checkpoint, so recovery resumes rather than restarts. Unthrottled (a
    * unit completion must never be dropped); a no-op for non-running jobs.
+   *
+   * `unitCursors` is the finer grain `completedUnits` cannot express
+   * (CHUNK-GRAIN-RESUME P2): how far an UNFINISHED unit got, so a job that
+   * dies mid-unit resumes there instead of at the top. It is written per
+   * committed chunk, not per unit.
+   *
+   * **The two merge differently, and the difference is the contract.**
+   * `completedUnits` is a set, so a union converges under concurrent snapshots
+   * — a set only grows. A cursor converges only if the merge is **monotone per
+   * unit**: a stale snapshot must never move one backward. `next` and `size`
+   * move TOGETHER as one observation; taking `size` from one snapshot and
+   * `next` from another would describe a chunk that never existed. A unit that
+   * reaches `completedUnits` drops its cursor, so "in progress with a cursor"
+   * and "complete" stay structurally exclusive rather than by convention.
+   *
+   * The rule belongs here rather than to any one driver because it is what
+   * makes a cursor safe to merge at all.
    */
-  checkpointUnits(jobId: JobId, completedUnits: string[]): Promise<void>;
+  checkpointUnits(jobId: JobId, completedUnits: string[], unitCursors?: Record<string, UnitCursor>): Promise<void>;
   /** Write progress into a running job's file (throttled, best-effort). */
   recordProgress(jobId: JobId, progress: Record<string, unknown>): Promise<void>;
   /**

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -392,8 +392,12 @@ export async function processHighlightJob(
   onProgress(30, { code: 'analyzing' }, echo);
 
   const dedupe = makeSpanDeduper();
-  let found = 0;
-  let created = 0;
+  // Seeded from what an earlier attempt already counted for this unit, so a
+  // resumed job's terminal record describes the document rather than the
+  // remainder it happened to run (CHUNK-GRAIN-RESUME HD3).
+  const prior = resumeCursors?.['highlighting'];
+  let found = prior?.found ?? 0;
+  let created = prior?.emitted ?? 0;
   await AnnotationDetection.detectHighlights(
     content, inferenceClient, params.instructions, params.density, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
@@ -409,7 +413,7 @@ export async function processHighlightJob(
       // One motivation per job, so exactly one unit — and with only one, a
       // unit-grain checkpoint could record nothing until the whole document
       // was done. The cursor is the entire resume story for these three types.
-      await onChunkComplete(fresh, { unit: 'highlighting', cursor });
+      await onChunkComplete(fresh, { unit: 'highlighting', cursor: { ...cursor, found, emitted: created } });
     },
   );
 
@@ -467,8 +471,12 @@ export async function processCommentJob(
   // caller didn't specify, matching what the LLM produces by default.
   const bodyLanguage = params.language ?? 'en';
   const dedupe = makeSpanDeduper();
-  let found = 0;
-  let created = 0;
+  // Seeded from what an earlier attempt already counted for this unit, so a
+  // resumed job's terminal record describes the document rather than the
+  // remainder it happened to run (CHUNK-GRAIN-RESUME HD3).
+  const prior = resumeCursors?.['commenting'];
+  let found = prior?.found ?? 0;
+  let created = prior?.emitted ?? 0;
   await AnnotationDetection.detectComments(
     content, inferenceClient, params.instructions, params.tone, params.density,
     params.language, params.sourceLanguage,
@@ -487,7 +495,7 @@ export async function processCommentJob(
       ));
       created += fresh.length;
       onProgress(60, { code: 'creating-annotations', count: created }, echo);
-      await onChunkComplete(fresh, { unit: 'commenting', cursor });
+      await onChunkComplete(fresh, { unit: 'commenting', cursor: { ...cursor, found, emitted: created } });
     },
   );
 
@@ -518,8 +526,12 @@ export async function processAssessmentJob(
 
   const bodyLanguage = params.language ?? 'en';
   const dedupe = makeSpanDeduper();
-  let found = 0;
-  let created = 0;
+  // Seeded from what an earlier attempt already counted for this unit, so a
+  // resumed job's terminal record describes the document rather than the
+  // remainder it happened to run (CHUNK-GRAIN-RESUME HD3).
+  const prior = resumeCursors?.['assessing'];
+  let found = prior?.found ?? 0;
+  let created = prior?.emitted ?? 0;
   await AnnotationDetection.detectAssessments(
     content, inferenceClient, params.instructions, params.tone, params.density,
     params.language, params.sourceLanguage,
@@ -541,7 +553,7 @@ export async function processAssessmentJob(
       ));
       created += fresh.length;
       onProgress(60, { code: 'creating-annotations', count: created }, echo);
-      await onChunkComplete(fresh, { unit: 'assessing', cursor });
+      await onChunkComplete(fresh, { unit: 'assessing', cursor: { ...cursor, found, emitted: created } });
     },
   );
 
@@ -586,8 +598,13 @@ export async function processReferenceJob(
   const entityTypeNames = params.entityTypes.map(String);
   const requestParams = [{ label: 'entity-types' as const, value: entityTypeNames.join(', ') }];
   const completedItems: CompletedItem[] = [];
-  let totalFound = 0;
-  let totalEmitted = 0;
+  // Seeded with what earlier attempts already counted for the units this
+  // attempt is RESUMING. Units that completed earlier carry no cursor — they
+  // are filtered out before this function sees them — so their share is still
+  // missing from the job total. That is the pre-existing unit-grain gap, named
+  // in CHUNK-GRAIN-RESUME rather than silently half-fixed here.
+  let totalFound = Object.values(resumeCursors ?? {}).reduce((n, c) => n + c.found, 0);
+  let totalEmitted = Object.values(resumeCursors ?? {}).reduce((n, c) => n + c.emitted, 0);
   let errors = 0;
   let totalUnderReportedPieces = 0;
   // The denominator: cumulative count-verifier expectations over accepted
@@ -650,8 +667,13 @@ export async function processReferenceJob(
 
     // One deduper per unit, held across its chunks.
     const dedupe = makeSpanDeduper();
-    let unitFound = 0;
-    let unitPersisted = 0;
+    // Seeded from what earlier attempts already counted for THIS unit, so the
+    // terminal record describes the document rather than the remainder this
+    // attempt happened to run. Absent (a first attempt) means zero, which is
+    // the truth rather than a default.
+    const priorUnit = resumeCursors?.[entityTypeName];
+    let unitFound = priorUnit?.found ?? 0;
+    let unitPersisted = priorUnit?.emitted ?? 0;
     // What remains unknown at the unit's end: floor-accepted pieces, folded.
     let underReported: { pieces: number; found: number; counted: number } | undefined;
     await extractEntities(
@@ -695,16 +717,26 @@ export async function processReferenceJob(
           built.push(buildAnnotation('linking', toMatch(reconciled), unresolvedBody));
         }
         const fresh = dedupe(built);
+        // What this chunk makes true ONCE IT IS DURABLE. Computed before the
+        // commit because the checkpoint is written inside it and has to carry
+        // the running totals — a checkpoint reporting only this attempt's share
+        // would reset the count on every death — but assigned after, so the
+        // invariant below still holds.
+        const nextFound = unitFound + chunkEntities.length;
+        const nextEmitted = unitPersisted + fresh.length;
         // Awaited: a failed commit fails the unit before it can checkpoint;
         // the cursor rides with it so the checkpoint trails the log by
         // construction rather than by the caller remembering to order them.
-        await onChunkComplete?.(fresh, { unit: entityTypeName, cursor });
+        await onChunkComplete?.(fresh, {
+          unit: entityTypeName,
+          cursor: { ...cursor, found: nextFound, emitted: nextEmitted },
+        });
         // Tallies move only PAST the awaited commit — a chunk that fails to
         // commit contributes nothing anywhere — and the numerator advances at
         // the same grain as the denominator: per chunk, in the same frame
         // family the viewer's found-of-~expected tally reads.
-        unitFound += chunkEntities.length;
-        unitPersisted += fresh.length;
+        unitFound = nextFound;
+        unitPersisted = nextEmitted;
         totalFound += chunkEntities.length;
         totalEmitted += fresh.length;
         emitTypeProgress(entityTypeName);
@@ -763,8 +795,14 @@ export async function processTagJob(
   // One deduper across every category: they share an emission stream, and
   // the key includes the body, so only true repeats collapse.
   const dedupe = makeSpanDeduper();
+  // Resumed tallies (CHUNK-GRAIN-RESUME HD3), and the two are seeded
+  // DIFFERENTLY because they accumulate differently. `found` sums each
+  // category's own running total at the end of that category, and those totals
+  // are already seeded — seeding here too would count the earlier attempt
+  // twice. `created` accumulates per chunk from this attempt only, so it must
+  // start at what earlier attempts committed.
   let found = 0;
-  let created = 0;
+  let created = Object.values(resumeCursors ?? {}).reduce((n, c) => n + c.emitted, 0);
   // byCategory counts the DEDUPED set so the per-category counts match what
   // is actually stored. The category is the first (tagging) TextualBody.
   const byCategory: Record<string, number> = {};
@@ -785,7 +823,11 @@ export async function processTagJob(
       { code: 'analyzing-tags' },
       position(),
     );
-    let categoryFound = 0;
+    // This category's own running tallies, seeded from its cursor so the
+    // checkpoint it writes stays continuable for a third attempt.
+    const priorCategory = resumeCursors?.[category];
+    let categoryFound = priorCategory?.found ?? 0;
+    let categoryCreated = priorCategory?.emitted ?? 0;
     await AnnotationDetection.detectTags(
       content, inferenceClient, params.schema, category, params.sourceLanguage,
       // Liveness (chunk boundaries + in-flight heartbeat): this category's
@@ -823,7 +865,11 @@ export async function processTagJob(
         // cursor — and the monotone merge would keep the furthest, which is the
         // right answer for at most one of them and silently skips text for the
         // rest. Same shape as reference's entity types, for the same reason.
-        await onChunkComplete(fresh, { unit: category, cursor });
+        categoryCreated += fresh.length;
+        await onChunkComplete(fresh, {
+          unit: category,
+          cursor: { ...cursor, found: categoryFound, emitted: categoryCreated },
+        });
       },
     );
     found += categoryFound;

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -381,6 +381,10 @@ export async function processHighlightJob(
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
   onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
+  /** Where earlier attempts left each unit (CHUNK-GRAIN-RESUME P3), keyed the
+   * same way the checkpoint is. A unit absent here starts at the top, which is
+   * every unit of a first attempt. */
+  resumeCursors?: Record<string, UnitCursor>,
 ): Promise<ProcessorResult<JobHighlightAnnotationResult>> {
   const echo = detectionEcho(params);
 
@@ -394,6 +398,7 @@ export async function processHighlightJob(
     content, inferenceClient, params.instructions, params.density, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
     (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
+    resumeCursors?.['highlighting'],
     async (matches, cursor) => {
       found += matches.length;
       // Highlights carry no body — motivation:'highlighting' on a target
@@ -447,6 +452,10 @@ export async function processCommentJob(
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
   onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
+  /** Where earlier attempts left each unit (CHUNK-GRAIN-RESUME P3), keyed the
+   * same way the checkpoint is. A unit absent here starts at the top, which is
+   * every unit of a first attempt. */
+  resumeCursors?: Record<string, UnitCursor>,
 ): Promise<ProcessorResult<JobCommentAnnotationResult>> {
   const echo = detectionEcho(params);
 
@@ -465,6 +474,7 @@ export async function processCommentJob(
     params.language, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
     (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
+    resumeCursors?.['commenting'],
     async (comments, cursor) => {
       found += comments.length;
       const fresh = dedupe(comments.map((c) =>
@@ -496,6 +506,10 @@ export async function processAssessmentJob(
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
   onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
+  /** Where earlier attempts left each unit (CHUNK-GRAIN-RESUME P3), keyed the
+   * same way the checkpoint is. A unit absent here starts at the top, which is
+   * every unit of a first attempt. */
+  resumeCursors?: Record<string, UnitCursor>,
 ): Promise<ProcessorResult<JobAssessmentAnnotationResult>> {
   const echo = detectionEcho(params);
 
@@ -511,6 +525,7 @@ export async function processAssessmentJob(
     params.language, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
     (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
+    resumeCursors?.['assessing'],
     async (assessments, cursor) => {
       found += assessments.length;
       const fresh = dedupe(assessments.map((a) =>
@@ -563,6 +578,10 @@ export async function processReferenceJob(
   signal?: AbortSignal,
   /** This chunk's novel annotations, awaited: the durability write. */
   onChunkComplete?: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
+  /** Where earlier attempts left each entity-type unit (CHUNK-GRAIN-RESUME P3).
+   * A unit absent here starts at the top; units already COMPLETE never reach
+   * this function at all, the caller having filtered them out. */
+  resumeCursors?: Record<string, UnitCursor>,
 ): Promise<{ result: JobReferenceAnnotationResult }> {
   const entityTypeNames = params.entityTypes.map(String);
   const requestParams = [{ label: 'entity-types' as const, value: entityTypeNames.join(', ') }];
@@ -655,6 +674,7 @@ export async function processReferenceJob(
         totalExpected += counted;
         emitTypeProgress(entityTypeName);
       },
+      resumeCursors?.[entityTypeName],
       async (chunkEntities, cursor) => {
         const built: Annotation[] = [];
         for (const entity of chunkEntities) {
@@ -731,6 +751,10 @@ export async function processTagJob(
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
   onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
+  /** Where earlier attempts left each CATEGORY (CHUNK-GRAIN-RESUME P3) — a tag
+   * job's units are its categories, not its motivation: each walks the whole
+   * document, so one shared cursor would skip text for all but one of them. */
+  resumeCursors?: Record<string, UnitCursor>,
 ): Promise<ProcessorResult<JobTagAnnotationResult>> {
   onProgress(10, { code: 'loading' });
   onProgress(30, { code: 'analyzing-tags' });
@@ -771,6 +795,7 @@ export async function processTagJob(
         { code: 'analyzing-tags' },
         position(),
       ),
+      resumeCursors?.[category],
       async (matches, cursor) => {
         categoryFound += matches.length;
         const fresh = dedupe(matches.map((t) => {

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -16,7 +16,7 @@ import { compileTypst, MAX_COMPILE_REPAIRS } from './workers/generation/typst-co
 import { withinByteBudget, MAX_PDF_BYTES } from '@semiont/content';
 import { resolveCitationTokens, collectContextResourceIds, type GenerationCitation } from './workers/generation/citation-resolver';
 import { annotationIdFor } from '@semiont/event-sourcing';
-import { didToAgent, GENERATABLE_MEDIA_TYPES, type Annotation, type GenerationJobParams, type Logger, type ResourceId, type SupportedMediaType, type components, type JobReferenceAnnotationResult, type JobHighlightAnnotationResult, type JobCommentAnnotationResult, type JobAssessmentAnnotationResult, type JobTagAnnotationResult } from '@semiont/core';
+import { didToAgent, GENERATABLE_MEDIA_TYPES, type Annotation, type GenerationJobParams, type Logger, type ResourceId, type SupportedMediaType, type components, type JobReferenceAnnotationResult, type JobHighlightAnnotationResult, type JobCommentAnnotationResult, type JobAssessmentAnnotationResult, type JobTagAnnotationResult, type UnitCursor } from '@semiont/core';
 import { reconcileSelector, createFragmentSelector, locate, type ReconciledSelector, type AnchoredText } from '@semiont/core';
 import type { InferenceClient } from '@semiont/inference';
 import type {
@@ -359,6 +359,20 @@ export function buildPdfAnnotation(
   };
 }
 
+/**
+ * Where one unit stands once the chunk just handed over is durable
+ * (CHUNK-GRAIN-RESUME P2).
+ *
+ * The unit is named HERE rather than in the detection layer, which knows about
+ * chunks and nothing about jobs: for `reference-annotation` a unit is an entity
+ * type, for `tag-annotation` a category — both loop over several — and for the
+ * other three the job runs exactly one unit, its own motivation.
+ */
+export interface UnitCheckpoint {
+  unit: string;
+  cursor: UnitCursor;
+}
+
 export async function processHighlightJob(
   content: string,
   inferenceClient: InferenceClient,
@@ -366,7 +380,7 @@ export async function processHighlightJob(
   buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
-  onChunkComplete: (annotations: Annotation[]) => Promise<void>,
+  onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
 ): Promise<ProcessorResult<JobHighlightAnnotationResult>> {
   const echo = detectionEcho(params);
 
@@ -380,14 +394,17 @@ export async function processHighlightJob(
     content, inferenceClient, params.instructions, params.density, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
     (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
-    async (matches) => {
+    async (matches, cursor) => {
       found += matches.length;
       // Highlights carry no body — motivation:'highlighting' on a target
       // is a complete annotation per the W3C Web Annotation Model.
       const fresh = dedupe(matches.map((h) => buildAnnotation('highlighting', h)));
       created += fresh.length;
       onProgress(60, { code: 'creating-annotations', count: created }, echo);
-      await onChunkComplete(fresh);
+      // One motivation per job, so exactly one unit — and with only one, a
+      // unit-grain checkpoint could record nothing until the whole document
+      // was done. The cursor is the entire resume story for these three types.
+      await onChunkComplete(fresh, { unit: 'highlighting', cursor });
     },
   );
 
@@ -429,7 +446,7 @@ export async function processCommentJob(
   buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
-  onChunkComplete: (annotations: Annotation[]) => Promise<void>,
+  onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
 ): Promise<ProcessorResult<JobCommentAnnotationResult>> {
   const echo = detectionEcho(params);
 
@@ -448,7 +465,7 @@ export async function processCommentJob(
     params.language, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
     (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
-    async (comments) => {
+    async (comments, cursor) => {
       found += comments.length;
       const fresh = dedupe(comments.map((c) =>
         // Match the pre-#651 CommentAnnotationWorker: include format and
@@ -460,7 +477,7 @@ export async function processCommentJob(
       ));
       created += fresh.length;
       onProgress(60, { code: 'creating-annotations', count: created }, echo);
-      await onChunkComplete(fresh);
+      await onChunkComplete(fresh, { unit: 'commenting', cursor });
     },
   );
 
@@ -478,7 +495,7 @@ export async function processAssessmentJob(
   buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
-  onChunkComplete: (annotations: Annotation[]) => Promise<void>,
+  onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
 ): Promise<ProcessorResult<JobAssessmentAnnotationResult>> {
   const echo = detectionEcho(params);
 
@@ -494,7 +511,7 @@ export async function processAssessmentJob(
     params.language, params.sourceLanguage,
     // Liveness (chunk boundaries + in-flight heartbeat): 30–60 band.
     (consumedChars, totalChars) => onProgress(30 + Math.round((consumedChars / totalChars) * 30), { code: 'analyzing' }, echo),
-    async (assessments) => {
+    async (assessments, cursor) => {
       found += assessments.length;
       const fresh = dedupe(assessments.map((a) =>
         // Single-object body with purpose aligned to motivation, matching the
@@ -509,7 +526,7 @@ export async function processAssessmentJob(
       ));
       created += fresh.length;
       onProgress(60, { code: 'creating-annotations', count: created }, echo);
-      await onChunkComplete(fresh);
+      await onChunkComplete(fresh, { unit: 'assessing', cursor });
     },
   );
 
@@ -545,7 +562,7 @@ export async function processReferenceJob(
   onUnitComplete: (entityType: string) => Promise<void>,
   signal?: AbortSignal,
   /** This chunk's novel annotations, awaited: the durability write. */
-  onChunkComplete?: (annotations: Annotation[]) => Promise<void>,
+  onChunkComplete?: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
 ): Promise<{ result: JobReferenceAnnotationResult }> {
   const entityTypeNames = params.entityTypes.map(String);
   const requestParams = [{ label: 'entity-types' as const, value: entityTypeNames.join(', ') }];
@@ -638,7 +655,7 @@ export async function processReferenceJob(
         totalExpected += counted;
         emitTypeProgress(entityTypeName);
       },
-      async (chunkEntities) => {
+      async (chunkEntities, cursor) => {
         const built: Annotation[] = [];
         for (const entity of chunkEntities) {
           const reconciled = reconcileSelector(content, {
@@ -659,8 +676,9 @@ export async function processReferenceJob(
         }
         const fresh = dedupe(built);
         // Awaited: a failed commit fails the unit before it can checkpoint;
-        // the retry re-runs it whole, into a log that dedupes by id.
-        await onChunkComplete?.(fresh);
+        // the cursor rides with it so the checkpoint trails the log by
+        // construction rather than by the caller remembering to order them.
+        await onChunkComplete?.(fresh, { unit: entityTypeName, cursor });
         // Tallies move only PAST the awaited commit — a chunk that fails to
         // commit contributes nothing anywhere — and the numerator advances at
         // the same grain as the denominator: per chunk, in the same frame
@@ -712,7 +730,7 @@ export async function processTagJob(
   buildAnnotation: BuildAnnotation,
   onProgress: OnProgress,
   /** This chunk's novel annotations, awaited: the durability write. */
-  onChunkComplete: (annotations: Annotation[]) => Promise<void>,
+  onChunkComplete: (annotations: Annotation[], checkpoint: UnitCheckpoint) => Promise<void>,
 ): Promise<ProcessorResult<JobTagAnnotationResult>> {
   onProgress(10, { code: 'loading' });
   onProgress(30, { code: 'analyzing-tags' });
@@ -753,7 +771,7 @@ export async function processTagJob(
         { code: 'analyzing-tags' },
         position(),
       ),
-      async (matches) => {
+      async (matches, cursor) => {
         categoryFound += matches.length;
         const fresh = dedupe(matches.map((t) => {
           const cat = t.category ?? 'unknown';
@@ -774,7 +792,13 @@ export async function processTagJob(
           byCategory[cat] = (byCategory[cat] ?? 0) + 1;
         }
         onProgress(60, { code: 'creating-tag-annotations', count: created });
-        await onChunkComplete(fresh);
+        // The unit is the CATEGORY, not the motivation. `tag-annotation` loops
+        // over `params.categories`, each walking the whole document from zero,
+        // so a single 'tagging' key would have every category overwriting one
+        // cursor — and the monotone merge would keep the furthest, which is the
+        // right answer for at most one of them and silently skips text for the
+        // rest. Same shape as reference's entity types, for the same reason.
+        await onChunkComplete(fresh, { unit: category, cursor });
       },
     );
     found += categoryFound;

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -11,7 +11,7 @@
  * - State machine is explicit and type-safe
  */
 
-import type { JobId, EntityType, ResourceId, UserId, GenerationJobParams, TagSchema } from '@semiont/core';
+import type { JobId, EntityType, ResourceId, UserId, GenerationJobParams, TagSchema, UnitCursor } from '@semiont/core';
 import type { JobReferenceAnnotationResult, JobHighlightAnnotationResult, JobCommentAnnotationResult, JobAssessmentAnnotationResult, JobTagAnnotationResult } from '@semiont/core';
 
 export type JobType = 'reference-annotation' | 'generation' | 'highlight-annotation' | 'assessment-annotation' | 'comment-annotation' | 'tag-annotation';
@@ -51,6 +51,18 @@ export interface JobMetadata {
    * duplicated.
    */
   completedUnits?: string[];
+  /**
+   * The finer grain `completedUnits` cannot express (CHUNK-GRAIN-RESUME P2):
+   * how far each UNFINISHED unit got, keyed by unit. Written per committed
+   * chunk, so a job that dies mid-unit resumes there rather than at the top —
+   * which for a one-unit job (every motivation job, and the 1958 document's
+   * single `Person` type) is the difference between resuming and restarting.
+   *
+   * A unit here is in progress, never complete; the two sets are disjoint by
+   * construction in `checkpointUnits`. Merged monotonically per unit, never
+   * unioned — see `mergeUnitCursors`.
+   */
+  unitCursors?: Record<string, UnitCursor>;
 }
 
 /**

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -607,6 +607,9 @@ async function handleJobInner(
       // The durability write, per chunk, awaited; folds into the terminal
       // durability evidence like every commit, and carries the unit's cursor.
       commitChunk,
+      // …and the other direction: where an earlier attempt left each unit
+      // (CHUNK-GRAIN-RESUME P3). Empty on a first attempt.
+      job.unitCursors,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),
@@ -620,6 +623,9 @@ async function handleJobInner(
       // The durability write, per chunk, awaited; folds into the terminal
       // durability evidence like every commit, and carries the unit's cursor.
       commitChunk,
+      // …and the other direction: where an earlier attempt left each unit
+      // (CHUNK-GRAIN-RESUME P3). Empty on a first attempt.
+      job.unitCursors,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),
@@ -633,6 +639,9 @@ async function handleJobInner(
       // The durability write, per chunk, awaited; folds into the terminal
       // durability evidence like every commit, and carries the unit's cursor.
       commitChunk,
+      // …and the other direction: where an earlier attempt left each unit
+      // (CHUNK-GRAIN-RESUME P3). Empty on a first attempt.
+      job.unitCursors,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),
@@ -682,6 +691,9 @@ async function handleJobInner(
       // The durability write, per chunk, awaited; folds into the terminal
       // durability evidence like every commit, and carries the unit's cursor.
       commitChunk,
+      // …and the other direction: where an earlier attempt left each unit
+      // (CHUNK-GRAIN-RESUME P3). Empty on a first attempt.
+      job.unitCursors,
     );
     // Cooperative cancellation (JOB-RESTART-SAFETY P4): the loop stopped
     // because a cancel was requested for this job. Announce it so the queue
@@ -709,6 +721,9 @@ async function handleJobInner(
       // The durability write, per chunk, awaited; folds into the terminal
       // durability evidence like every commit, and carries the unit's cursor.
       commitChunk,
+      // …and the other direction: where an earlier attempt left each unit
+      // (CHUNK-GRAIN-RESUME P3). Empty on a first attempt.
+      job.unitCursors,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),

--- a/packages/jobs/src/worker-process.ts
+++ b/packages/jobs/src/worker-process.ts
@@ -32,7 +32,7 @@ import { type HttpTransport } from '@semiont/http-transport';
 import { isGenerationJobParams, getPrimaryMediaType, assembleAnnotation, resourceId as makeResourceId, annotationId as makeAnnotationId, findClaimSpan, capabilitiesOf, isObject, isString, type EventMap, busRequest, BusRequestError } from '@semiont/core';
 
 import type { InferenceClient } from '@semiont/inference';
-import type { Logger, components, AssembledAnnotation } from '@semiont/core';
+import type { Logger, components, AssembledAnnotation, Annotation, UnitCursor } from '@semiont/core';
 import { workerBusAsPrimitive } from './worker-bus-primitive.js';
 import { extractPdfTextLayer, type ContentReads } from '@semiont/content';
 import { prepareDetection } from './workers/detection/prepare-detection';
@@ -48,6 +48,7 @@ import {
   buildPdfAnnotation,
   type OnProgress,
   type BuildAnnotation,
+  type UnitCheckpoint,
 } from './processors';
 
 /**
@@ -287,6 +288,12 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
   // it); cleared on every terminal outcome.
   const completedUnitsByJob = new Map<string, string[]>();
 
+  // The mid-unit half of the same checkpoint (CHUNK-GRAIN-RESUME P2). Kept
+  // beside `completedUnitsByJob` and for the same reason: `job:fail` is the
+  // clean-failure path, and without this a job that dies partway through its
+  // only unit reports a checkpoint that says nothing happened.
+  const unitCursorsByJob = new Map<string, Record<string, UnitCursor>>();
+
   // Cooperative cancellation (JOB-RESTART-SAFETY P4): a job:cancel-requested
   // targeting the ACTIVE job aborts its signal; the reference loop stops at
   // its next unit boundary and the job moves to cancelled/ carrying its
@@ -310,9 +317,10 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
     logger.info('Processing job', { jobId: job.jobId, type: job.type, resourceId: job.resourceId });
     const controller = new AbortController();
     activeCancel = { jobId: job.jobId, controller };
-    handleJob(adapter, config, job, completedUnitsByJob, controller.signal)
+    handleJob(adapter, config, job, completedUnitsByJob, controller.signal, unitCursorsByJob)
       .then(() => {
         completedUnitsByJob.delete(job.jobId);
+        unitCursorsByJob.delete(job.jobId);
       })
       .catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
@@ -321,7 +329,9 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
         const failureClass = classifyFailure(error);
         logger.error('Job failed', { jobId: job.jobId, error: message, failureClass, stack: error instanceof Error ? error.stack : undefined });
         const completedUnits = completedUnitsByJob.get(job.jobId);
+        const unitCursors = unitCursorsByJob.get(job.jobId);
         completedUnitsByJob.delete(job.jobId);
+        unitCursorsByJob.delete(job.jobId);
         const failAnnotationId = referenceIdOf(job);
         if (isJobType(job.type)) {
           emitEvent(session, 'job:fail', {
@@ -331,6 +341,10 @@ export function startWorkerProcess(config: WorkerProcessConfig): JobClaimAdapter
             ...(failAnnotationId ? { annotationId: failAnnotationId } : {}),
             error: message,
             ...(completedUnits && completedUnits.length > 0 ? { completedUnits } : {}),
+            // Where each unfinished unit got to. Absent rather than `{}` when
+            // nothing was reached: an empty object would claim units were
+            // tracked and none progressed.
+            ...(unitCursors && Object.keys(unitCursors).length > 0 ? { unitCursors } : {}),
             ...(failureClass !== undefined ? { failureClass } : {}),
             // What the commit path OBSERVED about durability, when the failure
             // came from a commit at all. Present only on that path: absent means
@@ -372,13 +386,16 @@ export async function handleJob(
   // next unit boundary and the job moves to cancelled/. Standalone callers
   // omit it — an undefined signal never aborts.
   signal?: AbortSignal,
+  // The mid-unit half of the checkpoint, same sharing rule as
+  // `completedUnitsByJob`: filled here, read by the failure path.
+  unitCursorsByJob: Map<string, Record<string, UnitCursor>> = new Map(),
 ): Promise<void> {
   const start = performance.now();
   let outcome: 'completed' | 'failed' = 'completed';
   try {
     return await withSpan(
       `job:${job.type}`,
-      () => handleJobInner(adapter, config, job, completedUnitsByJob, signal),
+      () => handleJobInner(adapter, config, job, completedUnitsByJob, signal, unitCursorsByJob),
       {
         kind: SpanKind.CONSUMER,
         attrs: {
@@ -402,6 +419,7 @@ async function handleJobInner(
   job: ActiveJob,
   completedUnitsByJob: Map<string, string[]>,
   signal?: AbortSignal,
+  unitCursorsByJob: Map<string, Record<string, UnitCursor>> = new Map(),
 ): Promise<void> {
   const { session, inferenceClient, generator } = config;
   const { userId, jobId } = job;
@@ -553,12 +571,42 @@ async function handleJobInner(
     }).catch(() => {});
   };
 
+  /**
+   * Per-unit resume positions for THIS attempt (CHUNK-GRAIN-RESUME P2),
+   * reported on every checkpoint and carried onto a terminal failure.
+   * In-memory only: the durable copy is the queue's, merged monotonically,
+   * because two checkpoints can be in flight and the older can land last.
+   */
+  const unitCursors = new Map<string, UnitCursor>();
+
+  /**
+   * Commit a chunk's annotations, then record where that leaves its unit.
+   *
+   * The order is the contract — the checkpoint must never lead the log — and
+   * it is enforced by being ONE step rather than two callbacks a caller has to
+   * sequence correctly. A commit that throws checkpoints nothing, so the retry
+   * re-runs that chunk into a log that dedupes it by id.
+   */
+  const commitChunk = async (annotations: Annotation[], checkpoint: UnitCheckpoint) => {
+    record(await commitAnnotations(session, String(resourceId), annotations));
+    unitCursors.set(checkpoint.unit, checkpoint.cursor);
+    // Published to the caller's accumulator as it moves: the failure path runs
+    // OUTSIDE this function, so a cursor only this scope knows about would be
+    // lost on exactly the failures it exists to survive.
+    unitCursorsByJob.set(job.jobId, Object.fromEntries(unitCursors));
+    await emitEvent(session, 'job:checkpoint', {
+      jobId: job.jobId,
+      completedUnits: [...(completedUnitsByJob.get(job.jobId) ?? [])],
+      unitCursors: Object.fromEntries(unitCursors),
+    });
+  };
+
   if (jobType === 'highlight-annotation') {
     const { result } = await processHighlightJob(
       ready!.text, inferenceClient, asJobParams<HighlightDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
       // The durability write, per chunk, awaited; folds into the terminal
-      // durability evidence like every commit.
-      async (annotations) => { record(await commitAnnotations(session, String(resourceId), annotations)); },
+      // durability evidence like every commit, and carries the unit's cursor.
+      commitChunk,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),
@@ -570,8 +618,8 @@ async function handleJobInner(
     const { result } = await processCommentJob(
       ready!.text, inferenceClient, asJobParams<CommentDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
       // The durability write, per chunk, awaited; folds into the terminal
-      // durability evidence like every commit.
-      async (annotations) => { record(await commitAnnotations(session, String(resourceId), annotations)); },
+      // durability evidence like every commit, and carries the unit's cursor.
+      commitChunk,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),
@@ -583,8 +631,8 @@ async function handleJobInner(
     const { result } = await processAssessmentJob(
       ready!.text, inferenceClient, asJobParams<AssessmentDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
       // The durability write, per chunk, awaited; folds into the terminal
-      // durability evidence like every commit.
-      async (annotations) => { record(await commitAnnotations(session, String(resourceId), annotations)); },
+      // durability evidence like every commit, and carries the unit's cursor.
+      commitChunk,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),
@@ -619,15 +667,21 @@ async function handleJobInner(
         // unit failing mid-stream never reaches here; its landed chunks
         // re-commit on retry into a log that dedupes by id.
         committed.push(unit);
+        // The unit is done, so it is no longer partway: dropping it keeps the
+        // reported payload consistent with what the queue stores, which treats
+        // the two sets as disjoint.
+        unitCursors.delete(unit);
+        unitCursorsByJob.set(job.jobId, Object.fromEntries(unitCursors));
         await emitEvent(session, 'job:checkpoint', {
           jobId: job.jobId,
           completedUnits: [...committed],
+          ...(unitCursors.size > 0 ? { unitCursors: Object.fromEntries(unitCursors) } : {}),
         });
       },
       signal,
       // The durability write, per chunk, awaited; folds into the terminal
-      // durability evidence like every commit.
-      async (annotations) => { record(await commitAnnotations(session, String(resourceId), annotations)); },
+      // durability evidence like every commit, and carries the unit's cursor.
+      commitChunk,
     );
     // Cooperative cancellation (JOB-RESTART-SAFETY P4): the loop stopped
     // because a cancel was requested for this job. Announce it so the queue
@@ -653,8 +707,8 @@ async function handleJobInner(
     const { result } = await processTagJob(
       ready!.text, inferenceClient, asJobParams<TagDetectionParams>(job.params), ready!.buildAnnotation, onProgress,
       // The durability write, per chunk, awaited; folds into the terminal
-      // durability evidence like every commit.
-      async (annotations) => { record(await commitAnnotations(session, String(resourceId), annotations)); },
+      // durability evidence like every commit, and carries the unit's cursor.
+      commitChunk,
     );
     await emitEvent(session, 'job:complete', {
       ...terminalBase(),

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -63,6 +63,9 @@ async function detectInChunks<T>(
    * WITH the results so a caller cannot record a position it has not made
    * durable (CHUNK-GRAIN-RESUME P2).
    */
+  /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3).
+   * Before the callback below, which stays last. */
+  resume?: UnitCursor,
   onChunkResults?: (parsed: T[], cursor: UnitCursor) => Promise<void>,
 ): Promise<T[]> {
   const limits = await client.limits();
@@ -100,7 +103,7 @@ async function detectInChunks<T>(
     // the unit's completion itself.
     if (next < totalChars) onActivity?.(next, totalChars);
     return outcome;
-  });
+  }, resume);
   return collected;
 }
 
@@ -124,6 +127,9 @@ export class AnnotationDetection {
     sourceLanguage?: string,
     onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
+    /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
+    resume?: UnitCursor,
+    /** This chunk's matches, as the chunk completes. Kept LAST. */
     onChunkResults?: (matches: CommentMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<CommentMatch[]> {
     return detectInChunks(
@@ -132,6 +138,7 @@ export class AnnotationDetection {
       'comment', COMMENT_ELEMENT_SCHEMA,
       (items) => MotivationParsers.parseComments(items, content),
       onActivity,
+      resume,
       onChunkResults,
     );
   }
@@ -151,6 +158,9 @@ export class AnnotationDetection {
     sourceLanguage?: string,
     onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
+    /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
+    resume?: UnitCursor,
+    /** This chunk's matches, as the chunk completes. Kept LAST. */
     onChunkResults?: (matches: HighlightMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<HighlightMatch[]> {
     return detectInChunks(
@@ -159,6 +169,7 @@ export class AnnotationDetection {
       'highlight', HIGHLIGHT_ELEMENT_SCHEMA,
       (items) => MotivationParsers.parseHighlights(items, content),
       onActivity,
+      resume,
       onChunkResults,
     );
   }
@@ -180,6 +191,9 @@ export class AnnotationDetection {
     sourceLanguage?: string,
     onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
+    /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
+    resume?: UnitCursor,
+    /** This chunk's matches, as the chunk completes. Kept LAST. */
     onChunkResults?: (matches: AssessmentMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<AssessmentMatch[]> {
     return detectInChunks(
@@ -188,6 +202,7 @@ export class AnnotationDetection {
       'assessment', ASSESSMENT_ELEMENT_SCHEMA,
       (items) => MotivationParsers.parseAssessments(items, content),
       onActivity,
+      resume,
       onChunkResults,
     );
   }
@@ -216,6 +231,9 @@ export class AnnotationDetection {
      * raw tags, so this path runs `validateTagOffsets` per chunk — a per-item
      * anchor against the full document, so partitioning changes nothing.
      */
+    /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
+    resume?: UnitCursor,
+    /** This chunk's matches, as the chunk completes. Kept LAST. */
     onChunkResults?: (matches: TagMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<TagMatch[]> {
     const categoryInfo = schema.tags.find((t) => t.name === category);
@@ -239,6 +257,7 @@ export class AnnotationDetection {
       'tag', TAG_ELEMENT_SCHEMA,
       (items) => MotivationParsers.parseTags(items),
       onActivity,
+      resume,
       onChunkResults
         ? async (raw, cursor) => onChunkResults(MotivationParsers.validateTagOffsets(raw, content, category), cursor)
         : undefined,

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -13,7 +13,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
 import { estimateTokens, type UnitCursor } from '@semiont/core';
 import { boundedGenerateStructured } from './inference-call';
-import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, DETECTION_TEMPERATURE } from './detection/detection-chunking';
+import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, type ChunkCursor, DETECTION_TEMPERATURE } from './detection/detection-chunking';
 import { MotivationPrompts } from './detection/motivation-prompts';
 import {
   MotivationParsers,
@@ -66,7 +66,7 @@ async function detectInChunks<T>(
   /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3).
    * Before the callback below, which stays last. */
   resume?: UnitCursor,
-  onChunkResults?: (parsed: T[], cursor: UnitCursor) => Promise<void>,
+  onChunkResults?: (parsed: T[], cursor: ChunkCursor) => Promise<void>,
 ): Promise<T[]> {
   const limits = await client.limits();
   const scaffoldTokens = estimateTokens(buildPrompt(''));
@@ -130,7 +130,7 @@ export class AnnotationDetection {
     /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
     resume?: UnitCursor,
     /** This chunk's matches, as the chunk completes. Kept LAST. */
-    onChunkResults?: (matches: CommentMatch[], cursor: UnitCursor) => Promise<void>,
+    onChunkResults?: (matches: CommentMatch[], cursor: ChunkCursor) => Promise<void>,
   ): Promise<CommentMatch[]> {
     return detectInChunks(
       client, content,
@@ -161,7 +161,7 @@ export class AnnotationDetection {
     /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
     resume?: UnitCursor,
     /** This chunk's matches, as the chunk completes. Kept LAST. */
-    onChunkResults?: (matches: HighlightMatch[], cursor: UnitCursor) => Promise<void>,
+    onChunkResults?: (matches: HighlightMatch[], cursor: ChunkCursor) => Promise<void>,
   ): Promise<HighlightMatch[]> {
     return detectInChunks(
       client, content,
@@ -194,7 +194,7 @@ export class AnnotationDetection {
     /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
     resume?: UnitCursor,
     /** This chunk's matches, as the chunk completes. Kept LAST. */
-    onChunkResults?: (matches: AssessmentMatch[], cursor: UnitCursor) => Promise<void>,
+    onChunkResults?: (matches: AssessmentMatch[], cursor: ChunkCursor) => Promise<void>,
   ): Promise<AssessmentMatch[]> {
     return detectInChunks(
       client, content,
@@ -234,7 +234,7 @@ export class AnnotationDetection {
     /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). */
     resume?: UnitCursor,
     /** This chunk's matches, as the chunk completes. Kept LAST. */
-    onChunkResults?: (matches: TagMatch[], cursor: UnitCursor) => Promise<void>,
+    onChunkResults?: (matches: TagMatch[], cursor: ChunkCursor) => Promise<void>,
   ): Promise<TagMatch[]> {
     const categoryInfo = schema.tags.find((t) => t.name === category);
     if (!categoryInfo) {

--- a/packages/jobs/src/workers/annotation-detection.ts
+++ b/packages/jobs/src/workers/annotation-detection.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
-import { estimateTokens } from '@semiont/core';
+import { estimateTokens, type UnitCursor } from '@semiont/core';
 import { boundedGenerateStructured } from './inference-call';
 import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, DETECTION_TEMPERATURE } from './detection/detection-chunking';
 import { MotivationPrompts } from './detection/motivation-prompts';
@@ -58,8 +58,12 @@ async function detectInChunks<T>(
    * caller commits them, and the loop must not run ahead of durability.
    * Unlike `onActivity` (a liveness heartbeat, which may repeat), this fires
    * exactly once per chunk, including the last.
+   *
+   * `cursor` is where the run stands once this chunk is committed — handed over
+   * WITH the results so a caller cannot record a position it has not made
+   * durable (CHUNK-GRAIN-RESUME P2).
    */
-  onChunkResults?: (parsed: T[]) => Promise<void>,
+  onChunkResults?: (parsed: T[], cursor: UnitCursor) => Promise<void>,
 ): Promise<T[]> {
   const limits = await client.limits();
   const scaffoldTokens = estimateTokens(buildPrompt(''));
@@ -90,7 +94,7 @@ async function detectInChunks<T>(
     );
     const fromChunk = parse(items);
     collected.push(...fromChunk);
-    await onChunkResults?.(fromChunk);
+    await onChunkResults?.(fromChunk, { next, size });
     // Chunk boundary: the cursor advances (real progress). Only when text
     // remains — the final cut has no boundary after it, and the caller reports
     // the unit's completion itself.
@@ -120,7 +124,7 @@ export class AnnotationDetection {
     sourceLanguage?: string,
     onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
-    onChunkResults?: (matches: CommentMatch[]) => Promise<void>,
+    onChunkResults?: (matches: CommentMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<CommentMatch[]> {
     return detectInChunks(
       client, content,
@@ -147,7 +151,7 @@ export class AnnotationDetection {
     sourceLanguage?: string,
     onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
-    onChunkResults?: (matches: HighlightMatch[]) => Promise<void>,
+    onChunkResults?: (matches: HighlightMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<HighlightMatch[]> {
     return detectInChunks(
       client, content,
@@ -176,7 +180,7 @@ export class AnnotationDetection {
     sourceLanguage?: string,
     onActivity?: (consumedChars: number, totalChars: number) => void,
     /** This chunk's matches, as the chunk completes. */
-    onChunkResults?: (matches: AssessmentMatch[]) => Promise<void>,
+    onChunkResults?: (matches: AssessmentMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<AssessmentMatch[]> {
     return detectInChunks(
       client, content,
@@ -212,7 +216,7 @@ export class AnnotationDetection {
      * raw tags, so this path runs `validateTagOffsets` per chunk — a per-item
      * anchor against the full document, so partitioning changes nothing.
      */
-    onChunkResults?: (matches: TagMatch[]) => Promise<void>,
+    onChunkResults?: (matches: TagMatch[], cursor: UnitCursor) => Promise<void>,
   ): Promise<TagMatch[]> {
     const categoryInfo = schema.tags.find((t) => t.name === category);
     if (!categoryInfo) {
@@ -236,7 +240,7 @@ export class AnnotationDetection {
       (items) => MotivationParsers.parseTags(items),
       onActivity,
       onChunkResults
-        ? async (raw) => onChunkResults(MotivationParsers.validateTagOffsets(raw, content, category))
+        ? async (raw, cursor) => onChunkResults(MotivationParsers.validateTagOffsets(raw, content, category), cursor)
         : undefined,
     );
     return MotivationParsers.validateTagOffsets(parsedTags, content, category);

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -24,7 +24,7 @@
  *   not a cost.
  */
 
-import { chunkText, cutChunk, type ChunkingConfig, type Logger } from '@semiont/core';
+import { chunkText, cutChunk, type ChunkingConfig, type Logger, type UnitCursor } from '@semiont/core';
 import { StructuredReadError, type InferenceLimits, type TokenUsage } from '@semiont/inference';
 import { recordDetectionCall } from '@semiont/observability';
 import { DeterministicJobError } from '../../failure-class';
@@ -300,14 +300,26 @@ export interface AdaptiveChunk {
  * durability (committing the chunk's annotations) still gates the next cut, and
  * a throw stops the walk where it stands rather than advancing past unprocessed
  * text.
+ *
+ * `resume` restarts a unit an earlier attempt left partway (CHUNK-GRAIN-RESUME
+ * P3) — the checkpoint P2 made durable, spent. Both halves of it matter and they
+ * are spent differently: the position is taken as given, while the size is
+ * seeded and then stepped ONCE, as if the last outcome had been a failure. It
+ * was: the job died. Opening at the budget instead would throw away the
+ * calibration the dead attempt paid for over its earlier chunks, and seeding
+ * unchanged would re-cut the identical piece — which at `DETECTION_TEMPERATURE`
+ * 0 returns the identical answer, failure included (HD2, option C).
  */
 export async function runAdaptiveChunks(
   text: string,
   budget: DetectionBudget,
   onChunk: (chunk: AdaptiveChunk) => Promise<CallOutcome>,
+  resume?: UnitCursor,
 ): Promise<void> {
-  let at = 0;
-  let size = budget.chunking.chunkSize;
+  let at = resume?.next ?? 0;
+  let size = resume
+    ? nextChunkSize({ truncated: true }, resume.size, budget.bounds)
+    : budget.chunking.chunkSize;
 
   while (at < text.length) {
     const { piece, next } = cutChunk(text, at, { chunkSize: size, overlap: budget.chunking.overlap });

--- a/packages/jobs/src/workers/detection/detection-chunking.ts
+++ b/packages/jobs/src/workers/detection/detection-chunking.ts
@@ -272,6 +272,14 @@ export function deriveDetectionBudget(
  * it. `at`/`next` over `totalChars` is exact progress — and, once
  * CHUNK-GRAIN-RESUME lands, the checkpoint identity a variable boundary forces
  * (an ordinal cannot name a chunk whose size is decided while the job runs). */
+/**
+ * The half of a `UnitCursor` the DETECTION layer can honestly report: where the
+ * walk stands and how it is cutting. The tallies belong to the processor, which
+ * owns unit identity and unit counts — this loop counts chunks, not annotations,
+ * and a zero it invented would be indistinguishable from a real one.
+ */
+export type ChunkCursor = Pick<UnitCursor, 'next' | 'size'>;
+
 export interface AdaptiveChunk {
   piece: string;
   /** The token size this piece was cut at. Hand it to `callChunkSubdividing`:

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -1,7 +1,7 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
 import { estimateTokens, getLocaleEnglishName, isObject, isString, type Logger, type UnitCursor } from '@semiont/core';
 import { boundedGenerateStructured, boundedGenerateWithMetadata } from '../inference-call';
-import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, DETECTION_TEMPERATURE, YIELD_COLLAPSE_BAND, YieldCollapseError, type UnderReportedPiece } from './detection-chunking';
+import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, type ChunkCursor, DETECTION_TEMPERATURE, YIELD_COLLAPSE_BAND, YieldCollapseError, type UnderReportedPiece } from './detection-chunking';
 
 /**
  * Entity reference extracted from text — pre-reconciliation.
@@ -177,7 +177,7 @@ export async function extractEntities(
    * position without durably committing the annotations would checkpoint ahead
    * of the log.
    */
-  onChunkResults?: (items: ExtractedEntity[], cursor: UnitCursor) => Promise<void>,
+  onChunkResults?: (items: ExtractedEntity[], cursor: ChunkCursor) => Promise<void>,
 ): Promise<ExtractedEntity[]> {
 
   // Format entity types for the prompt

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -159,11 +159,17 @@ export async function extractEntities(
   onUnderReport?: (verdict: UnderReportedPiece) => void,
   /** Each accepted piece's count-verifier expectation — the denominator. */
   onCounted?: (counted: number) => void,
+  /** Where an earlier attempt left this unit (CHUNK-GRAIN-RESUME P3). Absent on
+   * a first attempt, and then the run opens at the top exactly as before.
+   * Deliberately BEFORE the callback below, which stays last. */
+  resume?: UnitCursor,
   /**
    * This chunk's entities, awaited before the loop continues: the caller
    * commits them, and the loop must not run ahead of durability. Unlike
    * `onActivity` (a liveness heartbeat, which may repeat), this fires exactly
-   * once per chunk, including the last. Kept LAST on every detection seam.
+   * once per chunk, including the last. Kept LAST on every detection seam —
+   * test harnesses read it as the final positional argument, so a parameter
+   * appended after it silently starves them of results.
    *
    * `cursor` is where the run stands ONCE THIS CHUNK IS COMMITTED — the pair
    * CHUNK-GRAIN-RESUME checkpoints. It is handed over with the results rather
@@ -339,7 +345,7 @@ Example output:
     // the unit's completion itself.
     if (next < totalChars) onActivity?.(next, totalChars);
     return outcome;
-  });
+  }, resume);
 
   return collected;
 }

--- a/packages/jobs/src/workers/detection/entity-extractor.ts
+++ b/packages/jobs/src/workers/detection/entity-extractor.ts
@@ -1,5 +1,5 @@
 import type { ElementSchema, InferenceClient } from '@semiont/inference';
-import { estimateTokens, getLocaleEnglishName, isObject, isString, type Logger } from '@semiont/core';
+import { estimateTokens, getLocaleEnglishName, isObject, isString, type Logger, type UnitCursor } from '@semiont/core';
 import { boundedGenerateStructured, boundedGenerateWithMetadata } from '../inference-call';
 import { assertNotTruncated, callChunkSubdividing, deriveDetectionBudget, runAdaptiveChunks, DETECTION_TEMPERATURE, YIELD_COLLAPSE_BAND, YieldCollapseError, type UnderReportedPiece } from './detection-chunking';
 
@@ -164,8 +164,14 @@ export async function extractEntities(
    * commits them, and the loop must not run ahead of durability. Unlike
    * `onActivity` (a liveness heartbeat, which may repeat), this fires exactly
    * once per chunk, including the last. Kept LAST on every detection seam.
+   *
+   * `cursor` is where the run stands ONCE THIS CHUNK IS COMMITTED — the pair
+   * CHUNK-GRAIN-RESUME checkpoints. It is handed over with the results rather
+   * than reported separately so the two cannot drift: a caller that records the
+   * position without durably committing the annotations would checkpoint ahead
+   * of the log.
    */
-  onChunkResults?: (items: ExtractedEntity[]) => Promise<void>,
+  onChunkResults?: (items: ExtractedEntity[], cursor: UnitCursor) => Promise<void>,
 ): Promise<ExtractedEntity[]> {
 
   // Format entity types for the prompt
@@ -326,7 +332,7 @@ Example output:
       }
     }
     collected.push(...fromChunk);
-    await onChunkResults?.(fromChunk);
+    await onChunkResults?.(fromChunk, { next, size });
 
     // Chunk boundary: the cursor advances (real progress). Only when text
     // remains — the final cut has no boundary after it, and the caller reports

--- a/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
@@ -492,7 +492,7 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     } as never);
 
     await vi.waitFor(() => {
-      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f1', 'boom', undefined, undefined);
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f1', 'boom', undefined, undefined, undefined);
     });
   });
 
@@ -506,7 +506,7 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     } as never);
 
     await vi.waitFor(() => {
-      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f2', 'Location stalled', ['Person', 'Date'], undefined);
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f2', 'Location stalled', ['Person', 'Date'], undefined, undefined);
     });
   });
 
@@ -520,7 +520,7 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     } as never);
 
     await vi.waitFor(() => {
-      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f3', 'request exceeds size limits', undefined, 'deterministic');
+      expect(jobQueue.failJob).toHaveBeenCalledWith('job-f3', 'request exceeds size limits', undefined, 'deterministic', undefined);
     });
   });
 
@@ -561,7 +561,41 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     } as never);
 
     await vi.waitFor(() => {
-      expect(jobQueue.checkpointUnits).toHaveBeenCalledWith('job-ckpt', ['Person', 'Location']);
+      expect(jobQueue.checkpointUnits).toHaveBeenCalledWith('job-ckpt', ['Person', 'Location'], undefined);
+    });
+  });
+
+  it('forwards per-unit cursors to the queue on job:checkpoint (CHUNK-GRAIN-RESUME P2)', async () => {
+    // This handler is the only path from the wire to the queue, so a cursor it
+    // drops is a cursor that never becomes durable — and the crash it exists to
+    // survive is exactly the one that emits no job:fail.
+    eventBus.get('job:checkpoint').next({
+      jobId: 'job-ckpt-cur',
+      completedUnits: ['Person'],
+      unitCursors: { Location: { next: 5_000, size: 800 } },
+    } as never);
+
+    await vi.waitFor(() => {
+      expect(jobQueue.checkpointUnits).toHaveBeenCalledWith(
+        'job-ckpt-cur', ['Person'], { Location: { next: 5_000, size: 800 } },
+      );
+    });
+  });
+
+  it('forwards per-unit cursors to failJob on job:fail (CHUNK-GRAIN-RESUME P2)', async () => {
+    // The clean-failure twin of the above: `failJob` rebuilds the retried
+    // record, so a cursor it never receives cannot reach the next attempt.
+    eventBus.get('job:fail').next({
+      jobId: 'job-f-cur',
+      error: 'stalled mid-unit',
+      completedUnits: [],
+      unitCursors: { Person: { next: 12_400, size: 560 } },
+    } as never);
+
+    await vi.waitFor(() => {
+      expect(jobQueue.failJob).toHaveBeenCalledWith(
+        'job-f-cur', 'stalled mid-unit', [], undefined, { Person: { next: 12_400, size: 560 } },
+      );
     });
   });
 

--- a/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
+++ b/packages/make-meaning/src/__tests__/handlers/job-commands.test.ts
@@ -572,12 +572,12 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
     eventBus.get('job:checkpoint').next({
       jobId: 'job-ckpt-cur',
       completedUnits: ['Person'],
-      unitCursors: { Location: { next: 5_000, size: 800 } },
+      unitCursors: { Location: { next: 5_000, size: 800, found: 0, emitted: 0 } },
     } as never);
 
     await vi.waitFor(() => {
       expect(jobQueue.checkpointUnits).toHaveBeenCalledWith(
-        'job-ckpt-cur', ['Person'], { Location: { next: 5_000, size: 800 } },
+        'job-ckpt-cur', ['Person'], { Location: { next: 5_000, size: 800, found: 0, emitted: 0 } },
       );
     });
   });
@@ -589,12 +589,12 @@ describe('registerJobCommandHandlers — queue lifecycle sync', () => {
       jobId: 'job-f-cur',
       error: 'stalled mid-unit',
       completedUnits: [],
-      unitCursors: { Person: { next: 12_400, size: 560 } },
+      unitCursors: { Person: { next: 12_400, size: 560, found: 0, emitted: 0 } },
     } as never);
 
     await vi.waitFor(() => {
       expect(jobQueue.failJob).toHaveBeenCalledWith(
-        'job-f-cur', 'stalled mid-unit', [], undefined, { Person: { next: 12_400, size: 560 } },
+        'job-f-cur', 'stalled mid-unit', [], undefined, { Person: { next: 12_400, size: 560, found: 0, emitted: 0 } },
       );
     });
   });

--- a/packages/make-meaning/src/handlers/job-commands.ts
+++ b/packages/make-meaning/src/handlers/job-commands.ts
@@ -225,7 +225,7 @@ export function registerJobCommandHandlers(
 
   eventBus.get('job:fail').subscribe(async (event) => {
     try {
-      const outcome = await jobQueue.failJob(jobId(event.jobId), event.error, event.completedUnits, event.failureClass);
+      const outcome = await jobQueue.failJob(jobId(event.jobId), event.error, event.completedUnits, event.failureClass, event.unitCursors);
       if (outcome === 'retried') {
         logger.info('Job re-queued for retry', { jobId: event.jobId });
       } else if (outcome === null) {
@@ -260,7 +260,7 @@ export function registerJobCommandHandlers(
   // covers the crash path failJob never sees.
   eventBus.get('job:checkpoint').subscribe(async (event) => {
     try {
-      await jobQueue.checkpointUnits(jobId(event.jobId), event.completedUnits);
+      await jobQueue.checkpointUnits(jobId(event.jobId), event.completedUnits, event.unitCursors);
     } catch (error) {
       logger.error('Failed to checkpoint job units', {
         jobId: event.jobId,

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -2940,6 +2940,9 @@ type JobCancelCommand struct {
 	// JobType Type of background job
 	JobType    JobType `json:"jobType"`
 	ResourceId string  `json:"resourceId"`
+
+	// UnitCursors How far each in-progress unit got, keyed by unit — the grain `completedUnits` cannot express. A unit appearing here is NOT complete; a unit in `completedUnits` is skipped whole whatever cursor it last carried. Merged monotonically per unit: a stale snapshot must never move a cursor backward.
+	UnitCursors *map[string]UnitCursor `json:"unitCursors,omitempty"`
 }
 
 // JobCancelRequest Request to cancel a job. Target one running or pending job by `jobId` (JOB-RESTART-SAFETY P4), or a whole category of pending jobs by `jobType`. A `jobId`-targeted request that names a RUNNING job is honoured cooperatively by the owning worker, which stops at its next unit boundary and emits JobCancelCommand — the queue is never made to yank a running job out from under a live worker.
@@ -2965,6 +2968,9 @@ type JobCheckpointCommand struct {
 	// CompletedUnits Entity-type units whose annotations have been fully emitted so far. Unioned into the running job's metadata checkpoint; a retry after recovery skips them.
 	CompletedUnits []string `json:"completedUnits"`
 	JobId          string   `json:"jobId"`
+
+	// UnitCursors How far each in-progress unit got, keyed by unit — the grain `completedUnits` cannot express. A unit appearing here is NOT complete; a unit in `completedUnits` is skipped whole whatever cursor it last carried. Merged monotonically per unit: a stale snapshot must never move a cursor backward.
+	UnitCursors *map[string]UnitCursor `json:"unitCursors,omitempty"`
 }
 
 // JobClaimCommand Command to claim a pending job (atomic CAS: pending → running)
@@ -3105,6 +3111,9 @@ type JobFailCommand struct {
 	// JobType Type of background job
 	JobType    JobType `json:"jobType"`
 	ResourceId string  `json:"resourceId"`
+
+	// UnitCursors How far each in-progress unit got, keyed by unit — the grain `completedUnits` cannot express. A unit appearing here is NOT complete; a unit in `completedUnits` is skipped whole whatever cursor it last carried. Merged monotonically per unit: a stale snapshot must never move a cursor backward.
+	UnitCursors *map[string]UnitCursor `json:"unitCursors,omitempty"`
 
 	// WillRetry Whether the queue will re-queue this job for another attempt. Computed by the worker from the SAME predicate the queue applies at failJob (one decision site, `willRetryAfter` in @semiont/jobs) using the retry budget carried on the claimed record. FALSE (or absent) means this failure is TERMINAL: a client's job-watch stream ends here. TRUE means the work continues on a fresh attempt — the failure is an event, not the end, and a stream that terminated on it would report a recovering run as a failed one (JOB-RESTART-SAFETY P5).
 	WillRetry *bool `json:"willRetry,omitempty"`
@@ -4591,6 +4600,17 @@ type TokenRefreshRequest struct {
 // TokenRefreshResponse defines model for TokenRefreshResponse.
 type TokenRefreshResponse struct {
 	AccessToken string `json:"access_token"`
+}
+
+// UnitCursor How far a single unit got, for a resume that starts mid-unit rather than redoing it (CHUNK-GRAIN-RESUME P2). A unit is an entity type for reference-annotation, and the job's own motivation for the other annotation types — which is why a unit-grain checkpoint alone was too coarse: those jobs have exactly one unit, so nothing could be recorded until the whole document was done.
+//
+// MERGE IS MONOTONE PER UNIT, not a union. `completedUnits` is a set and converges under concurrent snapshots because a set only grows; a cursor converges only if a stale snapshot can never move it backward.
+type UnitCursor struct {
+	// Next Characters consumed once the last COMMITTED chunk completed — the resume position. Deliberately the chunk's `next`, never its `at`: the checkpoint must not lead the log, so it records where a chunk that is already durable ended, not where the in-flight one began. Recording `at` would make a resume re-run the chunk it already paid for.
+	Next int `json:"next"`
+
+	// Size The token size that last committed chunk was cut at — the calibration the attempt paid for over the chunks before it. A resume seeds from this and then takes ONE adaptive step, as if the last outcome were a failure, which it was: the job died. Seeding alone would re-cut the failing piece identically; opening at the default would discard the calibration. (CHUNK-GRAIN-RESUME HD2, option C.)
+	Size int `json:"size"`
 }
 
 // UpdateAnnotationBodyRequest defines model for UpdateAnnotationBodyRequest.

--- a/packages/sdk-go/client_gen.go
+++ b/packages/sdk-go/client_gen.go
@@ -4605,7 +4605,15 @@ type TokenRefreshResponse struct {
 // UnitCursor How far a single unit got, for a resume that starts mid-unit rather than redoing it (CHUNK-GRAIN-RESUME P2). A unit is an entity type for reference-annotation, and the job's own motivation for the other annotation types — which is why a unit-grain checkpoint alone was too coarse: those jobs have exactly one unit, so nothing could be recorded until the whole document was done.
 //
 // MERGE IS MONOTONE PER UNIT, not a union. `completedUnits` is a set and converges under concurrent snapshots because a set only grows; a cursor converges only if a stale snapshot can never move it backward.
+//
+// IT CARRIES THE UNIT'S RUNNING TALLIES TOO, and they are required. A resumed unit counts only the chunks it actually runs, so without them a retry's terminal record reports the remainder of the document as if it were the whole — measured at totalFound 19 where the document yielded 25. The position and the tallies are ONE observation of the same committed chunk; splitting them would let a resume take the saving and still report a number nobody can trust.
 type UnitCursor struct {
+	// Emitted Annotations actually committed for this unit through the last committed chunk, after dedupe. The pair (found, emitted) is what the job's terminal result reports, so a resumed unit seeds both and its record describes the whole document rather than one attempt's share.
+	Emitted int `json:"emitted"`
+
+	// Found Items detection has returned for this unit through the last committed chunk — the numerator a resumed attempt continues from rather than restarting at zero. Counts what the model reported, before dedupe.
+	Found int `json:"found"`
+
 	// Next Characters consumed once the last COMMITTED chunk completed — the resume position. Deliberately the chunk's `next`, never its `at`: the checkpoint must not lead the log, so it records where a chunk that is already durable ended, not where the in-flight one began. Recording `at` would make a resume re-run the chunk it already paid for.
 	Next int `json:"next"`
 

--- a/specs/src/components/schemas/JobCancelCommand.json
+++ b/specs/src/components/schemas/JobCancelCommand.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "description": "A worker's confirmation that it has cooperatively stopped a running job at a unit boundary (JOB-RESTART-SAFETY P4) — the queue moves the job to cancelled/. Distinct from JobCancelRequest (the client→worker REQUEST to stop): this is the worker announcing it did, so the running job is never yanked to cancelled/ out from under a live worker (the roach-motel race).",
+  "description": "A worker's confirmation that it has cooperatively stopped a running job at a unit boundary (JOB-RESTART-SAFETY P4) \u2014 the queue moves the job to cancelled/. Distinct from JobCancelRequest (the client\u2192worker REQUEST to stop): this is the worker announcing it did, so the running job is never yanked to cancelled/ out from under a live worker (the roach-motel race).",
   "properties": {
     "_userId": {
       "type": "string",
@@ -25,6 +25,13 @@
         "type": "string"
       },
       "description": "Entity-type units whose annotations were fully emitted before cancellation. Recorded on the cancelled job's metadata so the work already done stays visible."
+    },
+    "unitCursors": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "./UnitCursor.json"
+      },
+      "description": "How far each in-progress unit got, keyed by unit \u2014 the grain `completedUnits` cannot express. A unit appearing here is NOT complete; a unit in `completedUnits` is skipped whole whatever cursor it last carried. Merged monotonically per unit: a stale snapshot must never move a cursor backward."
     }
   },
   "required": [

--- a/specs/src/components/schemas/JobCheckpointCommand.json
+++ b/specs/src/components/schemas/JobCheckpointCommand.json
@@ -15,6 +15,13 @@
         "type": "string"
       },
       "description": "Entity-type units whose annotations have been fully emitted so far. Unioned into the running job's metadata checkpoint; a retry after recovery skips them."
+    },
+    "unitCursors": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "./UnitCursor.json"
+      },
+      "description": "How far each in-progress unit got, keyed by unit \u2014 the grain `completedUnits` cannot express. A unit appearing here is NOT complete; a unit in `completedUnits` is skipped whole whatever cursor it last carried. Merged monotonically per unit: a stale snapshot must never move a cursor backward."
     }
   },
   "required": [

--- a/specs/src/components/schemas/JobFailCommand.json
+++ b/specs/src/components/schemas/JobFailCommand.json
@@ -33,6 +33,13 @@
       },
       "description": "Entity-type units whose annotations were fully emitted before this failure (checkpointed resume). The queue records them on the retried job's metadata; a retried claim skips them so completed work is neither redone nor duplicated."
     },
+    "unitCursors": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "./UnitCursor.json"
+      },
+      "description": "How far each in-progress unit got, keyed by unit \u2014 the grain `completedUnits` cannot express. A unit appearing here is NOT complete; a unit in `completedUnits` is skipped whole whatever cursor it last carried. Merged monotonically per unit: a stale snapshot must never move a cursor backward."
+    },
     "failureClass": {
       "$ref": "./FailureClass.json"
     },

--- a/specs/src/components/schemas/UnitCursor.json
+++ b/specs/src/components/schemas/UnitCursor.json
@@ -1,17 +1,32 @@
 {
   "type": "object",
-  "description": "How far a single unit got, for a resume that starts mid-unit rather than redoing it (CHUNK-GRAIN-RESUME P2). A unit is an entity type for reference-annotation, and the job's own motivation for the other annotation types — which is why a unit-grain checkpoint alone was too coarse: those jobs have exactly one unit, so nothing could be recorded until the whole document was done.\n\nMERGE IS MONOTONE PER UNIT, not a union. `completedUnits` is a set and converges under concurrent snapshots because a set only grows; a cursor converges only if a stale snapshot can never move it backward.",
+  "description": "How far a single unit got, for a resume that starts mid-unit rather than redoing it (CHUNK-GRAIN-RESUME P2). A unit is an entity type for reference-annotation, and the job's own motivation for the other annotation types \u2014 which is why a unit-grain checkpoint alone was too coarse: those jobs have exactly one unit, so nothing could be recorded until the whole document was done.\n\nMERGE IS MONOTONE PER UNIT, not a union. `completedUnits` is a set and converges under concurrent snapshots because a set only grows; a cursor converges only if a stale snapshot can never move it backward.\n\nIT CARRIES THE UNIT'S RUNNING TALLIES TOO, and they are required. A resumed unit counts only the chunks it actually runs, so without them a retry's terminal record reports the remainder of the document as if it were the whole \u2014 measured at totalFound 19 where the document yielded 25. The position and the tallies are ONE observation of the same committed chunk; splitting them would let a resume take the saving and still report a number nobody can trust.",
   "properties": {
     "next": {
       "type": "integer",
       "minimum": 0,
-      "description": "Characters consumed once the last COMMITTED chunk completed — the resume position. Deliberately the chunk's `next`, never its `at`: the checkpoint must not lead the log, so it records where a chunk that is already durable ended, not where the in-flight one began. Recording `at` would make a resume re-run the chunk it already paid for."
+      "description": "Characters consumed once the last COMMITTED chunk completed \u2014 the resume position. Deliberately the chunk's `next`, never its `at`: the checkpoint must not lead the log, so it records where a chunk that is already durable ended, not where the in-flight one began. Recording `at` would make a resume re-run the chunk it already paid for."
     },
     "size": {
       "type": "integer",
       "minimum": 1,
-      "description": "The token size that last committed chunk was cut at — the calibration the attempt paid for over the chunks before it. A resume seeds from this and then takes ONE adaptive step, as if the last outcome were a failure, which it was: the job died. Seeding alone would re-cut the failing piece identically; opening at the default would discard the calibration. (CHUNK-GRAIN-RESUME HD2, option C.)"
+      "description": "The token size that last committed chunk was cut at \u2014 the calibration the attempt paid for over the chunks before it. A resume seeds from this and then takes ONE adaptive step, as if the last outcome were a failure, which it was: the job died. Seeding alone would re-cut the failing piece identically; opening at the default would discard the calibration. (CHUNK-GRAIN-RESUME HD2, option C.)"
+    },
+    "found": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Items detection has returned for this unit through the last committed chunk \u2014 the numerator a resumed attempt continues from rather than restarting at zero. Counts what the model reported, before dedupe."
+    },
+    "emitted": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Annotations actually committed for this unit through the last committed chunk, after dedupe. The pair (found, emitted) is what the job's terminal result reports, so a resumed unit seeds both and its record describes the whole document rather than one attempt's share."
     }
   },
-  "required": ["next", "size"]
+  "required": [
+    "next",
+    "size",
+    "found",
+    "emitted"
+  ]
 }

--- a/specs/src/components/schemas/UnitCursor.json
+++ b/specs/src/components/schemas/UnitCursor.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "description": "How far a single unit got, for a resume that starts mid-unit rather than redoing it (CHUNK-GRAIN-RESUME P2). A unit is an entity type for reference-annotation, and the job's own motivation for the other annotation types — which is why a unit-grain checkpoint alone was too coarse: those jobs have exactly one unit, so nothing could be recorded until the whole document was done.\n\nMERGE IS MONOTONE PER UNIT, not a union. `completedUnits` is a set and converges under concurrent snapshots because a set only grows; a cursor converges only if a stale snapshot can never move it backward.",
+  "properties": {
+    "next": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Characters consumed once the last COMMITTED chunk completed — the resume position. Deliberately the chunk's `next`, never its `at`: the checkpoint must not lead the log, so it records where a chunk that is already durable ended, not where the in-flight one began. Recording `at` would make a resume re-run the chunk it already paid for."
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "The token size that last committed chunk was cut at — the calibration the attempt paid for over the chunks before it. A resume seeds from this and then takes ONE adaptive step, as if the last outcome were a failure, which it was: the job died. Seeding alone would re-cut the failing piece identically; opening at the default would discard the calibration. (CHUNK-GRAIN-RESUME HD2, option C.)"
+    }
+  },
+  "required": ["next", "size"]
+}

--- a/specs/src/openapi.json
+++ b/specs/src/openapi.json
@@ -489,6 +489,9 @@
       "JobCheckpointCommand": {
         "$ref": "components/schemas/JobCheckpointCommand.json"
       },
+      "UnitCursor": {
+        "$ref": "./components/schemas/UnitCursor.json"
+      },
       "JobDeclinedResult": {
         "$ref": "components/schemas/JobDeclinedResult.json"
       },


### PR DESCRIPTION
A detection job checkpointed whole units. Four of the five detection types run exactly **one** unit, and the reference job measured in production ran one too, so in practice nothing could be recorded until the entire document was finished: a death at chunk 25 of 49 restarted at chunk 1 and re-paid for all 24. This PR gives the checkpoint a finer grain, spends it on resume, and closes the last two sites that decided retryability by inheriting a default.

## A checkpoint that can say "partway here" (`specs`, `@semiont/core`, `@semiont/jobs`, `@semiont/make-meaning`)

`UnitCursor` records how far an unfinished unit got, keyed by unit, beside the set of finished ones. It is written per committed chunk, not per unit.

- **It records the chunk's `next`, never its `at`.** The checkpoint must not lead the log, so it names where a chunk that is already durable *ended*, not where the in-flight one began. Recording `at` would make every resume re-run one chunk it had already paid for and committed.
- **The merge is monotone per unit, not a union.** A set converges under concurrent snapshots for free because it only grows; a cursor converges only if a stale snapshot can never move it backward. Two checkpoints can be in flight and the older can land last, so last-writer-wins would drag the resume position back. `next` and `size` move together because they are one observation of one chunk — taking the furthest position from one snapshot and the size from another would describe a chunk that was never cut.
- **A unit that completes drops its cursor**, so "in progress, here" and "finished" are structurally exclusive rather than a rule each reader has to remember, and a stale snapshot cannot resurrect a finished unit's position.
- **A tag job's units are its categories, not its motivation.** Tag detection loops over categories, each walking the whole document from zero. Keying them by motivation would have had every category writing one shared cursor, and the monotone merge keeping the furthest — correct for at most one category and **silently skipping text for the rest**, with no error anywhere.
- A malformed cursor read back off a claim is **dropped whole, never repaired**: the unit restarts from the top, which costs inference but is always correct, where a manufactured position would skip text nobody ever read and leave no trace.
- Commands and the generated Go client move together; the spec's own drift gate confirms the two match.

## A retried unit picks up where it died (`@semiont/jobs`)

The chunk walker takes a resume point and spends its two halves differently.

- The position is taken as given. The **size is seeded from the checkpoint and then stepped once**, as if the last outcome had been a failure — it was, the job died. Opening at the derived budget instead would discard the calibration the dead attempt paid for over its earlier chunks; seeding unchanged would re-cut the identical piece, which at temperature 0 returns the identical answer, failure included.
- **The processors own the unit → cursor lookup**, because they are where a unit gets its name: an entity type, a category, or the job's own motivation. That lookup is exactly where a wrong key would restart a unit silently, so each of the three shapes has its own test.
- Verified by recording the prompts: a resumed run's first model call does not contain the document's opening marker and does contain the text at the cursor, on **both** detection paths. A checkpoint already at the end costs zero model calls.

## The terminal record describes the document, not one attempt (`specs`, `@semiont/jobs`)

Measured on a 52K-character document: a full run reported `totalFound` **25**, a halfway resume reported **19**, and the schema calls that field "Total entities found". The finer grain made an existing defect bigger — a retry skipping finished units already lost their counts — so the cursor now carries the tallies too.

- `found` and `emitted` are **required**. The position and the counts are one observation, and a cursor carrying only half would let a resume take the saving and still report a number nobody can trust. A cursor missing them is dropped whole rather than zero-filled: one re-run, and a record that is true.
- Each processor seeds its counters from the cursor and writes **running** totals into the checkpoint it emits, so a third attempt seeds from the second the same way.
- A separate `ChunkCursor` type is what the detection layer reports. It counts chunks, not annotations, so it has no business claiming tallies — without the split it would have had to invent zeros at the seam, indistinguishable from real ones.

## The last two retry defaults become decisions (`@semiont/inference`, `@semiont/core`, `@semiont/jobs`)

Two sites in the retry census were still deciding by inheritance.

- **The inference client's retry count is now written down.** Two is also the vendor SDK's default, which is the point: the value does not change, but a future SDK bump can no longer change it for us without someone editing that line. The grounds are at the construction site — fast failures cost seconds and the SDK honors `retry-after`, which matters more now that entity types run concurrently; and slow failures never reach the retries at all, because our own 10-minute bound wraps the call and the SDK's default timeout is also 10 minutes, so a hung call trips ours during the first attempt.
- **The job classifier reads the shared rule instead of repeating it.** Its status branch was byte-identical to the catalog's job rule — a second opinion on a question already answered, and the census's finding was that where a bare list and a reasoned rule disagree, the list wins silently.
- **`>= 500` stays retryable for jobs, re-priced against what is true now.** A 5xx arriving at the job has already failed three times at the call, so it is a considered second chance rather than a hair-trigger; and the re-pay is now about one chunk rather than a ~26-minute prefix. The rule names both, and names what would reverse it.
- **A depth-exhausted unreadable response stays retryable, and stays unclassified rather than becoming "transient".** The argument for the opposite — at temperature 0 an identical call returns an identical failure — stopped applying when the resume began re-cutting that text at a different size. It is not promoted to `transient` because the wire vocabulary has two values and this is neither: not weather, but "the next attempt reads different input". **The existing test justified this as "sampling may fix it", which was never true** at temperature 0 — the verdict was right for a reason that never held.

## Verification

- jobs 622, core 723 (the 2 failures are environmental — no git binary in the container image), make-meaning 628, inference 72. Typecheck and build clean across core, jobs, make-meaning and inference; the generated Go client matches the spec under CI's own command.
- Mutation-tested throughout, with restores by string reversal rather than git. Several bit **nothing** on the first pass and are worth naming, because each was a real hole: dropping the measurement in the shared motivation loop (four of five detection types go through it, and the wiring tests only covered the reference path); the three per-unit cursor lookups; the claim adapter zero-filling a tally-less cursor; and the redundant-tail fix, which a source mutation could not reach at all because the consuming package resolves that dependency to its built output.
- A gate comparing the classifier to the shared rule across every status 100–599 **cannot distinguish derivation from an identical copy** — mutating the classifier back to its literal list leaves it green. It catches the failure mode that actually occurred: the two diverging. Proving the classifier *follows* the rule needed the job site to pin 502/503/504, the statuses where the three rules genuinely disagree and which nothing here had pinned.

## Still open

- **No live run yet.** The saving is arithmetic until a job is killed mid-document against a running stack and attempt 2 is measured against the ~26-minute baseline. No code hook is needed for that: the checkpoint is durable per chunk, so killing the worker and backdating the running file's mtime past the stale window is enough for the janitor to re-queue it carrying the cursor.
- **Skipped units still lose their counts.** A unit that finished entirely in an earlier attempt drops its cursor by the exclusivity rule above, so its share is missing from the job total. One-unit jobs — every motivation type, and the measured single-entity-type reference job — are fully fixed; multi-unit jobs are not. Closing it needs either a second durable home for finished units' tallies or undoing that exclusivity, and neither was decided here.
