### PR TITLE
Annotations stay W3C: the server stops stapling lookups, the panel follows the link

### DIFF
--- a/packages/make-meaning/src/__tests__/annotation-stays-w3c.test.ts
+++ b/packages/make-meaning/src/__tests__/annotation-stays-w3c.test.ts
@@ -1,0 +1,141 @@
+/**
+ * An `Annotation` on the wire is exactly the W3C annotation its author wrote
+ * (ANNOTATIONS-STAY-W3C D1).
+ *
+ * The server used to staple `_resolvedDocumentName` and
+ * `_resolvedDocumentMediaType` onto linking annotations on the way out — a
+ * lookup result wearing the shape of an authored fact. It went unnoticed for
+ * as long as it did because nothing could catch it: the fields were never in
+ * the spec, so `tsc` saw a cast on the reader's side and the request validator
+ * saw a schema with no `additionalProperties: false` to violate.
+ *
+ * So the guard is a test, and its allowed set is DERIVED from the spec rather
+ * than restated here. A hand-written key list would be a second answer to
+ * "what is an Annotation", and the next field added to the schema would make
+ * this gate wrong rather than the code.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { EventBus, annotationId, resourceId, userId, type Annotation } from '@semiont/core';
+import { createEventStore, type EventStore } from '@semiont/event-sourcing';
+import { AnnotationContext } from '../annotation-context';
+import { createTestProject, type TestProject } from './helpers/test-project';
+import { mockLogger } from './helpers/smelter-harness';
+
+/**
+ * The keys the spec declares. Read from the schema file, so this cannot drift
+ * from it: add a property there and it is allowed here the same day.
+ */
+const SPEC_KEYS: ReadonlySet<string> = (() => {
+  const here = join(fileURLToPath(import.meta.url), '..');
+  const schema = JSON.parse(
+    readFileSync(join(here, '../../../../specs/src/components/schemas/Annotation.json'), 'utf8'),
+  ) as { properties: Record<string, unknown> };
+  return new Set(Object.keys(schema.properties));
+})();
+
+/** Every key on `annotation` that the spec does not declare. */
+function undeclaredKeys(annotation: Annotation): string[] {
+  return Object.keys(annotation).filter((k) => !SPEC_KEYS.has(k));
+}
+
+const SOURCE = resourceId('res-w3c-source');
+const TARGET = resourceId('res-w3c-target');
+const USER = userId('did:web:test:users:test');
+
+describe('annotations carry only what the spec declares', () => {
+  let tp: TestProject;
+  let eventStore: EventStore;
+  let bus: EventBus;
+
+  beforeEach(async () => {
+    tp = await createTestProject('annotation-stays-w3c');
+    bus = new EventBus();
+    eventStore = createEventStore(tp.project, bus, mockLogger);
+
+    // Two resources: the target must EXIST and be named, because that is the
+    // only case the enricher fired on. A gate run against a missing target
+    // would pass while the defect sat untouched.
+    for (const [rid, name] of [[SOURCE, 'Source doc'], [TARGET, 'Target doc']] as const) {
+      await eventStore.appendEvent({
+        type: 'yield:created',
+        resourceId: rid, userId: USER, version: 1,
+        payload: { name, format: 'text/plain', contentChecksum: `cs-${rid}` },
+      });
+    }
+  });
+
+  afterEach(async () => {
+    bus.destroy();
+    await tp.teardown();
+  });
+
+  /** A resolved reference — the one shape the server decorated. */
+  const linkingAnnotation = (id: string): Annotation => ({
+    '@context': 'http://www.w3.org/ns/anno.jsonld',
+    type: 'Annotation',
+    id: annotationId(id),
+    motivation: 'linking',
+    target: { source: String(SOURCE), selector: [{ type: 'TextPositionSelector', start: 0, end: 4 }] },
+    body: [{ type: 'SpecificResource', source: String(TARGET), purpose: 'linking' }],
+    creator: { '@type': 'Person', name: 'Test User', '@id': 'did:web:test:users:test' },
+    created: '2026-09-12T00:00:00.000Z',
+  } as Annotation);
+
+  it('the annotation-list read adds nothing to a resolved reference', async () => {
+    await eventStore.appendEvent({
+      type: 'mark:added',
+      resourceId: SOURCE, userId: USER, version: 1,
+      payload: { annotation: linkingAnnotation('ann-linked') },
+    });
+
+    const annotations = await AnnotationContext.getAllAnnotations(SOURCE, { views: eventStore.viewStorage });
+    const linked = annotations.find((a) => a.id === 'ann-linked');
+    expect(linked, 'the linking annotation must be in the read').toBeDefined();
+
+    // Named rather than counted: a failure should say WHICH key leaked.
+    expect(undeclaredKeys(linked!)).toEqual([]);
+  });
+
+  it('holds for every annotation the read returns, not just the linked one', async () => {
+    // A highlight has no body to resolve, so it was never decorated — it is
+    // here so the gate covers the whole reply rather than one motivation.
+    await eventStore.appendEvent({
+      type: 'mark:added',
+      resourceId: SOURCE, userId: USER, version: 1,
+      payload: { annotation: linkingAnnotation('ann-a') },
+    });
+    await eventStore.appendEvent({
+      type: 'mark:added',
+      resourceId: SOURCE, userId: USER, version: 1,
+      payload: {
+        annotation: {
+          '@context': 'http://www.w3.org/ns/anno.jsonld',
+          type: 'Annotation',
+          id: annotationId('ann-highlight'),
+          motivation: 'highlighting',
+          target: { source: String(SOURCE), selector: [{ type: 'TextPositionSelector', start: 5, end: 9 }] },
+          creator: { '@type': 'Person', name: 'Test User', '@id': 'did:web:test:users:test' },
+          created: '2026-09-12T00:00:00.000Z',
+        } as Annotation,
+      },
+    });
+
+    const annotations = await AnnotationContext.getAllAnnotations(SOURCE, { views: eventStore.viewStorage });
+    expect(annotations.length).toBeGreaterThanOrEqual(2);
+    for (const a of annotations) {
+      expect(undeclaredKeys(a), `annotation ${a.id} carries undeclared keys`).toEqual([]);
+    }
+  });
+
+  it('the derived allow-set is the spec itself, not a copy of it', async () => {
+    // If this file ever stopped reading the schema, the gate above would pass
+    // against whatever list someone typed here. Pin the derivation.
+    expect(SPEC_KEYS.has('motivation')).toBe(true);
+    expect(SPEC_KEYS.has('_resolvedDocumentName')).toBe(false);
+    expect(SPEC_KEYS.size).toBeGreaterThan(5);
+  });
+});

