### PR TITLE
Keep domain events typed from the EventStore to the wire

### DIFF
--- a/packages/core/src/__tests__/domain-event-path-types.test.ts
+++ b/packages/core/src/__tests__/domain-event-path-types.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The path from the EventStore to the wire keeps its types.
+ *
+ * `getDomainEvent` existed to avoid `as keyof EventMap` when subscribing with a
+ * runtime `PersistedEventType` — but it got there by WIDENING the channel to
+ * every bus channel and ERASING the event to `StoredEvent`, then casting back to
+ * reconnect what it had just disconnected. The widening was never necessary:
+ * every persisted type is already a channel, which is the invariant pinned below.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '../event-bus';
+import type { EventMap } from '../bus-protocol';
+import type { PersistedEventType } from '../persisted-events';
+
+describe('the domain-event path needs no casts', () => {
+  it('every persisted event type is already a bus channel', () => {
+    // The invariant that made the widening unnecessary. Green today, and kept:
+    // it fails the day a persisted type is not a channel, which is the only way
+    // `as keyof EventMap` could become necessary again.
+    const holds: PersistedEventType extends keyof EventMap ? true : false = true;
+    expect(holds).toBe(true);
+  });
+
+  it('has no getDomainEvent to funnel casts through', () => {
+    const bus = new EventBus();
+    // @ts-expect-error — deleted; `get` is already channel-typed
+    expect(typeof bus.getDomainEvent).toBe('undefined');
+  });
+
+  it('get() on a persisted type yields that channel, not an erased one', () => {
+    // What replaces it: `get` carries the channel's own type through, so a
+    // subscriber sees `EventMap[K]` rather than a widened `StoredEvent`.
+    const bus = new EventBus();
+    const seen: EventMap['mark:added'][] = [];
+    bus.get('mark:added').subscribe((e) => seen.push(e));
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/core/src/event-bus.ts
+++ b/packages/core/src/event-bus.ts
@@ -9,8 +9,6 @@
 import { Subject } from 'rxjs';
 import { busLog, busLogEnabled, warnIfUnobservedReply, warnUnobservedRepliesEnabled } from './bus-log';
 import type { EventMap } from './bus-protocol';
-import type { StoredEvent } from './event-base';
-import type { PersistedEventType } from './persisted-events';
 
 /**
  * RxJS-based event bus
@@ -115,17 +113,6 @@ export class EventBus {
   }
 
   /**
-   * Get the RxJS Subject for a domain event type (PersistedEventType).
-   *
-   * Domain event channels carry `StoredEvent`. This method avoids the need
-   * for `as keyof EventMap` casts when subscribing to domain event channels
-   * using runtime `PersistedEventType` strings.
-   */
-  getDomainEvent(eventType: PersistedEventType): Subject<StoredEvent> {
-    return this.get(eventType as keyof EventMap) as unknown as Subject<StoredEvent>;
-  }
-
-  /**
    * Channel names with at least one live observer right now. Introspection
    * for composition-parity gates: `get()` creates subjects lazily, so mere
    * access does not count — only real subscriptions do. Scoped channels
@@ -221,11 +208,6 @@ export class ScopedEventBus {
       parentSubjects.set(scopedKey, new Subject<EventMap[E]>());
     }
     return parentSubjects.get(scopedKey)!;
-  }
-
-  /** Get the RxJS Subject for a domain event type on this scoped bus. */
-  getDomainEvent(eventType: PersistedEventType): Subject<StoredEvent> {
-    return this.get(eventType as keyof EventMap) as unknown as Subject<StoredEvent>;
   }
 
   /**

--- a/packages/event-sourcing/src/__tests__/append-seam-axioms.property.test.ts
+++ b/packages/event-sourcing/src/__tests__/append-seam-axioms.property.test.ts
@@ -112,8 +112,8 @@ class PublishFirstEventStore {
   async appendEvent(event: EventInput): Promise<StoredEvent> {
     const rid = event.resourceId as ResourceId;
     const storedEvent = await this.log.append(event, rid);
-    this.bus.getDomainEvent(storedEvent.type).next(storedEvent);
-    this.bus.scope(String(rid)).getDomainEvent(storedEvent.type).next(storedEvent);
+    this.bus.get(storedEvent.type).next(storedEvent);
+    this.bus.scope(String(rid)).get(storedEvent.type).next(storedEvent);
     await this.views.materializeResource(rid, storedEvent, () => this.log.getEvents(rid));
     return storedEvent;
   }
@@ -203,8 +203,8 @@ async function collectViolations(
   };
 
   const subscriptions = [
-    bus.getDomainEvent('yield:created').subscribe(observe),
-    bus.getDomainEvent('mark:added').subscribe(observe),
+    bus.get('yield:created').subscribe(observe),
+    bus.get('mark:added').subscribe(observe),
   ];
 
   try {

--- a/packages/event-sourcing/src/event-store.ts
+++ b/packages/event-sourcing/src/event-store.ts
@@ -111,11 +111,11 @@ export class EventStore {
 
     // 4. Publish to Core EventBus typed channels
     await timed('publish', () => {
-      this.coreEventBus.getDomainEvent(publishEvent.type).next(publishEvent);
+      this.coreEventBus.get(publishEvent.type).next(publishEvent);
 
       if (resourceId !== '__system__') {
         const scopedBus = this.coreEventBus.scope(resourceId as string);
-        scopedBus.getDomainEvent(publishEvent.type).next(publishEvent);
+        scopedBus.get(publishEvent.type).next(publishEvent);
       }
     });
 

--- a/packages/make-meaning/src/__tests__/fact-pump-types.test.ts
+++ b/packages/make-meaning/src/__tests__/fact-pump-types.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The fact pump carries typed events (DOMAIN-EVENT-PATH-TYPED P2).
+ *
+ * `archivist-main` hands the pump a correctly-typed merge of every persisted
+ * channel. The pump used to widen it back to `StoredEvent` at its own
+ * parameter, then cast its way out — `as keyof EventMap` to name the channel
+ * and `as never` to hand over the payload. The erasure was self-inflicted.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Observable } from 'rxjs';
+import type { EventMap, PersistedEventType } from '@semiont/core';
+import { createFactPump } from '../fact-pump';
+
+/**
+ * Equality, not assignability: a typed stream is already assignable to an
+ * erased one, so `extends` would have passed against the very code this
+ * phase replaces.
+ */
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+describe('the fact pump does not erase what it is given', () => {
+  it('takes the merged persisted-channel stream, not a widened one', () => {
+    const exact: Equals<
+      Parameters<typeof createFactPump>[0],
+      Observable<EventMap[PersistedEventType]>
+    > = true;
+    expect(exact).toBe(true);
+  });
+
+  it('rejects a stream of something that is not a persisted fact', () => {
+    // Asserted in the type system, not by calling: a `@ts-expect-error` on a
+    // real call still runs the call under vitest.
+    type Accepted<T> = Observable<T> extends Parameters<typeof createFactPump>[0] ? true : false;
+    const rejected: Accepted<{ nope: true }> = false;
+    expect(rejected).toBe(false);
+  });
+});

--- a/packages/make-meaning/src/__tests__/fact-pump.test.ts
+++ b/packages/make-meaning/src/__tests__/fact-pump.test.ts
@@ -23,8 +23,8 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { Subject } from 'rxjs';
-import type { Logger, StoredEvent } from '@semiont/core';
-import { resourceId as makeResourceId, userId } from '@semiont/core';
+import type { EventMap, Logger, PersistedEventType } from '@semiont/core';
+import { isNumber, isObject, resourceId as makeResourceId, userId } from '@semiont/core';
 import { createFactPump } from '../fact-pump';
 
 const mockLogger: Logger = {
@@ -34,26 +34,48 @@ const mockLogger: Logger = {
 
 const settle = () => new Promise((r) => setImmediate(r));
 
-function fact(seq: number, rid?: string): StoredEvent {
-  return {
-    id: `evt-${seq}`,
-    type: 'mark:added',
-    timestamp: new Date().toISOString(),
-    userId: userId('did:web:example:users:alice'),
-    version: 1,
-    ...(rid ? { resourceId: makeResourceId(rid) } : {}),
-    payload: {},
-    metadata: { sequenceNumber: seq },
-  } as unknown as StoredEvent;
+/** `deps.emit` is declared over every channel, so what reaches a mock is
+ *  `unknown` — narrowed by guard rather than asserted. */
+function seqOf(payload: unknown): number {
+  if (isObject(payload) && isObject(payload.metadata) && isNumber(payload.metadata.sequenceNumber)) {
+    return payload.metadata.sequenceNumber;
+  }
+  throw new Error('fact reached emit without metadata.sequenceNumber');
+}
+
+type Fact = EventMap[PersistedEventType];
+
+const envelope = (seq: number) => ({
+  id: `evt-${seq}`,
+  timestamp: new Date().toISOString(),
+  userId: userId('did:web:example:users:alice'),
+  version: 1,
+  metadata: { sequenceNumber: seq },
+});
+
+/**
+ * Cast-free, and that is the point: retyping the pump made the old single
+ * `as unknown as StoredEvent` fixture stop compiling, because it built one
+ * `mark:added` whose `resourceId` came and went. The types say that cannot
+ * happen — resource events REQUIRE a resourceId and only `frame:*` system
+ * events lack one — so the scoped and unscoped cases need different channels.
+ * The erased fixture had been hiding that for both.
+ */
+function scopedFact(seq: number, rid: string): EventMap['mark:archived'] {
+  return { ...envelope(seq), type: 'mark:archived', resourceId: makeResourceId(rid), payload: {} };
+}
+
+function systemFact(seq: number): EventMap['frame:entity-type-added'] {
+  return { ...envelope(seq), type: 'frame:entity-type-added', payload: { entityType: 'Person' } };
 }
 
 describe('fact pump', () => {
   it('publishes an unscoped fact once', async () => {
     const emit = vi.fn(async () => 1);
-    const facts$ = new Subject<StoredEvent>();
+    const facts$ = new Subject<Fact>();
     const pump = createFactPump(facts$, { emit, logger: mockLogger });
 
-    facts$.next(fact(1));
+    facts$.next(systemFact(1));
     await settle();
 
     expect(emit).toHaveBeenCalledTimes(1);
@@ -62,10 +84,10 @@ describe('fact pump', () => {
 
   it('publishes a resource-scoped fact globally AND to its scope', async () => {
     const emit = vi.fn(async () => 1);
-    const facts$ = new Subject<StoredEvent>();
+    const facts$ = new Subject<Fact>();
     const pump = createFactPump(facts$, { emit, logger: mockLogger });
 
-    facts$.next(fact(1, 'res-a'));
+    facts$.next(scopedFact(1, 'res-a'));
     await settle();
 
     expect(emit).toHaveBeenCalledTimes(2);
@@ -87,10 +109,10 @@ describe('fact pump', () => {
       inFlight -= 1;
       return 1;
     });
-    const facts$ = new Subject<StoredEvent>();
+    const facts$ = new Subject<Fact>();
     const pump = createFactPump(facts$, { emit, logger: mockLogger });
 
-    facts$.next(fact(1, 'res-a'));
+    facts$.next(scopedFact(1, 'res-a'));
     await settle();
     await settle();
 
@@ -103,13 +125,13 @@ describe('fact pump', () => {
     // why the growth in the bug report is still a hypothesis.
     let release: (() => void) | undefined;
     const emit = vi.fn(() => new Promise<number>((res) => { release = () => res(1); }));
-    const facts$ = new Subject<StoredEvent>();
+    const facts$ = new Subject<Fact>();
     const pump = createFactPump(facts$, { emit, logger: mockLogger });
 
     expect(pump.depth()).toBe(0);
-    facts$.next(fact(1));
-    facts$.next(fact(2));
-    facts$.next(fact(3));
+    facts$.next(systemFact(1));
+    facts$.next(systemFact(2));
+    facts$.next(systemFact(3));
     await settle();
 
     expect(pump.depth()).toBe(3);
@@ -125,16 +147,16 @@ describe('fact pump', () => {
     // event must not parallelise events against each other.
     const seen: number[] = [];
     const emit = vi.fn(async (_c: unknown, payload: unknown) => {
-      seen.push((payload as StoredEvent).metadata.sequenceNumber as number);
+      seen.push(seqOf(payload));
       await settle();
       return 1;
     });
-    const facts$ = new Subject<StoredEvent>();
+    const facts$ = new Subject<Fact>();
     const pump = createFactPump(facts$, { emit, logger: mockLogger });
 
-    facts$.next(fact(1));
-    facts$.next(fact(2));
-    facts$.next(fact(3));
+    facts$.next(systemFact(1));
+    facts$.next(systemFact(2));
+    facts$.next(systemFact(3));
     for (let i = 0; i < 12; i++) await settle();
 
     expect(seen).toEqual([1, 2, 3]);
@@ -145,12 +167,12 @@ describe('fact pump', () => {
     const emit = vi.fn()
       .mockRejectedValueOnce(new Error('gateway down'))
       .mockResolvedValue(1);
-    const facts$ = new Subject<StoredEvent>();
+    const facts$ = new Subject<Fact>();
     const pump = createFactPump(facts$, { emit, logger: mockLogger });
 
-    facts$.next(fact(1));
+    facts$.next(systemFact(1));
     await settle();
-    facts$.next(fact(2));
+    facts$.next(systemFact(2));
     await settle();
 
     expect(mockLogger.error).toHaveBeenCalled();

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -37,7 +37,7 @@ import { resourceId, userId, annotationId, EventBus } from '@semiont/core';
 import type { Logger } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
 import { MemoryGraphDatabase } from '@semiont/graph';
-import type { StoredEvent, EventMap, PersistedEventType } from '@semiont/core';
+import type { EventMap, PersistedEventType } from '@semiont/core';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';

--- a/packages/make-meaning/src/__tests__/weaver.test.ts
+++ b/packages/make-meaning/src/__tests__/weaver.test.ts
@@ -37,7 +37,7 @@ import { resourceId, userId, annotationId, EventBus } from '@semiont/core';
 import type { Logger } from '@semiont/core';
 import type { GraphDatabase } from '@semiont/graph';
 import { MemoryGraphDatabase } from '@semiont/graph';
-import type { StoredEvent } from '@semiont/core';
+import type { StoredEvent, EventMap, PersistedEventType } from '@semiont/core';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -878,7 +878,15 @@ describe('Weaver', () => {
     let seq = 0;
     const nextSeq = () => ++seq;
 
-    const stored = (type: string, rid: string | undefined, payload: unknown): StoredEvent => ({
+    // Channel-generic, so a fixture is the type its channel carries rather than
+    // an erased `StoredEvent` the bus then has to be cast back into. The one
+    // remaining assertion is the payload's — these specs build partial payloads
+    // on purpose, which is the fixture's business and not the path's.
+    const stored = <K extends PersistedEventType>(
+      type: K,
+      rid: string | undefined,
+      payload: unknown,
+    ): EventMap[K] => ({
       id: uuidv4(),
       type,
       timestamp: new Date().toISOString(),
@@ -887,10 +895,10 @@ describe('Weaver', () => {
       version: 1,
       payload,
       metadata: { sequenceNumber: nextSeq() },
-    } as unknown as StoredEvent);
+    } as unknown as EventMap[K]);
 
-    const deliver = async (e: StoredEvent) => {
-      coreEventBus.getDomainEvent(e.type as Parameters<EventBus['getDomainEvent']>[0]).next(e);
+    const deliver = async <K extends PersistedEventType>(e: EventMap[K] & { type: K }) => {
+      coreEventBus.get(e.type).next(e);
       await tick();
     };
 
@@ -948,8 +956,8 @@ describe('Weaver', () => {
 
       const e = stored('mark:added', 'dup-add-burst', { annotation: annotation('ann-dup-burst', 'dup-add-burst') });
       // Same event twice in the same burst window — no tick between.
-      coreEventBus.getDomainEvent('mark:added').next(e);
-      coreEventBus.getDomainEvent('mark:added').next(e);
+      coreEventBus.get('mark:added').next(e);
+      coreEventBus.get('mark:added').next(e);
       await tick();
 
       const { annotations } = await graphDb.listAnnotations({ resourceId: resourceId('dup-add-burst') });
@@ -1282,11 +1290,11 @@ describe('Weaver', () => {
         id: annotationId(aid), motivation: 'commenting', target: { source: rid }, body: [],
         created: '2026-01-01T00:00:00.000Z',
       });
-      const pushMark = (aid: string, seq: number) => coreEventBus.getDomainEvent('mark:added').next({
+      const pushMark = (aid: string, seq: number) => coreEventBus.get('mark:added').next({
         id: uuidv4(), type: 'mark:added', timestamp: new Date().toISOString(),
         userId: userId('user1'), resourceId: resourceId(rid), version: 1,
         payload: { annotation: ann(aid) }, metadata: { sequenceNumber: seq },
-      } as unknown as StoredEvent);
+      } as unknown as EventMap['mark:added']);
       pushMark('ann-b1', 2);
       pushMark('ann-b2', 3);
       pushMark('ann-b3', 4);

--- a/packages/make-meaning/src/archivist-main.ts
+++ b/packages/make-meaning/src/archivist-main.ts
@@ -346,7 +346,7 @@ async function main() {
   // so serialising them only doubled the drain time. `depth()` is published as
   // a gauge: an unbounded backlog with no number is how this went undiagnosed.
   const factPump = createFactPump(
-    merge(...PERSISTED_EVENT_TYPES.map((type) => localBus.getDomainEvent(type))),
+    merge(...PERSISTED_EVENT_TYPES.map((type) => localBus.get(type))),
     { emit: (channel, payload, scope) => httpTransport.emit(channel, payload, scope), logger },
   );
   pumps.push({ unsubscribe: () => factPump.unsubscribe() } as Subscription);

--- a/packages/make-meaning/src/fact-pump.ts
+++ b/packages/make-meaning/src/fact-pump.ts
@@ -25,7 +25,7 @@
  */
 
 import { from, concatMap, tap, type Observable, type Subscription } from 'rxjs';
-import type { EventMap, Logger, ResourceId, StoredEvent } from '@semiont/core';
+import type { EventMap, Logger, PersistedEventType, ResourceId } from '@semiont/core';
 import { errField } from '@semiont/core';
 
 export interface FactPumpDeps {
@@ -48,18 +48,20 @@ export interface FactPump {
   unsubscribe(): void;
 }
 
-export function createFactPump(facts$: Observable<StoredEvent>, deps: FactPumpDeps): FactPump {
+/** One fact, on its own channel — what `archivist-main`'s merge already yields. */
+type Fact = EventMap[PersistedEventType];
+
+export function createFactPump(facts$: Observable<Fact>, deps: FactPumpDeps): FactPump {
   let depth = 0;
 
-  const publish = async (event: StoredEvent): Promise<void> => {
+  const publish = async (event: Fact): Promise<void> => {
     try {
-      const type = event.type as keyof EventMap;
       // Concurrent: the global and scoped emits are independent, and the
       // event is the same object in both. Ordering between EVENTS is the
       // concatMap below; this parallelism does not touch it.
       await Promise.all([
-        deps.emit(type, event as never),
-        ...(event.resourceId ? [deps.emit(type, event as never, event.resourceId)] : []),
+        deps.emit(event.type, event),
+        ...(event.resourceId ? [deps.emit(event.type, event, event.resourceId)] : []),
       ]);
     } catch (error) {
       // Never rethrow: one unreachable gateway must not tear down the pump


### PR DESCRIPTION
A domain event now keeps its type from the EventStore all the way to the wire. Nothing on
that path erases it to `StoredEvent` or widens its channel to `keyof EventMap`, so nothing
has to cast its way back.

- `EventBus.getDomainEvent` is deleted, both copies — it widened the channel and erased the
  event, then cast to reconnect what it had just disconnected
- The fact pump takes `Observable<EventMap[PersistedEventType]>` and emits
  `deps.emit(event.type, event)` — its `as keyof EventMap` and two `as never` are gone
- Eight casts removed; no new type, no new helper, nothing added to make it work
- Type tests pin both ends, and fail if either is erased again

## `getDomainEvent` was undoing its own damage

Its doc comment said it existed to avoid `as keyof EventMap` when subscribing with a runtime
`PersistedEventType`. It got there by widening the channel to every bus channel and erasing
the event to `StoredEvent` — then casting back. The widening was never necessary: every
persisted type is already a bus channel, and `EventBus.get` was already channel-typed.

That invariant is now pinned as a permanent test rather than left as a comment:

```ts
const holds: PersistedEventType extends keyof EventMap ? true : false = true;
```

It fails the day a persisted type stops being a channel — the only way the cast could become
necessary again. All nine callers moved to `get`; the delete came last, since every caller
compiled against the method until it was moved.

## The fact pump was erasing a stream it was handed correctly

`archivist-main` already merged the persisted channels into a properly typed stream. The pump
widened it back at its own parameter and then cast its way out. The fix is the parameter:

```ts
type Fact = EventMap[PersistedEventType];

export function createFactPump(facts$: Observable<Fact>, deps: FactPumpDeps): FactPump {
  const publish = async (event: Fact): Promise<void> => {
    await Promise.all([
      deps.emit(event.type, event),
      ...(event.resourceId ? [deps.emit(event.type, event, event.resourceId)] : []),
    ]);
```

Ordering is untouched — one merged stream, drained one at a time by `concatMap`, exactly as
before. This changes types only, which is why the pump's six existing behavioural tests are
unchanged and are what prove it.

## The casts were hiding wrong-shaped fixtures, twice

This is the part worth reviewing. Removing the erasure did not just satisfy a rule — in both
phases it exposed test fixtures that had been the wrong shape all along.

In `weaver.test.ts`, fixtures built `as unknown as StoredEvent` were being handed to
`get('mark:added')`, which wants an `EnrichedEvent`. Fixed by making the builder
channel-generic rather than by casting at each call site — removing one cast instead of
adding three.

In the fact pump's tests, one fixture served both the scoped and unscoped cases by letting
`resourceId` come and go through a spread. The type system says that shape cannot exist:
every persisted type requires a `resourceId` except the `frame:*` system events. So the
fixture is now two — `scopedFact` on `mark:archived`, `systemFact` on
`frame:entity-type-added` — each fully typed and cast-free, since a builder for one concrete
channel needs no cast where a generic one does.

## Verification

`tsc --noEmit` clean in core, event-sourcing and make-meaning. Fact pump 6/6 behavioural plus
2 new type tests; event-sourcing 255/255 for the publish path. `getDomainEvent` appears
nowhere outside the test asserting its absence.

The type tests were mutation-checked rather than trusted: widening the pump's element type
back to `EventMap[keyof EventMap]` makes the equality assertion fail, and restoring it returns
`tsc` to zero. An equality check is deliberate — a typed stream is already assignable to an
erased one, so a bare assignability test would have passed against the code being replaced.

Still to do before merge: a live check that an annotation added in one browser reaches
another, confirming the path still delivers with its enrichment after the retype.

## Out of scope

`archivist-main.ts:312` keeps an inbound `as never` (HTTP → local bus). It is the mirror of
this change in the other direction and should get its own failing test rather than being
absorbed here.
