### PR TITLE
A PDF annotation's id depends on an artifact it does not carry — measured, written down, and held still

### DIFF
--- a/packages/content/src/__tests__/pdf-offset-stability.test.ts
+++ b/packages/content/src/__tests__/pdf-offset-stability.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The text layer's offsets are PINNED, because something downstream identifies
+ * annotations by them.
+ *
+ * `buildPdfAnnotation` stores no `TextPositionSelector` — it holds page geometry
+ * and the quoted text, on the stated grounds that the extracted text layer is a
+ * derived artifact whose char offsets are not a durable anchor. But the id it
+ * mints is content-addressed over `${start}:${end}:${exact}`, i.e. over exactly
+ * those offsets. So an extraction that moves them re-identifies every annotation
+ * on every PDF, and the duplicates are byte-identical in every stored field
+ * except `id` — no error, no signature, nothing downstream misbehaving.
+ *
+ * The rest of this suite cannot catch that. It looks spans up BY CONTENT —
+ * `items.find((b) => text.slice(b.start, b.end) === 'Drug A')` — which is the
+ * right shape for testing extraction behavior and is invariant under a uniform
+ * offset shift. These assertions are the opposite: absolute, and deliberately
+ * brittle.
+ *
+ * **A failure here is not necessarily a bug.** It means the extraction output
+ * moved — most likely a `pdfjs-dist` upgrade, which the caret pin permits without
+ * anyone deciding. Re-baselining is a legitimate response, but it is a DECISION:
+ * the same upgrade silently changes the id of every PDF annotation minted
+ * afterwards, so a document re-detected across it mints a fresh set alongside the
+ * old ones. Take that consciously, and say so in the commit.
+ *
+ * Measured 2026-09-12: `pdfjs-dist` 6.2.108 → 6.3.289 (a move the `^6.2.108`
+ * caret already allows) left these byte-identical across 1,192 pages of real
+ * documents — 1,254,746 text runs, streams and assembled text alike. This gate
+ * is what keeps that true rather than merely once-observed.
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import { describe, it, expect } from 'vitest';
+import { extractPdfTextLayer } from '../extract-pdf-text-layer';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.join(__dirname, 'fixtures');
+const readFixture = (name: string): Buffer => fs.readFileSync(path.join(FIXTURES, name));
+
+const WHY_IT_MOVED =
+  'Text-layer extraction changed. Every PDF annotation id is hashed over these '
+  + 'offsets, so re-baselining also re-identifies every PDF annotation minted from '
+  + 'here on. Check the pdfjs-dist version before accepting the new values.';
+
+describe('text-layer offsets are stable across engine versions', () => {
+  it('single-line: exact text and item offsets', async () => {
+    const layer = await extractPdfTextLayer(readFixture('single-line.pdf'));
+
+    expect(layer, WHY_IT_MOVED).not.toBeNull();
+    expect(layer!.text, WHY_IT_MOVED).toBe('known phrase from fixture \n');
+    expect(layer!.items, WHY_IT_MOVED).toEqual([
+      { start: 0, end: 25, page: 1, x: 72, y: 720, width: 138.048, height: 12 },
+    ]);
+  });
+
+  it('multi-line: the separator convention is part of the offsets', async () => {
+    // `anchorRuns` puts '\n' after a run pdf.js flags with `hasEOL` and ' '
+    // otherwise. That choice is what every offset after the first line depends
+    // on, so it is pinned here rather than left implicit — a change in how pdf.js
+    // reports line ends would move every subsequent offset without changing a
+    // single character of the text a reader sees.
+    const layer = await extractPdfTextLayer(readFixture('multi-line.pdf'));
+
+    expect(layer, WHY_IT_MOVED).not.toBeNull();
+    expect(layer!.text, WHY_IT_MOVED).toBe(
+      'first line of text\nsecond line of text\nthird line of text \n',
+    );
+    expect(layer!.items.map((item) => [item.start, item.end]), WHY_IT_MOVED).toEqual([
+      [0, 18], [19, 38], [39, 57],
+    ]);
+  });
+
+  it('the geometry an annotation actually STORES is pinned too', async () => {
+    // The id is hashed over offsets, but the rects are what the annotation
+    // carries — so they are what a reader could compare after the fact. If the
+    // report's preferred fix ever lands (identity from the durable anchor), these
+    // become the identity inputs, and this assertion becomes load-bearing rather
+    // than merely descriptive.
+    const layer = await extractPdfTextLayer(readFixture('multi-line.pdf'));
+
+    expect(layer!.items.map((item) => [item.page, item.x, item.y]), WHY_IT_MOVED).toEqual([
+      [1, 72, 720], [1, 72, 700], [1, 72, 680],
+    ]);
+  });
+});