--- a/packages/make-meaning/src/__tests__/event-enrichment.test.ts
+++ b/packages/make-meaning/src/__tests__/event-enrichment.test.ts
@@ -65,6 +65,43 @@ describe('wireEnrichment — what the EventStore publishes on the annotation cha
     expect((await published).annotation?.id).toBe('ann-enrich');
   });
 
+  // The enricher is the OTHER publication path for an annotation
+  // (ANNOTATIONS-STAY-W3C P2). The annotation-list reply has its own gate in
+  // annotation-stays-w3c.test.ts; this holds the bus to the same rule, because
+  // both read through `getAllAnnotations` and a decoration re-added there would
+  // reach subscribers as readily as readers.
+  //
+  // A LINKING annotation specifically: the server only ever decorated a
+  // resolved reference, so a commenting fixture would pass while the defect sat
+  // untouched.
+  it('a linking annotation goes out with no server-added keys', async () => {
+    const TARGET = resourceId('res-enrich-target');
+    await eventStore.appendEvent({
+      type: 'yield:created', resourceId: TARGET, userId: USER, version: 1,
+      payload: { name: 'Target doc', format: 'text/plain', contentChecksum: 'cs-target' },
+    });
+
+    const linking: Annotation = {
+      '@context': 'http://www.w3.org/ns/anno.jsonld',
+      type: 'Annotation',
+      id: annotationId('ann-linking'),
+      motivation: 'linking',
+      target: { source: RID, selector: { type: 'TextQuoteSelector', exact: 'quoted' } },
+      body: [{ type: 'SpecificResource', source: String(TARGET), purpose: 'linking' }],
+      created: '2026-01-01T00:00:00Z',
+    };
+
+    const published = nextOn('mark:added');
+    await eventStore.appendEvent({
+      type: 'mark:added', resourceId: RID, userId: USER, version: 1, payload: { annotation: linking },
+    });
+
+    const out = (await published).annotation!;
+    expect(out.id).toBe('ann-linking');
+    // Named, so a regression says which key came back.
+    expect(Object.keys(out).filter((k) => k.startsWith('_'))).toEqual([]);
+  });
+
   it('mark:body-updated carries the annotation AFTER the update — the new body, not the old', async () => {
     await addAnnotation();
     const published = nextOn('mark:body-updated');

--- a/packages/make-meaning/src/annotation-context.ts
+++ b/packages/make-meaning/src/annotation-context.ts
@@ -19,7 +19,6 @@ import type {
   ResourceId,
   ResourceAnnotations,
   AnnotationId,
-  AnnotationCategory,
   Logger,
 } from '@semiont/core';
 import { resourceId as createResourceId } from '@semiont/core';
@@ -370,80 +369,7 @@ Summary:`;
    */
   static async getAllAnnotations(resourceId: ResourceId, kb: ViewGet): Promise<Annotation[]> {
     const annotations = await this.getResourceAnnotations(resourceId, kb);
-
-    // Enrich resolved references with document names
-    return this.enrichResolvedReferences(annotations.annotations, kb);
-  }
-
-  /**
-   * Enrich reference annotations with resolved document names
-   * Adds _resolvedDocumentName property to annotations that link to documents
-   * @private
-   */
-  private static async enrichResolvedReferences(annotations: Annotation[], kb: ViewGet): Promise<Annotation[]> {
-    // Extract unique resolved resource IDs from reference annotations
-    const resolvedIds = new Set<string>();
-    for (const ann of annotations) {
-      if (ann.motivation === 'linking' && ann.body) {
-        const body = Array.isArray(ann.body) ? ann.body : [ann.body];
-        for (const item of body) {
-          if (item.type === 'SpecificResource' && item.purpose === 'linking' && item.source) {
-            resolvedIds.add(item.source);
-          }
-        }
-      }
-    }
-
-    if (resolvedIds.size === 0) {
-      return annotations;
-    }
-
-    // Batch fetch all resolved documents in parallel
-    const metadataPromises = Array.from(resolvedIds).map(async (id) => {
-      try {
-        const view = await kb.views.get(id as ResourceId);
-        if (view?.resource?.name) {
-          return {
-            id,
-            metadata: {
-              name: view.resource.name,
-              mediaType: view.resource.mediaType as string | undefined
-            }
-          };
-        }
-      } catch (e) {
-        // Document might not exist, skip
-      }
-      return null;
-    });
-
-    const results = await Promise.all(metadataPromises);
-    const idToMetadata = new Map<string, { name: string; mediaType?: string }>();
-    for (const result of results) {
-      if (result) {
-        idToMetadata.set(result.id, result.metadata);
-      }
-    }
-
-    // Add _resolvedDocumentName and _resolvedDocumentMediaType to annotations
-    return annotations.map(ann => {
-      if (ann.motivation === 'linking' && ann.body) {
-        const body = Array.isArray(ann.body) ? ann.body : [ann.body];
-        for (const item of body) {
-          if (item.type === 'SpecificResource' && item.purpose === 'linking' && item.source) {
-            const metadata = idToMetadata.get(item.source);
-            if (metadata) {
-              return {
-                ...ann,
-                _resolvedDocumentName: metadata.name,
-                _resolvedDocumentMediaType: metadata.mediaType
-              } as Annotation;
-            }
-          }
-        }
-      }
-      return ann;
-    });
+    return annotations.annotations;
   }
 
   /**
@@ -477,20 +403,6 @@ Summary:`;
   static async getAnnotation(annotationId: AnnotationId, resourceId: ResourceId, kb: ViewGet): Promise<Annotation | null> {
     const annotations = await this.getResourceAnnotations(resourceId, kb);
     return annotations.annotations.find((a: Annotation) => a.id === annotationId) || null;
-  }
-
-  /**
-   * List annotations with optional filtering
-   * @param filters - Optional filters like resourceId and type
-   * @throws Error if resourceId not provided (cross-resource queries not supported in view storage)
-   */
-  static async listAnnotations(filters: { resourceId?: ResourceId; type?: AnnotationCategory } | undefined, kb: ViewGet): Promise<Annotation[]> {
-    if (!filters?.resourceId) {
-      throw new Error('resourceId is required for annotation listing - cross-resource queries not supported in view storage');
-    }
-
-    // Use view storage directly
-    return this.getAllAnnotations(filters.resourceId, kb);
   }
 
   /**

--- a/packages/react-ui/src/components/resource/panels/ReferenceEntry.tsx
+++ b/packages/react-ui/src/components/resource/panels/ReferenceEntry.tsx
@@ -4,18 +4,13 @@ import type { Ref } from 'react';
 import { useTranslations } from '../../../contexts/TranslationContext';
 import type { Annotation } from '@semiont/core';
 import { resourceId } from '@semiont/core';
-import { getAnnotationExactText, isBodyResolved, getBodySource, getFragmentSelector, getSvgSelector, getTargetSelector } from '@semiont/core';
+import { getAnnotationExactText, isBodyResolved, getBodySource, getFragmentSelector, getSvgSelector, getTargetSelector, getPrimaryMediaType } from '@semiont/core';
 import { getEntityTypes } from '@semiont/ontology';
 import { getResourceIcon } from '../../../lib/resource-utils';
-import type { SemiontSession } from '@semiont/sdk';
+import { readyValue, type SemiontSession } from '@semiont/sdk';
+import { useObservable } from '../../../hooks/useObservable';
 import { renderAgentLabel } from './agent-label';
 import { useHoverEmitter } from '../../../hooks/useHoverEmitter';
-
-// Extended annotation type with runtime properties added by gateway enrichment
-interface EnrichedAnnotation extends Annotation {
-  _resolvedDocumentName?: string;
-  _resolvedDocumentMediaType?: string;
-}
 
 interface ReferenceEntryProps {
   /** Session for interaction routing (browse.click etc.); the panel threads it. */
@@ -58,11 +53,20 @@ export function ReferenceEntry({
   const hasSvgSelector = getSvgSelector(selector);
   const annotationType = hasFragmentSelector ? 'Fragment annotation' : hasSvgSelector ? 'Image annotation' : 'Annotation';
 
-  // Extract resolved document name and media type if enriched by gateway
-  const enrichedReference = reference as EnrichedAnnotation;
-  const resolvedDocumentName = enrichedReference._resolvedDocumentName;
-  const resolvedDocumentMediaType = enrichedReference._resolvedDocumentMediaType;
-  const resourceIcon = getResourceIcon(resolvedDocumentMediaType);
+  // The link target's name and media type are the TARGET resource's facts,
+  // read from that resource through the SDK's cache where they are displayed
+  // (ANNOTATIONS-STAY-W3C D3) — the annotation itself stays exactly W3C.
+  // `browse.resource` is stable per id (cache + scope wrappers memoize), so
+  // subscribing straight off the render read is safe; `failed` is an emission,
+  // never a stream error, so `readyValue` covers every unresolved state. A
+  // stub has no resolved body and requests nothing; and unlike a value stapled
+  // onto the annotation, the name follows a rename of the target.
+  const targetState = useObservable(
+    semiont && resolvedResourceUri ? semiont.browse.resource(resourceId(resolvedResourceUri)) : null,
+  );
+  const target = targetState ? readyValue(targetState) : undefined;
+  const resolvedDocumentName = target?.name;
+  const resourceIcon = getResourceIcon(getPrimaryMediaType(target));
 
   const handleOpen = () => {
     if (resolvedResourceUri) {
@@ -154,11 +158,13 @@ export function ReferenceEntry({
           )}
           {!selectedText && (
             <div className="semiont-annotation-entry__meta">
-              {/* A resource-level annotation with a resolved, named target is
-                  a derivation (the shape generation mints — the vocabulary
-                  deliberately has no 'deriving' purpose): qualify the link
-                  line below instead of showing the generic type label. */}
-              {!selector && resolvedDocumentName ? t('derived') : annotationType}
+              {/* A resource-level annotation with a RESOLVED body is a
+                  derivation (the shape generation mints — the vocabulary
+                  deliberately has no 'deriving' purpose). Keyed off the fact
+                  bind wrote, not off the target's name having loaded: the
+                  name arrives asynchronously now, and a headline keyed on it
+                  would flicker (ANNOTATIONS-STAY-W3C D4). */}
+              {!selector && isResolved ? t('derived') : annotationType}
             </div>
           )}
           {resolvedDocumentName && (

--- a/packages/react-ui/src/components/resource/panels/__tests__/ReferenceEntry.test.tsx
+++ b/packages/react-ui/src/components/resource/panels/__tests__/ReferenceEntry.test.tsx
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, act } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import type { CacheState } from '@semiont/sdk';
+import type { ResourceDescriptor } from '@semiont/core';
+import { getResourceIcon } from '../../../../lib/resource-utils';
 import '@testing-library/jest-dom';
 import type { ComponentProps } from 'react';
 import { renderWithProviders, createTestSemiontWrapper } from '../../../../test-utils';
@@ -81,6 +85,21 @@ describe('ReferenceEntry', () => {
         {...props}
       />,
     );
+
+  const descriptor = (name: string, mediaType = 'text/plain'): ResourceDescriptor => ({
+    '@id': 'linked-doc',
+    name,
+    representations: [{ mediaType, checksum: 'c', byteSize: 1 }],
+  }) as unknown as ResourceDescriptor;
+
+  const ready = (value: ResourceDescriptor): CacheState<ResourceDescriptor> =>
+    ({ status: 'ready', value });
+
+  /** Point the session's resource cache at a controlled stream for the link target. */
+  const mockLinkTarget = (state: CacheState<ResourceDescriptor> | BehaviorSubject<CacheState<ResourceDescriptor>>) => {
+    const source$ = state instanceof BehaviorSubject ? state : new BehaviorSubject(state);
+    return vi.spyOn(session!.client.browse, 'resource').mockReturnValue(source$ as never);
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -176,17 +195,12 @@ describe('ReferenceEntry', () => {
       expect(screen.getByText('Image annotation')).toBeInTheDocument();
     });
 
-    it('should render resolved document name when enriched', () => {
+    it('should render the resolved document name, read from the SDK resource cache', () => {
       mockIsBodyResolved.mockReturnValue(true);
       mockGetBodySource.mockReturnValue('linked-doc');
+      mockLinkTarget(ready(descriptor('My Linked Document', 'text/plain')));
 
-      const enrichedRef = {
-        ...createMockReference(),
-        _resolvedDocumentName: 'My Linked Document',
-        _resolvedDocumentMediaType: 'text/plain',
-      };
-
-      renderEntry({ reference: enrichedRef as Annotation });
+      renderEntry();
 
       expect(screen.getByText(/My Linked Document/)).toBeInTheDocument();
     });
@@ -201,13 +215,9 @@ describe('ReferenceEntry', () => {
       mockGetAnnotationExactText.mockReturnValue('');
       mockIsBodyResolved.mockReturnValue(true);
       mockGetBodySource.mockReturnValue('gen-doc');
+      mockLinkTarget(ready(descriptor('generated from Cedar County, Iowa')));
 
-      const provenanceRef = {
-        ...createMockReference({ target: { source: 'resource-1' } }),
-        _resolvedDocumentName: 'generated from Cedar County, Iowa',
-      };
-
-      renderEntry({ reference: provenanceRef as Annotation });
+      renderEntry({ reference: createMockReference({ target: { source: 'resource-1' } }) });
 
       expect(screen.getByText('ReferencesPanel.derived')).toBeInTheDocument();
       expect(screen.queryByText('Annotation')).not.toBeInTheDocument();
@@ -432,6 +442,68 @@ describe('ReferenceEntry', () => {
 
       const entry = container.firstChild as HTMLElement;
       expect(entry).toHaveAttribute('data-type', 'reference');
+    });
+  });
+
+  // ANNOTATIONS-STAY-W3C P1: the annotation on the wire is exactly W3C — the
+  // linked resource's name and media type are read from THAT resource through
+  // the SDK's cache, where they are displayed. No `_resolved*` fields.
+  describe('Link target resolved through the SDK', () => {
+    it('shows name and media-type icon for a pure W3C annotation, sourced from browse.resource', () => {
+      mockIsBodyResolved.mockReturnValue(true);
+      mockGetBodySource.mockReturnValue('linked-doc');
+      const spy = mockLinkTarget(ready(descriptor('My Linked Document', 'text/markdown')));
+
+      renderEntry();
+
+      expect(screen.getByText(/My Linked Document/)).toBeInTheDocument();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(getResourceIcon)).toHaveBeenCalledWith('text/markdown');
+    });
+
+    it('the name FOLLOWS the resource — a renamed descriptor re-renders the entry', () => {
+      mockIsBodyResolved.mockReturnValue(true);
+      mockGetBodySource.mockReturnValue('linked-doc');
+      const state$ = new BehaviorSubject<CacheState<ResourceDescriptor>>(ready(descriptor('Old Name')));
+      mockLinkTarget(state$);
+
+      renderEntry();
+      expect(screen.getByText(/Old Name/)).toBeInTheDocument();
+
+      act(() => state$.next(ready(descriptor('New Name'))));
+
+      expect(screen.getByText(/New Name/)).toBeInTheDocument();
+      expect(screen.queryByText(/Old Name/)).not.toBeInTheDocument();
+    });
+
+    it('a resource-level derivation headlines Derived BEFORE the name has loaded (keyed off isResolved)', () => {
+      mockGetAnnotationExactText.mockReturnValue('');
+      mockIsBodyResolved.mockReturnValue(true);
+      mockGetBodySource.mockReturnValue('gen-doc');
+      mockLinkTarget(new BehaviorSubject<CacheState<ResourceDescriptor>>({ status: 'pending' }));
+
+      renderEntry({ reference: createMockReference({ target: { source: 'resource-1' } }) });
+
+      expect(screen.getByText('ReferencesPanel.derived')).toBeInTheDocument();
+      expect(screen.queryByText('Annotation')).not.toBeInTheDocument();
+    });
+
+    it('a stub requests nothing — no browse.resource call for an unresolved reference', () => {
+      mockIsBodyResolved.mockReturnValue(false);
+      const spy = vi.spyOn(session!.client.browse, 'resource');
+
+      renderEntry();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('a null session performs no lookup and renders without error', () => {
+      mockIsBodyResolved.mockReturnValue(true);
+      mockGetBodySource.mockReturnValue('linked-doc');
+
+      renderEntry({ session: null });
+
+      expect(screen.getByText(/referenced text/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
An `Annotation` on the wire should be exactly the W3C annotation its author
wrote. It wasn't: on the way out, the server stapled `_resolvedDocumentName`
and `_resolvedDocumentMediaType` onto linking annotations — a lookup result
wearing the shape of an authored fact, and a stale one, since a stapled name
cannot follow a rename of the target.

Two halves.

**The panel follows the link itself.** `ReferenceEntry` stops reading the
stapled fields and resolves the target through the SDK —
`browse.resource(getBodySource(body))`, the same cached form `DerivedFromLink`
uses. The name now follows a rename, which a snapshot never could. The
"Derived" headline keys off `isResolved` — the fact `bind` wrote — so it cannot
flicker while the name loads. `EnrichedAnnotation` and its cast are deleted; a
stub requests nothing and a null session looks up nothing, both pinned. The two
existing tests are re-sourced to the SDK mock rather than dropped.

**The server stops adding them.** `enrichResolvedReferences` is gone and
`getAllAnnotations` returns the view's annotations unchanged.
`AnnotationContext.listAnnotations` goes with it — caller-free, and it only
forwarded — taking an orphaned `AnnotationCategory` import with it.

## The gate

Removing a field nothing declares is easy to undo by accident, so it is held by
a test whose allowed key set is **read from
`specs/src/components/schemas/Annotation.json` at test time**, never typed out.
A failure names the offending key. A third case pins the derivation itself, so
the gate cannot quietly degrade into a hand-maintained list — which would make
the gate wrong rather than the code the next time the schema grows.

This needs a test rather than the validator because `Annotation.json` has no
`additionalProperties: false`: the spec does not forbid extra keys, which is
precisely how this survived — `tsc` saw a cast on the reader's side and request
validation had nothing to violate. Closing the schema would be a wire change and
is deliberately not in this PR.

`getAllAnnotations` feeds two publication paths — the annotation-list reply and
the event enricher — so `event-enrichment.test.ts` gains a **linking**
annotation case. That is the only motivation the server ever decorated; a
commenting fixture would have passed while the defect sat untouched.

Mutation-checked: re-adding one derived field fails three cases, each naming the
key, including the enricher's — which is the evidence that both paths are
covered rather than one gate standing in for two.

## Census

No reader of `_resolvedDocument*` remains in this repo, and none exists in the
KB fleet, `semiont-workflows`, or `tapestry`. The residual risk is a consumer
outside those repos.

## Verification

`tsc --noEmit` clean for make-meaning, `apps/gateway`, `packages/react-ui`, and
`apps/browser`. make-meaning 634 passed / 1 expected fail (55 files);
gateway 382 passed — it has its own `getAllAnnotations` caller; react-ui
182/2731 and browser 38/536 for the panel half; `ReferenceEntry` 34/34.
make-meaning dist rebuilt and the downstream typechecks run against it.

Not covered here: a live bind through Search → Link, then renaming the target to
watch the entry follow.