--- a/packages/event-sourcing/src/identifier-utils.ts
+++ b/packages/event-sourcing/src/identifier-utils.ts
@@ -68,6 +68,33 @@ function canonical(value: unknown): string {
  * replaces produced, so nothing downstream that sized a column or a URL around
  * it changes, and ~126 bits, which is far more than a per-resource span space
  * needs.
+ *
+ * ## The no-op guarantee is conditional on `anchor`, and callers differ
+ *
+ * "Re-emitting is a no-op" holds exactly as far as `anchor` is stable, and that
+ * is the CALLER's property, not this function's. The two detection builders do
+ * not have it equally:
+ *
+ * - **Text** (`buildTextAnnotation`) passes `${start}:${end}:${exact}` and the
+ *   annotation STORES those offsets in a `TextPositionSelector`. Identity depends
+ *   only on fields the annotation carries, so the guarantee is unconditional and
+ *   any reader can verify it after the fact.
+ * - **PDF** (`buildPdfAnnotation`) passes the same shape, but the offsets come
+ *   from a text layer *derived* per attempt and are deliberately NOT stored — the
+ *   annotation carries page geometry and the quoted text instead. There the
+ *   guarantee holds only while that derivation is stable, and a reader holding two
+ *   annotations cannot tell whether they disagree because they are different facts
+ *   or because the text layer moved: every stored field would be identical.
+ *
+ * The derivation is cached per content checksum, but the entry is gated by a stamp
+ * over `@semiont/content`'s version plus the PDF engine and its traineddata, and
+ * that stamp is deliberately over-eager — **a release busts it and the same bytes
+ * are re-extracted by different code.** So the honest statement is: the PDF path's
+ * guarantee holds *per stamp generation*, and a release is the event that could end
+ * one. Measured 2026-09-12 across the caret-reachable engine move (pdfjs 6.2.108 →
+ * 6.3.289, 1,192 pages): the offsets did not move — and
+ * `pdf-offset-stability.test.ts` is what keeps that from being a one-time
+ * observation. The OCR path has not been measured.
  */
 export function annotationIdFor(identity: AnnotationIdentity): AnnotationId {
   const material = canonical({

--- a/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
+++ b/packages/jobs/src/__tests__/build-pdf-annotation.test.ts
@@ -63,6 +63,64 @@ type PdfSel = { type: string; value?: string; conformsTo?: string; exact?: strin
 const sels = (ann: ReturnType<typeof buildPdfAnnotation>): PdfSel[] => ann.target.selector as PdfSel[];
 const frags = (ann: ReturnType<typeof buildPdfAnnotation>) => sels(ann).filter(s => s.type === 'FragmentSelector');
 
+// A layer identical to LAYER except that one character of leading text has been
+// inserted — the shape a re-extraction takes if it ever emits one more (or one
+// fewer) character before the same visual span. Every offset shifts by one; the
+// GEOMETRY is untouched, because the words are still drawn in the same places.
+const SHIFTED_LAYER: PdfTextLayer = {
+  pages: [{ pageNumber: 1, widthPt: 612, heightPt: 792, textStart: 0, textEnd: 23, hasTextLayer: true }],
+  text: ' alpha beta\ngamma delta',
+  items: [
+    { start: 1,  end: 6,  page: 1, x: 72,  y: 720, width: 40, height: 12 }, // alpha
+    { start: 7,  end: 11, page: 1, x: 118, y: 720, width: 34, height: 12 }, // beta
+    { start: 12, end: 17, page: 1, x: 72,  y: 700, width: 45, height: 12 }, // gamma
+    { start: 18, end: 23, page: 1, x: 125, y: 700, width: 42, height: 12 }, // delta
+  ],
+  fields: [],
+};
+
+describe('a PDF annotation is identified by offsets it does not carry', () => {
+  // The defect, stated executably. `buildPdfAnnotation` deliberately stores NO
+  // TextPositionSelector — its own comment says the text layer is a derived
+  // artifact whose offsets are not a durable anchor — and then hashes the id
+  // over exactly those offsets.
+  //
+  // So two builds of the SAME visual span, against two extractions that differ
+  // only by a leading character, produce annotations that are identical in every
+  // stored field and different in `id`. Every dedupe layer keys on `id` and
+  // therefore lets both through, correctly; the identity was wrong upstream, and
+  // an operator sees duplicates with no error anywhere.
+  //
+  // This test asserts TODAY's behavior, and it is written to be FLIPPED if the
+  // identity is ever moved onto the durable anchor: the two ids would then be
+  // equal and the assertion below becomes `toBe`.
+  const span = { exact: 'gamma', start: 11, end: 16 };
+  const shifted = { exact: 'gamma', start: 12, end: 17 };
+
+  it('mints a DIFFERENT id for the same span when the extraction shifts by one character', () => {
+    const a = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting', span);
+    const b = buildPdfAnnotation(SHIFTED_LAYER, RID, USER_DID, GENERATOR, 'highlighting', shifted);
+
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('…while every field it actually STORES is identical — which is why the drift has no signature', () => {
+    const a = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting', span);
+    const b = buildPdfAnnotation(SHIFTED_LAYER, RID, USER_DID, GENERATOR, 'highlighting', shifted);
+
+    // Geometry: same page, same rectangle — the span did not move on the page.
+    expect(frags(b)).toEqual(frags(a));
+    // Quoted text: same.
+    const quoted = (ann: ReturnType<typeof buildPdfAnnotation>) =>
+      sels(ann).filter((sel) => sel.type === 'TextQuoteSelector').map((sel) => sel.exact);
+    expect(quoted(b)).toEqual(quoted(a));
+    // And neither carries the offsets their ids were computed from.
+    for (const ann of [a, b]) {
+      expect(sels(ann).some((sel) => sel.type === 'TextPositionSelector')).toBe(false);
+    }
+  });
+});
+
 describe('buildPdfAnnotation (#736 geometry tail)', () => {
   it('single-line span -> one FragmentSelector + a TextQuoteSelector, and no TextPositionSelector', () => {
     const ann = buildPdfAnnotation(LAYER, RID, USER_DID, GENERATOR, 'highlighting',

--- a/packages/jobs/src/processors.ts
+++ b/packages/jobs/src/processors.ts
@@ -278,6 +278,26 @@ export function buildTextAnnotation(
  * layer is a derived artifact, not the stored content, so its char offsets are
  * not a durable anchor.
  *
+ * **And the `id` is hashed over exactly those offsets** — `annotationIdFor` gets
+ * `spanAnchor(match)`, i.e. `${start}:${end}:${exact}`. That is worth stating
+ * plainly, because it sits in tension with the paragraph above: identity here
+ * depends on something the annotation refuses to store, on the grounds that it is
+ * not durable. The consequence is not a corrupt write but an invisible one — an
+ * extraction that moved would re-identify the same visual span, and the two
+ * annotations would agree in every stored field (same rects, same quoted text) and
+ * differ only in `id`, so every dedupe layer would correctly let both through.
+ *
+ * It is left as it is on evidence, not by oversight. The offsets come from a
+ * derivation cached per content checksum and gated by a stamp that a release of
+ * `@semiont/content`, the PDF engine or its traineddata busts by design; measured
+ * across the caret-reachable engine move (pdfjs 6.2.108 → 6.3.289) over 1,192 pages
+ * of real documents, they did not move, and `pdf-offset-stability.test.ts` in
+ * `@semiont/content` now fails if they ever do. The OCR path is unmeasured, and a
+ * scanned document takes its whole text from there. If that gate ever fires, this
+ * is the line to revisit: hashing the DURABLE anchor instead (page geometry plus
+ * `exact`) makes identity depend only on what the annotation carries — at the cost
+ * of one round of new ids for every PDF annotation minted afterwards.
+ *
  * Write-time invariant (geometry <-> text): geometry is item-level (word runs),
  * so the covered items' text must *contain* `exact` (whitespace-normalized) —
  * containment, not reconstruction. An empty cover (no overlapping items -> no


### PR DESCRIPTION
`buildPdfAnnotation` deliberately stores **no** `TextPositionSelector`. Its own comment says why: the extracted text layer is a derived artifact, so its character offsets are not a durable anchor. The id it mints is then hashed over exactly those offsets — `${start}:${end}:${exact}`. So identity depends on something the annotation refuses to store, on the grounds that it is not durable.

Confirmed in data, not just in code: across a 518-annotation production PDF, **0 of 518** annotations carry a `TextPositionSelector`. Every one of them is identified by offsets it does not hold.

This PR does not change that. It measures whether the dependency actually bites, writes the condition down where the promise is made, and adds the gate that keeps the measurement true. **192 additions, 0 deletions — no behavior changes.**

## Why it would be invisible if it fired

Two annotations for the same visual span, from different attempts, would agree on the quoted text, on the page rectangles, on body, motivation and target — and differ only in `id`. Every dedupe layer keys on `id` and would therefore let both through, *correctly*. Nothing downstream misbehaves; the identity was wrong upstream. An operator sees duplicates and no error anywhere.

## The measurement: the engine move the pin already allows

`pdfjs-dist` is pinned `^6.2.108`, and 6.3.289 satisfies that caret — so this is the upgrade a lockfile regeneration performs today, not a hypothetical future one. It is also the upgrade that was dropped from the Batch 7 Dependabot aggregate (#1319) because of a separate extraction regression, so it is a live candidate rather than a thought experiment.

Both versions were installed in an isolated scratch tree; the repository's `node_modules`, `package.json` and lockfile were not touched.

| | result |
|---|---|
| documents | 3 real PDFs, including the exact 518-annotation resource |
| scale | **1,192 pages · 1,254,746 text runs · ~98 MB of compared stream data** |
| `(str, hasEOL)` stream | byte-identical |
| geometry stream | byte-identical |
| assembled document text | byte-identical |

The `(str, hasEOL)` stream is the one that decides: `anchorRuns` reads **only** those two fields to build the document text, so they alone determine every offset. It was captured straight from `getTextContent()` with no project code replicated, so a difference could not have been an artifact of the harness.

**One correction worth recording.** The investigation's own instruction offered "the `@semiont/content` version, or the engine pin" as interchangeable inputs to move. They are not. The cache stamp is `content-<ver>+pdfjs-<ver>+tesseract-<ver>+eng-<ver>`, so bumping the version string alone busts the cache while changing no extraction code — a re-derivation that is bit-identical by construction. That experiment would have "cleared" the report having tested nothing but determinism, on the branch that decides whether to change every PDF annotation's identity.

**And one false lead, caught before it reached the conclusion.** `getFieldObjects()` returns 5 fields under 6.2.108 and **0** under 6.3.289. Since the extractor's class decision branches on `fields.length > 0`, this looked like the drift. It is not: `foldFormFields` *appends* folded values after the drawn text, so drawn-span offsets do not move. The flip makes form-value annotations cease to exist — which is the separately-tracked acroform regression, not this defect.

## The gate, and why the existing tests could not be it

Nothing in the suite could have caught an offset shift. The extraction tests locate spans **by content**:

```js
items.find((b) => text.slice(b.start, b.end) === 'Drug A')
```

That is the right shape for testing extraction behaviour, and it is exactly invariant under the failure mode in question. A uniform shift passes every one of them.

`pdf-offset-stability.test.ts` pins the opposite: absolute text and item offsets for two native fixtures, including the `hasEOL` separator convention that every offset after the first line depends on. Its failure message states what a failure *means* — the extraction moved, re-baselining is legitimate but it is a **decision**, because the same upgrade silently re-identifies every PDF annotation minted afterwards.

Mutation-proven: flipping that separator from `'\n'` to `' '` — a change that alters no character a reader ever sees — fails it.

## The contract now states its basis

- **`annotationIdFor`** promised that re-emission is "a no-op with no read". It now says that guarantee is conditional on `anchor`, and that **the condition belongs to the caller, not the function**: the text builder stores the offsets it hashes, so it holds unconditionally; the PDF builder does not, so it holds *per stamp generation* — and a release is the event that could end one.
- **`buildPdfAnnotation`** keeps its reasoning about the text layer being derived and states the tension directly beneath it: what the id is actually hashed over, why a failure would be invisible rather than corrupting, that it is left this way **on evidence rather than by oversight**, and what to change if the gate ever fires.
- **`build-pdf-annotation.test.ts`** states the defect executably — the same visual span built against extractions differing by one leading character mints different ids, while every stored field is identical. Mutation-proven by hashing the durable anchor instead, which makes the ids equal and fails it.

## Verification

- All PDF tests green, jobs 624, event-sourcing 255. Typecheck clean across core, content, jobs and event-sourcing. (The content package's git-staging failures are environmental — no `git` binary in the test container — and predate this branch.)
- Every claim above is a measurement or a code reference; the two inferences are labelled as such below.

## Still open — and the fix is deliberately parked

The obvious remedy is to hash the **durable** anchor instead (page geometry plus the quoted text), so identity depends only on fields the annotation carries. It is written up, its test already exists and is proven to bite, and it is **not** being done here: it costs one round of new ids for every PDF annotation minted afterwards, which is too high a price for a drift nobody has demonstrated.

Two things would change that answer, and both are named rather than left implicit:

1. **The OCR path is unmeasured, and it is where a drift would be total rather than marginal.** All three measured documents have native text layers. A scanned PDF takes its *entire* text from Tesseract, and the cache stamp reads the engine and its traineddata separately for precisely this reason — its own docstring notes that different traineddata means different recognised text. A traineddata move would shift 100% of a scanned document's offsets.
2. **A document that is both a filled AcroForm and a detectable grid** would flip extraction class across this upgrade, and the grid path rewrites page text — which does move offsets. Derived from the branch structure, not observed: the form and table fixtures are separate, and a combined one would settle it.

Until then, the stability gate firing is the trigger.
